### PR TITLE
style: rustfmt tombstone_tests.rs

### DIFF
--- a/crates/perry-runtime/src/object/tombstone_tests.rs
+++ b/crates/perry-runtime/src/object/tombstone_tests.rs
@@ -414,10 +414,7 @@ fn tombstone_publish_on_untraced_receiver_arms_old_carrier() {
         // `publish_object_shape_holes` mint-and-retire publish.
         let second = crate::string::js_string_from_bytes(b"key_number_03".as_ptr(), 13)
             as *const crate::StringHeader;
-        assert_eq!(
-            super::delete_rest::js_object_delete_field(obj, second),
-            1
-        );
+        assert_eq!(super::delete_rest::js_object_delete_field(obj, second), 1);
         let descriptor = super::shapes::object_shape_descriptor(obj)
             .expect("the tombstone publish must leave a resolvable descriptor");
         assert_eq!(


### PR DESCRIPTION
#9317 landed with formatting that `rustfmt` reformats, so `cargo fmt --all -- --check` — a required `lint` step — is currently red on `main`. One file, formatting only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted an internal test assertion for improved consistency.
  * No user-facing behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->