### PR TITLE
fix(release): build macOS x86_64 on an Intel runner; keep Android off Windows ARM64

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -375,7 +375,14 @@ jobs:
             target: aarch64-apple-darwin
             artifact: perry-macos-aarch64
             old_glibc_image: ""
-          - os: macos-15
+          # macos-15-intel, NOT macos-15: the bare label is the Arm64 image
+          # (see actions/runner-images). Building x86_64-apple-darwin there
+          # links brew's arm64-only LLVM, so every LLVM symbol is undefined at
+          # link once the in-process backend became default — the artifact
+          # shipped in v0.5.1220 and has been failing since. LLVM publishes no
+          # x86_64 macOS binary, so a native Intel runner is the only source of
+          # an x86_64 libLLVM.
+          - os: macos-15-intel
             target: x86_64-apple-darwin
             artifact: perry-macos-x86_64
             old_glibc_image: ""
@@ -654,12 +661,19 @@ jobs:
       # GitHub-hosted Windows runners pre-install the Android NDK at
       # `%ANDROID_NDK_HOME%`; we point cargo at its `aarch64-linux-android-*`
       # clang as the cross-linker.
+      # X64 only: the step below resolves the NDK toolchain under
+      # `prebuilt/windows-x86_64`, and the NDK ships no Windows-arm64 host
+      # toolchain, so `windows-11-arm` cannot run it. It also has no NDK
+      # installed, which is how this surfaced — the leg failed with
+      # "ANDROID_NDK_HOME not set" and blocked `create-release`, which requires
+      # every matrix leg to succeed. The same library is already produced by
+      # the `aarch64-linux-android` build-cross leg on Linux.
       - name: Install aarch64-linux-android Rust target (Windows)
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && runner.arch == 'X64'
         shell: pwsh
         run: rustup target add aarch64-linux-android
       - name: Build Android cross-compile libraries (Windows)
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && runner.arch == 'X64'
         shell: pwsh
         env:
           # API level 24 matches every other Android leg we cross-build for

--- a/changelog.d/9262-release-leg-runners.md
+++ b/changelog.d/9262-release-leg-runners.md
@@ -1,0 +1,6 @@
+The macOS x86_64 and Windows ARM64 release build legs work again. The x86_64
+macOS compiler was being built on `macos-15`, which is the Arm64 image, so it
+linked an arm64-only LLVM and failed with undefined symbols once the in-process
+LLVM backend became the default; it now builds on the Intel image. The Windows
+Android cross-build step no longer runs on the ARM64 runner, which has no NDK
+and for which the NDK ships no host toolchain.


### PR DESCRIPTION
Two release build legs that block `create-release`, which requires **every** matrix leg to succeed.

## macOS x86_64 — wrong runner architecture

`macos-15` is the **Arm64** image. [actions/runner-images](https://github.com/actions/runner-images) lists `macos-15-intel` / `macos-15-large` as the x86_64 one. So `x86_64-apple-darwin` was being built on an arm64 runner, where `brew install llvm@22` installs an arm64-only LLVM:

```
ld: warning: ignoring file .../libLLVM…
ld: symbol(s) not found for architecture x86_64
```

This became fatal when the in-process LLVM backend became the default (2026-08-17) and `perry` started linking libLLVM. The artifact shipped fine in v0.5.1220 (2026-07-04) and has been broken since.

LLVM publishes **no x86_64 macOS binary** (22.1.8 ships only `LLVM-22.1.8-macOS-ARM64.tar.xz`), so a native Intel runner is the only source of an x86_64 libLLVM. `macos-13` is retired.

Dropping the artifact was considered and rejected: `scripts/stage-npm.sh` builds the `darwin-x64` npm package from it — and `npm-publish` gates `create-release` — and the homebrew job downloads it to compute the formula's SHA256.

Scoped deliberately to the compiler `build` leg. The `build-cross` x86_64 leg already passes on arm64, because `perry-ui-macos` does not link LLVM.

## Windows ARM64 — Android cross-build on a runner that cannot do it

The step resolves its toolchain under `prebuilt/windows-x86_64` and the NDK ships no Windows-arm64 host toolchain, so it could only ever have run on the x86_64 runner — which is also the only Windows runner with an NDK installed. It failed with `ANDROID_NDK_HOME not set`. Now gated on `runner.arch == 'X64'`; the same library is already produced by the Linux `aarch64-linux-android` build-cross leg.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored reliable macOS x86_64 release builds by using a native Intel build environment.
  * Prevented unsupported Android cross-compilation steps from running on Windows ARM64 runners, improving release build reliability.

* **Documentation**
  * Added release notes describing the macOS and Windows build fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->