### PR TITLE
perf(codegen): the inline array-store tier covers tagged receivers (prime_sieve 4.5× → 1.8× node)

### DIFF
--- a/changelog.d/inline-store-tier-covers-tagged-arrays.md
+++ b/changelog.d/inline-store-tier-covers-tagged-arrays.md
@@ -1,0 +1,49 @@
+The inline array-store guard now covers receivers that are not raw-f64.
+
+`lower_index_set_fast` builds a guard that tests, inline, everything the
+out-of-line `js_typed_feedback_plain_array_index_set_guard` tests: array type,
+not-forwarded, no element descriptors, the integrity flags, the prototype-chain
+invalidation byte, and the length/capacity sanity bounds. It then jumps straight
+to the store, skipping the call.
+
+That whole tier was gated on `require_numeric_layout`, so it was built only for
+statically numeric receivers. A `boolean[]` — or any downgraded `any[]` — went to
+the call on every store, forever, even though the in-bounds arm below already
+knows how to store a tagged value into such a receiver (that arm is exactly what
+the out-of-line guard fronts today).
+
+Only two of the guard's conditions belong to the raw-f64 store, and they are now
+applied only when that store is the one being emitted:
+
+* the receiver's raw-f64 layout bits, because the raw arm writes an unboxed
+  double into the slot and that is valid only while the layout says the elements
+  are pointer-free — and a downgraded receiver has those bits clear by
+  definition, which is precisely why requiring them pinned `boolean[]` to the
+  call tier;
+* the runtime numeric-tag test on the stored value, which exists because a
+  `number[]` slot can genuinely receive a non-number and the raw arm would write
+  its NaN-boxed tag verbatim. The tagged arm stores the box as a box.
+
+Measured on an idle Mac mini, all binaries built in one run, interleaved, min of
+five, self-timed:
+
+| | main | with #9246 | this change | node |
+|---|---:|---:|---:|---:|
+| boolean-store loop | 207 ms | 138 ms | **64 ms** | 12 ms |
+| `11_prime_sieve` | 27 ms | 20 ms | **11 ms** | 6 ms |
+
+`11_prime_sieve` moves from 4.5× Node to 1.8×. A nested-loop read benchmark is
+unchanged, as expected.
+
+Verified against Node on a differential written for this change specifically —
+the guard must reject exactly what the call rejects: a frozen array (stores
+ignored), a sealed array and one under `preventExtensions` (in-bounds writes
+allowed, growth refused), an element accessor descriptor (the setter must run),
+extension past length, mixed types through one slot, and a store into an array
+that was numeric. Byte-identical, plus five pre-existing differentials unchanged.
+
+One case in that differential diverges from Node — an `Array.prototype` index
+setter installed with `Object.defineProperty` is bypassed — and it diverges
+**identically on unmodified main, for numeric receivers too**, so it is neither
+caused nor widened here. Filed separately; the flag the guards consult is only
+set by an index *write* to the prototype, never by `defineProperty`.

--- a/crates/perry-codegen/src/expr/index.rs
+++ b/crates/perry-codegen/src/expr/index.rs
@@ -209,7 +209,19 @@ pub(crate) fn lower_index_set_fast(
     // predicate (see `value_numeric` below) whenever it is not statically
     // known, so the tier covers those stores too and the flag only decides
     // whether those three instructions are emitted at all.
-    let inline_write_tier = require_numeric_layout && !super::typed_feedback_emission_enabled();
+    // #9237: the tier is no longer restricted to statically numeric receivers.
+    // Every condition the out-of-line guard checks is already tested inline here
+    // — array type, not-forwarded, no element descriptors, integrity flags, the
+    // prototype-chain invalidation flag, and the length/capacity sanity bounds —
+    // and the in-bounds arm below already knows how to store a tagged value into
+    // a non-raw-f64 receiver (that arm is what the out-of-line guard fronts
+    // today). Only two of the conditions are specific to the raw-f64 store, and
+    // they are now applied only when it is the one being emitted, so a
+    // `boolean[]` store reaches the same inline guard instead of paying
+    // `js_typed_feedback_plain_array_index_set_guard` per element: ~41% of such
+    // a loop, and the reason `benchmarks/suite/11_prime_sieve.ts` sits on the
+    // call tier for its whole run.
+    let inline_write_tier = !super::typed_feedback_emission_enabled();
     let cold_guard_idx = if inline_write_tier {
         Some(ctx.new_block("idxset.guard.cold"))
     } else {
@@ -288,13 +300,27 @@ pub(crate) fn lower_index_set_fast(
 
             let mut guard_ok = blk.and(I1, &is_array, &not_forwarded);
             guard_ok = blk.and(I1, &guard_ok, &integrity_clean);
-            guard_ok = blk.and(I1, &guard_ok, &is_dense);
+            if require_numeric_layout {
+                // Raw-f64 layout is a precondition of the RAW store only: that
+                // arm writes an unboxed double into the slot, which is valid
+                // only while the receiver's layout says its elements are
+                // pointer-free. A tagged store writes a NaN-boxed JSValue and
+                // is correct whatever the layout says — and for a downgraded
+                // receiver these bits are clear by definition, which is exactly
+                // why requiring them kept `boolean[]` on the call tier forever.
+                guard_ok = blk.and(I1, &guard_ok, &is_dense);
+            }
             guard_ok = blk.and(I1, &guard_ok, &default_prototype_chain);
             guard_ok = blk.and(I1, &guard_ok, &index_nonnegative);
             guard_ok = blk.and(I1, &guard_ok, &length_sane);
             guard_ok = blk.and(I1, &guard_ok, &capacity_sane);
             guard_ok = blk.and(I1, &guard_ok, &length_within_capacity);
-            if !value_is_canonical_raw_f64 {
+            // #9237: kept exactly where it is load-bearing. The comment below
+            // is about the RAW store — a `number[]` slot can genuinely receive a
+            // non-number at runtime, and writing its NaN-boxed tag verbatim as a
+            // double is the bug being prevented. The tagged arm stores the box
+            // as a box, so the test is dead work there and only there.
+            if require_numeric_layout && !value_is_canonical_raw_f64 {
                 // #7396: the out-of-line guard's `is_numeric_value_bits(value)`
                 // leg, inlined. It is load-bearing and NOT implied by
                 // `require_numeric_layout`: that is a *static* TypeScript


### PR DESCRIPTION
**Stacked on #9246** — the diff shown against `main` includes that PR's commit; review this one's second commit.

Completes the larger half of #9237.

## The gate was one conjunct

`lower_index_set_fast` builds an inline guard that tests everything the out-of-line `js_typed_feedback_plain_array_index_set_guard` tests — array type, not-forwarded, no element descriptors, integrity flags, the prototype-chain invalidation byte, length/capacity sanity — and on success jumps straight to the store, skipping the call. The whole tier was gated on `require_numeric_layout`:

```rust
let inline_write_tier = require_numeric_layout && !typed_feedback_emission_enabled();
```

So it was only ever *built* for statically numeric receivers. A `boolean[]`, or any downgraded `any[]`, took the call on every store for the life of the program — even though the in-bounds arm below already knows how to store a tagged value into such a receiver. That arm is precisely what the out-of-line guard fronts today; only the guard in front of it was missing.

Two of the guard's conditions genuinely belong to the raw-f64 store, and they now apply only when that store is the one being emitted:

- **the receiver's raw-f64 layout bits** — the raw arm writes an unboxed double into the slot, valid only while the layout says the elements are pointer-free. A downgraded receiver has those bits clear *by definition*, which is exactly why requiring them pinned `boolean[]` to the call tier permanently;
- **the runtime numeric-tag test on the value** — load-bearing because a `number[]` slot can genuinely receive a non-number (a hole/OOB read fallback returning `undefined` is the ordinary way) and the raw arm would write its NaN-boxed tag verbatim. The tagged arm stores the box as a box, so the test is dead work there and only there.

## Measurements

Idle Mac mini, all binaries built in one run, interleaved, min of five, self-timed:

| | main | with #9246 | **this change** | node |
|---|---:|---:|---:|---:|
| boolean-store loop | 207 ms | 138 ms | **64 ms** | 12 ms |
| `11_prime_sieve` | 27 ms | 20 ms | **11 ms** | 6 ms |
| `10_nested_loops` (read control) | 17 ms | 17 ms | 17 ms | 16 ms |

`11_prime_sieve` goes from **4.5× Node this morning to 1.8×**.

## Correctness

A differential written for this change, because widening a store guard is where a mistake would hide: a **frozen** array (stores ignored), a **sealed** array and one under **`preventExtensions`** (in-bounds writes allowed, growth refused), an **own element accessor descriptor** (the setter must run), **extension past length**, **mixed types through one slot**, and a store into an array that *was* numeric. Byte-identical to Node. The five pre-existing differentials are unchanged, and 31 `perry-codegen` suites pass.

**One case diverges, and it is not this change's**: an `Array.prototype` index setter installed via `Object.defineProperty` is bypassed. It diverges **identically on unmodified `main`, for numeric receivers too** — I built main specifically to check, because "my differential went red" is not the same as "my change broke it". Filed as #9249 with the mechanism: the flags both guards consult are only raised by an index *write* to the prototype, never by `defineProperty`.

https://claude.ai/code/session_012Ys25ni6VwDKE71o1NTYAT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved array-store performance, with faster boolean-store loops and prime-sieve benchmarks.
* **Bug Fixes**
  * Extended optimized array writes to support tagged arrays, including boolean and downgraded mixed-value arrays.
  * Preserved garbage-collection bookkeeping and write barriers for pointer-containing values.
  * Reduced unnecessary runtime bookkeeping during in-bounds array updates.
* **Tests**
  * Updated coverage to verify layout tracking and write barriers remain correct for numeric arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->