### PR TITLE
fix(release): unblock the Windows, musl and old-glibc release legs

### DIFF
--- a/changelog.d/9260-release-legs.md
+++ b/changelog.d/9260-release-legs.md
@@ -1,0 +1,6 @@
+The Windows, musl and old-glibc release build legs no longer fail before they
+start. `perry-runtime`'s test build imported two `malloc_trim` counters under a
+weaker `cfg` than their declarations, breaking compilation on Windows MSVC; the
+glibc-2.31 container never put the mounted Cargo bin directory on `PATH`, so
+`rustup` was not found; and the glibc-only `libc::backtrace` pair was selected
+for musl targets, where it does not exist.

--- a/crates/perry-runtime/src/arena/quarantine.rs
+++ b/crates/perry-runtime/src/arena/quarantine.rs
@@ -864,7 +864,14 @@ extern "C" fn fromspace_fault_handler(
     }
 }
 
-#[cfg(all(unix, any(target_os = "macos", target_os = "linux")))]
+// `libc::backtrace`/`backtrace_symbols_fd` are a glibc extension: they do not
+// exist in musl, so `target_os = "linux"` alone selected a body that cannot
+// compile for `x86_64-unknown-linux-musl` (#9245-era release leg, E0425). The
+// musl build takes the empty arm below.
+#[cfg(all(
+    unix,
+    any(target_os = "macos", all(target_os = "linux", target_env = "gnu"))
+))]
 fn emit_native_backtrace() {
     const MAX_FRAMES: usize = 64;
     let mut frames = [std::ptr::null_mut::<libc::c_void>(); MAX_FRAMES];
@@ -878,7 +885,10 @@ fn emit_native_backtrace() {
     }
 }
 
-#[cfg(all(unix, not(any(target_os = "macos", target_os = "linux"))))]
+#[cfg(all(
+    unix,
+    not(any(target_os = "macos", all(target_os = "linux", target_env = "gnu")))
+))]
 fn emit_native_backtrace() {}
 
 /// Name the objects that still HOLD the stale address, not just the frame that

--- a/crates/perry-runtime/src/exception.rs
+++ b/crates/perry-runtime/src/exception.rs
@@ -528,7 +528,12 @@ fn emit_uncaught_backtrace() {
     if !on {
         return;
     }
-    #[cfg(all(unix, any(target_os = "macos", target_os = "linux")))]
+    // glibc-only pair; musl has no `backtrace`, so this block must not be
+    // selected there (E0425 at release time on the musl leg).
+    #[cfg(all(
+        unix,
+        any(target_os = "macos", all(target_os = "linux", target_env = "gnu"))
+    ))]
     {
         const MAX_FRAMES: usize = 96;
         let mut frames = [std::ptr::null_mut::<libc::c_void>(); MAX_FRAMES];

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -172,8 +172,16 @@ mod cycle_malloc_trim;
 use cycle::*;
 #[cfg(test)]
 pub(crate) use cycle_malloc_trim::{
-    reset_test_malloc_trim_call_count, reset_test_malloc_trim_executed_count,
-    test_malloc_trim_call_count, test_malloc_trim_executed_count,
+    reset_test_malloc_trim_call_count, test_malloc_trim_call_count,
+};
+// The *executed* counters only exist where `malloc_trim` itself does, so the
+// import has to carry the same gate as the declaration. Importing them under a
+// bare `#[cfg(test)]` made `perry-runtime`'s test build fail to compile on
+// Windows MSVC (E0432) — a target the PR tier never builds, so only the full
+// tier's `windows-build`/`windows-arm64-build` saw it.
+#[cfg(all(test, any(target_env = "gnu", target_os = "macos")))]
+pub(crate) use cycle_malloc_trim::{
+    reset_test_malloc_trim_executed_count, test_malloc_trim_executed_count,
 };
 mod verify;
 

--- a/scripts/build_linux_glibc_2_31.sh
+++ b/scripts/build_linux_glibc_2_31.sh
@@ -43,6 +43,19 @@ export LLVM_SYS_221_PREFIX
   exit 1
 }
 
+# The image deliberately ships no Rust toolchain: release-packages.yml mounts
+# the runner's ~/.cargo and ~/.rustup and points CARGO_HOME/RUSTUP_HOME at
+# them. Those give cargo its data, not its binaries — nothing puts
+# $CARGO_HOME/bin on PATH inside the container, so `rustup` and `cargo`
+# resolved to nothing and the leg died with exit 127. This leg was added in
+# #8350 (2026-08-18), after the last successful release, so it had never once
+# run to completion.
+export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:$PATH"
+command -v rustup >/dev/null || {
+  echo "rustup not found on PATH ($PATH) — is \$CARGO_HOME/bin mounted?" >&2
+  exit 1
+}
+
 rustup target add "$target"
 
 cargo build --profile dist --target "$target" -p perry


### PR DESCRIPTION
Four defects blocking the v0.5.1519 release, found by the first full-tier + `stage`-mode release run on a candidate since v0.5.1220. **None of them is reachable from the PR tier**, which is why they accumulated.

## The fixes

**1. `gc/mod.rs` — Windows MSVC test build (E0432).** The two `malloc_trim` *executed* counters are declared `#[cfg(all(test, any(target_env = "gnu", target_os = "macos")))]` but imported under a bare `#[cfg(test)]`. On MSVC the declarations vanish and the import dangles, so `perry-runtime`'s test build does not compile. Import now carries the declaration's gate. Broke `windows-build` and `windows-arm64-build`.

**2. `thread_local_cold_allowlist.json` — stale record.** #9245 split `cycle.rs` into `cycle_malloc_trim.rs` and moved a `thread_local!` with it; the policy inventory still recorded it against `cycle.rs`, so the checker saw an unrecorded block in one file and a phantom in the other. Regenerated with `--update`: the entry moves, the count is unchanged. Broke `windows-build`'s GC structural audits.

**3. `build_linux_glibc_2_31.sh` — `rustup: command not found` (exit 127).** The container ships no Rust toolchain by design: `release-packages.yml` mounts the runner's `~/.cargo`/`~/.rustup` and points `CARGO_HOME`/`RUSTUP_HOME` at them. That gives cargo its *data*, not its *binaries* — nothing put `$CARGO_HOME/bin` on `PATH`. Added, with an explicit check so a future regression says why. **This leg was added 2026-08-18, after the last successful release, so it had never once run to completion.**

**4. `arena/quarantine.rs` + `exception.rs` — musl (E0425).** `libc::backtrace`/`backtrace_symbols_fd` are glibc extensions. Gating their call sites on `target_os = "linux"` selects them for musl, where they do not exist. Now `all(target_os = "linux", target_env = "gnu")`; musl takes the existing empty arm.

## Validation

59/60 local lint gates pass, including `cargo check --workspace --all-targets -D warnings` and workspace clippy. (The 60th was `cargo fmt`, now applied.)

**One limitation stated plainly:** the musl compile itself is *not* verified locally — `cargo check --target x86_64-unknown-linux-musl` cannot run on macOS because `libmimalloc-sys` needs a musl C cross-toolchain. I verified the premise instead: `rustc --print cfg --target x86_64-unknown-linux-musl` reports `target_env="musl"` (vs `"gnu"` for glibc), so the tightened gate provably selects the empty arm there. The full compile rests on CI.

## Not fixed here

Two further release-leg failures the same run exposed, both needing a decision rather than a code change:

- **`ANDROID_NDK_HOME` unset on `windows-11-arm`** — the Android cross-build step is gated only on `runner.os == 'Windows'`, so it runs on both Windows runners, but only the x86_64 one has the NDK.
- **macOS x86_64 link failure** — the matrix builds `x86_64-apple-darwin` on `macos-15`, an arm64 runner whose LLVM is arm64-only, so every LLVM symbol is undefined at link (`ld: warning: ignoring file …`, `symbol(s) not found for architecture x86_64`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build reliability across Windows, musl Linux, and older glibc environments.
  * Fixed runtime test builds that could fail on Windows.
  * Prevented unsupported native backtrace functionality from being used on musl Linux.
  * Improved toolchain detection for older glibc builds, providing clearer failures when unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->