### PR TITLE
fix(ci): build compile-smoke's ext wrappers with the stdlib archive

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2791,7 +2791,16 @@ jobs:
         # the precompile fixtures that link the archives directly could not
         # pass — masked for weeks by continue-on-error. Name the wrapper
         # crates explicitly (same set the parity harness builds).
-        run: cargo build --release -p perry -p perry-runtime -p perry-stdlib -p perry-runtime-static -p perry-stdlib-static
+        # The ext wrappers must build in the SAME cargo invocation as the
+        # stdlib archive. Separate invocations let cargo unify tokio
+        # differently for each, and the link is then refused: "the wrapper
+        # archive(s) below bundle a DIFFERENT tokio compilation than the
+        # stdlib archive" (#507, #7629). The refusal is correct -- two tokio
+        # compilations mean two `runtime::context::CONTEXT` thread-locals and
+        # a "no reactor running" panic. `test_issue_414_mysql_query_params`
+        # was the single compile-smoke failure this caused. Same set the
+        # doc-tests job already builds together.
+        run: cargo build --release -p perry -p perry-runtime -p perry-stdlib -p perry-runtime-static -p perry-stdlib-static -p perry-ext-ioredis -p perry-ext-mongodb -p perry-ext-mysql2 -p perry-ext-pg -p perry-ext-nodemailer
 
       - name: Issue #945 scalar method IR guard
         run: |

--- a/changelog.d/9290-compile-smoke-ext.md
+++ b/changelog.d/9290-compile-smoke-ext.md
@@ -1,0 +1,5 @@
+The `compile-smoke` CI job builds the database and mailer extension wrappers in
+the same cargo invocation as the stdlib archive. Building them separately let
+cargo unify tokio differently for each, and the linker guard correctly refused
+the resulting pair — two tokio compilations in one binary mean two independent
+runtime contexts and a "no reactor running" panic.


### PR DESCRIPTION
`compile-smoke` failed on release candidate `83754818ea` with **one** compile error out of 1348 (1347 passed, 67 skipped):

```
test_issue_414_mysql_query_params
Error: the wrapper archive(s) below bundle a DIFFERENT tokio compilation
than the stdlib archive they would be linked with
  libperry_stdlib.a      bundles tokio-e69c74b77ea3bbaf
  libperry_ext_mysql2.a  bundles tokio-aa3a849219b7b42b
```

**This is a job-configuration bug, not a product bug — and the guard is doing its job.** Two tokio compilations in one binary mean two independent `runtime::context::CONTEXT` thread-locals, and perry-stdlib's runtime then reports `there is no reactor running, must be called from the context of a Tokio 1.x runtime` (#507, #7629). Refusing the link is the correct outcome; the mistake is upstream.

The job named only `perry`, `perry-runtime`, `perry-stdlib` and the two `-static` wrappers, so `perry-ext-mysql2` was built by a separate invocation with its own feature unification. The fix names the ext wrappers in the same `cargo build`, which is what makes cargo unify tokio across them — **exactly what the `doc-tests` job already does** (`-p perry-ext-ioredis -p perry-ext-mongodb -p perry-ext-mysql2 -p perry-ext-pg -p perry-ext-nodemailer`). This adopts that same set rather than only `mysql2`, since any of them can hit the same class.

## Why this went unnoticed

`compile-smoke` was **cancelled on every prior release candidate**, so this is the first verdict it has produced. It was one of six jobs with no result on any candidate; two have now reported and both were configuration issues rather than product defects (the other, `parity (10)`, was a stale suppression — #9286).

The error message deserves credit: it names both tokio hashes, explains the runtime consequence, and prints the exact fix. That is what made this a five-minute diagnosis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compile-smoke validation for database, caching, and email integrations.
  * Prevented build failures caused by incompatible runtime components being bundled together.
  * Avoided potential “no reactor running” errors during compiled application execution.

* **Documentation**
  * Added a changelog entry describing the improved extension build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->