### PR TITLE
fix(runtime): drop c_int imports left behind by the longjmp removal

### DIFF
--- a/changelog.d/9351-unused-c-int.md
+++ b/changelog.d/9351-unused-c-int.md
@@ -1,0 +1,3 @@
+The `warnings` gate is green again. Five test modules in `perry-runtime` still
+imported `std::os::raw::c_int` after the code that used it was removed, which
+fails a `-D warnings` build.

--- a/crates/perry-runtime/src/native_abi.rs
+++ b/crates/perry-runtime/src/native_abi.rs
@@ -475,7 +475,6 @@ pub extern "C" fn js_native_abi_check_pod_object(value: f64) -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::os::raw::c_int;
 
     fn catch_runtime_throw(f: impl FnOnce()) -> bool {
         crate::exception::catch_js_throw(f).is_err()

--- a/crates/perry-runtime/src/native_arena.rs
+++ b/crates/perry-runtime/src/native_arena.rs
@@ -472,7 +472,6 @@ pub(crate) unsafe fn finalize_native_pod_view_for_gc(view: *mut NativePodViewHea
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::os::raw::c_int;
 
     fn boxed_ptr(ptr: *const u8) -> f64 {
         f64::from_bits(crate::value::JSValue::pointer(ptr).bits())

--- a/crates/perry-runtime/src/native_handle.rs
+++ b/crates/perry-runtime/src/native_handle.rs
@@ -408,7 +408,6 @@ pub(crate) unsafe fn finalize_native_handle_for_gc(handle: *mut NativeHandleHead
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::os::raw::c_int;
 
     /// The teardown-diagnostics gate must block every thread except the
     /// recorded owner — the unrecorded arm waving workers through is exactly

--- a/crates/perry-runtime/src/node_stream_tests.rs
+++ b/crates/perry-runtime/src/node_stream_tests.rs
@@ -3,7 +3,6 @@
 
 use super::*;
 use std::cell::RefCell;
-use std::os::raw::c_int;
 
 thread_local! {
     pub(super) static WRITE_CAPTURED: RefCell<Vec<Vec<u8>>> = const { RefCell::new(Vec::new()) };

--- a/crates/perry-runtime/src/object/tests.rs
+++ b/crates/perry-runtime/src/object/tests.rs
@@ -2,7 +2,6 @@
 #![cfg(test)]
 
 use super::*;
-use std::os::raw::c_int;
 
 #[test]
 fn call_method_depth_drop_is_idempotent_after_exception_restore() {


### PR DESCRIPTION
The `warnings` gate fails on the release candidate (`e539a6359e`, run 33457888163) with five instances of the same error:

```
error: unused import: `std::os::raw::c_int`
  --> crates/perry-runtime/src/native_abi.rs:478:9
  = note: `-D unused-imports` implied by `-D warnings`
```

Also `native_arena.rs:475`, `native_handle.rs:411`, `node_stream_tests.rs:6`, `object/tests.rs:5`.

Each of those files contains **exactly one** occurrence of `c_int` — the import itself — so nothing references them. They are residue from #9305/#9323 ("no Rust frame is ever a longjmp target"), which removed the `setjmp`/`longjmp` call sites that took `c_int` arguments but left the imports.

`ffi/setjmp.rs` keeps its import: it still uses `c_int` 16 times for the real extern signature (`unsafe extern "C" fn(*mut c_int) -> c_int`). I checked that one specifically rather than removing every match.

`warnings` is in `full-suite-gate`'s `needs`, so this blocks the v0.5.1519 release.

## Why the PR tier missed it

Worth a look from someone who knows the tier layout better than I do: these are all `#[cfg(test)]` modules, so they only surface in a build that includes test targets. If the PR tier's `warnings` step doesn't cover `--all-targets` for the affected crate, or scopes to the diff, an unused import inside a test module can land without ever being compiled. That would make this class recur.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed unused imports from runtime test modules.
  * Cleaned up compiler warnings, allowing builds configured to treat warnings as errors to complete successfully.
  * No runtime behavior or test logic was changed.

* **Documentation**
  * Added a changelog entry describing the warning cleanup and affected test modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->