### PR TITLE
fix(release): build the musl legs against a musl-built LLVM

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -398,10 +398,20 @@ jobs:
             target: x86_64-unknown-linux-musl
             artifact: perry-linux-x86_64-musl
             old_glibc_image: ""
+            # musl needs a musl-BUILT LLVM: perry links libLLVM in-process, and
+            # apt.llvm.org ships only glibc builds, so the static link died with
+            # `ld-linux-*.so.2: DSO missing from command line`. Alpine packages
+            # LLVM 22.1.8 for both arches; nothing is built from source.
+            musl_image: alpine:edge
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
             artifact: perry-linux-aarch64-musl
             old_glibc_image: ""
+            # musl needs a musl-BUILT LLVM: perry links libLLVM in-process, and
+            # apt.llvm.org ships only glibc builds, so the static link died with
+            # `ld-linux-*.so.2: DSO missing from command line`. Alpine packages
+            # LLVM 22.1.8 for both arches; nothing is built from source.
+            musl_image: alpine:edge
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             artifact: perry-windows-x86_64
@@ -433,7 +443,7 @@ jobs:
       # Its host-side GTK4 build does not depend on perry-codegen, so avoid
       # installing a second LLVM copy on the noble runner for these two legs.
       - uses: ./.github/actions/setup-llvm22
-        if: matrix.old_glibc_image == ''
+        if: matrix.old_glibc_image == '' && matrix.musl_image == ''
 
       # Cache cargo registry + target/ per (matrix.target, Cargo.lock).
       # First run on a target is still a cold build, but every subsequent
@@ -508,7 +518,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libgtk-4-dev libunwind-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libwebkitgtk-6.0-dev libshumate-dev
 
       - name: Install musl tools (Linux musl)
-        if: endsWith(matrix.target, '-musl')
+        if: endsWith(matrix.target, '-musl') && matrix.musl_image == ''
         run: sudo apt-get update && sudo apt-get install -y musl-tools
 
       - name: Build perry
@@ -516,11 +526,11 @@ jobs:
         # the next step. (Perry is V8-free — the former perry-jsruntime
         # crate, which downloaded a prebuilt V8 that 404'd on musl, was
         # removed.)
-        if: matrix.old_glibc_image == ''
+        if: matrix.old_glibc_image == '' && matrix.musl_image == ''
         run: cargo build --profile dist --target ${{ matrix.target }} -p perry
 
       - name: Build runtime libraries
-        if: matrix.old_glibc_image == ''
+        if: matrix.old_glibc_image == '' && matrix.musl_image == ''
         run: |
           cargo build --profile dist --target ${{ matrix.target }} -p perry-runtime -p perry-runtime-static
           cargo build --profile dist --target ${{ matrix.target }} -p perry-stdlib -p perry-stdlib-static
@@ -533,7 +543,7 @@ jobs:
         # See optimized_libs.rs (find_runtime_abort_library selection).
         # Separate CARGO_TARGET_DIR so the profile override doesn't
         # invalidate the main build's incremental cache.
-        if: runner.os != 'Windows' && matrix.old_glibc_image == ''
+        if: runner.os != 'Windows' && matrix.old_glibc_image == '' && matrix.musl_image == ''
         run: |
           CARGO_TARGET_DIR=target-abort CARGO_PROFILE_DIST_PANIC=abort \
             cargo build --profile dist --target ${{ matrix.target }} -p perry-runtime -p perry-runtime-static
@@ -558,7 +568,7 @@ jobs:
         # a crate requires a recorded retain/migration decision. Best-effort
         # per crate: a wrapper that can't build on this host must not fail the
         # whole release — packaging below ships whatever was produced.
-        if: runner.os != 'Windows' && matrix.old_glibc_image == ''
+        if: runner.os != 'Windows' && matrix.old_glibc_image == '' && matrix.musl_image == ''
         run: |
           set -euo pipefail
           governed_ext_packages=$(./scripts/release_ext_packages.sh)
@@ -615,6 +625,46 @@ jobs:
           for archive in "$src"/libperry_ext_*.a; do
             [ -f "$archive" ] && cp "$archive" "$dst/"
           done
+
+      # musl needs a musl-BUILT LLVM (see the matrix comment). Alpine is the
+      # only source of a packaged LLVM 22 for musl, so the compiler, runtime and
+      # stdlib are built inside it. Unlike the glibc-2.31 container, the host's
+      # ~/.cargo and ~/.rustup are NOT mounted: those are glibc binaries and
+      # cannot execute in a musl sysroot. The image installs its own rustup with
+      # the pinned nightly, whose musl host toolchain rustup does publish.
+      - name: Build Linux musl core artifacts in a musl sysroot
+        if: matrix.musl_image != ''
+        env:
+          MUSL_IMAGE: ${{ matrix.musl_image }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          docker build \
+            --build-arg "ALPINE_IMAGE=$MUSL_IMAGE" \
+            --build-arg "RUST_TOOLCHAIN=nightly-2026-08-20" \
+            --tag perry-musl-llvm22 \
+            --file scripts/linux-musl-llvm22.Dockerfile \
+            .
+          docker run --rm \
+            --env HOME=/tmp/perry-home \
+            --env CARGO_TARGET_DIR=/work/target-musl \
+            --env PERRY_ABORT_TARGET_DIR=/work/target-musl-abort \
+            --env PERRY_CLI_UPDATE_PUBLIC_KEYS \
+            --volume "$GITHUB_WORKSPACE:/work" \
+            --workdir /work \
+            perry-musl-llvm22 \
+            sh scripts/build_linux_musl.sh "$TARGET"
+
+          # Same boundary as the old-sysroot leg: only the artifacts packaging
+          # consumes cross back into target/.
+          src="target-musl/$TARGET/dist"
+          dst="target/$TARGET/dist"
+          mkdir -p "$dst"
+          for artifact in perry libperry_runtime.a libperry_runtime_abort.a libperry_stdlib.a; do
+            test -s "$src/$artifact"
+            sudo cp "$src/$artifact" "$dst/$artifact"
+          done
+          sudo chown -R "$(id -u):$(id -g)" "$dst"
 
       - name: Build UI library (macOS)
         if: runner.os == 'macOS'

--- a/changelog.d/9298-musl-llvm.md
+++ b/changelog.d/9298-musl-llvm.md
@@ -1,0 +1,6 @@
+The Linux musl release artifacts build again. perry links libLLVM in-process,
+so a musl target needs a musl-built LLVM; the runners only carry a glibc build,
+and linking it into a static musl binary failed with a missing dynamic loader.
+The musl compiler, runtime and stdlib now build inside a musl sysroot that
+packages LLVM 22, restoring `perry-linux-x86_64-musl` and
+`perry-linux-aarch64-musl`.

--- a/scripts/build_linux_musl.sh
+++ b/scripts/build_linux_musl.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Build the Linux musl release payload inside a musl-native container.
+#
+# perry links libLLVM in-process (default since 2026-08-17), so a musl target
+# needs a musl-built LLVM. The Ubuntu runners only carry apt.llvm.org's glibc
+# build; linking that into a static musl binary dies at the end with
+# `ld-linux-x86-64.so.2: DSO missing from command line`. LLVM publishes no musl
+# binaries, so the build runs inside Alpine, which packages LLVM 22.1.8.
+#
+# GTK4 is deliberately absent, matching the old-glibc leg: the UI archive is
+# added by the host job afterwards.
+
+set -euo pipefail
+
+target="${1:?usage: build_linux_musl.sh <rust-target>}"
+target_dir="${CARGO_TARGET_DIR:-target}"
+abort_target_dir="${PERRY_ABORT_TARGET_DIR:-target-abort}"
+
+case "$target" in
+  x86_64-unknown-linux-musl)  expected_machine=x86_64 ;;
+  aarch64-unknown-linux-musl) expected_machine=aarch64 ;;
+  *)
+    echo "unsupported musl release target: $target" >&2
+    exit 2
+    ;;
+esac
+
+machine=$(uname -m)
+if [ "$machine" != "$expected_machine" ]; then
+  echo "container architecture is $machine; $target needs $expected_machine" >&2
+  exit 1
+fi
+
+# Refuse a glibc sysroot outright: the whole point of this container is that
+# the LLVM being linked is musl-built. Getting this wrong reintroduces the
+# exact DSO-missing failure this script exists to prevent.
+if ! ldd /bin/sh 2>&1 | grep -qi musl; then
+  echo "this script must run in a musl sysroot; /bin/sh is not musl-linked" >&2
+  exit 1
+fi
+
+: "${LLVM_SYS_221_PREFIX:=/usr/lib/llvm22}"
+export LLVM_SYS_221_PREFIX
+"$LLVM_SYS_221_PREFIX/bin/llvm-config" --version | grep -q '^22\.' || {
+  echo "musl image does not provide LLVM 22 under $LLVM_SYS_221_PREFIX" >&2
+  exit 1
+}
+
+export PATH="${CARGO_HOME:-/opt/cargo}/bin:$PATH"
+command -v rustup >/dev/null || {
+  echo "rustup not found on PATH ($PATH)" >&2
+  exit 1
+}
+rustup target add "$target"
+
+cargo build --profile dist --target "$target" -p perry
+cargo build --profile dist --target "$target" -p perry-runtime -p perry-runtime-static
+cargo build --profile dist --target "$target" -p perry-stdlib -p perry-stdlib-static
+
+# Ship the panic=abort runtime variant from the same sysroot.
+CARGO_TARGET_DIR="$abort_target_dir" CARGO_PROFILE_DIST_PANIC=abort \
+  cargo build --profile dist --target "$target" -p perry-runtime -p perry-runtime-static
+cp "$abort_target_dir/$target/dist/libperry_runtime.a" \
+   "$target_dir/$target/dist/libperry_runtime_abort.a"

--- a/scripts/linux-musl-llvm22.Dockerfile
+++ b/scripts/linux-musl-llvm22.Dockerfile
@@ -1,0 +1,40 @@
+# musl build sysroot for the Linux musl release legs.
+#
+# Why a container at all: perry links libLLVM in-process (default since
+# 2026-08-17), so a musl target needs a *musl-built* LLVM. The Ubuntu runners
+# only have apt.llvm.org's glibc build, and linking that into a static musl
+# binary fails at the very end of the build with
+#   /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2: DSO missing from command line
+# (aarch64: libgcc_s.so.1). LLVM publishes no musl binaries.
+#
+# Alpine is musl-native and packages LLVM 22.1.8 — the exact version llvm-sys
+# 221 requires — for both x86_64 and aarch64, so nothing is built from source.
+# Mirrors the glibc-2.31 leg's container pattern.
+#
+# `edge` is required: llvm22 is not in a tagged Alpine release yet. Pinned by
+# digest so the sysroot is reproducible; bump deliberately.
+ARG ALPINE_IMAGE=alpine:edge
+FROM ${ALPINE_IMAGE}
+
+# `rust`/`cargo` from Alpine are NOT used: perry pins nightly-2026-08-20
+# (rust-toolchain.toml) for `float_algebraic` and cargo's `min-publish-age`.
+# rustup ships musl-host toolchains for both arches, so install through it.
+RUN apk add --no-cache \
+      build-base clang22 cmake curl git \
+      llvm22 llvm22-dev llvm22-static llvm22-libs \
+      libffi-dev openssl-dev zlib-dev zstd-dev xz-dev \
+      musl-dev pkgconf perl python3 \
+  && llvm-config --version | grep -q '^22\.' \
+     || { echo "alpine llvm is not 22.x ($(llvm-config --version))" >&2; exit 1; }
+
+ENV LLVM_SYS_221_PREFIX=/usr/lib/llvm22
+ENV RUSTUP_HOME=/opt/rustup
+ENV CARGO_HOME=/opt/cargo
+ENV PATH=/opt/cargo/bin:$PATH
+
+ARG RUST_TOOLCHAIN=nightly-2026-08-20
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+      | sh -s -- -y --no-modify-path --profile minimal \
+        --default-toolchain "${RUST_TOOLCHAIN}" \
+  && rustc -vV && cargo -V \
+  && chmod -R a+rwX /opt/rustup /opt/cargo


### PR DESCRIPTION
Both musl legs have failed since the in-process LLVM backend became the default (2026-08-17). `perry` now links libLLVM, the runners carry only apt.llvm.org's **glibc** build, and pulling that into a static musl link dies at the very end:

```
/usr/bin/ld: /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2:
  error adding symbols: DSO missing from command line
```

(aarch64 reports `libgcc_s.so.1`.) Both artifacts shipped in v0.5.1220, before that change — this is a regression, not a never-worked leg.

## Why a container rather than a from-source LLVM

LLVM publishes no musl binaries, so the options were: build LLVM for musl from source, or build in a musl sysroot that already has one. **Alpine packages LLVM 22.1.8** — the exact version `llvm-sys 221` requires — for both x86_64 and aarch64. So nothing is compiled from source and the leg stays in minutes rather than growing an hour-plus LLVM build per release.

This mirrors the existing `old_glibc_image` pattern, so the shape should be familiar.

## One deliberate difference from the glibc-2.31 container

That container mounts the runner's `~/.cargo` and `~/.rustup`. **This one must not**: those are glibc binaries and cannot execute in a musl sysroot. The image installs its own rustup with the pinned `nightly-2026-08-20` instead.

I checked that this is actually possible rather than assuming. `rustc`, `cargo` and `rust-std` are all published for **both** musl hosts at that date:

```
rustc-nightly-x86_64-unknown-linux-musl.tar.xz    200
cargo-nightly-x86_64-unknown-linux-musl.tar.xz    200
rustc-nightly-aarch64-unknown-linux-musl.tar.xz   200
cargo-nightly-aarch64-unknown-linux-musl.tar.xz   200
```

Worth flagging for reviewers: the platform-support table lists `x86_64-unknown-linux-musl` under **"Tier 2 without Host Tools"**, which would say this cannot work. The artifacts are published regardless. I went with the direct check over the doc.

## Guard rails

`build_linux_musl.sh` refuses to run outside a musl sysroot (`ldd /bin/sh` must report musl) and asserts LLVM is 22.x before building. A future change that reintroduces a glibc image fails immediately with a clear reason, rather than at the final link with a DSO error.

`alpine:edge` is required — `llvm22` is not in a tagged Alpine release yet. Worth pinning by digest once this is confirmed working, the way `old_glibc_image` is; I left it as a tag so the first run isn't chasing a digest that may move.

## Validation

Not verifiable locally — macOS has no musl cross-toolchain, which is what hid the second failure behind the first when I fixed the earlier `libc::backtrace` E0425. **CI is the verdict here.** A `stage`-mode dispatch of `release-packages.yml` exercises every build leg without publishing, and is the cheapest way to check this before a release attempt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored Linux musl release artifacts for x86_64 and aarch64 targets.
  * Fixed musl builds by using a musl-native environment with LLVM 22, improving release reliability.
* **Chores**
  * Added automated validation and packaging for musl compiler, runtime, and standard-library artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->