### PR TITLE
perf(runtime): tombstone deletes default-on again — the #9200 corruption that rolled them back is fixed (26x on populated delete)

### DIFF
--- a/changelog.d/9330-tombstones-default-on.md
+++ b/changelog.d/9330-tombstones-default-on.md
@@ -1,0 +1,9 @@
+### Performance
+
+- **Tombstone deletes are default-on again.** #9038's O(1) delete (6.5× on
+  populated delete, ~15× vs node at the time) was rolled back to opt-in by
+  #9212 because of #9200 — an evacuating minor could sweep a deleted
+  receiver's live keys array, leaving it shapeless. #9317 fixed that
+  structurally (every post-birth ShapeId publish arms `old_carrier` through a
+  single funnel), so the win returns to the default configuration.
+  `PERRY_OBJECT_TOMBSTONES=0` remains the kill switch.

--- a/crates/perry-runtime/src/object/delete_rest.rs
+++ b/crates/perry-runtime/src/object/delete_rest.rs
@@ -1500,13 +1500,19 @@ fn object_tombstone_deletes_enabled() -> bool {
     }
     static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ON.get_or_init(|| {
-        // #9200: keep tombstones opt-in until an evacuating-GC interaction
-        // with class dispatch is fixed. The default-on route can restore a
-        // deleted receiver to its canonical class shape after relocation,
-        // making Object.keys() empty and fixed-slot reads return wrong data.
-        matches!(
+        // DEFAULT-ON again (#9038's 6.5x populated-delete win). #9212 made
+        // this opt-in because of #9200 — an unarmed successor descriptor let
+        // an evacuating minor sweep a deleted receiver's live keys array —
+        // and #9317 fixed that structurally: every post-birth ShapeId publish
+        // now routes through `stamp_object_shape_id_with_carrier_note`, which
+        // arms `old_carrier` for any non-nursery receiver, so the descriptor
+        // (and the keys array only it reaches) is rooted by construction.
+        // `PERRY_OBJECT_TOMBSTONES=0` remains the kill switch for A/B and
+        // attribution — the same switch that isolated #9108, #9110 and #9200
+        // each in one command.
+        !matches!(
             std::env::var("PERRY_OBJECT_TOMBSTONES").as_deref(),
-            Ok("1") | Ok("on") | Ok("true")
+            Ok("0") | Ok("off") | Ok("false")
         )
     })
 }


### PR DESCRIPTION
Restores #9038's default. The chain of custody:

- **#9038** shipped O(1) tombstone deletes default-on (6.5× populated delete at the time).
- **#9212** returned them to opt-in because of **#9200**: an evacuating minor could sweep a deleted receiver's live keys array — the tombstone publish minted an *unarmed* successor descriptor, and that descriptor was the keys array's only root.
- **#9317** (merged) fixed that structurally: every post-birth ShapeId publish routes through `stamp_object_shape_id_with_carrier_note`, which arms `old_carrier` for any non-nursery receiver — the descriptor and its keys array are rooted **by construction**, not by the site remembering to.

This PR is the one-hunk default flip plus the changelog. `PERRY_OBJECT_TOMBSTONES=0` remains the kill switch — deliberately, since that same switch attributed #9108, #9110 and #9200 each in one command.

## Verified on this exact build

**The five-configuration matrix over both #9200 fixtures** — including the precise configuration that broke the old default — all byte-identical to node, 3/3 runs each:

| fixture | default (ON) | kill | HL=8+FORCE_EVAC | HL=4+FORCE+VERIFY | evac+kill |
|---|---|---|---|---|---|
| `tower_delete` | PASS | PASS | PASS | PASS | PASS |
| `tombstone_oldgen_delete` | PASS | PASS | PASS | PASS | PASS |

**Tombstone unit suite**: 27/27 with the flipped default.

**The win it restores** (500-key object, 200k delete/re-add rounds, interleaved on one box; node 24–25 ms):

| | ms |
|---|---|
| default (tombstones ON) | **82–89** |
| kill switch (old default) | 2,137–2,352 |

**~26×.** Perry remains ~3.4× node on this shape — the residual is the per-delete IC retirement documented in #9064, a separate lane.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Tombstone-based object deletion is now enabled by default, improving deletion speed.
  - An environment-variable kill switch remains available to disable the behavior when needed.
- **Documentation**
  - Added release notes describing the default behavior, rollback history, structural fix, and performance improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->