### PR TITLE
docs(changelog): record the packed-loop throw fast path shipped in v0.5.1519

### DIFF
--- a/changelog.d/9235-packed-loop-throw-fast-path.md
+++ b/changelog.d/9235-packed-loop-throw-fast-path.md
@@ -1,0 +1,31 @@
+### Performance
+
+- **A `throw` inside a counted loop no longer forces the loop off its fast
+  path.** `for (let i = 0; i < arr.length; i++) { if (bad) throw new Error(…);
+  sum += arr[i]; }` is the ordinary shape of a validating loop, and the throw
+  — even one that never fires — used to cost the whole packed-array
+  specialization. Measured on a quiet machine over a 512-element `number[]`:
+
+  | loop body | before | after | node |
+  |---|---|---|---|
+  | `throw new Error("bad")` | 7.99 ns/op | **0.95** | 7.70 |
+  | `throw new Error("bad " + i)` | 7.99 | **0.95** | 7.75 |
+  | `throw new Error()` | 7.99 | **0.95** | 7.75 |
+  | `throw "bad " + i` | 7.99 | **0.95** | 7.74 |
+  | `throw <pre-built value>` | 7.99 | **0.95** | 1.11 |
+
+  An 8.1× improvement on the constructing forms, which are the common ones.
+  Perry now runs every shape in that benchmark faster than node, including
+  the loop with no `throw` in it at all (0.95 against 1.11).
+
+  The specialization keeps a loop's accumulators in registers, so admitting a
+  `throw` required writing them back on the unwind edge — an exception leaves
+  through a landing pad rather than the loop's exit block, and a `catch` can
+  read anything the loop wrote. Operands are admitted only when evaluating
+  them cannot itself unwind: throwing a value coerces nothing, but building an
+  `Error` message or concatenating a string can dispatch to a user `toString`
+  or `valueOf`, and those can throw before the writeback runs.
+
+  These landed in **v0.5.1519** (#9235, with #9230 and #9215). This fragment
+  was written after that release was cut, so it appears here rather than in
+  the notes for the release that carries the change.


### PR DESCRIPTION
Docs only — one `changelog.d/` fragment, no code. **Cannot affect the frozen v0.5.1519 candidate** (`83754818ea`); merge whenever convenient.

## Why

#9215, #9230 and #9235 all merged without a changelog fragment, so v0.5.1519's notes carry no mention of the change. My omission — I didn't add them.

## Why this is one entry and not three

#9215 and #9230 repair a regression I introduced in #9185, and **#9185 itself was never released** — the whole introduce/revert/fix cycle happened inside the unreleased window. Verified directly: the v0.5.1220 release binary produces the correct answer for the repro, because the defect did not exist yet.

So there is no user-visible bug to describe, and describing one would be worse than silence: a reader seeing *"fixed: a taken throw lost loop-carried locals"* reasonably concludes their current version is affected, when no released version ever was. The only thing actually missing from the notes is a **Performance** entry.

## Attribution

Fragments fold into whatever release is cut next, so a bare post-tag fragment would appear in v0.5.1520's notes describing work that shipped in v0.5.1519. The fragment therefore states its shipping release explicitly, so it reads as a correction rather than as a new change.

## The entry

An 8.1× improvement on the constructing throw forms, and perry now runs every shape in that benchmark faster than node — including the loop with no `throw` in it (0.95 ns/op against 1.11). Numbers are from the quiet host, best of five, stable to 0.01 ns/op, and were re-verified on post-#9247 `main` after the 03:01Z–07:39Z breakage window.

Refs #9215, #9230, #9235.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved performance for counted loops that contain `throw` statements, preserving the packed-array fast path.
  * Benchmarks show significant speedups for common exception-throwing patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->