### PR TITLE
fix(release): name Alpine's llvm-config by its prefix

### DIFF
--- a/scripts/linux-musl-llvm22.Dockerfile
+++ b/scripts/linux-musl-llvm22.Dockerfile
@@ -24,13 +24,16 @@ RUN apk add --no-cache \
       llvm22 llvm22-dev llvm22-static llvm22-libs \
       libffi-dev openssl-dev zlib-dev zstd-dev xz-dev \
       musl-dev pkgconf perl python3 \
-  && llvm-config --version | grep -q '^22\.' \
-     || { echo "alpine llvm is not 22.x ($(llvm-config --version))" >&2; exit 1; }
+  # Alpine installs LLVM 22 under /usr/lib/llvm22 and does NOT put its
+  # llvm-config on PATH (the bare name is unversioned and absent), so the
+  # check has to name the prefix explicitly.
+  && /usr/lib/llvm22/bin/llvm-config --version | grep -q '^22\.' \
+     || { echo "alpine llvm is not 22.x ($(/usr/lib/llvm22/bin/llvm-config --version 2>&1))" >&2; exit 1; }
 
 ENV LLVM_SYS_221_PREFIX=/usr/lib/llvm22
 ENV RUSTUP_HOME=/opt/rustup
 ENV CARGO_HOME=/opt/cargo
-ENV PATH=/opt/cargo/bin:$PATH
+ENV PATH=/opt/cargo/bin:/usr/lib/llvm22/bin:$PATH
 
 ARG RUST_TOOLCHAIN=nightly-2026-08-20
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \


### PR DESCRIPTION
Follow-up to #9298. The musl image's LLVM version check invoked a bare `llvm-config`, which Alpine does not put on `PATH` — its LLVM 22 installs under `/usr/lib/llvm22` and only versioned tools are exposed. So `docker build` failed here:

```
#6 6.911 /bin/sh: line 0: llvm-config: not found
ERROR: process "/bin/sh -c apk add --no-cache …" did not complete successfully
```

The packages install correctly — the apk run reached 76/80 before my assertion ran. **Only the assertion was wrong**, and it failed before any Rust was compiled, so the musl legs never got as far as exercising the fix they were added for (stage run 33443904901).

Two changes:

- Name the prefix explicitly: `/usr/lib/llvm22/bin/llvm-config`. `build_linux_musl.sh` already did this correctly via `$LLVM_SYS_221_PREFIX/bin/llvm-config`; only the Dockerfile used the bare name.
- Put `/usr/lib/llvm22/bin` on `PATH` so the rest of the LLVM tooling is reachable by plain name inside the image.

The failure message is also improved to print what `llvm-config` actually reported, rather than re-running a command that just failed to resolve.

Worth noting the guard did its job in one respect: it caught the mismatch at image-build time rather than letting the build proceed and fail at the final link, which is the failure this whole container exists to avoid.
