### PR TITLE
fix(bench): reject implausible wall times; correct polyglot bench.rs setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,17 @@ Ahead-of-time machine code means no engine boot and no JIT warmup — and on mea
 | Image convolution (4K, 5×5 Gaussian) | **354 ms** | 1,207 ms — *3.4× slower* | 915 ms — *2.6× slower* | 392 ms |
 | Fibonacci (recursive calls) | **309 ms** | 987 ms — *3.2× slower* | 518 ms — *1.7× slower* | 316 ms |
 | JSON pipeline (100 records) | **39 ms** | 144 ms — *3.7× slower* | 51 ms — *1.3× slower* | 34 ms |
+| JSON pipeline (500k records, 108 MB) | **1,649 ms** | 1,010 ms — *1.6× faster* | 647 ms — *2.5× faster* | 604 ms |
 | Object allocation (1M objects) | **2 ms** | 8 ms — *4× slower* | 6 ms — *3× slower* | <1 ms |
 | Array write (10M elements) | **3 ms** | 9 ms — *3× slower* | 6 ms — *2× slower* | 7 ms |
 | Peak memory (JSON pipeline) | **3.5 MB** | 36 MB — *10× more* | 11 MB — *3× more* | 1.2 MB |
 
 Look at the Rust column again: on convolution, fibonacci, and the array-write loop, TypeScript compiled with Perry **runs even with — or ahead of — Rust**. And Electron isn't in the table because it doesn't compete here: it ships a whole browser engine per app, where a comparable Perry app is a single-digit-MB native binary.
 
-<sub>Sources: convolution & JSON from the [systems-language report](benchmarks/honest_bench/REPORT.md); fibonacci, object allocation & array write from the [polyglot sweep](benchmarks/polyglot/RESULTS.md) (Perry default mode, no fast-math).</sub>
+<sub>Sources: convolution & JSON from the [systems-language report](https://github.com/PerryTS/perry/blob/7beb3a50ca/benchmarks/honest_bench/REPORT.md)
+— pinned to `7beb3a50ca`, the last revision whose artifact contains these values; the copy at HEAD was regenerated in #7641 on a host
+where the harness clock was invalid and now reads 0.0 ms in every timing cell (see this PR). Re-pin to `main` once it is regenerated.
+Fibonacci, object allocation & array write from the [polyglot sweep](benchmarks/polyglot/RESULTS.md) (Perry default mode, no fast-math).</sub>
 
 We publish *everything*, including the workloads where V8's JIT still beats us — no cherry-picked table can survive an open harness. Run it yourself: `./benchmarks/run_public_baseline.sh` ([methodology](benchmarks/README.md)).
 

--- a/benchmarks/honest_bench/harness/run_bench.sh
+++ b/benchmarks/honest_bench/harness/run_bench.sh
@@ -81,6 +81,24 @@ PYTHON
 
   local wall_ns=$((end_ns - start_ns))
 
+  # A measured wall time must be strictly positive: `start_ns` and `end_ns`
+  # bracket a child process that actually ran. A non-positive delta means the
+  # clock pair is not comparable (e.g. the two `python3` samples did not share
+  # a reference point), so the sample carries no timing information at all.
+  #
+  # Without this gate such a sample is written to results.json, survives
+  # report.py's `exit_code == 0` filter, and is published as a median. That is
+  # how the 2026-08-08 regeneration (#7641) shipped 150 negative wall_ms rows
+  # and a REPORT.md whose every timing cell reads 0.0 ms.
+  if (( wall_ns <= 0 )); then
+    echo "run_bench.sh: implausible wall time for ${WORKLOAD}/${LANGUAGE} run ${run}:" >&2
+    echo "  start_ns=${start_ns} end_ns=${end_ns} delta=${wall_ns} ns" >&2
+    echo "  The monotonic clock samples are not comparable across processes on" >&2
+    echo "  this host. Refusing to record a timing-free sample." >&2
+    rm -f "$tmp_out" "$tmp_err"
+    exit 3
+  fi
+
   local stdout_first stdout_last
   stdout_first=$(head -1 "$tmp_out" 2>/dev/null | head -c 200 || true)
   stdout_last=$(tail -1  "$tmp_out" 2>/dev/null | head -c 200 || true)

--- a/benchmarks/honest_bench/scripts/report.py
+++ b/benchmarks/honest_bench/scripts/report.py
@@ -111,6 +111,23 @@ def stats_for(rows):
     wall = [r["wall_ms"]    for r in rows if r["exit_code"] == 0]
     rss  = [r["max_rss_kb"] for r in rows if r["exit_code"] == 0]
     failures = sum(1 for r in rows if r["exit_code"] != 0)
+
+    # `exit_code == 0` alone is not enough to make a sample meaningful: a run
+    # can succeed (correct stdout, correct checksum) and still carry a wall
+    # time that is physically impossible. Report those loudly instead of
+    # taking their median -- a median of zeros renders as a confident "0.0 ms"
+    # table cell and reads exactly like a real result.
+    implausible = [w for w in wall if w <= 0]
+    if implausible:
+        raise SystemExit(
+            f"report.py: {len(implausible)} of {len(wall)} successful runs have a "
+            f"non-positive wall_ms (min {min(implausible)}).\n"
+            "  results.json carries no usable timing data; a report generated from "
+            "it would be fiction.\n"
+            "  Re-run ./run.sh on this host and check that run_bench.sh's monotonic "
+            "clock samples are comparable across processes."
+        )
+
     if not wall:
         return None, None, None, None, failures
     return (

--- a/benchmarks/polyglot/bench.rs
+++ b/benchmarks/polyglot/bench.rs
@@ -1,6 +1,7 @@
+use std::hint::black_box;
 use std::time::Instant;
 
-fn fib(n: i32) -> i32 {
+fn fib(n: i64) -> i64 {
     if n < 2 {
         return n;
     }
@@ -9,7 +10,7 @@ fn fib(n: i32) -> i32 {
 
 fn bench_fibonacci() {
     let start = Instant::now();
-    let result = fib(40);
+    let result = fib(black_box(40));
     let elapsed = start.elapsed().as_millis();
     println!("fibonacci:{}", elapsed);
     println!("  checksum: {}", result);
@@ -28,6 +29,15 @@ fn bench_loop_overhead() {
 
 fn bench_array_write() {
     let mut arr = vec![0.0_f64; 10_000_000];
+    // suite/03_array_write.ts fills every slot BEFORE it calls Date.now(), so
+    // its timed loop overwrites resident pages. `vec![0.0; N]` is calloc, whose
+    // pages are mapped lazily -- without this pre-touch the Rust timed loop
+    // additionally pays ~10M first-touch faults the TS timed loop does not,
+    // and the column measures page-fault cost rather than store throughput.
+    for slot in arr.iter_mut() {
+        *slot = 0.0;
+    }
+    black_box(&arr);
     let start = Instant::now();
     for i in 0..10_000_000 {
         arr[i] = i as f64;
@@ -72,10 +82,12 @@ fn bench_object_create() {
     let start = Instant::now();
     let mut sum: f64 = 0.0;
     for i in 0..1_000_000 {
-        let p = Point {
+        // Without the barrier LLVM proves the struct never escapes and removes
+        // the allocation entirely, reporting 0 ms for a loop that never ran.
+        let p = black_box(Point {
             x: i as f64,
             y: i as f64 * 2.0,
-        };
+        });
         sum += p.x + p.y;
     }
     let elapsed = start.elapsed().as_millis();


### PR DESCRIPTION
## Summary

`honest_bench` can record wall times that are physically impossible, and nothing
downstream notices. The artifact committed at `38ff7ecc` contains 150 negative
`wall_ms` samples out of 300, and `REPORT.md` is generated from them.

This PR adds two guards so that failure is loud instead of silent, re-runs the
suite on Linux to show the harness working end to end, and fixes three setup
issues in `benchmarks/polyglot/bench.rs` that `RESULTS.md` already identifies.

## 1. The harness publishes timing-free samples as results

From `benchmarks/honest_bench/results/results.json` at `38ff7ecc`:

```json
{"workload": "image_convolution",  "language": "rust", "wall_ms": -0.108458, "exit_code": 0, "output_match": true}
{"workload": "json_pipeline_full", "language": "node", "wall_ms":  0.026375, "exit_code": 0, "output_match": true}
```

All 300 measured samples are sub-millisecond noise around zero; 150 are negative.
The second row claims Node processed the 108 MB JSON fixture in 26 microseconds.

The runs themselves were fine — `exit_code` is 0 and the FNV checksums match.
Only the *timing* is meaningless. `report.py` filters on `exit_code == 0` alone
(`scripts/report.py:111`), so these samples flow into `statistics.median()` and
render as confident cells:

```
| rust  | -0.0 | 0.0 | 48.9 MB | 295.5 KB | 112 | 20/20 |
| perry | -0.0 | 0.1 | 56.1 MB |   4.6 MB |  92 | 20/20 |
```

The generated ratio lines then contradict the file's own prose — the
`json_pipeline_full` table reports `perry = 1.00×` (fastest) while the Bottom
line section above it says Perry is slowest at ~2.7×.

### When it started

| commit | date | `rust`/`image_convolution` median | negative rows |
|---|---|---:|---:|
| `8a7ea9986b` | 2026-05-14 | 392.1 ms | 0 |
| `7beb3a50ca` | 2026-08-01 | 392.1 ms | 0 |
| `6fb58cdead` | 2026-08-07 | 429.8 ms | 0 |
| `88e0812a7d` (#7641) | 2026-08-08 | **-0.001 ms** | **150** |

\#7641 changed no harness code — it regenerated data on a different host (metadata
switches to `Apple M1 / 8 cores / 8 GB`). So this looks host-specific:
`run_bench.sh` samples `time.monotonic_ns()` in two separate `python3` processes
and subtracts them, and Python documents that clock's reference point as
undefined. On Linux the pair is boot-relative and valid (I measured 522 ms for a
known 500 ms child); on the host behind #7641 it evidently is not.

I could not reproduce the underlying clock behaviour — I don't have that machine —
so this PR does not change the timing mechanism. It only makes the harness refuse
to emit or report a sample it cannot stand behind.

### The fix

- `harness/run_bench.sh` — abort with the offending `start_ns`/`end_ns` pair
  rather than writing a non-positive sample.
- `scripts/report.py` — refuse to build a report from an artifact containing
  non-positive successful samples, and say how many.

Verified both directions:

- current committed `results.json` → exits 1 with
  `10 of 20 successful runs have a non-positive wall_ms (min -0.108458)`
- pre-#7641 artifact (`7beb3a50ca`) → regenerates normally, restoring
  `rust 392.1 / zig 245.4 / perry 354.0 / node 1206.6 / bun 915.4`

## 2. A clean run on Linux x86_64 with the fixed harness

To confirm the harness works once the gate is in place, I ran the full suite on
Linux. Setup reproduces your reference exactly: the generated fixture is
byte-identical (112,695,869 bytes), and all three runtimes match the committed
Bun oracle — `checksum=2ba2e053` for convolution, `hash=7fc66fa8` and
sha256 `a1d5a65c…` for the JSON pipeline.

**Host:** i9-12900HK, Linux 6.17, otherwise idle. Perry 0.5.1220 (latest release),
rustc 1.95.0, Node 22.23.1. No Zig or Bun available, so those columns are absent.
5 warmup + 20 measured, medians. **180/180 runs output-verified; 0 implausible
samples — the new gate never fired.**

| Workload | Perry | Rust | Node | Perry vs Rust |
|---|---:|---:|---:|---:|
| Image convolution (4K, 5×5) | **288.3 ms** | 322.0 ms | 1,183.0 ms | **0.90× — Perry ahead** |
| JSON pipeline (100 records) | 32.4 ms | 16.5 ms | 60.4 ms | 1.97× |
| JSON pipeline (500k records) | 5,746.2 ms | 694.5 ms | 1,090.4 ms | 8.27× |

Peak RSS on the same runs:

| Workload | Perry | Rust | Node |
|---|---:|---:|---:|
| Image convolution | 78.6 MB | 49.1 MB | 114.0 MB |
| JSON pipeline (100 records) | 38.7 MB | 2.1 MB | 58.5 MB |
| JSON pipeline (500k records) | 977.2 MB | 427.6 MB | 564.3 MB |

Three things worth recording from this run:

1. **The convolution result reproduces — with an important caveat.** Perry does
   beat Rust here on x86_64 too (0.90×), the same direction and margin as your
   arm64 figure. Your `image_conv/rust/src/main.rs` is an ordinary
   bounds-checked implementation with no handicap. But the result is specific to
   the *implementation shape*, not to the languages — see below.
2. **The 100-record JSON row is architecture-sensitive.** Your table has Perry at
   1.15× Rust; here it is 1.97×, and peak RSS is 38.7 MB against the 3.5 MB in the
   README's memory row. Worth a look before the next regeneration.
3. **The 500k-record row is much worse on x86_64** — 8.27× Rust here versus the
   ~2.7× your REPORT prose records on arm64.

### Why the convolution row favours Perry

The kernel clamps both coordinates inside the innermost loop. That makes every
index data-dependent, which blocks a chain of LLVM optimisations: it cannot hoist
the bounds check, use fixed offsets, or unroll the 5×5 cleanly. Measured on the
blur alone:

| Rust variant | median | |
|---|---:|---|
| upstream (clamp in inner loop) | 256.2 ms | baseline |
| + 3-byte slice per tap | 261.9 ms | no change — bounds checks are not the cost |
| clamps removed from interior only | 229.9 ms | 10% |
| interior/border split + windowed row | **121.9 ms** | **2.1×** |

Neither change alone helps much; they unlock together. (Not vectorisation — the
LLVM IR contains no vector ops in either variant.)

Applying that same interior/border split to **both** implementations, through
this harness, all output-verified against `2ba2e053`:

| | median | σ |
|---|---:|---:|
| rust, as shipped | 323.5 ms | 57.6 |
| perry, as shipped | 287.7 ms | 85.0 |
| rust + split | **155.8 ms** | 5.0 |
| perry + split | 4,421.8 ms | 144.3 |

The identical source change makes Rust 2.08× faster and Perry ~14× slower. So at
equal naive implementation quality Perry is ahead by 1.12×; at equal *optimised*
quality Rust is ahead by 28×. Both statements are true, and the README currently
reports only the first. A sentence noting that the row reflects the naive kernel
shape would make it much harder to argue with.

I hit a separate silent-miscompilation bug while building the Perry side of that
comparison — an 8-line repro where a store to a module-global `Buffer` is dropped
entirely. It is unrelated to benchmarking, so I am filing it on its own rather
than burying it here. Verified on 0.5.1220 (latest release); not yet checked
against `main`.

These are one host and one Perry release; they are offered as a second data point,
not as a replacement for your Apple Silicon numbers.

## 3. `benchmarks/polyglot/bench.rs`

Three changes, each already described in `benchmarks/polyglot/RESULTS.md`:

**`bench_array_write`** — `suite/03_array_write.ts` fills every slot before calling
`Date.now()`, so its timed loop overwrites resident pages. The Rust version used
`vec![0.0; 10_000_000]` (calloc, lazily mapped) and timed the loop that
first-touches them, additionally paying ~10M page faults the TS loop had already
paid. Pre-touching before the timer mirrors the TS setup. Measured here:
`19 ms → 5 ms`, which ties Perry 0.5.1220 on the same machine. `RESULTS.md`
already notes *"the Rust result is `-O` with bounds-checked indexing;
`.iter_mut()` would match Perry."*

**`fib`** — was `i32`. `RESULTS.md` states *"Perry's type inference refines the TS
`number` parameter to i64"*, so `i64` is the like-for-like peer: `240 ms → 214 ms`.
(`RESULTS.md` currently describes the Rust fib as f64-typed, which hasn't matched
this file for some time — worth a separate look.)

**`bench_object_create`** — without a barrier LLVM proves `Point` never escapes and
deletes the loop, which is why the row reports 0 ms. `RESULTS.md` says exactly
that: *"the compiler proves the struct never escapes and eliminates the whole
loop."* A `black_box` makes the row measure the allocation it claims to:
`0 ms → 1 ms`.

These move published numbers, so the polyglot sweep needs a re-run on your
reference hardware. Happy to drop this section if you'd rather take the harness
fix alone — it is a separate commit.

## 4. README

Two changes, both using **your own** published numbers rather than mine, so
nothing is substituted across architectures:

- **Pinned the `REPORT.md` citation to `7beb3a50ca`.** The README's convolution and
  JSON values match that revision's artifact exactly, so they were correct when
  written; the file at HEAD no longer contains them. Re-pin to `main` after the
  next good regeneration.
- **Added the 500k-record JSON row** to the performance table, using the figures
  already in your `REPORT.md` prose (Perry 1,649 / Rust 604 / Node 1,010 /
  Bun 647). The table currently shows only the 100-record fixture. Given the
  paragraph directly beneath it — *"We publish everything, including the workloads
  where V8's JIT still beats us"* — this row seemed to belong there.

## Testing

- `report.py` against both the broken and the last-good artifact (above).
- Full `honest_bench` run on Linux, 180 rows, all output-verified (§2).
- `rustc -O -C codegen-units=1 bench.rs` builds clean; output format unchanged, so
  `run_all.sh`'s `name:elapsed_ms` parsing is unaffected.
- No committed result artifact is modified by this PR.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added JSON pipeline performance results for processing 500,000 records.
  - Updated benchmark source references and clarified the reliability of reported timings.

- **Bug Fixes**
  - Benchmark runs now reject invalid or non-positive timing samples instead of recording misleading results.
  - Reports now stop with guidance to rerun when timing data is unusable.

- **Tests**
  - Improved benchmark accuracy by preventing compiler optimizations and memory initialization effects from distorting measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->