### PR TITLE
fix(runtime): separate user prototype override signal

### DIFF
--- a/changelog.d/9333-user-prototype-override-signal.md
+++ b/changelog.d/9333-user-prototype-override-signal.md
@@ -1,0 +1,9 @@
+Internal prototype wiring no longer masquerades as a user
+`Object.setPrototypeOf` override. Object metadata now keeps the conservative
+prototype-divergence signal used by cache and shape invalidation separate from
+the user-origin signal consumed by property and method dispatch.
+
+User-facing `Object.setPrototypeOf`, object-literal `__proto__`, and
+recorded `Object.create` paths publish both signals. Runtime wiring through the
+loud prototype recorder retains its existing invalidation behavior without
+sending those objects through user-override dispatch.

--- a/crates/perry-runtime/src/array/subclass.rs
+++ b/crates/perry-runtime/src/array/subclass.rs
@@ -26,9 +26,10 @@ pub(super) use loop_guard::{js_packed_arraylike_loop_guard, js_packed_ecs_u32_lo
 // surviving address reuse: fresh allocations have it clear, and both words
 // ride an evacuation without a side-table re-key walk.
 //
-//     bit 0       existing custom-[[Prototype]] flag
+//     bit 0       prototype-semantic divergence
 //     bit 1       payload valid
 //     bit 2       compact nonnegative-int entity proof (mode 2)
+//     bit 3       user-origin prototype signal
 //     bits 8..31  verified prefix bound (24 bits, max 16,000,000)
 //     bits 32..63 exact semantic ShapeId
 const PACKED_NUMERIC_META_VALID: u64 = 1 << 1;
@@ -109,9 +110,9 @@ pub(super) struct ValidatedObjectReceiver {
 /// Dense Array-subclass paths have just completed that proof, so repeating it
 /// ahead of every receiver-local layout-cache hit is both redundant and hot.
 #[inline(always)]
-unsafe fn validated_object_has_prototype_override(obj: *const ObjectHeader) -> bool {
+unsafe fn validated_object_has_prototype_divergence(obj: *const ObjectHeader) -> bool {
     let meta = (*obj).meta;
-    !meta.is_null() && (*meta).flags & crate::object::OBJECT_META_FLAG_PROTO_OVERRIDE != 0
+    !meta.is_null() && (*meta).flags & crate::object::OBJECT_META_FLAG_PROTO_DIVERGED != 0
 }
 
 #[inline(always)]
@@ -244,7 +245,7 @@ unsafe fn build_dense_layout(obj: *const ObjectHeader) -> Option<DenseSubclassLa
     let class_id = (*obj).class_id;
     if class_id == 0
         || !is_array_subclass_class_id(class_id)
-        || validated_object_has_prototype_override(obj)
+        || validated_object_has_prototype_divergence(obj)
     {
         return None;
     }
@@ -359,7 +360,7 @@ fn validated_object_receiver_for_value(value: f64) -> Option<ValidatedObjectRece
 fn dense_layout_for_validated_object(obj: *const ObjectHeader) -> Option<DenseSubclassLayout> {
     // This is per receiver, not per ShapeId. A cached layout built before
     // Object.setPrototypeOf must not let this object borrow the old proof.
-    if unsafe { validated_object_has_prototype_override(obj) } {
+    if unsafe { validated_object_has_prototype_divergence(obj) } {
         return None;
     }
     if let Some(layout) = unsafe { owner_cached_dense_layout(obj) } {

--- a/crates/perry-runtime/src/array/subclass_loop_guard.rs
+++ b/crates/perry-runtime/src/array/subclass_loop_guard.rs
@@ -474,7 +474,7 @@ pub extern "C" fn js_packed_arraylike_loop_revalidate_live(
     let object = raw.cast::<ObjectHeader>();
     let current_receiver_word = unsafe { ptr::read_unaligned(raw.cast::<u64>()) };
     if current_receiver_word != receiver_word
-        || crate::object::prototype_chain::object_has_prototype_override(raw as usize)
+        || crate::object::prototype_chain::object_has_prototype_divergence(raw as usize)
     {
         return 0;
     }
@@ -619,7 +619,7 @@ fn revalidate_admitted_subclass_live(
     }
     let meta = unsafe { (*object).meta };
     if !meta.is_null()
-        && unsafe { (*meta).flags } & crate::object::OBJECT_META_FLAG_PROTO_OVERRIDE != 0
+        && unsafe { (*meta).flags } & crate::object::OBJECT_META_FLAG_PROTO_DIVERGED != 0
     {
         return 0;
     }

--- a/crates/perry-runtime/src/array/subclass_tests.rs
+++ b/crates/perry-runtime/src/array/subclass_tests.rs
@@ -265,10 +265,7 @@ fn dense_array_subclass_cache_declines_a_per_instance_prototype_override() {
     crate::object::js_object_set_index_polymorphic(obj as i64, 0.0, 11.0);
 
     assert_eq!(array_subclass_fast_index_get(receiver, 0), Some(11.0));
-    crate::object::prototype_chain::object_set_static_prototype(
-        obj as usize,
-        crate::value::TAG_NULL,
-    );
+    crate::object::prototype_chain::object_set_user_prototype(obj as usize, crate::value::TAG_NULL);
     assert_eq!(
         array_subclass_fast_index_get(receiver, 0),
         None,

--- a/crates/perry-runtime/src/gc/tests/dead_owner_side_tables.rs
+++ b/crates/perry-runtime/src/gc/tests/dead_owner_side_tables.rs
@@ -738,14 +738,14 @@ fn test_object_meta_prototype_survives_copied_minor_move() {
     let (proto, _) = unsafe { alloc_nursery_test_object(0) };
     let old_owner = owner as usize;
     let old_proto = proto as usize;
-    crate::object::prototype_chain::object_set_static_prototype(old_owner, ptr_bits(old_proto));
+    crate::object::prototype_chain::object_set_user_prototype(old_owner, ptr_bits(old_proto));
     assert_eq!(
         crate::object::prototype_chain::object_static_prototype(old_owner),
         Some(ptr_bits(old_proto)),
         "test premise: the meta-resident prototype reads back before the GC"
     );
     assert!(
-        crate::object::prototype_chain::object_has_prototype_override(old_owner),
+        crate::object::prototype_chain::object_has_user_prototype_override(old_owner),
         "test premise: the per-instance override bit lives in the meta record"
     );
     js_shadow_slot_set(0, ptr_bits(old_owner));
@@ -765,7 +765,7 @@ fn test_object_meta_prototype_survives_copied_minor_move() {
         "the meta record's prototype slot must be rewritten to the moved proto"
     );
     assert!(
-        crate::object::prototype_chain::object_has_prototype_override(new_owner),
+        crate::object::prototype_chain::object_has_user_prototype_override(new_owner),
         "the non-pointer meta flags must travel with the copied record"
     );
 

--- a/crates/perry-runtime/src/object/field_get_set/prototype_override.rs
+++ b/crates/perry-runtime/src/object/field_get_set/prototype_override.rs
@@ -23,9 +23,9 @@ use crate::value::JSValue;
 ///
 /// This is the same polarity `canonical_shape_excludes_own_property` uses: a
 /// question we cannot answer here defers to the tail rather than fabricating a
-/// verdict. The flag is also set by ~20 runtime prototype-wiring sites that are
-/// not user `setPrototypeOf` calls at all, so "flagged" is far weaker evidence
-/// than the original code assumed.
+/// verdict. The dedicated user-origin signal excludes internal runtime wiring,
+/// even when that wiring uses the loud setter and its conservative cache
+/// invalidations.
 ///
 /// `None` therefore means either no override, or an override that does not
 /// carry this key — in both cases the caller keeps its existing fallback.
@@ -36,7 +36,7 @@ pub(super) fn inherited_field_if_overridden(
     if key.is_null() {
         return None;
     }
-    if !crate::object::prototype_chain::object_has_prototype_override(obj as usize) {
+    if !crate::object::prototype_chain::object_has_user_prototype_override(obj as usize) {
         return None;
     }
     crate::object::prototype_chain::resolve_inherited_field(obj as usize, key)

--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -193,7 +193,7 @@ pub extern "C" fn js_object_set_field_by_name(
                         // a cached edge here could hand it a foreign slot
                         // index below the floor.
                         && crate::object::reserved_slot_floor_for_class_id(class_id) == 0
-                        && !super::prototype_chain::object_has_prototype_override(raw)
+                        && !super::prototype_chain::object_has_prototype_divergence(raw)
                         && super::prop_plan::store_plan_check(class_id, key as usize)
                     {
                         let prev_shape_id = super::shapes::object_shape_stamp(o);

--- a/crates/perry-runtime/src/object/field_set_by_name/tail.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name/tail.rs
@@ -279,7 +279,7 @@ pub(crate) fn set_field_by_name_object_tail(
             && obj_class_id != NATIVE_MODULE_CLASS_ID
             && crate::object::object_is_regular(obj)
             && (*gc_header)._reserved & PLAN_BLOCKING_FLAGS == 0
-            && !super::prototype_chain::object_has_prototype_override(obj as usize);
+            && !super::prototype_chain::object_has_prototype_divergence(obj as usize);
         let plan_fast = plan_eligible
             && super::prop_plan::store_plan_check(obj_class_id, interned_key as usize);
 
@@ -512,7 +512,7 @@ pub(crate) fn set_field_by_name_object_tail(
                 && obj_class_id != NATIVE_MODULE_CLASS_ID
                 && crate::object::object_is_regular(obj)
                 && obj_flags & PLAN_BLOCKING_FLAGS == 0
-                && !super::prototype_chain::object_has_prototype_override(obj as usize);
+                && !super::prototype_chain::object_has_prototype_divergence(obj as usize);
             if !plan_fast && record_plan_eligible {
                 super::prop_plan::store_plan_record(obj_class_id, interned_key as usize);
             }

--- a/crates/perry-runtime/src/object/iterator_prototypes.rs
+++ b/crates/perry-runtime/src/object/iterator_prototypes.rs
@@ -206,15 +206,15 @@ fn set_to_string_tag(obj: *mut ObjectHeader, tag: &str) {
 /// Uses the class-DEFAULT variant, not `object_set_static_prototype`. Attaching
 /// `%ArrayIteratorPrototype%` to a fresh array iterator is exactly what that
 /// function documents — a chain identical for every instance of the class — and
-/// not a user `Object.setPrototypeOf`. The loud variant additionally sets
-/// `OBJECT_META_FLAG_PROTO_OVERRIDE`, which made `object_has_prototype_override`
-/// answer true for EVERY built-in iterator. Any caller that treats an override
-/// as "the per-instance chain is authoritative, resolve methods by ordinary
-/// inheriting lookup" then reached the `%…IteratorPrototype%` `next` THUNK,
+/// not a user `Object.setPrototypeOf`. Before #9251, the loud variant's
+/// divergence bit was also the user-override signal, so every built-in iterator
+/// appeared user-reparented. A caller treating that as "the per-instance chain
+/// is authoritative, resolve methods by ordinary inheriting lookup" then
+/// reached the `%…IteratorPrototype%` `next` THUNK,
 /// which resolves its receiver from `js_implicit_this_get()` rather than the
 /// bound `this` (#7576) — producing `Method %IteratorPrototype%.next called on
 /// incompatible receiver`. The prototype itself is still recorded either way;
-/// only the override flag and the plan-cache flush differ.
+/// the class-default variant also avoids the divergence bit and cache flushes.
 fn chain_to(child: *mut ObjectHeader, parent: *mut ObjectHeader) {
     let parent_bits = crate::value::js_nanbox_pointer(parent as i64).to_bits();
     super::prototype_chain::object_link_class_default_prototype(child as usize, parent_bits);

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -1549,8 +1549,8 @@ pub(crate) unsafe fn object_keys_array(obj: *const ObjectHeader) -> *mut ArrayHe
 /// `ObjectMeta` migration.
 #[repr(C)]
 pub struct ObjectMeta {
-    /// Custom `[[Prototype]]` recorded by `Object.setPrototypeOf` / object
-    /// literal `__proto__`: the NaN-boxed proto bits,
+    /// Custom `[[Prototype]]` recorded by a user-facing operation or runtime
+    /// prototype wiring: the NaN-boxed proto bits,
     /// `crate::value::TAG_NULL` for an explicit null prototype, or 0 when
     /// unset (fall back to default prototype resolution).
     pub prototype: u64,
@@ -1567,8 +1567,11 @@ pub struct ObjectMeta {
     /// Same summary for accessor descriptors (`get`/`set` installs) — the
     /// `accessor_descriptors` table twin of `attr_key_bits`.
     pub accessor_key_bits: u64,
-    /// Object-only state and compact scalar proof payloads. Bit 0 is the
-    /// custom-prototype flag. #8690 reserves bits 1..2 and 8..63 for the
+    /// Object-only state and compact scalar proof payloads. Bit 0 records
+    /// prototype-semantic divergence (including runtime wiring); bit 3 records
+    /// that a user-facing operation chose the prototype. Keeping those signals
+    /// separate prevents internal wiring from masquerading as
+    /// `Object.setPrototypeOf`. #8690 reserves bits 1..2 and 8..63 for the
     /// packed Array-subclass numeric-prefix proof (kind, verified bound, and
     /// ShapeId);
     /// its address-reuse-safe authority is a type-specific GcHeader bit.
@@ -1650,7 +1653,8 @@ pub struct ObjectMeta {
     pub elements: u64,
 }
 
-pub(crate) const OBJECT_META_FLAG_PROTO_OVERRIDE: u64 = 1;
+pub(crate) const OBJECT_META_FLAG_PROTO_DIVERGED: u64 = 1;
+pub(crate) const OBJECT_META_FLAG_USER_PROTO_OVERRIDE: u64 = 1 << 3;
 
 /// Authoritative ordinary-object discriminator. RegExp has its own GC kind,
 /// and heap class-expression values carry their kind in the immutable ShapeId

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1282,7 +1282,7 @@ pub unsafe extern "C-unwind" fn js_native_call_method(
         let candidate = jsval().as_pointer::<ObjectHeader>() as usize;
         if crate::value::addr_class::is_above_handle_band(candidate)
             && crate::object::is_valid_obj_ptr(candidate as *const u8)
-            && super::prototype_chain::object_has_prototype_override(candidate)
+            && super::prototype_chain::object_has_user_prototype_override(candidate)
         {
             let method_key =
                 crate::string::js_string_from_bytes(method_name.as_ptr(), method_name.len() as u32);

--- a/crates/perry-runtime/src/object/object_literal_ops.rs
+++ b/crates/perry-runtime/src/object/object_literal_ops.rs
@@ -121,14 +121,14 @@ pub unsafe extern "C" fn js_object_literal_set_prototype(obj_value: f64, proto_v
     let proto_bits = proto_value.to_bits();
     let proto_jsv = crate::value::JSValue::from_bits(proto_bits);
     if proto_jsv.is_null() {
-        super::prototype_chain::object_set_static_prototype(obj as usize, TAG_NULL);
+        super::prototype_chain::object_set_user_prototype(obj as usize, TAG_NULL);
         return f64::from_bits(crate::value::TAG_UNDEFINED);
     }
     if crate::symbol::js_is_symbol(proto_value) != 0 {
         return f64::from_bits(crate::value::TAG_UNDEFINED);
     }
     if value_is_object_like(proto_value) {
-        super::prototype_chain::object_set_static_prototype(obj as usize, proto_bits);
+        super::prototype_chain::object_set_user_prototype(obj as usize, proto_bits);
     }
     f64::from_bits(crate::value::TAG_UNDEFINED)
 }

--- a/crates/perry-runtime/src/object/object_ops/define_properties.rs
+++ b/crates/perry-runtime/src/object/object_ops/define_properties.rs
@@ -448,7 +448,7 @@ pub extern "C" fn js_object_set_prototype_of(obj_value: f64, proto: f64) -> f64 
             0
         };
         if crate::value::addr_class::is_small_handle(handle_id) {
-            super::super::prototype_chain::object_set_static_prototype(handle_id, proto_bits);
+            super::super::prototype_chain::object_set_user_prototype(handle_id, proto_bits);
             return obj_value;
         }
     }
@@ -487,7 +487,7 @@ pub extern "C" fn js_object_set_prototype_of(obj_value: f64, proto: f64) -> f64 
         // user-visible `Object.setPrototypeOf` entry rather than poisoning the
         // fast path for every program during initialization.
         crate::object::invalidate_class_prototype_fast_guards();
-        super::super::prototype_chain::object_set_static_prototype(obj_ptr_for_record, proto_bits);
+        super::super::prototype_chain::object_set_user_prototype(obj_ptr_for_record, proto_bits);
         // A grown array's local may still hold the FORWARDED (old) pointer;
         // the spec [[HasProperty]]/[[Get]] helpers look the prototype up by
         // the CLEANED address. Record under both keys so either resolves
@@ -502,7 +502,7 @@ pub extern "C" fn js_object_set_prototype_of(obj_value: f64, proto: f64) -> f64 
                     obj_ptr_for_record as *const crate::array::ArrayHeader,
                 ) as usize;
                 if cleaned != 0 && cleaned != obj_ptr_for_record {
-                    super::super::prototype_chain::object_set_static_prototype(cleaned, proto_bits);
+                    super::super::prototype_chain::object_set_user_prototype(cleaned, proto_bits);
                 }
             }
         }

--- a/crates/perry-runtime/src/object/object_ops/prototype.rs
+++ b/crates/perry-runtime/src/object/object_ops/prototype.rs
@@ -80,7 +80,7 @@ pub extern "C" fn js_object_create(proto_value: f64) -> f64 {
     // has/call-object-create.js, set/call-parameters-prototype.js.)
     if crate::proxy::js_proxy_is_proxy(proto_value) != 0 {
         let obj = js_object_alloc(0, 0);
-        crate::object::prototype_chain::object_set_static_prototype(
+        crate::object::prototype_chain::object_set_user_prototype(
             obj as usize,
             proto_value.to_bits(),
         );
@@ -94,7 +94,7 @@ pub extern "C" fn js_object_create(proto_value: f64) -> f64 {
     // numeric keys on descendants.
     if crate::typedarray_props::typed_array_addr_from_value(proto_value).is_some() {
         let obj = js_object_alloc(0, 0);
-        crate::object::prototype_chain::object_set_static_prototype(
+        crate::object::prototype_chain::object_set_user_prototype(
             obj as usize,
             proto_value.to_bits(),
         );

--- a/crates/perry-runtime/src/object/prototype_chain.rs
+++ b/crates/perry-runtime/src/object/prototype_chain.rs
@@ -154,11 +154,26 @@ pub(crate) unsafe fn meta_capable_object(obj_ptr: usize) -> Option<*mut crate::O
     Some(obj_ptr as *mut crate::ObjectHeader)
 }
 
-/// Record `Object.setPrototypeOf(obj_ptr, proto)`. `proto_bits` is the NaN-box
-/// bits of the prototype object (POINTER-tagged) or `TAG_NULL`. Idempotent
-/// overwrite.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum PrototypeLinkKind {
+    ClassDefault,
+    RuntimeWiring,
+    UserOverride,
+}
+
+/// Record runtime prototype wiring while preserving the loud setter's cache
+/// invalidations and shape-semantic transition. This deliberately does not
+/// claim that the user replaced the receiver's prototype.
 pub fn object_set_static_prototype(obj_ptr: usize, proto_bits: u64) {
-    object_set_static_prototype_impl(obj_ptr, proto_bits, true)
+    object_set_static_prototype_impl(obj_ptr, proto_bits, PrototypeLinkKind::RuntimeWiring)
+}
+
+/// Record a prototype selected by a user-facing operation such as
+/// `Object.setPrototypeOf` or an object-literal `__proto__`. This has the same
+/// invalidation behavior as the loud runtime setter and additionally publishes
+/// the dedicated user-origin signal consumed by class dispatch.
+pub(crate) fn object_set_user_prototype(obj_ptr: usize, proto_bits: u64) {
+    object_set_static_prototype_impl(obj_ptr, proto_bits, PrototypeLinkKind::UserOverride)
 }
 
 /// Construct-path variant: link a fresh instance to its class-DEFAULT
@@ -171,10 +186,12 @@ pub fn object_set_static_prototype(obj_ptr: usize, proto_bits: u64) {
 /// flushed the plan cache on EVERY function-ctor construction, which kept it
 /// permanently cold in fiber-heavy workloads.
 pub(crate) fn object_link_class_default_prototype(obj_ptr: usize, proto_bits: u64) {
-    object_set_static_prototype_impl(obj_ptr, proto_bits, false)
+    object_set_static_prototype_impl(obj_ptr, proto_bits, PrototypeLinkKind::ClassDefault)
 }
 
-fn object_set_static_prototype_impl(obj_ptr: usize, proto_bits: u64, instance_override: bool) {
+fn object_set_static_prototype_impl(obj_ptr: usize, proto_bits: u64, link_kind: PrototypeLinkKind) {
+    let prototype_diverged = link_kind != PrototypeLinkKind::ClassDefault;
+    let user_override = link_kind == PrototypeLinkKind::UserOverride;
     if obj_ptr == 0 {
         return;
     }
@@ -196,12 +213,12 @@ fn object_set_static_prototype_impl(obj_ptr: usize, proto_bits: u64, instance_ov
     // A per-instance prototype override invalidates class-keyed interception
     // verdicts (the overridden chain can differ from the class chain), and the
     // object itself must never satisfy a class-keyed plan again.
-    if instance_override {
+    if prototype_diverged {
         crate::object::prop_plan::prop_plan_epoch_bump();
         // #7480: a `[[Prototype]]` swap on a live instance is prototype
         // surgery — the same class of event as writing onto `C.prototype`, so
         // it retires every outstanding element-shape proof. Deliberately
-        // inside the `instance_override` gate: the quiet sibling
+        // inside the `prototype_diverged` gate: the quiet sibling
         // (`object_link_class_default_prototype`) fires on every `new F()`.
         crate::array::invalidate_all_element_shapes();
     }
@@ -221,8 +238,11 @@ fn object_set_static_prototype_impl(obj_ptr: usize, proto_bits: u64, instance_ov
             });
             let proto_bits = proto_handle.get_heap_word_u64();
             (*meta).prototype = proto_bits;
-            if instance_override {
-                (*meta).flags |= crate::object::OBJECT_META_FLAG_PROTO_OVERRIDE;
+            if prototype_diverged {
+                (*meta).flags |= crate::object::OBJECT_META_FLAG_PROTO_DIVERGED;
+            }
+            if user_override {
+                (*meta).flags |= crate::object::OBJECT_META_FLAG_USER_PROTO_OVERRIDE;
             }
             // GC_STORE_AUDIT(BARRIERED): meta-record prototype slot store —
             // the record is an arena allocation, so the ordinary object-slot
@@ -232,7 +252,7 @@ fn object_set_static_prototype_impl(obj_ptr: usize, proto_bits: u64, instance_ov
                 &(*meta).prototype as *const u64 as usize,
                 proto_bits,
             );
-            if instance_override {
+            if prototype_diverged {
                 crate::object::shapes::transition_object_shape_semantics(obj);
             }
             return;
@@ -293,19 +313,31 @@ pub fn object_static_prototype(obj_ptr: usize) -> Option<u64> {
         .and_then(|map| map.get(&obj_ptr).copied())
 }
 
-/// True only for a per-instance `Object.setPrototypeOf` / literal
-/// `__proto__` override. Class-default prototype links use the same metadata
-/// record but deliberately leave this bit clear so class-keyed store plans
-/// remain valid.
 #[inline]
-pub(crate) fn object_has_prototype_override(obj_ptr: usize) -> bool {
+fn object_has_prototype_flag(obj_ptr: usize, flag: u64) -> bool {
     unsafe {
         let Some(obj) = meta_capable_object(obj_ptr) else {
             return false;
         };
         let meta = (*obj).meta;
-        !meta.is_null() && (*meta).flags & crate::object::OBJECT_META_FLAG_PROTO_OVERRIDE != 0
+        !meta.is_null() && (*meta).flags & flag != 0
     }
+}
+
+/// True when this receiver's recorded prototype diverges from its class
+/// default, regardless of whether runtime wiring or a user-facing operation
+/// selected it. Cache guards use this conservative signal.
+#[inline]
+pub(crate) fn object_has_prototype_divergence(obj_ptr: usize) -> bool {
+    object_has_prototype_flag(obj_ptr, crate::object::OBJECT_META_FLAG_PROTO_DIVERGED)
+}
+
+/// True only when a user-facing operation selected this receiver's prototype.
+/// Runtime wiring can use the same metadata record and loud invalidations, but
+/// it deliberately leaves this distinct bit clear.
+#[inline]
+pub(crate) fn object_has_user_prototype_override(obj_ptr: usize) -> bool {
+    object_has_prototype_flag(obj_ptr, crate::object::OBJECT_META_FLAG_USER_PROTO_OVERRIDE)
 }
 
 pub(crate) fn default_object_prototype_bits() -> Option<u64> {
@@ -581,6 +613,50 @@ pub(crate) fn test_prototype_registry_latch_armed() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn runtime_wiring_and_user_override_publish_distinct_signals() {
+        let _no_move = crate::gc::GcSuppressScope::new();
+
+        let runtime_wired = crate::object::js_object_alloc(0, 0);
+        object_set_static_prototype(runtime_wired as usize, crate::value::TAG_NULL);
+        let runtime_meta = unsafe { (*runtime_wired).meta };
+        assert!(!runtime_meta.is_null());
+        assert_ne!(
+            unsafe { (*runtime_meta).flags } & crate::object::OBJECT_META_FLAG_PROTO_DIVERGED,
+            0,
+            "the loud runtime setter must retain its conservative divergence signal"
+        );
+        assert!(object_has_prototype_divergence(runtime_wired as usize));
+        assert!(
+            !object_has_user_prototype_override(runtime_wired as usize),
+            "runtime prototype wiring must not masquerade as a user override"
+        );
+
+        let class_default = crate::object::js_object_alloc(0, 0);
+        object_link_class_default_prototype(class_default as usize, crate::value::TAG_NULL);
+        let class_default_meta = unsafe { (*class_default).meta };
+        assert!(!class_default_meta.is_null());
+        assert_eq!(
+            unsafe { (*class_default_meta).flags }
+                & (crate::object::OBJECT_META_FLAG_PROTO_DIVERGED
+                    | crate::object::OBJECT_META_FLAG_USER_PROTO_OVERRIDE),
+            0,
+            "class-default links must publish neither divergence signal"
+        );
+        assert!(!object_has_prototype_divergence(class_default as usize));
+
+        let user_overridden = crate::object::js_object_alloc(0, 0);
+        object_set_user_prototype(user_overridden as usize, crate::value::TAG_NULL);
+        let user_meta = unsafe { (*user_overridden).meta };
+        assert!(!user_meta.is_null());
+        assert_ne!(
+            unsafe { (*user_meta).flags } & crate::object::OBJECT_META_FLAG_PROTO_DIVERGED,
+            0
+        );
+        assert!(object_has_prototype_divergence(user_overridden as usize));
+        assert!(object_has_user_prototype_override(user_overridden as usize));
+    }
 
     #[test]
     fn inherited_lookup_stops_on_recorded_prototype_cycle() {

--- a/crates/perry-runtime/src/object/tests.rs
+++ b/crates/perry-runtime/src/object/tests.rs
@@ -287,7 +287,7 @@ fn recorded_prototype_constructor_overrides_plain_object_constructor() {
         let instance = js_object_alloc(class_id, 0);
         let constructor_key = crate::string::js_string_from_bytes(b"constructor".as_ptr(), 11);
         js_object_set_field_by_name(prototype, constructor_key, 42.0);
-        crate::object::prototype_chain::object_set_static_prototype(
+        crate::object::prototype_chain::object_set_user_prototype(
             instance as usize,
             crate::value::js_nanbox_pointer(prototype as i64).to_bits(),
         );

--- a/crates/perry-runtime/src/perf_hooks/prototypes.rs
+++ b/crates/perry-runtime/src/perf_hooks/prototypes.rs
@@ -219,9 +219,10 @@ fn perf_constructor_prototype(class_name: &str) -> f64 {
 /// Link runtime-created perf objects through their built-in class hierarchy.
 ///
 /// This is class-default wiring, not a user `Object.setPrototypeOf` override.
-/// The loud setter marks the receiver with `OBJECT_META_FLAG_PROTO_OVERRIDE`;
-/// method dispatch then treats the chain as user-replaced and re-dispatches an
-/// already bound prototype method back through `js_native_call_method`,
+/// Before #9251, the loud setter's divergence bit was also interpreted as a
+/// user-origin signal; method dispatch then treated the chain as user-replaced
+/// and re-dispatched an already bound prototype method through
+/// `js_native_call_method`,
 /// recursing until the process exhausts its stack (#9281).
 fn link_perf_class_default_prototype(obj: usize, proto_bits: u64) {
     crate::object::prototype_chain::object_link_class_default_prototype(obj, proto_bits);

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -1997,7 +1997,7 @@ fn ordinary_set_with_receiver(target: f64, key: f64, value: f64, receiver: f64) 
                             // neither record nor honor store plans.
                             let plan_eligible = header._reserved & crate::gc::OBJ_FLAG_NULL_PROTO
                                 == 0
-                                && !crate::object::prototype_chain::object_has_prototype_override(
+                                && !crate::object::prototype_chain::object_has_prototype_divergence(
                                     addr,
                                 )
                                 && class_id != crate::object::NATIVE_MODULE_CLASS_ID

--- a/crates/perry/tests/issue_9131_prototype_method_replacement.rs
+++ b/crates/perry/tests/issue_9131_prototype_method_replacement.rs
@@ -104,13 +104,15 @@ console.log("swap-after:", readA(a));
 
 /// #9244: the per-instance prototype-override fast path in
 /// `js_native_call_method` resolves the method by ordinary property lookup.
-/// A generator carries the override flag but has no own or inherited `map` —
-/// Perry synthesizes the iterator helpers (#2874) further down the dispatch
-/// tower. Returning on the lookup MISS called `undefined`, so
-/// `[...gen().map(f)]` threw `TypeError: undefined is not iterable`. Only a
-/// resolved callable may take the fast path; a miss must fall through.
+/// Before #9251, a runtime-wired generator carried the shared override flag but
+/// had no own or inherited `map` — Perry synthesizes iterator helpers (#2874)
+/// further down the dispatch tower. Returning on the lookup MISS called
+/// `undefined`, so `[...gen().map(f)]` threw `TypeError: undefined is not
+/// iterable`. The dedicated user-origin signal now keeps runtime wiring out of
+/// that path; the genuine resolved override below still proves that user
+/// replacement wins over the class vtable.
 #[test]
-fn overridden_receiver_miss_falls_through_to_synthesized_helpers() {
+fn runtime_wiring_preserves_synthesized_helpers_and_user_override_still_wins() {
     let stdout = compile_and_run(
         r#"
 function* gen() {


### PR DESCRIPTION
Fixes #9251

## Summary

- split ObjectMeta prototype state into a conservative chain-divergence signal and a distinct user-origin signal
- keep runtime prototype wiring on its existing invalidation path without classifying it as Object.setPrototypeOf
- route Object.setPrototypeOf, object-literal __proto__, and recorded Object.create paths through the user-aware recorder
- preserve divergence-based cache guards while limiting replacement dispatch to genuine user-origin overrides

No version bump is included.

## Tests

- cargo fmt --all -- --check
- cargo test -p perry-runtime runtime_wiring_and_user_override_publish_distinct_signals
- targeted Array-subclass, property-dispatch, and moving-GC runtime regressions
- cargo test -p perry --test issue_9131_prototype_method_replacement
- direct Perry/Node output diffs for iterator_helpers_2874, language_types_object_part_a, object_string_wrappers, and 5592_class_expr_rebind_computed_accessor
- full perry-runtime run: 2,886 passed; two unrelated parallel-only failures passed immediately when rerun individually with one test thread
- scripts/check_file_size.sh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected prototype handling so internal runtime wiring is no longer mistaken for a user-applied prototype override.
  - Preserved proper method and property dispatch when prototypes are changed through user-facing operations.
  - Improved cache and optimization invalidation when prototype chains genuinely diverge.
  - Ensured built-in iterator prototype links do not trigger unnecessary user-override behavior or cache invalidation.
- **Tests**
  - Added coverage confirming distinct handling for runtime wiring, default prototypes, and user overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->