### PR TITLE
fix(runtime): restore Node-API host build after Buffer refactor

### DIFF
--- a/changelog.d/9282-node-api-host-buffer-brand.md
+++ b/changelog.d/9282-node-api-host-buffer-brand.md
@@ -1,0 +1,4 @@
+Fixed the feature-gated Node-API host build after the Buffer branding refactor.
+Allowlisted native addons once again link the complete 145-symbol host ABI and
+load their authenticated sidecars instead of falling back to a runtime without
+Node-API support.

--- a/crates/perry-runtime/src/node_api_host/buffers.rs
+++ b/crates/perry-runtime/src/node_api_host/buffers.rs
@@ -145,7 +145,7 @@ pub unsafe extern "C" fn napi_get_buffer_info(
     length: *mut usize,
 ) -> NapiStatus {
     let owner = match pointer_owner(env, value) {
-        Ok(owner) if is_node_buffer(owner) => owner,
+        Ok(owner) if crate::buffer::is_node_buffer(owner) => owner,
         _ => return set_status(env, NapiStatus::InvalidArg, "value must be a Buffer"),
     };
     let buffer = owner as *const BufferHeader;


### PR DESCRIPTION
## Summary

Restore the feature-gated Node-API host build after the Buffer branding refactor so allowlisted native addons link the complete host ABI and load their authenticated sidecars.

## Changes

- Qualify the shared `is_node_buffer` helper from `crate::buffer` in `napi_get_buffer_info`.
- Preserve the checked-in 145-symbol Node-API inventory unchanged.

## Related issue

Fixes #9266

## Test plan

- `cargo build --release -p perry-runtime-static -p perry-stdlib-static --no-default-features --features perry-runtime/full,perry-stdlib/async-runtime,perry-runtime/node-api-host,perry-runtime/global-math,perry-runtime/global-webcrypto,perry-runtime/alloc-mimalloc,perry-runtime/keepalive-anchors`
- `RUST_TEST_THREADS=1 cargo test -p perry-runtime --features node-api-host node_api_host::` (17 passed)
- `RUST_TEST_THREADS=1 cargo test -p perry --test node_api_host_e2e real_node_api_addon_resolves_from_host_and_authenticates_sidecar -- --exact --nocapture`
- `RUST_TEST_THREADS=1 cargo test -p perry --test node_api_host_e2e published_napi_rs_addon_runs_sync_and_async_work -- --exact --nocapture`
- Independent ELF inspection: all 145 inventory symbols are present in the host dynamic symbol table.
- `cargo fmt --all -- --check`

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log
- [x] I've read CONTRIBUTING.md and agree to the Code of Conduct


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed feature-gated Node-API host builds so allowlisted native add-ons load with the complete host interface and authenticated sidecars.
  * Corrected Buffer ownership validation when retrieving Node-API buffer information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->