### PR TITLE
runtime: JSON.parse<T[]> routes through the shared tape gate — typed roundtrip beats node (526→132ms)

### DIFF
--- a/changelog.d/typed-json-parse-tape-route.md
+++ b/changelog.d/typed-json-parse-tape-route.md
@@ -1,0 +1,29 @@
+**`JSON.parse<T[]>` now routes through the same tape gate as the generic
+entry, and `bench_json_typed_roundtrip` beats node** (565 ms → 161 ms against
+node's 298; identical checksums).
+
+The schema-directed typed parse (#179 Step 1b) was written against the
+pre-tape `DirectParser`. Step 2 then made the tape-based lazy parse the
+generic default for exactly the payloads the specialization targets — and
+nobody went back. The result inverted the feature's premise: the "fast path"
+parsed 4× slower than the generic parser it claims to specialize (589 ms vs
+144 ms on the benchmark's blob), and its eagerly materialized output
+re-stringified 8× slower than the tape's lazy values (580 ms vs 72 ms),
+because lazy tape values serialize almost directly from the tape. The
+benchmark built to showcase the typed path was measuring its abandonment.
+
+Both entries now share one `tape_route_eligible` predicate, and the typed
+entry delegates to the generic one whenever the tape qualifies — licensed by
+its own documented contract ("no user-visible difference from
+`JSON.parse(blob) as T[]`"). The shape hint keeps the window the tape
+declines: sub-1 KB payloads, above-16 MB payloads, and non-array roots. One
+deliberate behavior unification rides along: `PERRY_JSON_TAPE=0/1` previously
+had no effect on the typed entry; through the shared gate both entries now
+honor it consistently.
+
+The route agreement is pinned by a test that runs typed and untyped parses
+over both blob-size windows under all three tape modes and a moving
+collector, asserting byte-identical re-stringify output — which doubles as
+node parity, since the blob is stringify output and a byte-identical
+roundtrip pins field order, number formatting, and escaping through every
+route.

--- a/crates/perry-runtime/src/json/parse_api.rs
+++ b/crates/perry-runtime/src/json/parse_api.rs
@@ -237,6 +237,41 @@ pub unsafe fn js_json_parse_result(text_ptr: *const StringHeader) -> Result<JSVa
 ///
 /// Uses a direct recursive-descent parser that constructs Perry JSValues
 /// without any intermediate representation.
+/// One tape-eligibility gate for BOTH parse entries.
+///
+/// This predicate used to live inline in `js_json_parse`, and the typed entry
+/// (`js_json_parse_typed_array`) had no gate at all — it was written against
+/// the pre-tape `DirectParser` (#179 Step 1b) and never learned that Step 2
+/// made the tape the generic default. The result: the "schema-directed fast
+/// path" ran 4x slower than the generic parser it claims to specialize, and
+/// its eagerly materialized output re-stringified 8x slower than the tape's
+/// lazy values. Sharing the gate is what keeps the two entries from drifting
+/// again.
+///
+/// Tape laziness currently pays off only for top-level arrays: object/scalar
+/// roots materialize eagerly after building the tape, so they do two parses'
+/// worth of work. Peek the first meaningful byte and keep object-root API
+/// payloads on the direct parser. The size window: lazy fires at 1 KB and
+/// above (tiny parses don't pay the tape build) and below 16 MB (very large
+/// blobs are dominated by the iterate-all idiom, where the direct parser's
+/// tree-build is faster end-to-end).
+pub(crate) fn tape_route_eligible(len: usize, bytes: &[u8]) -> bool {
+    const LAZY_MIN_BLOB_BYTES: usize = 1024;
+    const LAZY_MAX_BLOB_BYTES: usize = 16 * 1024 * 1024;
+    match tape_mode_from_env() {
+        TapeMode::ForceOn => true,
+        TapeMode::ForceOff => false,
+        TapeMode::Auto => {
+            (LAZY_MIN_BLOB_BYTES..=LAZY_MAX_BLOB_BYTES).contains(&len)
+                && bytes
+                    .iter()
+                    .copied()
+                    .find(|b| !matches!(b, b' ' | b'\t' | b'\n' | b'\r'))
+                    == Some(b'[')
+        }
+    }
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn js_json_parse(text_ptr: *const StringHeader) -> JSValue {
     if text_ptr.is_null() {
@@ -309,25 +344,7 @@ pub unsafe extern "C" fn js_json_parse(text_ptr: *const StringHeader) -> JSValue
     // Escape hatch via PERRY_JSON_TAPE=1 (force lazy regardless
     // of size, useful for testing) / =0 (force direct, useful as
     // a correctness fallback).
-    const LAZY_MIN_BLOB_BYTES: usize = 1024;
-    const LAZY_MAX_BLOB_BYTES: usize = 16 * 1024 * 1024;
-    let tape_mode = tape_mode_from_env();
-    let use_tape = match tape_mode {
-        TapeMode::ForceOn => true,
-        TapeMode::ForceOff => false,
-        TapeMode::Auto => {
-            // Tape laziness currently pays off only for top-level arrays:
-            // object/scalar roots materialize eagerly after building the tape,
-            // so they do two parses' worth of work. Peek the first meaningful
-            // byte and keep object-root API payloads on the direct parser.
-            (LAZY_MIN_BLOB_BYTES..=LAZY_MAX_BLOB_BYTES).contains(&len)
-                && bytes
-                    .iter()
-                    .copied()
-                    .find(|b| !matches!(b, b' ' | b'\t' | b'\n' | b'\r'))
-                    == Some(b'[')
-        }
-    };
+    let use_tape = tape_route_eligible(len, bytes);
     if use_tape {
         if let Some(result) = try_parse_via_tape(text_ptr, bytes) {
             return result;
@@ -550,6 +567,20 @@ pub unsafe extern "C" fn js_json_parse_typed_array(
     }
     let data_ptr = (text_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
     let bytes = std::slice::from_raw_parts(data_ptr, len);
+
+    // #179 Step 2 made the tape-based lazy parse the generic default for
+    // exactly the payloads this specialization targets (>= 1 KB top-level
+    // arrays). The tape both parses faster than the shape-hinted
+    // `DirectParser` and produces lazy values whose re-stringify serializes
+    // from the tape — measured on the typed-roundtrip benchmark, the shape
+    // path was 589ms parse + 580ms stringify against the tape's 144 + 72.
+    // This entry's own contract ("no user-visible difference from
+    // `JSON.parse(blob) as T[]`") licenses full delegation; the shape hint
+    // keeps earning its keep only in the window the tape declines (sub-1 KB,
+    // > 16 MB, or a non-array root).
+    if tape_route_eligible(len, bytes) {
+        return js_json_parse(text_ptr);
+    }
 
     // Deep input uses the generic entry's heap-stack fallback. The shape fast
     // path is deliberately retained for ordinary payloads only.

--- a/crates/perry/tests/typed_json_parse_tape_route.rs
+++ b/crates/perry/tests/typed_json_parse_tape_route.rs
@@ -1,0 +1,127 @@
+//! `JSON.parse<T[]>` routes through the same tape gate as the generic entry.
+//!
+//! The schema-directed typed parse (#179 Step 1b) was written against the
+//! pre-tape `DirectParser`, and Step 2 then made the tape-based lazy parse
+//! the GENERIC default for exactly the payloads the specialization targets.
+//! Nobody went back: the "fast path" parsed 4x slower than the generic
+//! parser it claims to specialize (589ms vs 144ms on the typed-roundtrip
+//! benchmark's blob), and its eagerly materialized output re-stringified 8x
+//! slower than the tape's lazy values (580ms vs 72ms).
+//!
+//! Both entries now share one `tape_route_eligible` predicate, and the typed
+//! entry delegates to the generic one whenever the tape qualifies — licensed
+//! by its own documented contract ("no user-visible difference from
+//! `JSON.parse(blob) as T[]`"). The shape hint keeps the window the tape
+//! declines: sub-1KB payloads, >16MB payloads, non-array roots.
+//!
+//! These tests pin OUTPUT EQUALITY across every route: typed vs untyped
+//! parse, under the tape's three env modes, both blob-size windows, and a
+//! moving collector. If a future change makes any route disagree, the
+//! roundtrip strings diverge.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+const SOURCE: &str = r#"
+interface Item {
+  id: number;
+  name: string;
+  value: number;
+  tags: string[];
+  nested: { x: number; y: number };
+}
+// Two blobs: one above the 1KB tape floor (tape route in auto mode), one
+// below it (shape-hint route in every mode).
+function build(n: number): string {
+  const items: Item[] = [];
+  for (let i = 0; i < n; i++) {
+    items.push({
+      id: i,
+      name: "item_" + i,
+      value: i * 3.14159,
+      tags: ["tag_" + (i % 10), "tag_" + (i % 5)],
+      nested: { x: i, y: i * 2 }
+    });
+  }
+  return JSON.stringify(items);
+}
+const big = build(200);
+const tiny = build(3);
+for (const blob of [big, tiny]) {
+  const typed = JSON.parse<Item[]>(blob);
+  const untyped = JSON.parse(blob) as Item[];
+  const a = JSON.stringify(typed);
+  const b = JSON.stringify(untyped);
+  console.log("len:" + typed.length + " eq_untyped:" + (a === b) + " eq_blob:" + (a === blob));
+  console.log("probe:" + typed[1].name + ":" + typed[1].nested.y + ":" + typed[1].tags[1]);
+}
+"#;
+
+const EXPECTED: &str = "len:200 eq_untyped:true eq_blob:true\nprobe:item_1:2:tag_1\nlen:3 eq_untyped:true eq_blob:true\nprobe:item_1:2:tag_1\n";
+
+fn compile(dir: &Path) -> PathBuf {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, SOURCE).expect("write entry");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .env("PERRY_NO_CACHE", "1")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    output
+}
+
+fn run(bin: &Path, dir: &Path, tape_mode: Option<&str>, moving_gc: bool) -> Output {
+    let mut command = Command::new(bin);
+    command.current_dir(dir);
+    if let Some(mode) = tape_mode {
+        command.env("PERRY_JSON_TAPE", mode);
+    }
+    if moving_gc {
+        command
+            .env("PERRY_GC_FORCE_EVACUATE", "1")
+            .env("PERRY_GC_VERIFY_EVACUATION", "1");
+    }
+    command.output().expect("run compiled binary")
+}
+
+/// Every route agrees: tape auto (typed delegates for the big blob, shape
+/// path for the tiny one), forced tape, forced direct — with and without a
+/// moving collector. `eq_blob` doubles as node-parity: the blob was produced
+/// by stringify, so a byte-identical re-stringify pins field order, number
+/// formatting, and escaping through every route.
+#[test]
+fn typed_and_untyped_parse_agree_across_every_tape_mode() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let bin = compile(dir.path());
+    for tape_mode in [None, Some("0"), Some("1")] {
+        for moving_gc in [false, true] {
+            let output = run(&bin, dir.path(), tape_mode, moving_gc);
+            assert!(
+                output.status.success(),
+                "binary failed with tape={tape_mode:?} moving_gc={moving_gc}\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert_eq!(
+                String::from_utf8_lossy(&output.stdout),
+                EXPECTED,
+                "route disagreement with tape={tape_mode:?} moving_gc={moving_gc}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
`bench_json_typed_roundtrip`, the last 2×-class benchmark loser, now **beats node**: 526 ms → **132 ms** against node's 240 (idle Mac mini, min of 7, flat spreads, identical checksums).

## The stale fork

`JSON.parse<T[]>` (#179 Step 1b, schema-directed) was written against the pre-tape `DirectParser`. Step 2 then made the **tape-based lazy parse** the generic default for exactly the payloads the specialization targets — and nobody went back. Decomposed on the benchmark's blob:

| | perry before | route |
|---|---|---|
| typed parse | 589 ms | shape-hinted `DirectParser` |
| generic parse | **144 ms** | tape |
| stringify of typed output | 580 ms | eager object walk |
| stringify of generic output | **72 ms** | serializes ~from the tape |

The "fast path" was 4× slower going in and produced objects 8× slower coming out. The benchmark built to showcase the typed path was measuring its abandonment.

## The fix

One shared `tape_route_eligible` predicate for both entries — the same drift-prevention shape as a matcher and its lowering sharing one index parser — with the typed entry delegating to the generic whenever the tape qualifies. Delegation is licensed by the typed entry's own documented contract: *"no user-visible difference from `JSON.parse(blob) as T[]`"*. The shape hint keeps the window the tape declines (sub-1 KB, >16 MB, non-array roots). `PERRY_JSON_TAPE=0/1` now consistently governs both entries (previously it silently didn't apply to the typed one).

## A trap this nearly shipped with

Inserting the shared predicate anchored on the `fn` line placed it **between `#[no_mangle]` and `js_json_parse`** — the attribute silently re-attached to the new helper, which exported unmangled while the generic entry lost its C symbol. It compiled clean, and linked clean for every typed-parse program (the delegation is an internal Rust call). Only **untyped** callers failed, at link. It was caught because the verify matrix kept the untyped control fixtures next to the typed ones. The predicate now sits above the attribute block and the archive is `nm`-verified for both symbols; the commit message records the mechanism since it generalizes to any attributed item.

## Tests

- New `typed_json_parse_tape_route.rs`: typed and untyped parses over both blob-size windows × all three `PERRY_JSON_TAPE` modes × moving collector — asserting **byte-identical re-stringify output**, which doubles as node parity (a byte-identical roundtrip of stringify output pins field order, number formatting, and escaping through every route).
- Pre-existing JSON integration tests green: `ffi_string_json_parse`, `json_parse_strict`, `json_stringify_handle_band`.
- `perry-runtime` lib 2894/0 (single-threaded).

https://claude.ai/code/session_01Pcq6j6y57TdKSR2Zx2D187

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Typed JSON array parsing now supports efficient lazy parsing for qualifying payloads, improving consistency with standard JSON parsing.
  - Tape-based parsing is applied consistently across supported payload sizes and parsing modes.

- **Bug Fixes**
  - Improved consistency between typed and untyped JSON parsing while preserving byte-identical round-trip output.

- **Tests**
  - Added coverage for payload sizes, parsing modes, garbage collection settings, and round-trip correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->