### PR TITLE
fix(release): prime the macOS x86_64 dependency cache (from #9327)

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -405,6 +405,17 @@ jobs:
     # preflight is only in `needs` for its outputs (the update-manifest signing
     # steps bake the release tag into the signed URL); await-tests is the gate.
     needs: [preflight, await-tests, prime-macos-x86_64-cache]
+    # `prime-macos-x86_64-cache` is a cache warmer, never a gate, so its result
+    # must not decide whether the release builds. `continue-on-error` keeps a
+    # failure there from failing the RUN, but this is the repository's first
+    # JOB-level use of it and GitHub's `needs` semantics for that case are not
+    # worth a silently skipped release to find out. State the gate explicitly:
+    # await-tests decides, preflight must have produced its outputs, and the
+    # warmer's outcome is deliberately unexamined.
+    if: >-
+      ${{ !cancelled()
+      && needs.preflight.result == 'success'
+      && needs.await-tests.result == 'success' }}
     strategy:
       # Don't let one platform's build failure cancel the others (mirrors
       # build-cross). A broken cross-host target should not strand the

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -358,12 +358,53 @@ jobs:
           echo "All gate workflows passed — proceeding to build/publish."
 
   # ---------------------------------------------------------------------------
+  # Warm the x86_64-apple-darwin dependency cache before `build` runs.
+  #
+  # The macOS x86_64 leg must run on an Intel runner: the bare `macos-15` label
+  # is the Arm64 image, whose arm64-only LLVM cannot link an x86_64 binary.
+  # Intel runners are materially slower -- the arm64 leg takes ~3h40m WITH a
+  # warm cache -- and a cold `dist` build there ran to GitHub's hard 6h job
+  # ceiling and was cancelled. A cancelled job SKIPS its post-steps, so
+  # `rust-cache` saved nothing, leaving that leg unable to warm its own cache:
+  # it cannot finish without a cache and cannot cache without finishing.
+  #
+  # This job breaks the loop. `rust-cache` caches THIRD-PARTY dependencies only
+  # (it deliberately evicts workspace-crate fingerprints -- see #4856 in the
+  # build job), and those are the bulk of a cold build. Compiling them here
+  # under a timeout safely inside the ceiling, with `cache-on-failure`, saves
+  # the cache even if this job does not finish, so `build` starts from
+  # compiled dependencies.
+  #
+  # `continue-on-error` is deliberate: this is an optimization, never a gate.
+  # If it fails or times out, `build` runs exactly as it would have.
+  prime-macos-x86_64-cache:
+    needs: [preflight]
+    runs-on: macos-15-intel
+    timeout-minutes: 330
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Install Rust toolchain
+        run: rustup toolchain install nightly-2026-08-20 --profile minimal --target x86_64-apple-darwin
+      - uses: ./.github/actions/setup-llvm22
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          # MUST match the build job's key for this target, or this warms a
+          # cache nothing reads.
+          shared-key: "release-x86_64-apple-darwin"
+          cache-on-failure: true
+          workspaces: |
+            . -> target
+      - name: Compile dependencies for x86_64-apple-darwin
+        run: cargo build --profile dist --target x86_64-apple-darwin -p perry
+
+  # ---------------------------------------------------------------------------
   # Build release binaries for all platforms
   # ---------------------------------------------------------------------------
   build:
     # preflight is only in `needs` for its outputs (the update-manifest signing
     # steps bake the release tag into the signed URL); await-tests is the gate.
-    needs: [preflight, await-tests]
+    needs: [preflight, await-tests, prime-macos-x86_64-cache]
     strategy:
       # Don't let one platform's build failure cancel the others (mirrors
       # build-cross). A broken cross-host target should not strand the

--- a/changelog.d/9327-macos-x64-cache-prime.md
+++ b/changelog.d/9327-macos-x64-cache-prime.md
@@ -1,0 +1,6 @@
+The macOS x86_64 release leg can complete again. It must build on an Intel
+runner to link an x86_64 LLVM, but a cold dependency build there exceeded
+GitHub's six-hour job ceiling and was cancelled before its cache was saved —
+so the leg could never warm the cache it needed. A preparatory job now compiles
+the dependencies within the ceiling and saves them, leaving the release build
+to compile only the workspace crates.


### PR DESCRIPTION
Lands #9327 with one hardening. The author's commit is preserved.

The diagnosis is right and the deadlock is real: the macOS x86_64 leg must run on an Intel runner, a cold `dist` build there hit GitHub's hard 6h ceiling, and a cancelled job skips its post-steps — so `rust-cache` saved nothing and the leg could never warm the cache it needed to finish. A priming job with `cache-on-failure` inside the ceiling breaks that cycle.

**The hardening.** `prime-macos-x86_64-cache` is a `needs` dependency of `build`, and it is this repository's first *job-level* `continue-on-error` — every other use is step-level. The PR's stated contract is "if it fails or times out, `build` runs exactly as it would have", which relies on GitHub treating a `continue-on-error` job failure as satisfying a `needs` edge. That may well be right, but the cost of it being wrong is a release that silently builds nothing, which is the same shape as the "gate unable to fail" family CLAUDE.md catalogues.

So `build` now names its gate explicitly rather than inferring it:

```yaml
if: >-
  ${{ !cancelled()
  && needs.preflight.result == 'success'
  && needs.await-tests.result == 'success' }}
```

`await-tests` stays the gate, `preflight` must have produced the outputs the signing steps consume, and the warmer's outcome is deliberately unexamined — which is exactly the intent the comment already stated. It holds whatever `continue-on-error` does to the `needs` edge.

**Verified:** the workflow parses, `build.needs` and the new `if` resolve as intended, `check_node_version_consistency.py` passes, and `actionlint` reports 7 issues on this branch and 7 on `origin/main` — no new findings (the two shellcheck style hits at lines 208 and 849 are pre-existing).

**Separately — not fixed here, and still live:** `build-cross` at line 1183 still pairs `os: macos-15` (the Arm64 image) with `target: x86_64-apple-darwin` for `perry-ui-macos`. That is the same arm64-LLVM-cannot-link-x86_64 mismatch this PR fixes at line 426, one matrix over, and because `build-cross` sets `fail-fast: false` it fails quietly as a missing x86_64 UI bundle rather than a red release. Worth its own change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of macOS Intel release builds by preparing and caching dependencies before compilation.
  - Prevented cold dependency builds from exceeding the CI job time limit and being cancelled.

- **Documentation**
  - Added a changelog entry describing the macOS x86_64 release build reliability improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->