### PR TITLE
fix(mysql2): decode JSON columns instead of returning null (#9349)

### DIFF
--- a/crates/perry-ext-mysql2/Cargo.toml
+++ b/crates/perry-ext-mysql2/Cargo.toml
@@ -18,7 +18,8 @@ perry-ffi.workspace = true
 # Without it every query against such a server fails at connect with
 # "RSA auth backend disabled" — which broke `pool.execute`/`query` (e.g. an
 # Auth.js credentials `authorize` DB lookup, surfaced as a CallbackRouteError).
-sqlx = { version = "0.9.0", default-features = false, features = ["runtime-tokio", "mysql", "mysql-rsa", "chrono"] }
+serde_json = { version = "1", features = ["preserve_order"] }
+sqlx = { version = "0.9.0", default-features = false, features = ["runtime-tokio", "mysql", "mysql-rsa", "chrono", "json"] }
 tokio = { workspace = true }
 chrono.workspace = true
 

--- a/crates/perry-ext-mysql2/src/lib.rs
+++ b/crates/perry-ext-mysql2/src/lib.rs
@@ -227,6 +227,11 @@ enum RawValue {
     Bool(bool),
     Float64(f64),
     String(String),
+    /// A MySQL JSON column. Held as the decoded document and materialised into
+    /// a JS value on the main thread, because mysql2 in Node hands back the
+    /// parsed value -- not the source text -- and drizzle's `json()` mapper,
+    /// among others, relies on that.
+    Json(serde_json::Value),
 }
 
 #[derive(Clone, Debug)]
@@ -309,6 +314,15 @@ fn extract_raw_value(row: &MySqlRow, index: usize, type_name: &str) -> RawValue 
             .try_get::<chrono::NaiveTime, _>(index)
             .map(|d| RawValue::String(d.format("%H:%M:%S").to_string()))
             .unwrap_or(RawValue::Null),
+        "JSON" => row
+            .try_get::<serde_json::Value, _>(index)
+            .map(RawValue::Json)
+            // Needs sqlx's "json" feature, enabled in Cargo.toml with this
+            // change. Without it MySQL JSON has no Decode impl at all, so the
+            // String and Vec<u8> attempts in the catch-all below both failed
+            // their type check and every JSON column read back as NULL --
+            // silently, because NULL is legal for a nullable JSON column.
+            .unwrap_or(RawValue::Null),
         _ => row
             .try_get::<String, _>(index)
             .map(RawValue::String)
@@ -362,6 +376,55 @@ fn raw_value_to_jsvalue(v: &RawValue) -> JsValue {
         RawValue::Bool(b) => JsValue::from_bool(*b),
         RawValue::Float64(f) => JsValue::from_number(*f),
         RawValue::String(s) => JsValue::from_string_ptr(alloc_string(s).as_raw()),
+        RawValue::Json(v) => json_value_to_jsvalue(v),
+    }
+}
+
+/// Materialise a decoded JSON document as a JS value.
+///
+/// Built here rather than by handing the text to the runtime's JSON parser:
+/// `perry_ffi` exports `json_stringify` and no counterpart, and adding a
+/// `json_parse` to the public ABI for this would be a wider change than the
+/// bug warrants.
+///
+/// Object key order matches the stored document, which is what Node's mysql2
+/// gives you. That needs serde_json's "preserve_order" feature -- without it
+/// the map is a BTreeMap and keys come back alphabetised. Nothing should
+/// depend on JSON object key order, but silently reordering a document that
+/// round-trips through the database is the kind of difference that surfaces
+/// much later, in a diff nobody can explain.
+fn json_value_to_jsvalue(value: &serde_json::Value) -> JsValue {
+    match value {
+        serde_json::Value::Null => JsValue::NULL,
+        serde_json::Value::Bool(b) => JsValue::from_bool(*b),
+        // Every JSON number becomes an f64, which is what JSON.parse does too.
+        serde_json::Value::Number(n) => JsValue::from_number(n.as_f64().unwrap_or(f64::NAN)),
+        serde_json::Value::String(s) => JsValue::from_string_ptr(alloc_string(s).as_raw()),
+        serde_json::Value::Array(items) => {
+            let mut arr = unsafe { js_array_alloc(items.len() as u32) };
+            for item in items {
+                // Reassigned, never reused: the push may reallocate and move
+                // the array, exactly as the row and field builders below do.
+                arr = unsafe { js_array_push(arr, json_value_to_jsvalue(item)) };
+            }
+            JsValue::from_object_ptr(arr)
+        }
+        serde_json::Value::Object(map) => {
+            let names: Vec<&str> = map.keys().map(|k| k.as_str()).collect();
+            let (packed, shape_id) = build_object_shape(&names);
+            let obj = unsafe {
+                js_object_alloc_with_shape(
+                    shape_id,
+                    names.len() as u32,
+                    packed.as_ptr(),
+                    packed.len() as u32,
+                )
+            };
+            for (i, (_, v)) in map.iter().enumerate() {
+                unsafe { js_object_set_field(obj, i as u32, json_value_to_jsvalue(v)) };
+            }
+            JsValue::from_object_ptr(obj)
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #9349.

Every MySQL `JSON` column read back as `null` — through drizzle's typed builder, through `db.execute`, and through the raw driver alike. A `VARCHAR` in the same row decoded correctly, so this was specific to the JSON column type.

## Cause

Two layers, and the second one is why the obvious fix doesn't work on its own:

1. `extract_raw_value` has no `"JSON"` arm, so JSON falls to the catch-all, which tries `try_get::<String>` then `try_get::<Vec<u8>>`. Both fail their sqlx type check and the column becomes `RawValue::Null`.
2. Underneath that, sqlx is built here **without its `json` feature**, so MySQL JSON has no `Decode` impl at all. I patched the arm first, rebuilt, and the value was still null — adding an arm alone changes nothing.

A note for whoever touches this next: there are **two** independent copies of `extract_raw_value`, one in `perry-stdlib/src/mysql2/result.rs` and one here. A `createPool` program runs *this* one. I patched the stdlib copy first and spent a rebuild cycle wondering why nothing changed.

## The fix

- Enable sqlx's `json` feature and decode to `serde_json::Value`.
- Add a `RawValue::Json` variant and a `"JSON"` arm ahead of the catch-all.
- Materialise it into a real JS object graph, not text — mysql2 in Node returns the decoded value, and drizzle's `json()` mapper plus every ordinary property access depend on that.

`json_value_to_jsvalue` builds the graph from the object/array primitives `perry_ffi` already exports. It does **not** hand the text to the runtime's parser: `perry_ffi` exports `json_stringify` and no counterpart, and adding a `json_parse` to the public ABI felt like a wider change than this bug warrants. Say the word if you'd rather have the ABI export and reuse the existing parser — it would be less code here.

`serde_json`'s `preserve_order` keeps object keys in document order, matching Node. Without it the map is a `BTreeMap` and keys come back alphabetised.

## Verification

Against MySQL 8 on 0.5.1519, output is now byte-identical to Node's:

```
doc    : {"on":true,"name":"läuft","tiers":[{"step":25,"upTo":500},{"step":100,"upTo":null}]}
arr    : [1,2.5,"x",null,true,{"k":"v"}]
scalar : 42 number
nul    : null
nested : 25 | bool true | utf8 läuft | null-in-obj null
entries: 3 keys
isArray: true len 6
```

Covering nested objects and arrays, floats, booleans, `null` inside an object, UTF-8, scalar documents, SQL `NULL`, `Array.isArray` and `Object.entries`. Before the change every one of those printed `null`.

Compiles clean on both `main` (sqlx 0.9.0) and an older base carrying sqlx 0.8.6.

## Why it mattered

The failure was silent, because `null` is legal for a nullable JSON column. On a real deployment it surfaced four layers away as `TypeError: Cannot convert undefined or null to object`, having already wedged a scheduler loop — while the health endpoint kept answering `ok`, since it runs `SELECT 1`, the one query with no columns to decode.

The affected columns there were an auction's bid-increment ladder, an audit log's before/after snapshots and a shipment's tracking payload, so the visible symptom was not an error but wrong numbers and a blank audit trail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MySQL JSON columns are now returned as parsed JavaScript values instead of `NULL`.
  * JSON data now round-trips correctly, matching expected mysql2 behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->