### PR TITLE
fix(hir): prevent statement-lowering stack overflow

### DIFF
--- a/changelog.d/9301-statement-lowering-stack.md
+++ b/changelog.d/9301-statement-lowering-stack.md
@@ -1,0 +1,14 @@
+The Linux `cargo-test` gate no longer aborts with a stack overflow while
+collecting a statically reachable JavaScript package (#9196).
+
+The module graph was finite: the debugger instead found
+`lower_body_stmt`'s roughly 144 KiB unoptimized frame repeated across ordinary
+nested blocks in Perry's synthesized CommonJS wrapper. A handful of those
+bounded frames exhausted libtest's default 2 MiB worker stack before the
+expression lowerer's existing stack guard could run.
+
+Statement lowering now checks the remaining stack before entering that large
+frame and grows onto a bounded segment near the red zone, matching expression
+and type lowering. The heavy implementation stays behind a non-inlined call
+boundary so debug builds cannot move its frame ahead of the guard. The complete
+1,060-test `perry` binary passes on Linux without a global stack-size override.

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -32,6 +32,9 @@ use detect::{
 
 use for_await::lower_runtime_for_await_iterator_body;
 
+const BODY_STMT_STACK_RED_ZONE: usize = 512 * 1024;
+const BODY_STMT_STACK_SEGMENT: usize = 2 * 1024 * 1024;
+
 // Keep the property-hoist pass and its large `Stmt`/`Expr` return place out of
 // recursive `lower_body_stmt` frames. At the unoptimized test profile, adding
 // those temporaries to the monolithic lowering function exhausted Rust's
@@ -73,7 +76,19 @@ fn finish_for_with_property_array_hoist(
     }]
 }
 
+/// Lower one statement while keeping the large debug-only lowering frame off
+/// a nearly exhausted caller stack. `lower_body_stmt_impl` is intentionally a
+/// separate non-inlined function: the unoptimized frame is large enough that
+/// a handful of ordinary nested blocks can overflow Rust's default 2 MiB test
+/// thread before expression lowering gets a chance to grow the stack (#9196).
 pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Vec<Stmt>> {
+    stacker::maybe_grow(BODY_STMT_STACK_RED_ZONE, BODY_STMT_STACK_SEGMENT, || {
+        lower_body_stmt_impl(ctx, stmt)
+    })
+}
+
+#[inline(never)]
+fn lower_body_stmt_impl(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Vec<Stmt>> {
     let mut result = Vec::new();
 
     match stmt {


### PR DESCRIPTION
## Summary

- grow the stack before entering the large unoptimized `lower_body_stmt` frame
- keep the heavy implementation behind a non-inlined boundary so the guard runs first
- preserve loop-property hoisting and all existing lowering behavior

Closes #9196.

## Root cause

The Linux debugger stops in `lower_body_stmt`, whose debug frame is about 144 KiB. Ordinary nested blocks in the synthesized CommonJS wrapper accumulate enough bounded lowering frames to exhaust libtest’s default 2 MiB thread stack. This is not a module-graph cycle.

## Validation

- `cargo test -p perry --bin perry` (1060 passed)
- named #9196 regression after the final rebase, plus a constrained `RUST_MIN_STACK=1048576` run
- `cargo test -p perry-hir`
- `cargo test -p perry --test loop_property_array_hoist` (enabled/disabled equivalence)
- `cargo check -p perry`
- changed HIR file passes `rustfmt --check`
- `./scripts/check_file_size.sh`

`cargo fmt --all -- --check` passed on the original base. Current `main` (`d20fb4fd2`) independently fails it in untouched `loops.rs` and `stable_packed_accumulator.rs`; this PR leaves those unrelated files unchanged.

No version files are changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a Linux test failure that could cause a stack overflow while processing statically reachable JavaScript packages.
  - Improved stability when lowering deeply nested or complex module code.
  - Verified the complete test suite passes without requiring a global stack-size increase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->