### PR TITLE
fix(ci): point the thread-local ratchet at cycle_malloc_trim.rs (main is red, blocking all PRs)

### DIFF
--- a/scripts/thread_local_cold_allowlist.json
+++ b/scripts/thread_local_cold_allowlist.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Files still declaring raw `thread_local!`. Every entry is a declaration that pays `_tlv_get_addr` on Darwin; the count is a ratchet, so adding one to an already-listed file fails too. New code should use `crate::perry_thread_local!` \u2014 see crates/perry-runtime/src/tls_hot.rs. Regenerate with scripts/check_thread_locals.py --update.",
-  "_hot_declarations": 275,
+  "_hot_declarations": 278,
   "files": {
     "crates/perry-runtime/src/agent.rs": 1,
     "crates/perry-runtime/src/arena/block.rs": 2,
@@ -29,7 +29,7 @@
     "crates/perry-runtime/src/fs/stream.rs": 1,
     "crates/perry-runtime/src/gc/barrier/mod.rs": 2,
     "crates/perry-runtime/src/gc/barrier_arming.rs": 1,
-    "crates/perry-runtime/src/gc/cycle.rs": 1,
+    "crates/perry-runtime/src/gc/cycle_malloc_trim.rs": 1,
     "crates/perry-runtime/src/gc/fromspace_scan.rs": 1,
     "crates/perry-runtime/src/gc/layout.rs": 1,
     "crates/perry-runtime/src/gc/layout_tables.rs": 1,


### PR DESCRIPTION
**`main` is currently red on `self-test-checkers`, which fails that check on every open PR.** Two-line allowlist fix.

## Not any one PR's diff

Reproduced against a pristine `origin/main` worktree:

```
thread-local policy check FAILED:
  crates/perry-runtime/src/gc/cycle_malloc_trim.rs: 1 raw `thread_local!` block(s), none allowed.
  crates/perry-runtime/src/gc/cycle.rs: recorded as having 1 cold `thread_local!` block(s), but has none.
```

I found it because it was failing on my own #9258, whose diff touches only `perry-codegen/src/stmt/loops.rs` and therefore cannot affect `perry-runtime` thread-locals — "impossible for this diff" turned out to be the right first hypothesis.

## Both halves are one event, and it traces to my #9245

#9245 added 20 lines to `cycle.rs`, pushing it past the 2000-line cap, so the merge split `cycle_malloc_trim.rs` out of it. The `#[cfg(test)]` malloc-trim counters moved with the split and the allowlist was not regenerated — leaving a stale entry for the old path and an unrecorded one for the new. My change is the proximate cause, so this is mine to clean up.

## Recorded rather than converted

`TEST_MALLOC_TRIM_CALLS` and `TEST_MALLOC_TRIM_EXECUTED` are both `#[cfg(test)]`-gated counters, so they are cold by construction. `crate::perry_thread_local!` exists to keep a *hot* address out of `_tlv_get_addr`; these are never on a shipping path, so converting them would add indirection for no benefit and misrepresent them as hot.

## One incidental change, flagged

`--update` also refreshes `_hot_declarations` 275 → 278. That is a recount of `perry_thread_local!` uses added since the file was last regenerated, not anything of mine. It moving *up* means more declarations sit on the hot macro, which is the direction the ratchet wants.

After: `thread-local policy OK: 278 hot declarations, 125 raw blocks in 88 recorded cold files, capacity 768`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal tracking for hot declarations.
  * Refreshed the thread-local cold allowlist to reflect current runtime coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->