### PR TITLE
fix(release): clear field-shadow and WebAssembly parity blockers

### DIFF
--- a/changelog.d/9242-release-parity-blockers.md
+++ b/changelog.d/9242-release-parity-blockers.md
@@ -1,0 +1,4 @@
+Method calls now preserve same-named instance fields declared on the receiver
+class or an ancestor instead of bypassing them with direct prototype dispatch.
+The default-runtime WebAssembly parity fixture also reliably stays out of the
+auto-linked host mode, restoring coverage of graceful degradation.

--- a/crates/perry-codegen/src/lower_call/method_override.rs
+++ b/crates/perry-codegen/src/lower_call/method_override.rs
@@ -867,6 +867,37 @@ pub(super) struct SubclassDispatchArm {
     pub target_fn: String,
 }
 
+/// A declared instance field is an own property on every constructed object,
+/// so it wins over a same-named prototype method. The direct-method guards
+/// prove the receiver's class/shape and prototype stability, but that is not
+/// enough to skip ordinary own-property lookup when the expected shape itself
+/// contains the method name. Computed fields are conservatively treated as a
+/// possible shadow because their runtime key is not available here.
+fn class_chain_may_declare_method_field(ctx: &FnCtx<'_>, class_name: &str, property: &str) -> bool {
+    let mut current = Some(class_name.to_string());
+    let mut seen = std::collections::HashSet::new();
+    for _ in 0..64 {
+        let Some(name) = current else {
+            return false;
+        };
+        if !seen.insert(name.clone()) {
+            return true;
+        }
+        let Some(class) = ctx.classes.get(&name).copied() else {
+            return true;
+        };
+        if class
+            .fields
+            .iter()
+            .any(|field| field.key_expr.is_some() || (!field.is_private && field.name == property))
+        {
+            return true;
+        }
+        current = class.extends_name.clone();
+    }
+    true
+}
+
 /// Emit a typed-feedback runtime guard before a known class-method direct call.
 ///
 /// The guard validates that the receiver still has the expected class shape,
@@ -892,6 +923,13 @@ pub(super) fn emit_guarded_direct_method_call(
     shape_only_guard: bool,
     subclass_arms: &[SubclassDispatchArm],
 ) -> Option<String> {
+    // `class C { m = fn; m() {} }` and an inherited field with the same name
+    // both require ordinary own-property lookup. Falling back here reaches
+    // `emit_own_method_override_check` / dynamic dispatch in the caller.
+    if class_chain_may_declare_method_field(ctx, receiver_class_name, property) {
+        return None;
+    }
+
     let truthy_result_kind = ctx
         .truthy_call_result_requested
         .then(|| constructive_method_truthiness(ctx, direct_fn))

--- a/crates/perry-codegen/tests/native_proof_regressions.rs
+++ b/crates/perry-codegen/tests/native_proof_regressions.rs
@@ -13896,6 +13896,16 @@ fn scalar_method_boolean_predicate_rejects_mutation_call_accessor_and_dynamic_pr
                 ),
                 "mutation must dispatch directly to the resolved method on the heap receiver:\n{ir}"
             );
+        } else if case == "inherited_field_shadow" {
+            // A declared field on the base class is an own property on the
+            // constructed child. The safe fallback therefore probes the own
+            // slot and invokes its value, rather than entering the prototype
+            // method dispatcher that would skip the shadow.
+            assert!(
+                ir.contains("call double @js_object_get_own_field_or_undef")
+                    && ir.contains("call double @js_native_call_value"),
+                "inherited field shadow must probe and dispatch the own method value:\n{ir}"
+            );
         } else {
             assert!(
                 ir.contains("call double @js_native_call_method"),

--- a/test-files/test_parity_webassembly_graceful_fail_default.ts
+++ b/test-files/test_parity_webassembly_graceful_fail_default.ts
@@ -1,7 +1,9 @@
-// Resolve the namespace through a computed key so this test deliberately does
-// not trigger the compiler's static WebAssembly host auto-linking. It checks
-// the default runtime's honest graceful degradation instead.
-const WA: any = (globalThis as any)["Web" + "Assembly"];
+// Resolve the namespace through a runtime-computed key so this test
+// deliberately does not trigger WebAssembly host auto-linking. A `+` here is
+// constant-folded before feature detection, which would turn this default-
+// runtime fixture into a host-runtime test.
+const namespaceKey = ["Web", "Assembly"].join("");
+const WA: any = (globalThis as any)[namespaceKey];
 const validAdd = new Uint8Array([
   0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
   0x01, 0x07, 0x01, 0x60, 0x02, 0x7f, 0x7f, 0x01,


### PR DESCRIPTION
Fixes #9240.
Fixes #9241.

Clears the two new failures from the v0.5.1519 full CI run:

- guarded direct method calls now fall back to own-property lookup when the class or an ancestor declares a same-named instance field (and conservatively for computed fields), preserving JavaScript field-over-prototype semantics;
- the default-runtime WebAssembly fixture now computes its namespace key at runtime, preventing constant folding from accidentally enabling the real wasm host.

Release evidence on the exact candidate base `01463b81610f089cc566011d16ea5e5b08ec70a8`:

- `test_issue_945_scalar_method_guards`: PASS, 100% parity
- `test_parity_webassembly_graceful_fail_default`: PASS, 100% expected-output parity
- `scripts/run_issue_945_scalar_method_ir_guard.sh`: PASS (safe scalar fast path retained)
- `cargo fmt --check --all`: PASS

Failed release jobs:

- parity 12: https://github.com/PerryTS/perry/actions/runs/33346563641/job/99353328925
- parity 9: https://github.com/PerryTS/perry/actions/runs/33346563641/job/99353328887


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved method dispatch when inherited or computed instance fields share a name with a method.
  * Prevented direct method calls from bypassing own-property overrides, ensuring the correct implementation is selected.
  * Improved compatibility for applications that use fields and methods with the same name across class hierarchies.
  * Corrected WebAssembly feature detection in the default runtime, restoring reliable graceful degradation when the feature is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->