### PR TITLE
fix(ws): expose WebSocketServer clients set

### DIFF
--- a/crates/perry-api-manifest/src/entries/part_1.rs
+++ b/crates/perry-api-manifest/src/entries/part_1.rs
@@ -414,6 +414,10 @@ pub(crate) const API_MANIFEST_PART_1: &[ApiEntry] = &[
     method("ws", "send", true, None),
     method("ws", "close", true, None),
     method("ws", "readyState", true, None),
+    // `WebSocketServer.clients` is a data getter. It is represented as a
+    // receiver method internally because native-handle getters dispatch
+    // through the same table as zero-argument methods.
+    internal_method("ws", "clients", true, None),
     // Node-compatible WebSocket ready-state constants. The `ws` package
     // exposes these on both the module/default export and WebSocket class:
     // CONNECTING=0, OPEN=1, CLOSING=2, CLOSED=3.

--- a/crates/perry-codegen/src/ext_registry.rs
+++ b/crates/perry-codegen/src/ext_registry.rs
@@ -504,6 +504,7 @@ const FFI_REGISTRY: &[(&str, OwnerKind)] = &[
     ("js_ws_send_to_client",                        OwnerKind::WellKnown("ws")),
     ("js_ws_close_client",                          OwnerKind::WellKnown("ws")),
     ("js_ws_server_new",                            OwnerKind::WellKnown("ws")),
+    ("js_ws_server_clients",                        OwnerKind::WellKnown("ws")),
     ("js_ws_server_close",                          OwnerKind::WellKnown("ws")),
 
     // ── #1724: global Blob/File + URL object-URL helpers ──────────────

--- a/crates/perry-codegen/src/lower_call/native_table/net_events.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/net_events.rs
@@ -59,6 +59,18 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
         args: &[],
         ret: NR_F64,
     },
+    // #9325 — `WebSocketServer.clients` is a persistent JS Set. HIR only
+    // routes this getter for the WebSocketServer/Server classes, so the table
+    // can use the same generic ws receiver convention as `readyState`.
+    NativeModSig {
+        module: "ws",
+        has_receiver: true,
+        method: "clients",
+        class_filter: None,
+        runtime: "js_ws_server_clients",
+        args: &[],
+        ret: NR_F64,
+    },
     // Issue #577 Phase 4 — `("ws", "Client")` instance methods.
     // The wsId delivered to `Server.on('upgrade', (req, wsId, head) => …)`
     // is NaN-boxed POINTER_TAG so unbox_to_i64 (called by the dispatch

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi/web.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi/web.rs
@@ -129,6 +129,7 @@ pub(crate) fn declare_web(module: &mut LlModule) {
     module.declare_function("js_ws_close_client_i64", VOID, &[I64]);
     module.declare_function("js_ws_on_client_i64", I64, &[I64, I64, I64]);
     module.declare_function("js_ws_server_close", VOID, &[I64]);
+    module.declare_function("js_ws_server_clients", DOUBLE, &[I64]);
     module.declare_function("js_ws_server_new", I64, &[DOUBLE]);
     // #1113 — `wss.handleUpgrade(req, socket, head, cb)`. Receiver
     // (the noServer WsServerHandle) is passed as I64 (post-unbox_to_i64

--- a/crates/perry-ext-ws/src/lib.rs
+++ b/crates/perry-ext-ws/src/lib.rs
@@ -36,8 +36,8 @@ pub mod mask;
 use futures_util::{SinkExt, StreamExt};
 use lazy_static::lazy_static;
 use perry_ffi::{
-    alloc_string, gc_register_mutable_root_scanner_named, get_handle_mut, iter_handles_of_mut,
-    notify_main_thread, register_handle, spawn_async,
+    alloc_set, alloc_string, gc_register_mutable_root_scanner_named, get_handle_mut,
+    iter_handles_of_mut, notify_main_thread, register_handle, set_add, set_delete, spawn_async,
     spawn_blocking_with_reactor as spawn_blocking, take_handle, GcRootVisitor, Handle, JsClosure,
     JsString, JsValue, ObjectHeader, RawClosureHeader, StringHeader,
 };
@@ -99,6 +99,10 @@ pub struct WsServerHandle {
     pub port: u16,
     pub is_listening: bool,
     pub client_ids: Vec<usize>,
+    /// The persistent JavaScript `Set` exposed as `WebSocketServer.clients`.
+    /// Stored as NaN-boxed bits so the mutable-root scanner can rewrite it
+    /// when a moving collection evacuates the Set header.
+    pub clients_bits: u64,
     pub shutdown_tx: Option<mpsc::UnboundedSender<()>>,
 }
 
@@ -145,6 +149,7 @@ fn scan_ws_roots(visitor: &mut GcRootVisitor<'_>) {
         }
     }
     iter_handles_of_mut::<WsServerHandle, _>(|server| {
+        visitor.visit_nanbox_u64_slot(&mut server.clients_bits);
         for cb_vec in server.listeners.values_mut() {
             for cb in cb_vec.iter_mut() {
                 visitor.visit_i64_slot(cb);
@@ -156,6 +161,55 @@ fn scan_ws_roots(visitor: &mut GcRootVisitor<'_>) {
 fn push_ws_event(ev: PendingWsEvent) {
     WS_PENDING_EVENTS.lock().unwrap().push(ev);
     notify_main_thread();
+}
+
+#[inline]
+fn client_js_value(ws_id: usize) -> JsValue {
+    // Server-side clients are represented throughout this wrapper as ordinary
+    // numeric handles (the same value delivered to `connection` listeners).
+    JsValue::from_number(ws_id as f64)
+}
+
+/// Add a connection to a server's persistent JS-visible clients Set.
+///
+/// This runs only on the JS/main thread: either while handling
+/// `handleUpgrade`, or while draining a queued standalone-server connection.
+fn track_server_client(server_handle: Handle, ws_id: usize) {
+    let clients_bits = if let Some(server) = get_handle_mut::<WsServerHandle>(server_handle) {
+        if !server.client_ids.contains(&ws_id) {
+            server.client_ids.push(ws_id);
+        }
+        server.clients_bits
+    } else {
+        return;
+    };
+
+    // Do not hold a handle-registry guard across a runtime collection point:
+    // Set growth can notify the GC, whose ws scanner walks this same registry.
+    let updated = set_add(JsValue::from_bits(clients_bits), client_js_value(ws_id));
+    if !updated.is_undefined() && updated.bits() != clients_bits {
+        if let Some(server) = get_handle_mut::<WsServerHandle>(server_handle) {
+            server.clients_bits = updated.bits();
+        }
+    }
+}
+
+/// Remove a connection from its parent server and return that parent for
+/// dispatching the server-level close event after the bookkeeping is current.
+fn untrack_server_client(ws_id: usize) -> Option<Handle> {
+    let parent = WS_CLIENT_PARENT_SERVER.lock().unwrap().remove(&ws_id);
+    if let Some(server_handle) = parent {
+        let clients_bits = get_handle_mut::<WsServerHandle>(server_handle).map(|server| {
+            server.client_ids.retain(|client_id| *client_id != ws_id);
+            server.clients_bits
+        });
+        if let Some(clients_bits) = clients_bits {
+            // Keep runtime collection points outside the registry guard; see
+            // the matching add path above.
+            set_delete(JsValue::from_bits(clients_bits), client_js_value(ws_id));
+        }
+    }
+    parent
 }
 
 // ── Client connect ────────────────────────────────────────────────
@@ -690,6 +744,7 @@ pub extern "C" fn js_ws_server_new(opts_f64: f64) -> Handle {
     ensure_gc_scanner_registered();
     let port = extract_port(opts_f64);
     let no_server = extract_no_server(opts_f64);
+    let clients_bits = alloc_set(4).bits();
 
     if no_server || port == 0 {
         // Listener-only handle — no bind, no accept loop, no shutdown
@@ -700,6 +755,7 @@ pub extern "C" fn js_ws_server_new(opts_f64: f64) -> Handle {
             port: 0,
             is_listening: false,
             client_ids: Vec::new(),
+            clients_bits,
             shutdown_tx: None,
         });
     }
@@ -710,6 +766,7 @@ pub extern "C" fn js_ws_server_new(opts_f64: f64) -> Handle {
         port,
         is_listening: false,
         client_ids: Vec::new(),
+        clients_bits,
         shutdown_tx: Some(shutdown_tx),
     });
     WS_ACTIVE_SERVERS.fetch_add(1, Ordering::Relaxed);
@@ -795,6 +852,17 @@ pub extern "C" fn js_ws_server_new(opts_f64: f64) -> Handle {
         });
     });
     server_handle
+}
+
+/// Return the persistent `Set` exposed as `WebSocketServer.clients`.
+///
+/// The Set is allocated with the server, updated before connection/close
+/// callbacks run, and rooted through the server handle for its full lifetime.
+#[no_mangle]
+pub extern "C" fn js_ws_server_clients(handle: i64) -> f64 {
+    get_handle_mut::<WsServerHandle>(handle)
+        .map(|server| f64::from_bits(server.clients_bits))
+        .unwrap_or_else(|| f64::from_bits(JsValue::UNDEFINED.bits()))
 }
 
 fn extract_port(opts_f64: f64) -> u16 {
@@ -1090,11 +1158,9 @@ pub unsafe extern "C" fn js_ws_handle_upgrade(
         .lock()
         .unwrap()
         .insert(ws_id, server_handle);
-    if let Some(s) = get_handle_mut::<WsServerHandle>(server_handle) {
-        if !s.client_ids.contains(&ws_id) {
-            s.client_ids.push(ws_id);
-        }
-    }
+    // `ws` adds the socket to `clients` before invoking handleUpgrade's
+    // callback. Keep that ordering so the callback observes itself in the Set.
+    track_server_client(server_handle, ws_id);
 
     if cb != 0 {
         // Accept either a NaN-boxed POINTER_TAG closure or a raw
@@ -1135,6 +1201,9 @@ pub extern "C" fn js_ws_process_pending() -> i32 {
     for ev in events {
         match ev {
             PendingWsEvent::Connection(server_handle, client_id) => {
+                // Match `ws`: clients is current before the user-visible
+                // `connection` callback fires.
+                track_server_client(server_handle, client_id);
                 let listeners = listeners_on_server(server_handle, "connection");
                 for cb in listeners {
                     if cb != 0 {
@@ -1176,6 +1245,10 @@ pub extern "C" fn js_ws_process_pending() -> i32 {
                 }
             }
             PendingWsEvent::Close(ws_id, _code, _reason) => {
+                // The upstream `ws` package installs its tracking listener
+                // before handing the socket to user code, so user close
+                // callbacks observe the client as already removed.
+                let parent = untrack_server_client(ws_id);
                 let listeners = listeners_on_client(ws_id, "close");
                 if !listeners.is_empty() {
                     for cb in listeners {
@@ -1189,7 +1262,6 @@ pub extern "C" fn js_ws_process_pending() -> i32 {
                 } else {
                     // #746 follow-up: server-level `wss.on('close',
                     // (ws) => ...)` parity with perry-stdlib::ws.
-                    let parent = WS_CLIENT_PARENT_SERVER.lock().unwrap().get(&ws_id).copied();
                     if let Some(server_handle) = parent {
                         for cb in listeners_on_server(server_handle, "close") {
                             if cb != 0 {
@@ -1203,7 +1275,6 @@ pub extern "C" fn js_ws_process_pending() -> i32 {
                 }
                 WS_CONNECTIONS.lock().unwrap().remove(&ws_id);
                 WS_CLIENT_LISTENERS.lock().unwrap().remove(&ws_id);
-                WS_CLIENT_PARENT_SERVER.lock().unwrap().remove(&ws_id);
             }
             PendingWsEvent::Error(ws_id, err) => {
                 let listeners = listeners_on_client(ws_id, "error");
@@ -1359,11 +1430,13 @@ mod tests {
         );
 
         let server_callback = young_gc_root();
+        let clients_before = alloc_set(4).bits();
         let server_handle = register_handle(WsServerHandle {
             listeners: HashMap::from([("connection".to_string(), vec![server_callback])]),
             port: 0,
             is_listening: false,
             client_ids: Vec::new(),
+            clients_bits: clients_before,
             shutdown_tx: None,
         });
 
@@ -1375,8 +1448,47 @@ mod tests {
             let server = get_handle::<WsServerHandle>(server_handle)
                 .expect("server handle should remain live");
             assert_rewritten(server_callback, server.listeners["connection"][0]);
+            assert_ne!(server.clients_bits, clients_before);
+            let clients = JsValue::from_bits(server.clients_bits)
+                .as_pointer::<perry_runtime::set::SetHeader>();
+            assert_eq!(perry_runtime::set::js_set_size(clients), 0);
         }
         WS_CLIENT_LISTENERS.lock().unwrap().remove(&client_id);
+        drop_handle(server_handle);
+    }
+
+    #[test]
+    fn server_clients_is_a_stable_set_that_tracks_connections() {
+        let _lock = GC_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let undefined = f64::from_bits(JsValue::UNDEFINED.bits());
+        let server_handle = js_ws_server_new(undefined);
+
+        let first = js_ws_server_clients(server_handle);
+        let second = js_ws_server_clients(server_handle);
+        assert_eq!(first.to_bits(), second.to_bits());
+        let clients =
+            JsValue::from_bits(first.to_bits()).as_pointer::<perry_runtime::set::SetHeader>();
+        assert!(!clients.is_null());
+        assert_eq!(perry_runtime::set::js_set_size(clients), 0);
+
+        let client_id = 9_325_001;
+        track_server_client(server_handle, client_id);
+        let clients = JsValue::from_bits(js_ws_server_clients(server_handle).to_bits())
+            .as_pointer::<perry_runtime::set::SetHeader>();
+        assert_eq!(perry_runtime::set::js_set_size(clients), 1);
+        assert_eq!(perry_runtime::set::js_set_has(clients, client_id as f64), 1);
+
+        WS_CLIENT_PARENT_SERVER
+            .lock()
+            .unwrap()
+            .insert(client_id, server_handle);
+        assert_eq!(untrack_server_client(client_id), Some(server_handle));
+        let clients = JsValue::from_bits(js_ws_server_clients(server_handle).to_bits())
+            .as_pointer::<perry_runtime::set::SetHeader>();
+        assert_eq!(perry_runtime::set::js_set_size(clients), 0);
+
         drop_handle(server_handle);
     }
 

--- a/crates/perry-ffi/src/jsvalue.rs
+++ b/crates/perry-ffi/src/jsvalue.rs
@@ -365,6 +365,63 @@ extern "C" {
     fn js_object_alloc_null_proto(class_id: u32, field_count: u32) -> *mut ObjectHeader;
     fn js_object_set_keys(obj: *mut ObjectHeader, keys_array: *mut ArrayHeader);
     fn js_object_get_field_by_name(obj: *const ObjectHeader, key: *const StringHeader) -> JsValue;
+
+    #[link_name = "js_set_alloc"]
+    fn runtime_js_set_alloc(capacity: u32) -> *mut RuntimeSetHeader;
+    #[link_name = "js_set_add"]
+    fn runtime_js_set_add(set: *mut RuntimeSetHeader, value: f64) -> *mut RuntimeSetHeader;
+    #[link_name = "js_set_delete"]
+    fn runtime_js_set_delete(set: *mut RuntimeSetHeader, value: f64) -> i32;
+}
+
+/// Opaque header for a runtime-owned JavaScript `Set`.
+///
+/// Native wrappers never inspect this layout; the type only prevents a set
+/// pointer from being confused with an ordinary object pointer at the FFI
+/// boundary.
+#[repr(C)]
+struct RuntimeSetHeader {
+    _private: [u8; 0],
+}
+
+/// Allocate an empty JavaScript `Set` with an initial capacity hint.
+///
+/// The returned value is a normal NaN-boxed JavaScript object and must be kept
+/// in a GC-visible slot whenever a native wrapper retains it across calls.
+pub fn alloc_set(capacity: u32) -> JsValue {
+    let set = unsafe { runtime_js_set_alloc(capacity) };
+    if set.is_null() {
+        JsValue::UNDEFINED
+    } else {
+        JsValue::from_object_ptr(set)
+    }
+}
+
+/// Add `value` to a JavaScript `Set` allocated by [`alloc_set`].
+///
+/// Returns the set value so callers can retain the runtime's current pointer.
+/// Passing a non-pointer value is a no-op and returns `undefined`.
+pub fn set_add(set: JsValue, value: JsValue) -> JsValue {
+    let set_ptr = set.as_pointer::<RuntimeSetHeader>();
+    if set_ptr.is_null() {
+        return JsValue::UNDEFINED;
+    }
+    let updated = unsafe { runtime_js_set_add(set_ptr, f64::from_bits(value.bits())) };
+    if updated.is_null() {
+        JsValue::UNDEFINED
+    } else {
+        JsValue::from_object_ptr(updated)
+    }
+}
+
+/// Delete `value` from a JavaScript `Set` allocated by [`alloc_set`].
+///
+/// Returns whether the value was present. Passing a non-pointer value is a
+/// no-op that returns `false`.
+pub fn set_delete(set: JsValue, value: JsValue) -> bool {
+    let set_ptr = set.as_pointer::<RuntimeSetHeader>();
+    !set_ptr.is_null()
+        && unsafe { runtime_js_set_delete(set_ptr, f64::from_bits(value.bits())) != 0 }
 }
 
 /// Compute `(packed_keys_bytes, shape_id)` for use with

--- a/crates/perry-ffi/src/lib.rs
+++ b/crates/perry-ffi/src/lib.rs
@@ -72,10 +72,10 @@ pub use handle::{
 
 mod jsvalue;
 pub use jsvalue::{
-    alloc_null_proto_object, alloc_object, build_object_shape, js_array_alloc, js_array_get,
-    js_array_length, js_array_push, js_array_set, js_object_alloc_with_shape, js_object_get_field,
-    js_object_live_slot_count, js_object_set_field, object_field_by_name, JsValue,
-    SHORT_STRING_MAX_LEN,
+    alloc_null_proto_object, alloc_object, alloc_set, build_object_shape, js_array_alloc,
+    js_array_get, js_array_length, js_array_push, js_array_set, js_object_alloc_with_shape,
+    js_object_get_field, js_object_live_slot_count, js_object_set_field, object_field_by_name,
+    set_add, set_delete, JsValue, SHORT_STRING_MAX_LEN,
 };
 
 mod closure;

--- a/crates/perry-hir/src/lower/expr_member/native_dispatch.rs
+++ b/crates/perry-hir/src/lower/expr_member/native_dispatch.rs
@@ -109,13 +109,18 @@ pub(crate) fn is_native_dispatch_member(module: &str, class: &str, prop: &str) -
             "Agent" => matches!(prop, "createConnection" | "createSocket"),
             _ => true,
         },
-        // #6117 — ws client instances: `readyState` is a native data getter
-        // (npm ws: CONNECTING=0 / OPEN=1 / CLOSING=2 / CLOSED=3) dispatched
-        // to `js_ws_ready_state`. Server instances expose no readyState, and
-        // every other bare member read stays a plain PropertyGet (method
-        // CALLS like `ws.send(..)` arrive via the call-expression path, not
-        // this bare-read block).
-        "ws" => prop == "readyState" && !matches!(class, "WebSocketServer" | "Server"),
+        // #6117 / #9325 — native data getters on ws handles. Client instances
+        // expose `readyState`; server instances expose the persistent
+        // connection-tracking `clients` Set. Every other bare member read
+        // stays a plain PropertyGet (method CALLS like `ws.send(..)` arrive
+        // through the call-expression path, not this bare-read block).
+        "ws" => {
+            if matches!(class, "WebSocketServer" | "Server") {
+                prop == "clients"
+            } else {
+                prop == "readyState"
+            }
+        }
         // events / net instances dispatch their EventEmitter / socket methods
         // and getters through the class_filter table. These modules expose no
         // user own-property surface in the bundle walls, so keep dispatching
@@ -632,5 +637,22 @@ mod tests {
         assert!(!is_native_dispatch_member("lru-cache", "LRUCache", "set"));
         assert!(!is_native_dispatch_member("lru-cache", "LRUCache", "has"));
         assert!(!is_native_dispatch_member("lru-cache", "LRUCache", "clear"));
+    }
+
+    #[test]
+    fn ws_dispatches_client_and_server_data_getters_separately() {
+        assert!(is_native_dispatch_member("ws", "WebSocket", "readyState"));
+        assert!(!is_native_dispatch_member("ws", "WebSocket", "clients"));
+        assert!(is_native_dispatch_member(
+            "ws",
+            "WebSocketServer",
+            "clients"
+        ));
+        assert!(is_native_dispatch_member("ws", "Server", "clients"));
+        assert!(!is_native_dispatch_member(
+            "ws",
+            "WebSocketServer",
+            "readyState"
+        ));
     }
 }

--- a/crates/perry-runtime/src/stdlib_stubs.rs
+++ b/crates/perry-runtime/src/stdlib_stubs.rs
@@ -110,6 +110,12 @@ mod ws_stubs {
     }
 
     #[no_mangle]
+    pub extern "C" fn js_ws_server_clients(_handle: i64) -> f64 {
+        perry_stub_warn("js_ws_server_clients", WS_REASON, None);
+        f64::from_bits(crate::value::TAG_UNDEFINED)
+    }
+
+    #[no_mangle]
     pub extern "C" fn js_ws_server_close(_handle: i64) {
         perry_stub_warn("js_ws_server_close", WS_REASON, None);
     }

--- a/crates/perry-stdlib/src/ws.rs
+++ b/crates/perry-stdlib/src/ws.rs
@@ -5,6 +5,8 @@
 
 #[cfg(not(target_os = "ios"))]
 use futures_util::{SinkExt, StreamExt};
+#[cfg(not(target_os = "ios"))]
+use perry_runtime::set::{js_set_add, js_set_alloc, js_set_delete, SetHeader};
 use perry_runtime::{
     js_closure_call0, js_closure_call1, js_closure_call2, js_string_from_bytes, ClosureHeader,
     JSValue, StringHeader,
@@ -119,6 +121,7 @@ fn scan_ws_roots_mut(visitor: &mut perry_runtime::gc::RuntimeRootVisitor<'_>) {
     }
 
     for_each_handle_mut_of::<WsServerHandle, _>(|server| {
+        visitor.visit_nanbox_u64_slot(&mut server.clients_bits);
         for cb_vec in server.listeners.values_mut() {
             for cb in cb_vec.iter_mut() {
                 visitor.visit_i64_slot(cb);
@@ -164,6 +167,9 @@ pub struct WsServerHandle {
     pub is_listening: bool,
     /// Track connected client IDs for cleanup
     pub client_ids: Vec<usize>,
+    /// Persistent JS `Set` exposed through `WebSocketServer.clients`.
+    /// NaN-boxed so the mutable-root scanner can rewrite a moved header.
+    pub clients_bits: u64,
     /// Shutdown signal sender
     pub shutdown_tx: Option<mpsc::UnboundedSender<()>>,
 }
@@ -219,8 +225,39 @@ fn cleanup_ws_client(ws_id: usize) {
 
     let parent = WS_CLIENT_PARENT_SERVER.lock().unwrap().remove(&ws_id);
     if let Some(server_handle) = parent {
-        if let Some(server) = get_handle_mut::<WsServerHandle>(server_handle) {
+        let clients_bits = get_handle_mut::<WsServerHandle>(server_handle).map(|server| {
             server.client_ids.retain(|client_id| *client_id != ws_id);
+            server.clients_bits
+        });
+        if let Some(clients_bits) = clients_bits {
+            let clients =
+                JSValue::from_bits(clients_bits).as_pointer::<SetHeader>() as *mut SetHeader;
+            js_set_delete(clients, ws_id as f64);
+        }
+    }
+}
+
+#[cfg(not(target_os = "ios"))]
+fn new_server_clients_set() -> u64 {
+    JSValue::pointer(js_set_alloc(4) as *const u8).bits()
+}
+
+#[cfg(not(target_os = "ios"))]
+fn track_server_client(server_handle: Handle, ws_id: usize) {
+    let clients_bits = if let Some(server) = get_handle_mut::<WsServerHandle>(server_handle) {
+        if !server.client_ids.contains(&ws_id) {
+            server.client_ids.push(ws_id);
+        }
+        server.clients_bits
+    } else {
+        return;
+    };
+    let clients = JSValue::from_bits(clients_bits).as_pointer::<SetHeader>() as *mut SetHeader;
+    let updated = js_set_add(clients, ws_id as f64);
+    let updated_bits = JSValue::pointer(updated as *const u8).bits();
+    if updated_bits != clients_bits {
+        if let Some(server) = get_handle_mut::<WsServerHandle>(server_handle) {
+            server.clients_bits = updated_bits;
         }
     }
 }
@@ -1033,6 +1070,7 @@ pub unsafe extern "C" fn js_ws_server_new(opts_f64: f64) -> Handle {
         port,
         is_listening: false,
         client_ids: Vec::new(),
+        clients_bits: new_server_clients_set(),
         shutdown_tx: Some(shutdown_tx),
     });
     WS_ACTIVE_SERVERS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -1228,6 +1266,15 @@ pub unsafe extern "C" fn js_ws_server_new(opts_f64: f64) -> Handle {
     server_handle
 }
 
+/// Return the persistent `Set` exposed as `WebSocketServer.clients`.
+#[cfg(not(target_os = "ios"))]
+#[no_mangle]
+pub extern "C" fn js_ws_server_clients(handle: i64) -> f64 {
+    get_handle_mut::<WsServerHandle>(handle)
+        .map(|server| f64::from_bits(server.clients_bits))
+        .unwrap_or_else(|| f64::from_bits(JSValue::undefined().bits()))
+}
+
 /// Close the WebSocketServer and all its client connections
 /// wss.close(callback?) -> void
 #[cfg(not(target_os = "ios"))]
@@ -1310,6 +1357,9 @@ pub unsafe extern "C" fn js_ws_process_pending() -> i32 {
     for event in events.drain(..) {
         match event {
             PendingWsEvent::Connection(server_handle, client_ws_id) => {
+                // Keep `clients` current before invoking user connection
+                // listeners, matching the ordering in the npm `ws` package.
+                track_server_client(server_handle, client_ws_id);
                 // Get 'connection' listeners from server
                 let listeners: Vec<i64> = get_handle_mut::<WsServerHandle>(server_handle)
                     .and_then(|s| s.listeners.get("connection").cloned())
@@ -1529,6 +1579,7 @@ mod tests {
             port: 0,
             is_listening: false,
             client_ids: Vec::new(),
+            clients_bits: new_server_clients_set(),
             shutdown_tx: None,
         });
 
@@ -1553,6 +1604,7 @@ mod tests {
             port: 0,
             is_listening: false,
             client_ids: vec![client_id],
+            clients_bits: new_server_clients_set(),
             shutdown_tx: None,
         });
 

--- a/crates/perry/tests/issue_9325_ws_server_clients.rs
+++ b/crates/perry/tests/issue_9325_ws_server_clients.rs
@@ -1,0 +1,76 @@
+//! Regression test for #9325: `WebSocketServer.clients` must be the stable,
+//! iterable `Set` that npm `ws` exposes, even before any client connects.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonicalize workspace root")
+}
+
+fn compile_and_run(dir: &Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-cache")
+        .env_remove("PERRY_NO_AUTO_OPTIMIZE")
+        .env("PERRY_WORKSPACE_ROOT", workspace_root())
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+#[test]
+fn websocket_server_clients_is_a_stable_iterable_set() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+import { WebSocketServer } from "ws";
+
+const wss = new WebSocketServer({ port: 0 });
+const first = wss.clients;
+const second = wss.clients;
+
+console.log(Object.prototype.toString.call(first));
+console.log(typeof first[Symbol.iterator]);
+let count = 0;
+for (const _client of first) count += 1;
+console.log(first === second, count, first.size);
+"#,
+    );
+
+    assert_eq!(stdout, "[object Set]\nfunction\ntrue 0 0\n");
+}


### PR DESCRIPTION
## Summary

- expose a stable, iterable WebSocketServer.clients Set
- keep connected clients synchronized before connection and close callbacks
- root the Set across GC in both the ws extension and bundled fallback
- add an end-to-end regression for the issue repro
- no version bump

## Testing

- cargo fmt --all -- --check
- cargo check -p perry-ext-ws --lib
- cargo check -p perry-stdlib --lib
- cargo test -p perry --test issue_9325_ws_server_clients
- cargo test -p perry-hir ws_dispatches_client_and_server_data_getters_separately
- cargo test -p perry-codegen --test manifest_consistency
- cargo test -p perry-ffi --features runtime-link

Fixes #9325

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `WebSocketServer.clients` through the `ws` API.
  * The property now returns a stable, iterable `Set`, including before any clients connect.
  * Connected clients are added before connection handlers run and removed when connections close.

* **Bug Fixes**
  * Improved WebSocket client tracking to keep the exposed client collection accurate throughout each connection’s lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->