### PR TITLE
fix(json): round-trip lazy tape numbers through f64

### DIFF
--- a/crates/perry-runtime/src/json/stringify_api.rs
+++ b/crates/perry-runtime/src/json/stringify_api.rs
@@ -49,6 +49,121 @@ pub(crate) unsafe fn redirect_lazy_to_materialized(value: f64) -> f64 {
     f64::from_bits(JSValue::object_ptr((*lazy).materialized as *mut u8).bits())
 }
 
+/// Return one validated JSON number token and its exclusive end offset.
+/// The tape builder already accepted this input; the checks here keep the
+/// lazy stringify path fail-closed if a retained blob or tape is corrupted.
+fn json_number_token(bytes: &[u8], start: usize) -> Option<(usize, &[u8])> {
+    let mut end = start;
+    if bytes.get(end) == Some(&b'-') {
+        end += 1;
+    }
+    match bytes.get(end) {
+        Some(b'0') => end += 1,
+        Some(b'1'..=b'9') => {
+            end += 1;
+            while bytes.get(end).is_some_and(u8::is_ascii_digit) {
+                end += 1;
+            }
+        }
+        _ => return None,
+    }
+    if bytes.get(end) == Some(&b'.') {
+        end += 1;
+        let fraction_start = end;
+        while bytes.get(end).is_some_and(u8::is_ascii_digit) {
+            end += 1;
+        }
+        if end == fraction_start {
+            return None;
+        }
+    }
+    if matches!(bytes.get(end), Some(b'e' | b'E')) {
+        end += 1;
+        if matches!(bytes.get(end), Some(b'+' | b'-')) {
+            end += 1;
+        }
+        let exponent_start = end;
+        while bytes.get(end).is_some_and(u8::is_ascii_digit) {
+            end += 1;
+        }
+        if end == exponent_start {
+            return None;
+        }
+    }
+    Some((end, bytes.get(start..end)?))
+}
+
+/// Small source-form integers are already their canonical NumberToString
+/// spelling and are exactly representable as `f64`. This avoids reparsing and
+/// formatting the overwhelmingly common ID/index case while inspecting a lazy
+/// array for number spellings that need normalization.
+fn is_trivially_canonical_json_integer(token: &[u8]) -> bool {
+    let (negative, digits) = match token.strip_prefix(b"-") {
+        Some(digits) => (true, digits),
+        None => (false, token),
+    };
+    !digits.is_empty()
+        && digits.len() <= 15
+        && digits.iter().all(u8::is_ascii_digit)
+        && !(negative && digits == b"0")
+}
+
+/// Normalize number spellings in an otherwise byte-copyable lazy JSON array.
+/// `JSON.parse` converts every number token to an IEEE-754 double, so the
+/// stringify shortcut must not preserve source spellings such as `1e-400`,
+/// `1.0`, or `9007199254740993`. Allocate a rewritten buffer only when a token
+/// differs from the canonical formatting of the `f64` it denotes.
+fn normalize_lazy_json_numbers<'a>(
+    tape: &[crate::json_tape::TapeEntry],
+    blob: &'a [u8],
+    root_start: usize,
+    root_end: usize,
+) -> Option<std::borrow::Cow<'a, [u8]>> {
+    let original = blob.get(root_start..root_end)?;
+    let mut rewritten: Option<Vec<u8>> = None;
+    let mut copied_until = root_start;
+    let mut canonical = String::new();
+
+    for entry in tape {
+        if entry.kind != crate::json_tape::KIND_NUMBER {
+            continue;
+        }
+        let number_start = entry.offset as usize;
+        if number_start < root_start || number_start >= root_end {
+            continue;
+        }
+        let (number_end, token) = json_number_token(blob, number_start)?;
+        if number_end > root_end {
+            return None;
+        }
+        if is_trivially_canonical_json_integer(token) {
+            continue;
+        }
+
+        let value = std::str::from_utf8(token).ok()?.parse::<f64>().ok()?;
+        canonical.clear();
+        unsafe { stringify::write_number(&mut canonical, value) };
+        if canonical.as_bytes() == token {
+            continue;
+        }
+
+        let output = rewritten.get_or_insert_with(|| Vec::with_capacity(original.len()));
+        if number_start < copied_until {
+            return None;
+        }
+        output.extend_from_slice(blob.get(copied_until..number_start)?);
+        output.extend_from_slice(canonical.as_bytes());
+        copied_until = number_end;
+    }
+
+    if let Some(mut output) = rewritten {
+        output.extend_from_slice(blob.get(copied_until..root_end)?);
+        Some(std::borrow::Cow::Owned(output))
+    } else {
+        Some(std::borrow::Cow::Borrowed(original))
+    }
+}
+
 /// Issue #179 Phase 4: lazy-stringify fast path. If `value` is a
 /// lazy-parse top-level array whose `materialized` is still null (no
 /// indexed access or mutation has forced tree build), memcpy the
@@ -63,7 +178,9 @@ pub(crate) unsafe fn redirect_lazy_to_materialized(value: f64) -> f64 {
 /// value (modulo whitespace the user's original blob may contain —
 /// `JSON.stringify` never emits whitespace for the 2-arg form, so
 /// this is only correct when the blob came from `JSON.stringify` or
-/// is otherwise whitespace-free in the array span).
+/// is otherwise whitespace-free in the array span). Number tokens are
+/// normalized separately: their source spelling is preserved only when it
+/// matches the canonical formatting of the `f64` produced by `JSON.parse`.
 pub(crate) unsafe fn try_stringify_lazy_array(value: f64) -> Option<*mut StringHeader> {
     let bits = value.to_bits();
     let top16 = bits >> 48;
@@ -139,8 +256,8 @@ pub(crate) unsafe fn try_stringify_lazy_array(value: f64) -> Option<*mut StringH
     if end > blob_bytes.len() || start > end {
         return None;
     }
-    let slice = &blob_bytes[start..end];
-    Some(json_string_from_output_bytes(slice))
+    let normalized = normalize_lazy_json_numbers(tape, blob_bytes, start, end)?;
+    Some(json_string_from_output_bytes(normalized.as_ref()))
 }
 
 #[no_mangle]

--- a/crates/perry/tests/issue_9252_json_tape_numbers.rs
+++ b/crates/perry/tests/issue_9252_json_tape_numbers.rs
@@ -1,0 +1,95 @@
+//! #9252: tape-backed arrays must expose JSON numbers as their `f64` values,
+//! even when stringify can otherwise reuse the retained source bytes.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+const SOURCE: &str = r#"
+const inputs = [
+  "[1e308]",
+  "[-1e308]",
+  "[1e-400]",
+  "[5e-324]",
+  "[1.7976931348623157e308]",
+  "[9007199254740993]",
+  "[1.25e2]",
+  "[1e400]",
+  "[-1e-400]",
+  "[-0]",
+  "[1.0]",
+  "[1e308,1,1e-400,2,9007199254740993,5e-324]",
+  "[{\"n\":1e308,\"text\":\"1e-400\"}]"
+];
+for (const input of inputs) {
+  console.log(JSON.stringify(JSON.parse(input)));
+}
+"#;
+
+const EXPECTED: &str = "[1e+308]\n\
+[-1e+308]\n\
+[0]\n\
+[5e-324]\n\
+[1.7976931348623157e+308]\n\
+[9007199254740992]\n\
+[125]\n\
+[null]\n\
+[0]\n\
+[0]\n\
+[1]\n\
+[1e+308,1,0,2,9007199254740992,5e-324]\n\
+[{\"n\":1e+308,\"text\":\"1e-400\"}]\n";
+
+fn compile(dir: &Path) -> PathBuf {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, SOURCE).expect("write entry");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-auto-optimize")
+        .env("PERRY_NO_CACHE", "1")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    output
+}
+
+fn run(bin: &Path, dir: &Path, tape_mode: &str) -> Output {
+    Command::new(bin)
+        .current_dir(dir)
+        .env("PERRY_JSON_TAPE", tape_mode)
+        .output()
+        .expect("run compiled binary")
+}
+
+#[test]
+fn json_tape_numbers_round_trip_through_f64() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let bin = compile(dir.path());
+    for tape_mode in ["0", "1"] {
+        let output = run(&bin, dir.path(), tape_mode);
+        assert!(
+            output.status.success(),
+            "binary failed with tape={tape_mode}\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout),
+            EXPECTED,
+            "tape={tape_mode}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- normalize tape-backed JSON number spellings through the same decimal-to-`f64` conversion and JS formatter used by materialized values
- retain the lazy byte-copy path for already-canonical numbers, allocating a rewritten buffer only when a token changes
- cover underflow, overflow, subnormals, exponent formatting, unsafe-integer rounding, negative zero, multiple replacements, and number-like strings in forced-direct and forced-tape modes

Fixes #9252.

No version or changelog files are changed.

## Validation

- `cargo test -p perry --test issue_9252_json_tape_numbers -- --nocapture`
- `cargo test -p perry-runtime json_tape -- --nocapture` (27 passed)
- `cargo test -p perry --test typed_json_parse_tape_route -- --nocapture`
- `cargo fmt --all -- --check`
- `./scripts/check_file_size.sh`

Additional baseline check: `cargo test -p perry --test issue_9184_json_parse_strict -- --nocapture` aborts with the same non-unwinding runtime panic on this branch and on a clean `origin/main` worktree on `perrymaster.skelpo.net`; the failing test forces `PERRY_JSON_TAPE=0`, so it does not enter the changed path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected `JSON.stringify` output for parsed numbers with non-canonical spellings, including very large, very small, decimal, and negative-zero values.
  * Ensured serialized numbers consistently reflect the values produced by `JSON.parse`.
  * Improved handling of mixed arrays and objects across supported JSON parsing modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->