### PR TITLE
fix(release): stage Android cross libs only where they can be built

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -902,16 +902,27 @@ jobs:
           # `<install-dir>/<triple>/release/<libname>.a` so we mirror that
           # layout inside the zip — the `aarch64-linux-android/release/`
           # subdir lives alongside `perry.exe`.
-          $androidLibDir = "staging/aarch64-linux-android/release"
-          New-Item -ItemType Directory -Force -Path $androidLibDir | Out-Null
-          $androidLibs = @("libperry_runtime.a", "libperry_stdlib.a", "libperry_ui_android.a")
-          foreach ($lib in $androidLibs) {
-            $src = "target/aarch64-linux-android/dist/$lib"
-            if (-not (Test-Path -LiteralPath $src -PathType Leaf)) {
-              Write-Error "Required Android library missing from ${{ matrix.artifact }}: $src"
-              exit 1
+          # Only the x86_64 Windows runner builds these: the NDK ships no
+          # Windows-arm64 host toolchain (the step resolves its compiler under
+          # `prebuilt/windows-x86_64`) and the ARM runner has no NDK at all.
+          # Requiring them unconditionally made the ARM leg fail in packaging
+          # once the build step was correctly skipped. `perry-windows-aarch64`
+          # has never shipped -- v0.5.1220 carries only `perry-windows-x86_64`
+          # -- so this does not remove anything users have; it makes the leg
+          # internally consistent. Android cross-compilation from a Windows
+          # ARM host needs an NDK that supports that host.
+          if ($env:RUNNER_ARCH -eq "X64") {
+            $androidLibDir = "staging/aarch64-linux-android/release"
+            New-Item -ItemType Directory -Force -Path $androidLibDir | Out-Null
+            $androidLibs = @("libperry_runtime.a", "libperry_stdlib.a", "libperry_ui_android.a")
+            foreach ($lib in $androidLibs) {
+              $src = "target/aarch64-linux-android/dist/$lib"
+              if (-not (Test-Path -LiteralPath $src -PathType Leaf)) {
+                Write-Error "Required Android library missing from ${{ matrix.artifact }}: $src"
+                exit 1
+              }
+              Copy-Item $src $androidLibDir
             }
-            Copy-Item $src $androidLibDir
           }
           Compress-Archive -Path staging/* -DestinationPath "${{ matrix.artifact }}.zip"
 

--- a/changelog.d/9292-winarm-android-staging.md
+++ b/changelog.d/9292-winarm-android-staging.md
@@ -1,0 +1,4 @@
+The Windows ARM64 release leg no longer requires the Android cross-compiled
+archives it cannot build. The NDK ships no Windows-arm64 host toolchain, so
+those libraries are staged into the bundle only on the x86_64 Windows runner
+that can produce them.


### PR DESCRIPTION
Follow-up to gating the Windows Android cross-build to the x86_64 runner (#9262). That gate was correct, but **incomplete on my part** — it stopped the ARM runner *building* the Android libraries while leaving the packaging step still *requiring* them:

```
Write-Error: Required Android library missing from perry-windows-aarch64:
  target/aarch64-linux-android/dist/libperry_runtime.a
```

So the leg moved from failing at the build step to failing one step later. Confirmed on stage-validation run 33395471638: the two Android steps show `skipped` and `Package release archive (Windows)` shows `failure`.

This gates the staging on the same condition as the build.

## Why removing the requirement is right rather than a capability loss

The NDK resolves its toolchain under `prebuilt/windows-x86_64` and ships **no Windows-arm64 host toolchain**, and the ARM runner has no NDK installed. So these libraries cannot be produced on that host — the previous behaviour was requiring an output nothing could generate.

**`perry-windows-aarch64` has never shipped.** v0.5.1220 (the last release) carries only `perry-windows-x86_64.zip`. So this leg has never produced an artifact, and nothing users currently have is affected. Android cross-compilation from a Windows ARM host would need an NDK supporting that host; the x86_64 Windows bundle keeps its Android libraries unchanged (#872).

## Note

I would rather flag this as my own incomplete change than let it read as a new failure. The general lesson is the one this session kept re-learning: gating a producer without checking its consumers just relocates the failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows ARM64 release packaging by removing its dependency on unavailable Android cross-compiled libraries.
  - Ensured Android libraries are included only in Windows x64 packages, preventing ARM64 packaging failures and enabling more reliable ARM64 releases.

- **Documentation**
  - Added release notes documenting the updated Windows ARM64 packaging behavior and platform-specific library handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->