### PR TITLE
codegen: static magnitude bound keeps affine indices from wrapping i64 (#9294 follow-up)

### DIFF
--- a/changelog.d/affine-index-magnitude-bound.md
+++ b/changelog.d/affine-index-magnitude-bound.md
@@ -1,0 +1,29 @@
+**The affine index materialization can no longer wrap i64** (#9294
+follow-up, from a review flag on its sibling PR).
+
+#9294 computed `a[<affine>]` indices in i64 on the claim that proven-i32
+leaves cannot overflow it. That is true for one multiply — `|i32 * i32|` is
+at most 2^62 — and false beyond it: three chained near-2^31 factors reach
+2^93, wrap i64, and a wrapped value that happens to land inside `[0, len)`
+passes the unsigned bounds check and reads a DIFFERENT element than the
+generic path, silently — JS computes the index in doubles, goes out of
+bounds, and yields `undefined`.
+
+Measured honestly: the wrap is LATENT today, not live. Neither a
+const-folded spelling nor parameter leaves of a triple-multiply chain
+currently reach the affine lowering — admission happens to be blocked by
+which locals carry i32 shadow slots, an accident of unrelated analyses
+rather than a guarantee. Widening shadow coverage is a plausible future
+change, and it would have turned this into a silent wrong-read with no
+failing test anywhere.
+
+The fix is a static magnitude bound, `affine_index_magnitude_bound`:
+interval arithmetic in i128 at match time with every leaf at its i32
+extreme, admitting a tree only when its worst case fits i63. Admission
+therefore costs nothing at run time; `i * size + k` (2^62 + 2^31) stays
+admitted and matmul's numbers are unchanged, while any tree that could wrap
+declines to the generic path. One shared predicate gates both the matcher
+and the lowering, so the two cannot drift. A tripwire test pins the exact
+2^64 tree (`2^21 * 2^22 * (2^21 + k)`) to node's `NaN` under both collector
+modes — it passes today on both sides and exists to fail the moment
+admission widens past the bound.

--- a/crates/perry-codegen/src/expr/index_get.rs
+++ b/crates/perry-codegen/src/expr/index_get.rs
@@ -42,7 +42,7 @@ use super::{
 
 mod foreign_counter;
 mod guarded_array;
-pub(crate) use foreign_counter::packed_f64_loop_index_parts;
+pub(crate) use foreign_counter::{affine_index_fits_i64, packed_f64_loop_index_parts};
 use foreign_counter::{
     affine_packed_loop_read, emit_affine_index_i64, foreign_packed_loop_read,
     packed_f64_loop_offset_read,

--- a/crates/perry-codegen/src/expr/index_get/foreign_counter.rs
+++ b/crates/perry-codegen/src/expr/index_get/foreign_counter.rs
@@ -103,6 +103,45 @@ pub(crate) fn packed_f64_loop_offset_read(
 ///
 /// The bare-local cases belong to `foreign_packed_loop_read` and the clone's
 /// own counter path; this is `a[i * size + k]`.
+
+/// Conservative magnitude bound of an affine index tree, with every leaf at
+/// its i32 extreme. `None` means a node outside the affine grammar.
+///
+/// #9294 shipped the i64 materialization with the claim that proven-i32
+/// leaves cannot overflow it. That is true for one multiply — |i32 * i32|
+/// <= 2^62 — and FALSE beyond it: three chained near-2^31 factors reach
+/// 2^93, wrap i64, and a wrapped value that happens to land in [0, len)
+/// passes the unsigned bounds check and reads a DIFFERENT element than the
+/// generic path (JS computes the index in doubles, goes out of bounds, and
+/// yields `undefined`). Flagged by review on the follow-up PR. The bound is
+/// computed in i128 at match time, so admission costs nothing at run time:
+/// a tree whose worst case fits i63 cannot wrap, and anything else declines
+/// to the generic path.
+pub(crate) fn affine_index_magnitude_bound(index: &Expr) -> Option<i128> {
+    match index {
+        Expr::Integer(v) => Some((*v as i128).unsigned_abs().min(1 << 31) as i128),
+        Expr::Number(n) if n.fract() == 0.0 && n.abs() <= f64::from(i32::MAX) => {
+            Some(n.abs() as i128)
+        }
+        Expr::LocalGet(_) => Some(1_i128 << 31),
+        Expr::Binary { op, left, right } => {
+            let l = affine_index_magnitude_bound(left)?;
+            let r = affine_index_magnitude_bound(right)?;
+            match op {
+                perry_hir::BinaryOp::Add | perry_hir::BinaryOp::Sub => l.checked_add(r),
+                perry_hir::BinaryOp::Mul => l.checked_mul(r),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+/// The i64 materialization is wrap-free for exactly the trees this accepts.
+pub(crate) fn affine_index_fits_i64(index: &Expr) -> bool {
+    affine_index_magnitude_bound(index).is_some_and(|b| b < (1_i128 << 63))
+}
+
 pub(crate) fn affine_packed_loop_read(
     ctx: &FnCtx<'_>,
     arr_id: u32,
@@ -117,7 +156,9 @@ pub(crate) fn affine_packed_loop_read(
         .rev()
         .find(|fact| fact.array_local_id == arr_id && fact.affine_indices)?
         .clone();
-    affine_index_leaves_materializable(ctx, index, fact.index_local_id).then_some(fact)
+    (affine_index_fits_i64(index)
+        && affine_index_leaves_materializable(ctx, index, fact.index_local_id))
+    .then_some(fact)
 }
 
 /// Every leaf must be readable as an i32 here, matching exactly what the

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -2746,7 +2746,7 @@ mod unary_bigint_tests;
 #[cfg(test)]
 mod unary_bitnot_tests;
 pub(crate) use index_get::{
-    numeric_index_has_integer_array_index_proof, packed_f64_loop_index_parts,
+    affine_index_fits_i64, numeric_index_has_integer_array_index_proof, packed_f64_loop_index_parts,
 };
 pub(crate) use masked_window::masked_window_fact_for_index;
 /// Rooting coverage for the computed-store arms the TS corpora cannot reach

--- a/crates/perry-codegen/src/stmt/loops.rs
+++ b/crates/perry-codegen/src/stmt/loops.rs
@@ -2277,6 +2277,10 @@ pub(super) fn packed_f64_range_loop_pure_expr_collect(
                 // loop from that tier, which is a regression, not a win.
                 if packed_f64_range_loop_index_is_affine_with(index, counter_id, leaf_ok)
                     && expr_mentions_local(index, counter_id)
+                    // #9294 follow-up: the i64 materialization is wrap-free
+                    // only when the tree's worst case fits i63. Shared with
+                    // the lowering so the two cannot disagree.
+                    && crate::expr::affine_index_fits_i64(index)
                 {
                     record_packed_f64_range_affine_access(accesses, *arr_id);
                     return true;

--- a/crates/perry/tests/affine_index_overflow_bound.rs
+++ b/crates/perry/tests/affine_index_overflow_bound.rs
@@ -1,0 +1,81 @@
+//! The affine index materialization cannot wrap i64 (#9294 follow-up).
+//!
+//! #9294 computed `a[<affine>]` indices in i64 on the claim that proven-i32
+//! leaves cannot overflow it. True for one multiply (|i32 * i32| <= 2^62),
+//! false beyond: `2^21 * 2^22 * (2^21 + k)` at `k = 0` is exactly 2^64, the
+//! i64 computation wraps to 0, the wrapped index passes the unsigned bounds
+//! check, and the fast path reads `a[0]` — the WRONG element, silently —
+//! where JS computes the index in doubles, goes out of bounds, and yields
+//! `undefined` (NaN after the add). Flagged by review on the follow-up PR.
+//!
+//! The fix is a static magnitude bound (`affine_index_magnitude_bound`):
+//! interval arithmetic in i128 at match time with every leaf at its i32
+//! extreme, admitting the tree only when its worst case fits i63 — so
+//! admission costs nothing at run time and the matcher and the lowering
+//! share one predicate. `i * size + k` (2^62 + 2^31) stays admitted; this
+//! tree (~2^74) declines to the generic path.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+const SOURCE: &str = r#"
+function run(a: number[]): number {
+  const x = 2097152;
+  const y = 4194304;
+  const z = 2097152;
+  let s = 0.0;
+  for (let k = 0; k < 1; k++) {
+    s = s * 1.0 + a[x * y * (z + k)];
+  }
+  return s;
+}
+const a: number[] = [];
+for (let i = 0; i < 64; i++) a.push(7.5 + i);
+console.log("s:" + run(a));
+"#;
+
+/// The wrapped read must not happen: node's answer is NaN (the index is far
+/// out of bounds in double arithmetic), and the wrap would print `s:7.5` —
+/// element 0, in bounds, wrong.
+#[test]
+fn a_multiply_chain_that_wraps_i64_declines_to_the_generic_path() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    let output = dir.path().join("main_bin");
+    std::fs::write(&entry, SOURCE).expect("write entry");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .env("PERRY_NO_CACHE", "1")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    for moving_gc in [false, true] {
+        let mut command = Command::new(&output);
+        command.current_dir(dir.path());
+        if moving_gc {
+            command
+                .env("PERRY_GC_FORCE_EVACUATE", "1")
+                .env("PERRY_GC_VERIFY_EVACUATION", "1");
+        }
+        let run = command.output().expect("run binary");
+        assert!(run.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&run.stdout),
+            "s:NaN\n",
+            "a wrapped affine index read an in-bounds element the generic path \
+             never touches (moving_gc={moving_gc})"
+        );
+    }
+}


### PR DESCRIPTION
Follow-up to #9294, acting on the review flag posted on #9303's closing review: *"nested affine arithmetic can overflow before bounds validation and potentially read a different in-bounds element than the normal path."*

**The flag is right about the arithmetic.** #9294's soundness claim — proven-i32 leaves cannot overflow the i64 materialization — holds for one multiply (`|i32 · i32| ≤ 2⁶²`) and fails beyond it: three chained near-2³¹ factors reach 2⁹³, wrap i64, and a wrapped value landing inside `[0, len)` passes the unsigned bounds check and silently reads a **different element** than the generic path (JS computes the index in doubles, goes out of bounds, yields `undefined`).

**Measured honestly: the wrap is latent, not live.** I built the exact 2⁶⁴ tree (`2²¹ · 2²² · (2²¹ + k)`) in both a const-folded spelling and a parameter-leaf spelling and ran both against a **main-built compiler**: neither reaches the affine lowering today — admission happens to be blocked by which locals carry i32 shadow slots, an accident of unrelated analyses, not a guarantee. Widening shadow coverage is a plausible future change, and it would have turned this into a silent wrong-read with no failing test anywhere.

## The fix

`affine_index_magnitude_bound`: interval arithmetic in **i128 at match time**, every leaf at its i32 extreme, admit only when the worst case fits i63. The guarantee becomes structural and admission costs nothing at run time. One shared predicate (`affine_index_fits_i64`) gates **both** the matcher and the lowering — the drift rule from #9259/#9312, applied here before the two could disagree.

- `i * size + k` bounds at 2⁶² + 2³¹ → stays admitted. Matmul control: 4 affine blocks, 72 ms, checksum identical — unchanged.
- Any tree that could wrap → declines to the generic path.

## The tripwire

The test pins the 2⁶⁴ tree to node's `NaN` under both collector modes. It **passes today on both sides of the fix** — by the accident above, verified against a main-built baseline — and exists to fail the moment admission widens past the bound: the wrapped read would print `s:7.5` (element 0, in bounds, wrong). The commit message records the reachability analysis so a future reader knows the test's passing-on-main was established, not assumed.

## Gates

`perry-codegen` lib 1378/0; `issue_9253_affine_range_index` 3/3 (the #9294 regression suite, unchanged); rustfmt clean.

https://claude.ai/code/session_01Pcq6j6y57TdKSR2Zx2D187

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented certain complex array indexes from overflowing and accessing an incorrect in-bounds element.
  - Safely falls back to the generic indexing path when an affine index may exceed supported limits.
  - Ensured consistent behavior across garbage-collection modes.

- **Tests**
  - Added regression coverage for extreme chained index calculations, including out-of-bounds results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->