### PR TITLE
fix(link): preserve futures channel wrapper provider

### DIFF
--- a/changelog.d/9121-futures-channel-wrapper-provider.md
+++ b/changelog.d/9121-futures-channel-wrapper-provider.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Preserve the wrapper-local `futures_channel` wake provider when prepared HTTP archives retain receiver code that calls it.

--- a/crates/perry/src/commands/compile/strip_dedup.rs
+++ b/crates/perry/src/commands/compile/strip_dedup.rs
@@ -1791,7 +1791,7 @@ fn shared_dep_members_to_remove(
             let replacement_defined = replacement_defined_by_candidate.get(c).unwrap_or(&empty);
             let still_needed = kept_undefined.iter().any(|s| {
                 defined.contains(*s)
-                    && (!replacement_defined.contains(*s) || requires_bundled_native_companion(s))
+                    && (!replacement_defined.contains(*s) || requires_bundled_wrapper_provider(s))
             });
             if still_needed {
                 to_remove.remove(c);
@@ -1815,6 +1815,22 @@ fn shared_dep_members_to_remove(
 /// links fail with hundreds of undefined `ring_core_*` references.
 fn requires_bundled_native_companion(symbol: &str) -> bool {
     symbol.trim_start_matches('_').starts_with("ring_core_")
+}
+
+/// Symbols whose same-named stdlib archive-index entry is not sufficient
+/// replacement evidence for a wrapper-first link.
+///
+/// `futures_channel::mpsc::SenderTask::notify` can appear in the matching
+/// stdlib member's archive index while remaining unavailable to retained
+/// `perry-ext-http` receiver CGUs in the final link (#9121). Keep the wrapper's
+/// provider whenever one of those retained CGUs references it. Rust v0
+/// mangling preserves identifier text, so the predicate works on the raw
+/// symbol spelling used by `llvm-nm` as well as on demangled test fixtures.
+fn requires_bundled_wrapper_provider(symbol: &str) -> bool {
+    requires_bundled_native_companion(symbol)
+        || (symbol.contains("futures_channel")
+            && symbol.contains("SenderTask")
+            && symbol.contains("notify"))
 }
 
 mod object_format;

--- a/crates/perry/src/commands/compile/strip_dedup/strip_dedup_tests.rs
+++ b/crates/perry/src/commands/compile/strip_dedup/strip_dedup_tests.rs
@@ -5,7 +5,8 @@
 
 use super::{
     force_localize_symbol, is_panic_unwind_symbol, parse_nm_archive_map, parse_nm_archive_output,
-    requires_bundled_native_companion, shared_dep_members_to_remove,
+    requires_bundled_native_companion, requires_bundled_wrapper_provider,
+    shared_dep_members_to_remove,
 };
 
 #[test]
@@ -166,6 +167,15 @@ fn ring_core_symbols_require_the_bundled_native_companion() {
 }
 
 #[test]
+fn futures_channel_sender_notify_requires_the_bundled_provider() {
+    let notify = "_RNvNtCs9W6CGWSfoiL_15futures_channel4mpscNtB5_10SenderTask6notify";
+    assert!(requires_bundled_wrapper_provider(notify));
+    assert!(!requires_bundled_wrapper_provider(
+        "_RNvNtCs9W6CGWSfoiL_15futures_channel4mpsc12next_message"
+    ));
+}
+
+#[test]
 fn shared_dep_fixed_point_keeps_ring_native_half_with_kept_rust_half() {
     use std::collections::{BTreeSet, HashMap, HashSet};
 
@@ -286,6 +296,41 @@ fn issue_8930_requires_needed_symbol_in_matching_stdlib_member() {
         &present_in_match,
     );
     assert!(removed.contains("futures_channel.o"));
+}
+
+#[test]
+fn issue_9121_keeps_indexed_sender_notify_provider() {
+    use std::collections::{BTreeSet, HashMap, HashSet};
+
+    let notify = "_RNvNtCs9W6CGWSfoiL_15futures_channel4mpscNtB5_10SenderTask6notify";
+    let candidates: BTreeSet<String> = ["futures_channel.o".to_string()].into_iter().collect();
+    let defined_by_member: HashMap<String, HashSet<String>> = [(
+        "futures_channel.o".to_string(),
+        [notify.to_string()].into_iter().collect(),
+    )]
+    .into_iter()
+    .collect();
+    let undefined_by_member: HashMap<String, HashSet<String>> = [(
+        "perry_ext_http_receiver.o".to_string(),
+        [notify.to_string()].into_iter().collect(),
+    )]
+    .into_iter()
+    .collect();
+    let replacement_defined_by_candidate: HashMap<String, HashSet<String>> = [(
+        "futures_channel.o".to_string(),
+        [notify.to_string()].into_iter().collect(),
+    )]
+    .into_iter()
+    .collect();
+
+    let removed = shared_dep_members_to_remove(
+        &candidates,
+        &defined_by_member,
+        &undefined_by_member,
+        &replacement_defined_by_candidate,
+    );
+
+    assert!(!removed.contains("futures_channel.o"));
 }
 
 #[cfg(target_os = "windows")]


### PR DESCRIPTION
## Summary

- keep the wrapper-local futures_channel SenderTask::notify provider when retained wrapper members reference it, even when the matching stdlib archive index advertises the symbol
- preserve the existing Ring native-companion safety rule
- add focused predicate and fixed-point regressions plus a changelog fragment

Fixes #9121.

## Testing

- cargo fmt --all -- --check
- cargo test -p perry --bin perry commands::compile::strip_dedup::strip_dedup_tests -- --nocapture
- cargo test -p perry --test issue_5920_wrapper_bundled_runtime_async_starvation fire_and_forget_fetch_survives_recompile -- --exact --nocapture
- cargo clippy -p perry --bins

The integration regression compiles the same fetch program twice and requires both binaries to print PASS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed prepared HTTP archives that could fail when receiving data through asynchronous channels.
  * Ensured required channel notification support remains available when archives are optimized.
  * Preserved compatibility for applications using futures-based HTTP handling.

* **Tests**
  * Added coverage for channel notification and archive optimization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->