### PR TITLE
refactor(codegen): defuse the guarded-wildcard trap in accumulator_rhs_is_numeric

### DIFF
--- a/crates/perry-codegen/src/stmt/stable_packed_accumulator.rs
+++ b/crates/perry-codegen/src/stmt/stable_packed_accumulator.rs
@@ -67,11 +67,18 @@ fn accumulator_rhs_is_numeric(
                 // expression lowers to a tag-test diamond over
                 // `js_dynamic_string_or_number_add` — the same cost #9060 and
                 // #9091 removed for the bare-counter form.
-                _ if offset_reads_inlined => {
-                    crate::expr::packed_f64_loop_index_parts(index)
-                        .is_some_and(|(i, _)| i == counter_id)
+                // Single unguarded catch-all, deliberately. A guarded `_ if flag =>`
+                // arm here makes any LATER arm unreachable while the flag is true,
+                // and the compiler cannot warn — reachability depends on the runtime
+                // guard. #9303's first cut added an index form below exactly such an
+                // arm and verified as a complete no-op in the range tier while
+                // passing every flag-false test. New index forms extend the body of
+                // THIS arm.
+                _ => {
+                    offset_reads_inlined
+                        && crate::expr::packed_f64_loop_index_parts(index)
+                            .is_some_and(|(i, _)| i == counter_id)
                 }
-                _ => false,
             }
         }
         Expr::LocalGet(id) => {


### PR DESCRIPTION
Semantically identical one-hunk refactor, agreed with @ecs1 as the backstop for #9303's rebase.

`_ if offset_reads_inlined =>` was a **guarded wildcard**: any match arm placed after it is reachable only while the flag is false, and the compiler cannot warn — reachability depends on the runtime guard. #9303's first cut added an index form below it and verified as a complete no-op in the range tier while passing every flag-false test, which is exactly how such an arm fails: the flag-false tests *look* like coverage.

The guard moves into the body of a single unguarded catch-all; future index forms extend that body, where one set of tests covers both flag states.

Refs #9279 (which introduced the arm), #9303 (which rebases onto this).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined handling for indexed numeric expressions during packed-load processing.
  * Preserved existing behavior while making future index cases easier to extend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->