### PR TITLE
fix(release): prime the macOS x86_64 dependency cache

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -358,12 +358,53 @@ jobs:
           echo "All gate workflows passed — proceeding to build/publish."
 
   # ---------------------------------------------------------------------------
+  # Warm the x86_64-apple-darwin dependency cache before `build` runs.
+  #
+  # The macOS x86_64 leg must run on an Intel runner: the bare `macos-15` label
+  # is the Arm64 image, whose arm64-only LLVM cannot link an x86_64 binary.
+  # Intel runners are materially slower -- the arm64 leg takes ~3h40m WITH a
+  # warm cache -- and a cold `dist` build there ran to GitHub's hard 6h job
+  # ceiling and was cancelled. A cancelled job SKIPS its post-steps, so
+  # `rust-cache` saved nothing, leaving that leg unable to warm its own cache:
+  # it cannot finish without a cache and cannot cache without finishing.
+  #
+  # This job breaks the loop. `rust-cache` caches THIRD-PARTY dependencies only
+  # (it deliberately evicts workspace-crate fingerprints -- see #4856 in the
+  # build job), and those are the bulk of a cold build. Compiling them here
+  # under a timeout safely inside the ceiling, with `cache-on-failure`, saves
+  # the cache even if this job does not finish, so `build` starts from
+  # compiled dependencies.
+  #
+  # `continue-on-error` is deliberate: this is an optimization, never a gate.
+  # If it fails or times out, `build` runs exactly as it would have.
+  prime-macos-x86_64-cache:
+    needs: [preflight]
+    runs-on: macos-15-intel
+    timeout-minutes: 330
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Install Rust toolchain
+        run: rustup toolchain install nightly-2026-08-20 --profile minimal --target x86_64-apple-darwin
+      - uses: ./.github/actions/setup-llvm22
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          # MUST match the build job's key for this target, or this warms a
+          # cache nothing reads.
+          shared-key: "release-x86_64-apple-darwin"
+          cache-on-failure: true
+          workspaces: |
+            . -> target
+      - name: Compile dependencies for x86_64-apple-darwin
+        run: cargo build --profile dist --target x86_64-apple-darwin -p perry
+
+  # ---------------------------------------------------------------------------
   # Build release binaries for all platforms
   # ---------------------------------------------------------------------------
   build:
     # preflight is only in `needs` for its outputs (the update-manifest signing
     # steps bake the release tag into the signed URL); await-tests is the gate.
-    needs: [preflight, await-tests]
+    needs: [preflight, await-tests, prime-macos-x86_64-cache]
     strategy:
       # Don't let one platform's build failure cancel the others (mirrors
       # build-cross). A broken cross-host target should not strand the

--- a/changelog.d/9327-macos-x64-cache-prime.md
+++ b/changelog.d/9327-macos-x64-cache-prime.md
@@ -1,0 +1,6 @@
+The macOS x86_64 release leg can complete again. It must build on an Intel
+runner to link an x86_64 LLVM, but a cold dependency build there exceeded
+GitHub's six-hour job ceiling and was cancelled before its cache was saved —
+so the leg could never warm the cache it needed. A preparatory job now compiles
+the dependencies within the ceiling and saves them, leaving the release build
+to compile only the workspace crates.


### PR DESCRIPTION
The macOS x86_64 leg now fails on **wall clock, not correctness** — and cannot fix itself without help.

## What happened

#9262 moved it to `macos-15-intel` because the bare `macos-15` label is the **Arm64** image, whose arm64-only LLVM cannot link an x86_64 binary. That fix worked: in stage run 33395471638 the job compiled all the way through `perry-stdlib-static`, so the link failure is genuinely gone.

But it ran **13:52:22Z → 19:52:44Z — exactly six hours**, GitHub's hard job ceiling, and was cancelled. For comparison the arm64 leg takes ~3h40m *with a warm cache*; Intel runners are materially slower and the `dist` profile is `lto = "thin", codegen-units = 1`.

## Why a plain retry cannot work

A **cancelled** job skips its post-steps, so `rust-cache` saved nothing. I confirmed this on the run: `Post Run Swatinem/rust-cache` shows `skipped`. That leaves the leg in a loop — it cannot finish without a warm cache, and cannot warm one without finishing.

`cache-on-failure` alone does not break the loop either: it covers *failed* jobs, not cancelled ones, and a job hitting the 6h ceiling is cancelled.

## The fix

A preparatory job compiles the third-party dependencies for `x86_64-apple-darwin` under a **330-minute** timeout — safely inside the ceiling, so it terminates as a *timeout* rather than a ceiling cancellation — with `cache-on-failure: true` so the cache is saved even if it does not finish.

This works because `rust-cache` stores **dependencies only**; it deliberately evicts workspace-crate fingerprints (see the `#4856` step in the build job). Dependencies are the bulk of a cold build, so `build` then starts from compiled dependencies and recompiles only the workspace crates.

Two properties worth checking in review:

- It shares the build job's cache key exactly (`release-x86_64-apple-darwin` vs `release-${{ matrix.target }}`). A mismatch would silently warm a cache nothing reads.
- It is `continue-on-error: true`, so it is an optimization and never a gate. If it fails or times out, `build` runs exactly as it does today.

## Honest limitation

This may need more than one run to warm the cache enough, and if even a fully warm Intel build exceeds six hours it will not be sufficient. In that case the remaining options are reducing that leg's package set, relaxing `codegen-units` for it (which ships a differently-optimized binary), or dropping `perry-macos-x86_64` — 43 downloads in v0.5.1220, and it cascades into npm's `darwin-x64` package and the homebrew formula.

A `stage`-mode dispatch shows the answer without publishing anything.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved macOS Intel release build times by pre-caching dependencies before compilation.
  * Increased reliability of releases by helping builds complete within the available execution window.

* **Documentation**
  * Added a changelog entry describing the macOS Intel build optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->