### PR TITLE
docs(contributing): do not cancel the CI run of the PR being merged (4 PRs through this hole in one day)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,6 +135,38 @@ on Node 22 while the suite grew Node 24/26 features and hid 14 tests that way.
 Any PR touching `crates/` also needs a `changelog.d/<PR-number>-<slug>.md`
 fragment; see [changelog.d/README.md](changelog.d/README.md).
 
+**Never cancel the CI run of the PR you are about to merge.** Cancelling other
+runs to free capacity is fine and expected on a 20-slot org. Cancelling the run
+of the PR being merged is not, because a cancelled job is neither a pass nor a
+failure, and two separate protections go quiet at once:
+
+* **`pr-gate` never reports**, so the single required context is absent rather
+  than red. That is what invites the admin bypass, and the bypass is what lands
+  the change.
+* **The changelog fragment stops being required.** That check is a step inside
+  the `lint` job, conditioned on `github.event_name == 'pull_request'`, so a
+  cancelled `lint` skips it silently — the PR merges with no fragment, and the
+  omission is invisible until the release notes are cut weeks later and the
+  change simply is not in them.
+
+The gate logic itself is correct and does not need changing: `gate` in
+`.github/workflows/test.yml` runs `if: always()` and treats `failure` **and**
+`cancelled` as failures, precisely so a cancelled dependency cannot read as
+green. Every incident here has been a bypass of a working gate, so resist the
+urge to "fix" the gate.
+
+Both failure modes were observed on the same day. #9169 merged with `lint`
+failing and five jobs cancelled; its gap shards never ran and it broke method
+dispatch and property lookup on `main` for four and a half hours (#9247).
+Separately, #9215, #9230 and #9235 each merged with `lint` **cancelled** — all
+three touched `crates/`, none carried a fragment, and the work is consequently
+absent from its release notes.
+
+If you are reviewing status before a merge, note that "no failing checks" is
+not "all checks ran": `CANCELLED` is neither, and tooling that filters for
+`FAILURE` will report a clean bill of health for a PR whose gate never
+executed.
+
 UI doc-tests launch real windows. On headless hosts, wrap in `xvfb-run -a` (Linux) or rely on `PERRY_UI_TEST_MODE=1` which auto-exits after one frame.
 
 ## Asking questions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,10 +162,16 @@ Separately, #9215, #9230 and #9235 each merged with `lint` **cancelled** — all
 three touched `crates/`, none carried a fragment, and the work is consequently
 absent from its release notes.
 
-If you are reviewing status before a merge, note that "no failing checks" is
-not "all checks ran": `CANCELLED` is neither, and tooling that filters for
-`FAILURE` will report a clean bill of health for a PR whose gate never
-executed.
+**Before merging, check that `pr-gate` is present and passing — not that
+nothing is red.** Those are different assertions, and only the first one is
+worth anything. `CANCELLED` is neither a pass nor a failure, and a gate that
+never ran is *absent from the status list altogether*, so both states read as
+clean under any check that looks for failures. `pr-gate: pass` is a positive
+statement that the fan-in ran and every dependency was `success` or `skipped`;
+"0 failing" is satisfied just as well by a PR whose gate never executed. The
+same hole exists one level up for release automation: require the gate's
+conclusion to be `success`, since a skipped or absent required context also
+satisfies "not failing".
 
 UI doc-tests launch real windows. On headless hosts, wrap in `xvfb-run -a` (Linux) or rely on `PERRY_UI_TEST_MODE=1` which auto-exits after one frame.
 


### PR DESCRIPTION
Docs only, one paragraph in CONTRIBUTING.md. Raised by @perry-99 during the v0.5.1519 freeze; filed as a PR so Ralph can rule on the policy.

## Four PRs through one hole in a single day, confirmed from both ends

- **#9169** merged with `lint` failing and `check` / `cargo-test` / `gap-suite-build` / `gc-stress-build` / `e2e-scoped` cancelled. Its gap shards never ran; it broke method dispatch and property lookup on `main` for four and a half hours, until #9247.
- **#9215, #9230, #9235** each merged with `lint` **CANCELLED** — `status=COMPLETED conclusion=CANCELLED` on all three, `pr-gate` absent from the rollup entirely. All three touch `crates/`, none carries a `changelog.d/` fragment, and the work is consequently missing from v0.5.1519's release notes (#9255 records it for the next set).

Broken code in through one end, release-note fragments silently dropped out through the other — one mechanism, observed twice, on the same day. One occurrence is an accident; four is a hole.

Those three are mine, which is how the second failure mode surfaced: I went looking for why my own fragments were missing and found that the check enforcing them never ran. That makes it a process defect rather than a contributor error — the convention cannot be violated knowingly if nothing reports the violation.

## The rule

Cancelling other runs for capacity is fine and expected on a 20-slot org. Cancelling **the run of the PR you are about to merge** is not, because a cancelled job is neither a pass nor a failure, and two protections go quiet at once:

1. **`pr-gate` never reports** — the single required context is *absent* rather than red, which is what invites the admin bypass, and the bypass is what lands the change.
2. **The changelog fragment stops being required** — that check is a step inside `lint` conditioned on `github.event_name == 'pull_request'`, so a cancelled `lint` skips it silently, and the omission stays invisible until the notes are cut.

## The check to teach: `pr-gate` present and passing

Not "nothing is red". Those are different assertions and only the first is worth anything:

- A gate that never ran is **absent from the status list**, and `CANCELLED` is neither pass nor fail. Both read as clean under any check that looks for failures.
- `pr-gate: pass` is a *positive* statement that the fan-in ran and every dependency was `success` or `skipped`. "0 failing" is satisfied equally well by a PR whose gate never executed.

I made exactly that mistake, twice over: I reported one of these PRs as "29 checks, failing: none" while its `lint` sat cancelled. @perry-99 audited their release tooling against this and has made the dispatch condition require `full-suite-gate` conclusion `success` plus zero cancelled jobs — the same hole exists one level up, because a skipped or absent required context also satisfies "not failing".

## What this deliberately does not propose

**No change to the gate.** `gate` in `.github/workflows/test.yml` (line ~3746) already runs `if: always()`, and its documented verdict is *"every other needed job must be `success` or `skipped`; `failure` and `cancelled` fail"* — precisely so a cancelled dependency cannot read as green. Every incident here is a bypass of a gate that works. The text says so explicitly, so nobody reads this and goes hunting for a gate bug.

Refs #9169, #9247, #9215, #9230, #9235, #9255.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance to avoid cancelling CI runs for pull requests being merged.
  * Documented how to interpret gate results and verify successful release checks.
  * Added notes on incidents where cancelled checks affected release validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->