### PR TITLE
test(parity): drop the stale test_stress_promises known-failure entry

### DIFF
--- a/changelog.d/9286-stale-known-failure.md
+++ b/changelog.d/9286-stale-known-failure.md
@@ -1,0 +1,4 @@
+The parity triage list no longer suppresses `test_stress_promises`, which now
+passes on Linux. A `known_failures.json` entry that outlives its bug silently
+absorbs that test's next regression, so the gate requires stale entries to be
+removed.

--- a/test-parity/known_failures.json
+++ b/test-parity/known_failures.json
@@ -922,15 +922,6 @@
       "linux"
     ]
   },
-  "test_stress_promises": {
-    "issue": "8841",
-    "added": "2026-08-25",
-    "category": "bug-open",
-    "reason": "Reproduces 5/5 on both pre-#8835 r13 and r14: Perry dies with SIGSEGV (exit 139) after six output lines while Node exits 0. Tracked in #8841.",
-    "platforms": [
-      "linux"
-    ]
-  },
   "test_take_screenshot": {
     "issue": "8271",
     "added": "2026-08-17",


### PR DESCRIPTION
`parity (10)` fails the stale-entry check on candidate `83754818ea`:

```
STALE known_failures.json entries — these tests PASS on linux:
  - test_stress_promises
```

Per #7582, an entry that outlives its bug is not a triage note — it is a permanent suppression of that test's next regression. One entry removed, nothing else touched.

**Worth noting this is the first verdict `parity (10)` has ever produced.** It was cancelled on every prior release candidate, so it sat in the set of six jobs that had never completed. It turns out to be a one-line cleanup rather than a blocker.

## Recorded uncertainty

#8841 is still **open**, and no targeted fix for this SIGSEGV appears in main's history — so this may be a bug that is currently *masked* rather than fixed. The entry claims it reproduced 5/5 on the revisions it was filed against; that cannot be re-verified from macOS, and the gate's Linux verdict is the only current evidence.

I am following the gate's policy rather than second-guessing it, because the failure modes are asymmetric: if the SIGSEGV returns, a red gate is visible and fixable, whereas a stale suppression silently absorbs the next real regression in this test.

If it does return, the right response is a fresh entry against a fresh issue with current evidence — not restoring this one, whose reasoning is two weeks and many merges stale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated test validation so the promise stress test is no longer treated as an expected Linux failure.
  * Future regressions in this area will now be detected instead of being silently ignored.

* **Documentation**
  * Added a changelog entry explaining the updated failure handling and test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->