### PR TITLE
fix(transform): keep cross-module shape barriers in source modules

### DIFF
--- a/changelog.d/9284-cross-module-shape-barriers.md
+++ b/changelog.d/9284-cross-module-shape-barriers.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Cross-module function localization now leaves object-shape barriers in their
+  source modules, preventing unrelated safe argument-shape clones in importers
+  from falling back to generic dispatch.

--- a/crates/perry-codegen/src/collectors/ptr_shape_entry.rs
+++ b/crates/perry-codegen/src/collectors/ptr_shape_entry.rs
@@ -2,36 +2,7 @@
 
 use super::*;
 
-/// Whether an expression node is a §5.2 shape barrier for the module-wide
-/// first-increment kill rule. Targets are NOT inspected — any occurrence
-/// disables all `Ptr<Shape>` promotion in the module.
-pub(crate) fn expr_is_shape_barrier(expr: &Expr) -> bool {
-    match expr {
-        Expr::ObjectDefineProperty(..)
-        | Expr::ObjectDefineProperties(..)
-        | Expr::ReflectDefineProperty { .. }
-        | Expr::ObjectSetPrototypeOf(..)
-        | Expr::ReflectSetPrototypeOf { .. }
-        | Expr::ReflectSet { .. }
-        | Expr::ReflectDelete { .. }
-        | Expr::ReflectPreventExtensions(..)
-        | Expr::Delete(..)
-        | Expr::ProxyNew { .. } => true,
-        // `__proto__` writes mutate the prototype chain of an arbitrary
-        // object. Reads and class-prototype naming are handled by the
-        // dispatch-stability facts; only writes are shape barriers.
-        Expr::PropertySet { property, .. } | Expr::PropertyUpdate { property, .. } => {
-            property == "__proto__"
-        }
-        Expr::PutValueSet { key, .. } => {
-            matches!(key.as_ref(), Expr::String(k) if k == "__proto__")
-        }
-        Expr::IndexSet { index, .. } => {
-            matches!(index.as_ref(), Expr::String(k) if k == "__proto__")
-        }
-        _ => false,
-    }
-}
+pub(crate) use perry_hir::expr_is_shape_barrier;
 
 /// Entry point: collect the shape-proven pointer locals of one lowered region.
 /// `not_bigint_locals` feeds the numeric-field proof.

--- a/crates/perry-hir/src/analysis.rs
+++ b/crates/perry-hir/src/analysis.rs
@@ -33,6 +33,39 @@ pub fn body_reads_dynamic_this(stmts: &[Stmt]) -> bool {
     stmts.iter().any(uses_this_stmt)
 }
 
+/// Whether an expression node can invalidate module-wide object-shape proofs.
+///
+/// Targets are deliberately not inspected. Representation selection treats any
+/// occurrence as a conservative shape barrier, and transforms that relocate an
+/// expression across modules must preserve that module attribution.
+pub fn expr_is_shape_barrier(expr: &Expr) -> bool {
+    match expr {
+        Expr::ObjectDefineProperty(..)
+        | Expr::ObjectDefineProperties(..)
+        | Expr::ReflectDefineProperty { .. }
+        | Expr::ObjectSetPrototypeOf(..)
+        | Expr::ReflectSetPrototypeOf { .. }
+        | Expr::ReflectSet { .. }
+        | Expr::ReflectDelete { .. }
+        | Expr::ReflectPreventExtensions(..)
+        | Expr::Delete(..)
+        | Expr::ProxyNew { .. } => true,
+        // `__proto__` writes mutate the prototype chain of an arbitrary
+        // object. Reads and class-prototype naming are handled by the
+        // dispatch-stability facts; only writes are shape barriers.
+        Expr::PropertySet { property, .. } | Expr::PropertyUpdate { property, .. } => {
+            property == "__proto__"
+        }
+        Expr::PutValueSet { key, .. } => {
+            matches!(key.as_ref(), Expr::String(k) if k == "__proto__")
+        }
+        Expr::IndexSet { index, .. } => {
+            matches!(index.as_ref(), Expr::String(k) if k == "__proto__")
+        }
+        _ => false,
+    }
+}
+
 /// Collect every `LocalId` referenced by `expr` (and its sub-expressions).
 ///
 /// Per-variant work focuses on the LocalId-bearing variants (LocalGet,

--- a/crates/perry-hir/src/lib.rs
+++ b/crates/perry-hir/src/lib.rs
@@ -31,8 +31,8 @@ pub mod types;
 pub mod walker;
 
 pub use analysis::{
-    collect_local_refs_expr, collect_local_refs_stmt, infer_expr_type, infer_refinable_expr_type,
-    HirTypeEnv, HirTypeFacts,
+    collect_local_refs_expr, collect_local_refs_stmt, expr_is_shape_barrier, infer_expr_type,
+    infer_refinable_expr_type, HirTypeEnv, HirTypeFacts,
 };
 pub use audit::{audit_module, AuditManifest, ModuleAudit};
 pub use capability::{audit_module_capabilities, CapabilityPolicy, CapabilityViolation};

--- a/crates/perry-transform/src/inline/cross_module.rs
+++ b/crates/perry-transform/src/inline/cross_module.rs
@@ -7,6 +7,12 @@ use super::*;
 
 pub fn is_cross_module_safe(body: &[Stmt]) -> bool {
     fn check_expr(expr: &Expr) -> bool {
+        // Shape barriers are attributed module-wide during representation
+        // selection. Relocating one would conservatively poison unrelated
+        // shape proofs in the importer, so leave the source call outlined.
+        if perry_hir::expr_is_shape_barrier(expr) {
+            return false;
+        }
         match expr {
             // The disqualifying variants — anything tied to a particular
             // module's symbol table.
@@ -345,6 +351,13 @@ fn cross_function_expr_is_safe(
     allowed_ids: &HashSet<FuncId>,
     extern_names: &mut Vec<String>,
 ) -> bool {
+    // Keep module-wide shape barriers attributed to their source module.
+    // Argument containment already rejects values that escape through the
+    // remaining external call; moving the whole helper graph would instead
+    // disable shape proofs for unrelated locals in every importer.
+    if perry_hir::expr_is_shape_barrier(expr) {
+        return false;
+    }
     match expr {
         Expr::FuncRef(id) => allowed_ids.contains(id),
         Expr::ExternFuncRef { name, .. } => {
@@ -1131,6 +1144,9 @@ pub fn gather_cross_module_methods_with_extern_imports(
 /// rules for FuncRef / GlobalGet / NativeModuleRef / Closure.
 pub fn is_cross_module_safe_with_externs(body: &[Stmt], extern_names: &mut Vec<String>) -> bool {
     fn check_expr(expr: &Expr, extern_names: &mut Vec<String>) -> bool {
+        if perry_hir::expr_is_shape_barrier(expr) {
+            return false;
+        }
         match expr {
             Expr::FuncRef(_)
             | Expr::GlobalGet(_)

--- a/crates/perry-transform/src/inline/mod.rs
+++ b/crates/perry-transform/src/inline/mod.rs
@@ -1244,6 +1244,58 @@ mod tests {
     }
 
     #[test]
+    fn cross_module_free_function_graph_with_shape_barrier_is_rejected() {
+        let mut source = Module::new("/src/reshape.ts");
+        let mut helper = function(
+            1,
+            vec![Stmt::Return(Some(Expr::Delete(Box::new(
+                Expr::PropertyGet {
+                    object: Box::new(Expr::LocalGet(10)),
+                    property: "removed".to_string(),
+                    byte_offset: 0,
+                },
+            ))))],
+        );
+        helper.params.push(Param {
+            id: 10,
+            name: "value".to_string(),
+            ty: Type::Any,
+            default: None,
+            decorators: Vec::new(),
+            is_rest: false,
+            arguments_object: None,
+        });
+        let mut root = function(
+            2,
+            vec![Stmt::Return(Some(Expr::Call {
+                callee: Box::new(Expr::FuncRef(1)),
+                args: vec![Expr::Undefined],
+                type_args: Vec::new(),
+                byte_offset: 0,
+            }))],
+        );
+        root.name = "reshape".to_string();
+        root.is_exported = true;
+        source.functions.extend([helper, root]);
+        source.exported_functions.push(("reshape".to_string(), 2));
+
+        let mut barrier_free = source.clone();
+        barrier_free.functions[0].body = vec![Stmt::Return(Some(Expr::PropertyGet {
+            object: Box::new(Expr::LocalGet(10)),
+            property: "removed".to_string(),
+            byte_offset: 0,
+        }))];
+        assert!(
+            gather_cross_module_functions(&barrier_free).contains_key("reshape"),
+            "the helper graph must otherwise be eligible for localization"
+        );
+        assert!(
+            gather_cross_module_functions(&source).is_empty(),
+            "a transitive shape barrier must keep the helper graph outlined"
+        );
+    }
+
+    #[test]
     fn cross_module_free_function_with_module_local_is_rejected() {
         let mut source = Module::new("/src/constants.ts");
         let mut reads_module_binding = function(1, vec![Stmt::Return(Some(Expr::LocalGet(99)))]);


### PR DESCRIPTION
## Summary

Cross-module helper-graph localization now keeps object-shape barriers attributed to their source modules. This restores direct argument-shape clones for unrelated safe locals without relaxing the guarded fallback required when a real barrier is present in the caller.

The regression came from the cross-module function-graph localization added in `59a4c9aa`: it cloned `reshape` and its transitive `delete` helper into `main.ts`. Module dispatch facts are collected after transformation, so that imported `delete` armed the caller-wide rule-5 barrier and forced the otherwise contained `exact` local onto `pshape_arg.fallback`.

## Changes

- Share the object-shape barrier classifier between HIR transforms and codegen.
- Decline cross-module function and method relocation when a candidate contains a shape barrier; values passed to the remaining outlined call still go through the existing containment/escape checks.
- Add a transform regression proving that an otherwise-localizable transitive helper graph is rejected specifically because it contains `delete`.
- Add a changelog fragment; no version or release metadata was changed.

## Related issue

Fixes #9264

## Test plan

Run on `root@perrymaster.skelpo.net`:

- `cargo build -p perry -p perry-runtime-static -p perry-stdlib-static`
- `RUST_TEST_THREADS=1 cargo test -p perry --test issue_8774_argument_shape_clones -- --nocapture` (2 passed)
- `cargo test -p perry-codegen unrelated_module_shape_barrier_keeps_guarded_argument_route -- --nocapture`
- `cargo test -p perry-hir -p perry-transform`
- `RUST_MIN_STACK=33554432 ./scripts/test_affected_crates.sh --base origin/main`
- `SKIP_COMPILE_GATES=1 ./scripts/run_lint_gates.sh` (all 58 local gates passed; 2 CI-only expressions skipped)
- `cargo clippy -p perry-hir -p perry-transform -p perry-codegen --all-targets`

The affected-crates runner needs the larger test-thread stack on this host because `statically_reachable_trusted_js_package_is_aot_compiled_without_route_entry` also overflows at the default stack on an untouched `origin/main`; the isolated test and full affected scope pass with the setting above.

- [ ] `cargo build --release` clean (focused static/compiler dev build used above)
- [ ] Full platform-independent workspace test command (affected-crates scope used above)
- [x] Added a regression test in the affected transform crate
- [x] Docs update is not applicable; no CLI, stdlib, runtime API, or platform UI behavior changed

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md
- [x] My commit follows the repository's `fix:` prefix convention
- [x] I've read CONTRIBUTING.md and agree to the Code of Conduct


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-module function optimization to correctly detect object-shape-changing operations.
  * Prevented unsafe localization when code modifies or deletes object properties, changes prototypes, or creates proxies.
  * Preserved safer dispatch behavior for affected functions.

* **Tests**
  * Added coverage verifying that shape barriers in helper functions prevent unsafe cross-module localization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->