### PR TITLE
fix(runtime): preserve array prototypes across growth

### DIFF
--- a/changelog.d/9340-array-growth-prototype.md
+++ b/changelog.d/9340-array-growth-prototype.md
@@ -1,0 +1,11 @@
+### fix(runtime): preserve custom array prototypes across growth
+
+Growing an array's dense element storage now transfers its recorded
+`[[Prototype]]` metadata to the replacement allocation. Moving GC now
+rekeys and traces the same metadata for arrays as well. An array retargeted
+with `Object.setPrototypeOf`, `Reflect.setPrototypeOf`, or `__proto__`
+therefore keeps that exact prototype across collection and after an indexed
+write or array mutator reallocates its backing storage.
+
+In particular, an explicit null prototype no longer silently regains
+`Array.prototype` when the array grows. Fixes #9304.

--- a/crates/perry-runtime/src/gc/layout.rs
+++ b/crates/perry-runtime/src/gc/layout.rs
@@ -1278,6 +1278,13 @@ pub(crate) unsafe fn layout_transfer(old_user: *mut u8, new_user: *mut u8) {
         // record is address-keyed and has to follow the move — same split,
         // and same call site, as `TYPED_LAYOUTS` below.
         crate::array::transfer_element_shape(old_user as usize, new_user as usize);
+        // #9304: real arrays keep explicit [[Prototype]] values in the
+        // residual address-keyed registry. Array growth and moving GC both
+        // replace the owner allocation through this transfer hook.
+        crate::object::prototype_chain::object_static_prototype_owner_moved(
+            old_user as usize,
+            new_user as usize,
+        );
     } else {
         crate::array::clear_array_numeric_layout_ptr(new_user as usize);
         crate::array::clear_element_shape_ptr(new_user as usize);

--- a/crates/perry-runtime/src/gc/layout_slot_visit.rs
+++ b/crates/perry-runtime/src/gc/layout_slot_visit.rs
@@ -151,6 +151,16 @@ pub(super) unsafe fn visit_gc_rewrite_slot_descriptors(
     match gc_type_rewrite_descriptor_kind((*header).obj_type) {
         GcRewriteDescriptorKind::Array => {
             visit_gc_layout_slot_descriptors(header, &mut visit);
+            // #9304: unlike shaped objects, real arrays keep an explicit
+            // [[Prototype]] in the residual side table. Treat that value as
+            // the array's child edge so collection retains and rewrites a
+            // movable custom prototype after layout_transfer rekeys its owner.
+            crate::object::prototype_chain::visit_object_static_prototype_slot_mut(
+                user_ptr as usize,
+                |slot| {
+                    visit(fixed_slot(slot));
+                },
+            );
         }
         GcRewriteDescriptorKind::Object => {
             // #6759 Phase B / #6812: the per-object meta record is a raw-

--- a/crates/perry-runtime/src/object/field_get_set/array_retargeted_proto.rs
+++ b/crates/perry-runtime/src/object/field_get_set/array_retargeted_proto.rs
@@ -8,6 +8,28 @@
 use super::accessors::array_prototype_property_value;
 use crate::value::JSValue;
 
+/// Follow an array-growth forwarding stub before any address-keyed property or
+/// `[[Prototype]]` lookup.
+///
+/// # Safety
+/// `obj` must point to the user payload of a tracked `GC_TYPE_ARRAY` block.
+#[inline]
+pub(super) unsafe fn live_array_owner(
+    obj: *const crate::object::ObjectHeader,
+) -> Option<*const crate::object::ObjectHeader> {
+    let gc_header =
+        unsafe { (obj as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader };
+    if unsafe { (*gc_header).gc_flags } & crate::gc::GC_FLAG_FORWARDED == 0 {
+        return Some(obj);
+    }
+
+    // #9304: growth leaves aliases at the old allocation while the residual
+    // side tables follow the replacement. Resolve that forwarding edge once
+    // for all of the array branch's own-property and prototype-chain probes.
+    let live = crate::array::clean_arr_ptr(obj as *const crate::array::ArrayHeader);
+    (!live.is_null()).then_some(live as *const crate::object::ObjectHeader)
+}
+
 /// `arr.__proto__` IS the array's `[[Prototype]]` — the spec models it as an
 /// `Object.prototype` accessor returning `[[GetPrototypeOf]](this)`. Without
 /// this a retargeted array reported the WRONG object while

--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
@@ -870,13 +870,13 @@ pub(crate) fn get_field_by_name_object_tail(
             }
             return JSValue::undefined();
         }
-        // Arrays: handle `.length` so dynamic property access on a
-        // typed-Any local returned from `JSON.parse("[1,2,3]")` picks
-        // up the real length instead of falling through to object
-        // field lookup and returning undefined. The array-length
-        // inline fast path in codegen fires only when the type is
-        // statically known, so this branch catches the dynamic case.
+        // Arrays: dynamic `.length` access on a typed-Any local returned by
+        // `JSON.parse("[1,2,3]")` must read the array instead of an object field.
+        // The codegen inline fast path only covers statically known array types.
         if gc_type == crate::gc::GC_TYPE_ARRAY {
+            let Some(obj) = super::array_retargeted_proto::live_array_owner(obj) else {
+                return JSValue::undefined();
+            };
             if !key.is_null() {
                 // #7498: OWNED — this is the `[...obj.arr]` arm, and it hands
                 // `key_bytes`/`name` to `array_prototype_property_value` and

--- a/crates/perry-runtime/src/object/object_ops/prototype.rs
+++ b/crates/perry-runtime/src/object/object_ops/prototype.rs
@@ -446,6 +446,10 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
     //    form here too.
     if top16 == 0x7FFD {
         let raw_addr = bits & 0x0000_FFFF_FFFF_FFFF;
+        // #9304: ArrayHeader growth leaves aliases pointing at a forwarding
+        // stub while the address-keyed [[Prototype]] entry follows the live
+        // allocation. Canonicalize before any registry lookup.
+        let raw_addr = crate::value::resolve_forwarding(raw_addr as usize) as u64;
         if raw_addr != 0 && raw_addr >= (crate::gc::GC_HEADER_SIZE as u64) + 0x1000 {
             if let Some(proto) = typed_array_instance_prototype(raw_addr as usize) {
                 return proto;
@@ -649,6 +653,8 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
         }
     }
     if top16 == 0 && bits >= (crate::gc::GC_HEADER_SIZE as u64) + 0x1000 {
+        // Module-level arrays use raw pointers and need the same canonical key.
+        let bits = crate::value::resolve_forwarding(bits as usize) as u64;
         if let Some(proto) = typed_array_instance_prototype(bits as usize) {
             return proto;
         }

--- a/crates/perry-runtime/src/object/prototype_chain.rs
+++ b/crates/perry-runtime/src/object/prototype_chain.rs
@@ -380,8 +380,9 @@ pub(crate) fn prune_dead_object_prototype_owners(is_dead_owner: &dyn Fn(usize) -
     }
 }
 
-/// Migrate the side-table entry when the owner object is evacuated by a moving
-/// GC. Mirrors `closure_dynamic_props_owner_moved`.
+/// Migrate the residual side-table entry when an owner's allocation address
+/// changes, either through moving GC or an `ArrayHeader` growth replacement.
+/// Mirrors `closure_dynamic_props_owner_moved`.
 pub(crate) fn object_static_prototype_owner_moved(old_owner: usize, new_owner: usize) {
     if old_owner == 0 || new_owner == 0 || old_owner == new_owner {
         return;

--- a/test-files/test_gap_9304_array_growth_prototype.ts
+++ b/test-files/test_gap_9304_array_growth_prototype.ts
@@ -1,0 +1,57 @@
+// parity-env: PERRY_GC_FORCE_EVACUATE=1 PERRY_GC_VERIFY_EVACUATION=1 PERRY_GC_PROTECT_FROMSPACE=1
+// #9304: replacing an ArrayHeader during dense growth must carry its recorded
+// [[Prototype]] entry to the new owner address. The element copy already kept
+// the indexed values and length, but the address-keyed prototype registry was
+// left on the forwarding stub, so the live array silently regained the default
+// Array.prototype chain.
+//
+// Moving GC replaces the owner address through the same layout-transfer hook
+// and must also trace a custom prototype value. Exercise both mechanisms.
+
+declare function gc(): void;
+
+const nulled: any = [4, 5];
+const nulledAlias: any = nulled;
+Object.setPrototypeOf(nulled, null);
+console.log("null before:", Object.getPrototypeOf(nulled) === null, typeof nulled.map);
+if (typeof gc === "function") gc();
+nulled[9] = 1;
+console.log(
+  "null after indexed grow:",
+  Object.getPrototypeOf(nulled) === null,
+  Object.getPrototypeOf(nulledAlias) === null,
+  typeof nulled.map,
+  typeof nulledAlias.map,
+);
+console.log("null indexed value:", nulled.length, nulled[0], nulled[9]);
+
+// The registry transfer is prototype-value agnostic: preserve an object
+// prototype and its inherited surface too, including over a second growth.
+const custom: any = { marker: "kept" };
+const retargeted: any = [7, 8];
+Object.setPrototypeOf(retargeted, custom);
+if (typeof gc === "function") gc();
+retargeted[9] = 2;
+retargeted[20] = 3;
+console.log(
+  "object after indexed grows:",
+  Object.getPrototypeOf(retargeted) === custom,
+  retargeted.marker,
+  typeof retargeted.map,
+  retargeted.length,
+  retargeted[20],
+);
+
+// Array.prototype.push.call reaches the same reallocation primitive even when
+// the custom chain deliberately makes receiver.push unavailable.
+const pushed: any = [10, 11, 12, 13];
+Object.setPrototypeOf(pushed, null);
+if (typeof gc === "function") gc();
+console.log("borrowed push length:", Array.prototype.push.call(pushed, 14));
+console.log(
+  "null after push grow:",
+  Object.getPrototypeOf(pushed) === null,
+  typeof pushed.push,
+  pushed.length,
+  pushed[4],
+);


### PR DESCRIPTION
## Summary

Preserve an array's explicit `[[Prototype]]`—including `null`—when dense element growth or moving GC replaces the array allocation.

## Changes

- Transfer the address-keyed array prototype entry through the shared layout-transfer hook used by growth and moving GC.
- Trace and rewrite custom array prototype values during collection.
- Canonicalize stale array-growth aliases before reflective and dynamic property lookups.
- Add a forced-evacuation parity regression covering null and object prototypes, indexed growth, borrowed `push`, and retained aliases.
- Add a changelog fragment without changing the workspace version.

## Related issue

Fixes #9304

## Test plan

- [x] `cargo build --release -p perry -p perry-runtime-static -p perry-stdlib-static`
- [x] `cargo test -q -p perry-runtime -- --test-threads=1` — 2,887 passed, 4 ignored, 0 failed
- [x] Focused Node/Perry output diff with forced evacuation and from-space protection
- [x] `./scripts/pre-tag-check.sh --quick`
- [x] `python3 scripts/check_test_registration.py`
- [x] Added `test-files/test_gap_9304_array_growth_prototype.ts`
- [x] Docs not required; this restores existing JavaScript prototype semantics

## Screenshots / output

```text
null before: true undefined
null after indexed grow: true true undefined undefined
null indexed value: 10 4 1
object after indexed grows: true kept undefined 21 3
borrowed push length: 5
null after push grow: true undefined 5 14
```

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md
- [x] My commit follows the repository's `fix:` prefix convention
- [x] I've read CONTRIBUTING.md and agree to the Code of Conduct


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved custom and null array prototypes during array growth and garbage-collector relocation.
  - Maintained inherited properties and prototype behavior after indexed growth, repeated growth, and borrowed `Array.prototype.push` calls.
  - Ensured prototype changes made through supported JavaScript APIs remain effective after memory relocation.

- **Tests**
  - Added regression coverage for array prototype preservation across growth and moving garbage collection.

- **Documentation**
  - Added a changelog entry describing the corrected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->