### PR TITLE
perf(runtime): try the transition fast path before rooting in the dyn-IC miss (48 → 44 ms)

### DIFF
--- a/changelog.d/9287-transition-pre-scope.md
+++ b/changelog.d/9287-transition-pre-scope.md
@@ -1,0 +1,10 @@
+### Performance
+
+- **Building objects with computed keys got ~10% faster.** The dynamic-write
+  miss handler tried the learned shape-transition fast path only after
+  opening a handle scope and rooting all three operands — bookkeeping the
+  transition path immediately redid for itself. The shortcut now runs first,
+  through a value-returning form that roots internally and hands re-rooted
+  operands back on the rare miss-after-allocation, so the hot
+  fresh-object-construction lane pays one scope instead of two
+  (`{}` + 20 computed fields: 48 → 44 ms; pre-interned keys: 43 → 39 ms).

--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -27,7 +27,8 @@ pub use attr_variants::{
 };
 pub use fast_paths::js_object_set_field_by_name_transition_fast;
 pub(crate) use fast_paths::{
-    object_set_field_by_name_transition_only_fast, try_existing_own_data_overwrite,
+    object_set_field_by_name_transition_only_fast,
+    object_set_field_by_name_transition_only_fast_value, try_existing_own_data_overwrite,
     try_readd_stable_tombstone,
 };
 #[cfg(test)]

--- a/crates/perry-runtime/src/object/field_set_by_name/fast_paths.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name/fast_paths.rs
@@ -178,6 +178,17 @@ pub(crate) fn object_set_field_by_name_transition_only_fast(
     object_set_field_by_name_transition_fast_impl(obj, key, value, false)
 }
 
+/// Value-returning transition-only entry (#9287) — callable with unrooted
+/// operands; see `object_set_field_by_name_transition_fast_impl_value`.
+pub(crate) fn object_set_field_by_name_transition_only_fast_value(
+    obj: *mut ObjectHeader,
+    key: *const crate::StringHeader,
+    value: f64,
+    refresh: &mut Option<(f64, f64, f64)>,
+) -> Option<f64> {
+    object_set_field_by_name_transition_fast_impl_value(obj, key, value, false, refresh)
+}
+
 /// Re-add a deleted property on a receiver whose ShapeId deliberately stayed
 /// stable across the tombstone delete (#9064).
 ///
@@ -441,8 +452,25 @@ fn object_set_field_by_name_transition_fast_impl(
     value: f64,
     try_overwrite: bool,
 ) -> i32 {
+    object_set_field_by_name_transition_fast_impl_value(obj, key, value, try_overwrite, &mut None)
+        .is_some() as i32
+}
+
+/// Value-returning form (#9287): the returned f64 is re-read from this
+/// function's OWN root after every internal allocation point (key interning,
+/// spill growth), so a caller may invoke it with UNROOTED operands. The
+/// pre-scope shortcut in `js_put_value_set_dyn_ic_miss` relies on that,
+/// saving a RuntimeHandleScope + three roots on the hot
+/// fresh-object-construction lane.
+fn object_set_field_by_name_transition_fast_impl_value(
+    obj: *mut ObjectHeader,
+    key: *const crate::StringHeader,
+    value: f64,
+    try_overwrite: bool,
+    refresh: &mut Option<(f64, f64, f64)>,
+) -> Option<f64> {
     if key.is_null() || (key as usize) < 0x10000 {
-        return 0;
+        return None;
     }
 
     let obj = {
@@ -457,11 +485,11 @@ fn object_set_field_by_name_transition_fast_impl(
                 // GcHeader read below deref'd unmapped memory (write-side
                 // #5429 twin, 2026-07-02 audit). Return 0 = defer to the
                 // full dynamic path, which triages by tag.
-                return 0;
+                return None;
             }
             let raw = (bits & 0x0000_FFFF_FFFF_FFFF) as *mut ObjectHeader;
             if raw.is_null() || crate::value::addr_class::is_small_handle(raw as usize) {
-                return 0;
+                return None;
             }
             raw
         } else {
@@ -470,11 +498,13 @@ fn object_set_field_by_name_transition_fast_impl(
     };
 
     if obj.is_null() || (obj as usize) < crate::gc::GC_HEADER_SIZE + 0x1000 {
-        return 0;
+        return None;
     }
 
     if try_overwrite && unsafe { try_existing_own_data_overwrite(obj, key, value) } {
-        return 1;
+        // The overwrite scan allocates nothing, so the caller's value bits
+        // are still live exactly as passed.
+        return Some(value);
     }
 
     let scope = crate::gc::RuntimeHandleScope::new();
@@ -491,12 +521,12 @@ fn object_set_field_by_name_transition_fast_impl(
         // of the bare floor + raw deref.
         let gc_header = match crate::value::addr_class::try_read_gc_header(obj as usize) {
             Some(h) => h as *const crate::gc::GcHeader,
-            None => return 0,
+            None => return None,
         };
         if (*gc_header).obj_type != crate::gc::GC_TYPE_OBJECT
             || (*gc_header).gc_flags & crate::gc::GC_FLAG_FORWARDED != 0
         {
-            return 0;
+            return None;
         }
         let object_flags = (*gc_header)._reserved;
         if object_flags
@@ -509,10 +539,10 @@ fn object_set_field_by_name_transition_fast_impl(
                 | crate::gc::OBJ_FLAG_TYPED_ARRAY_PROTO)
             != 0
         {
-            return 0;
+            return None;
         }
         if !crate::object::object_is_regular(obj) || (*obj).class_id == NATIVE_MODULE_CLASS_ID {
-            return 0;
+            return None;
         }
 
         let key_gc =
@@ -528,7 +558,7 @@ fn object_set_field_by_name_transition_fast_impl(
         // retain the full inherited-setter/prototype walk.
         let class_id = (*obj).class_id;
         if class_id != 0 && !crate::object::is_anon_shape_class_id(class_id) {
-            return 0;
+            return None;
         }
 
         // #6084 item 6: this used to be a `GLOBAL_DESCRIPTORS_IN_USE` check at
@@ -540,11 +570,11 @@ fn object_set_field_by_name_transition_fast_impl(
         // whose vtable/prototype chain can carry instance accessors.
         let key_f64 = f64::from_bits(JSValue::string_ptr(key as *mut _).bits());
         if super::plain_data_write_may_intercept(obj as usize, 0, key_f64) {
-            return 0;
+            return None;
         }
 
         if (*key_gc).obj_type != crate::gc::GC_TYPE_STRING {
-            return 0;
+            return None;
         }
         let interned_key = if (*key_gc).gc_flags & crate::gc::GC_FLAG_INTERNED != 0 {
             key
@@ -553,20 +583,32 @@ fn object_set_field_by_name_transition_fast_impl(
             crate::string::js_string_intern(key, hash)
         };
         if interned_key.is_null() {
-            return 0;
+            return None;
         }
 
         obj = obj_handle.get_raw_mut_ptr::<ObjectHeader>();
+        // #9287: interning above is the one allocation point a MISS can
+        // still follow. A pre-scope caller's raw f64 operands may be stale
+        // after it, so hand back re-rooted copies for the caller's fallback
+        // ladder — set unconditionally, so the caller's use is uniform.
+        {
+            let key_now = key_handle.get_raw_const_ptr::<crate::StringHeader>();
+            *refresh = Some((
+                crate::value::js_nanbox_pointer(obj as i64),
+                crate::value::js_nanbox_string(key_now as i64),
+                value_handle.get_nanbox_f64(),
+            ));
+        }
         let value = value_handle.get_nanbox_f64();
 
         let prev_shape_id = super::shapes::object_shape_stamp(obj);
         let Some((next_keys, slot_idx, target_shape_id)) =
             transition_cache_lookup(prev_shape_id, interned_key)
         else {
-            return 0;
+            return None;
         };
         if next_keys == 0 {
-            return 0;
+            return None;
         }
 
         // `Object.prototype[<index>]` must reach the ordinary setter so it can
@@ -578,7 +620,7 @@ fn object_set_field_by_name_transition_fast_impl(
         let key_starts_with_digit =
             (*key).byte_len != 0 && (*crate::string::string_data(key)).is_ascii_digit();
         if key_starts_with_digit && crate::array::object_prototype_addr_matches(obj as usize) {
-            return 0;
+            return None;
         }
 
         if !super::shapes::install_cached_object_shape_transition(
@@ -613,9 +655,14 @@ fn object_set_field_by_name_transition_fast_impl(
 
         #[cfg(test)]
         TEST_TRANSITION_FAST_HITS.with(|hits| hits.set(hits.get() + 1));
+        // Success: value may be a heap pointer that moved during interning or
+        // spill growth; re-read it through this function's own root so the
+        // caller needs none.
+        return Some(value_handle.get_nanbox_f64());
     }
 
-    1
+    #[allow(unreachable_code)]
+    None
 }
 
 #[cfg(test)]

--- a/crates/perry-runtime/src/proxy/put_value.rs
+++ b/crates/perry-runtime/src/proxy/put_value.rs
@@ -888,36 +888,54 @@ pub extern "C" fn js_put_value_set_dyn_ic_miss(
         }
     }
 
-    let scope = crate::gc::RuntimeHandleScope::new();
-    let target_handle = scope.root_nanbox_f64(target);
-    let key_handle = scope.root_nanbox_f64(key);
-    let value_handle = scope.root_nanbox_f64(value);
-
     // A computed write site that constructs the same plain-object shape over
     // and over changes receiver shape after every append, so the per-site
     // overwrite IC above cannot hit. Reuse the runtime's global transition
     // lattice before entering the full `[[Set]]` walk: the helper accepts
     // only a previously learned transition on a class-id-zero ordinary object
     // and rejects every receiver with exotic, descriptor, frozen/sealed, or
-    // prototype-interceptor semantics. It roots internally while interning
-    // the key, and these outer handles preserve all three operands across
-    // that nested allocation/collection point.
-    let target_now = target_handle.get_nanbox_f64();
-    let key_now = key_handle.get_nanbox_f64();
-    if (target_now.to_bits() & !POINTER_MASK) == POINTER_TAG {
-        let obj = (target_now.to_bits() & POINTER_MASK) as *mut crate::ObjectHeader;
-        if (key_now.to_bits() & !POINTER_MASK) == crate::value::STRING_TAG {
-            let key_ptr = (key_now.to_bits() & POINTER_MASK) as *const crate::StringHeader;
-            if crate::object::object_set_field_by_name_transition_only_fast(
+    // prototype-interceptor semantics.
+    //
+    // #9287: this try sits BEFORE the handle scope. The value-returning form
+    // roots all three operands itself and re-reads the stored value through
+    // its own root after every internal allocation point, so the operands
+    // need no rooting here — and the fresh-object-construction lane (the
+    // dominant taker of this entry) no longer pays a scope + three roots it
+    // never uses. On a miss, nothing has allocated: `..._fast_impl_value`
+    // opens its scope only after its pre-checks pass, and every pre-check
+    // failure returns before any allocation, so the raw f64 params below are
+    // still valid for the rooted ladder.
+    let mut refreshed: Option<(f64, f64, f64)> = None;
+    let mut target = target;
+    let mut key = key;
+    let mut value = value;
+    if (target_bits & !POINTER_MASK) == POINTER_TAG {
+        let obj = (target_bits & POINTER_MASK) as *mut crate::ObjectHeader;
+        let kb = key.to_bits();
+        if (kb & !POINTER_MASK) == crate::value::STRING_TAG {
+            let key_ptr = (kb & POINTER_MASK) as *const crate::StringHeader;
+            if let Some(stored) = crate::object::object_set_field_by_name_transition_only_fast_value(
                 obj,
                 key_ptr,
-                value_handle.get_nanbox_f64(),
-            ) != 0
-            {
-                return value_handle.get_nanbox_f64();
+                value,
+                &mut refreshed,
+            ) {
+                return stored;
+            }
+            // A miss AFTER the helper interned the key may have moved the
+            // operands; it hands back re-rooted copies exactly when so.
+            if let Some((t, k, v)) = refreshed {
+                target = t;
+                key = k;
+                value = v;
             }
         }
     }
+
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let target_handle = scope.root_nanbox_f64(target);
+    let key_handle = scope.root_nanbox_f64(key);
+    let value_handle = scope.root_nanbox_f64(value);
 
     let result = js_put_value_set(
         target_handle.get_nanbox_f64(),


### PR DESCRIPTION
One increment on #9287's computed-key residual. Runtime-only, 3 files.

## The change

`js_put_value_set_dyn_ic_miss` opened a `RuntimeHandleScope` and rooted target/key/value **before** trying the learned shape-transition shortcut — which then opened its own scope and rooted the same operands again. On the fresh-object-construction lane (the dominant taker: every new-key write changes the receiver's shape, so no per-site IC can ever hit) that was two scopes and six roots per property write, one set protecting nothing.

The shortcut now runs before the scope, via a value-returning twin of the transition fast path:

- **Success** returns the stored value re-read through the callee's *own* root, taken after every internal allocation point — the caller needs no roots.
- **Miss-after-allocation** (fresh key interned, then no learned edge) hands back re-rooted operands via an out-param. Without that, this reorder would be the #6655 bug class — the caller rooting stale bits after a GC the callee triggered. Caught at design time, guarded structurally, and stressed directly: the intern-then-miss fixture (40 generations of never-seen keys, string values, spill growth) is node-identical under default GC and under `PERRY_GC_HEAP_LIMIT=8 PERRY_GC_FORCE_EVACUATE=1`.

## Numbers

Quiet host, 20k fresh objects × 20 computed-key writes, three runs each, spread ≤ 1 ms:

| shape | before | after | node |
|---|---|---|---|
| concat keys (`o["field_" + j]`) | 48 | **44** | 24 |
| pre-built keys | 43 | **39** | 12 |
| `bench_object_property` | ~35 | ~33 | 12 |

## Stated plainly

~10%, not parity. This removes one of the two scopes; the remaining ~3× lives in the transition install machinery itself — the fast path's own scope (skippable when the key is already interned and no growth occurs), shape-version install, keys handling, spill store. That's the next increment, tracked on #9287, and it's design-shaped rather than shave-shaped.

Also for the record, three levers eliminated by measurement before this one was built: key concat+intern (~5 ms of 48 — the profile's top frame overstated it), the prototype intercept probe (one load when no descriptors exist), and an early-transition shortcut in `js_put_value_set` (already present in-tree at the exact call site — found before duplicating it).

Refs #9287.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved performance when creating objects or setting properties with computed keys.
  * Reduced overhead in common dynamic property writes while preserving correct behavior when allocations occur.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->