### PR TITLE
fix: keep main green after #9329

### DIFF
--- a/changelog.d/9330-9329-followup.md
+++ b/changelog.d/9330-9329-followup.md
@@ -1,0 +1,15 @@
+### Internal
+
+- **Scopes the dyn-IC refresh key read.** #9329's pre-scope shortcut hands
+  re-rooted operands back on a miss, and read the key pointer into a local to
+  build that tuple — one over `fast_paths.rs`'s raw-handle ceiling of 8. The
+  read now happens inside `with_const_ptr`, which is the idiom for exactly this
+  shape: a raw pointer whose validity window is one non-allocating callback.
+
+- **Classifies `TEST_TRANSITION_FAST_HITS`** in the root-holder inventory. It
+  is a `cfg(test)` `Cell<u64>` hit counter, holds no JSValue, and does not
+  exist in a release build.
+
+- **Gates the now-test-only transition wrapper.** #9329 moved the production
+  caller to the value-returning form, leaving the `i32` wrapper reachable only
+  from the transition tests — an unused-function error under `-D warnings`.

--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -27,7 +27,6 @@ pub use attr_variants::{
 };
 pub use fast_paths::js_object_set_field_by_name_transition_fast;
 pub(crate) use fast_paths::{
-    object_set_field_by_name_transition_only_fast,
     object_set_field_by_name_transition_only_fast_value, try_existing_own_data_overwrite,
     try_readd_stable_tombstone,
 };

--- a/crates/perry-runtime/src/object/field_set_by_name/fast_paths.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name/fast_paths.rs
@@ -170,6 +170,9 @@ pub extern "C" fn js_object_set_field_by_name_transition_fast(
 /// `(current_keys, key)`, so the lookup returns 0 and the caller performs the
 /// ordinary write. Skipping the up-front linear overwrite scan is important
 /// for repeated computed-key object construction.
+// #9287 moved the production caller to the value-returning form; this i32
+// wrapper survives only as the shape the transition tests assert against.
+#[cfg(test)]
 pub(crate) fn object_set_field_by_name_transition_only_fast(
     obj: *mut ObjectHeader,
     key: *const crate::StringHeader,

--- a/crates/perry-runtime/src/object/field_set_by_name/fast_paths.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name/fast_paths.rs
@@ -591,14 +591,17 @@ fn object_set_field_by_name_transition_fast_impl_value(
         // still follow. A pre-scope caller's raw f64 operands may be stale
         // after it, so hand back re-rooted copies for the caller's fallback
         // ladder — set unconditionally, so the caller's use is uniform.
-        {
-            let key_now = key_handle.get_raw_const_ptr::<crate::StringHeader>();
-            *refresh = Some((
-                crate::value::js_nanbox_pointer(obj as i64),
-                crate::value::js_nanbox_string(key_now as i64),
-                value_handle.get_nanbox_f64(),
-            ));
-        }
+        // The key pointer is only valid for the duration of this
+        // non-allocating tuple build, so scope it rather than binding it.
+        *refresh = Some(
+            key_handle.with_const_ptr::<crate::StringHeader, _>(|key_now| {
+                (
+                    crate::value::js_nanbox_pointer(obj as i64),
+                    crate::value::js_nanbox_string(key_now as i64),
+                    value_handle.get_nanbox_f64(),
+                )
+            }),
+        );
         let value = value_handle.get_nanbox_f64();
 
         let prev_shape_id = super::shapes::object_shape_stamp(obj);

--- a/scripts/gc_runtime_root_holders.json
+++ b/scripts/gc_runtime_root_holders.json
@@ -295,6 +295,12 @@
       "why": "Source order for Symbol-keyed class members: HashMap<(class_id, SymbolHeader::id, is_static), u32>. The u64 is the symbol's stable id (read once at registration in record_class_symbol_member_order), NOT its address, so the table needs no re-key when a Symbol is evacuated; the value is an order index. The member values themselves live in CLASS_SYMBOL_METHODS/CLASS_SYMBOL_ACCESSORS, which scan_class_symbol_member_keys_mut visits and rewrite_class_symbol_method_key_if_forwarded re-keys."
     },
     {
+      "file": "crates/perry-runtime/src/object/field_set_by_name/fast_paths.rs",
+      "name": "TEST_TRANSITION_FAST_HITS",
+      "verdict": "not_a_gc_pointer",
+      "why": "#[cfg(test)] hit counter for the learned shape-transition fast path: a thread_local Cell<u64> incremented on each hit and reset by test_reset_transition_fast_hits. Holds a count, never a JSValue or heap pointer, and does not exist in a release build."
+    },
+    {
       "file": "crates/perry-runtime/src/object/global_this/fetch_globals.rs",
       "name": "TEST_COLLECT_BEFORE_GLOBAL_THIS_ALLOC",
       "verdict": "test_only",


### PR DESCRIPTION
Three things #9329 needs to keep `main` green. All were validated with it as one build before it merged.

**The raw-handle ceiling.** The pre-scope shortcut hands re-rooted operands back on a miss, and built that tuple from a key pointer read into a local — taking `fast_paths.rs` to 9 against its ceiling of 8. The read now happens inside `with_const_ptr`, which is the ratchet's own idiom for this shape: a raw pointer whose validity window is a single non-allocating callback. Real work happens inside the closure, so this is the intended use rather than a wrapper that satisfies the regex and changes nothing. Debt returns to 963 with no ceiling touched.

**`TEST_TRANSITION_FAST_HITS`** became newly visible to `gc_runtime_root_holders.py`. It is a `cfg(test)` `Cell<u64>` hit counter — no JSValue, and absent from release builds — so it gets a `not_a_gc_pointer` verdict.

**An unused-function error.** #9329 moved the production caller to the value-returning form, leaving the `i32` wrapper reachable only from the transition tests. `-D warnings` rejects both it and its re-export; the wrapper is now `#[cfg(test)]`.

**On the change itself:** I checked the rooting argument rather than the benchmark, since moving work *before* rooting is the shape that breaks root-store dominance. It holds. The pre-checks that can decline are allocation-free, so a caller's raw operands are still valid on an early miss; `js_string_intern` — the one call the comment flags as an allocation point — turns out not to allocate at all (fixed-size direct-mapped table, no heap traffic); `refresh` is set unconditionally after it, so every later decline hands back re-rooted operands; and the success path re-reads the value through the function's own root. The caller uses the refreshed triple rather than its originals.

`perry-runtime` 8 suites green under `RUST_TEST_THREADS=1`; release build clean with no warnings; file-size, raw-handle (all three invocations), root-holder, shape-census, unrooted-local and fmt gates pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of optimized property updates.
  * Prevented test-only performance counters from affecting release builds.
* **Tests**
  * Updated test instrumentation and runtime checks for optimized field transitions.
* **Documentation**
  * Added changelog notes describing the runtime and testing updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->