### PR TITLE
fix(mysql2): fold the JSON array arm so no local spans a nested conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6078,6 +6078,7 @@ dependencies = [
  "chrono",
  "perry-ffi",
  "perry-runtime",
+ "serde_json",
  "sqlx",
  "tokio",
 ]
@@ -8104,6 +8105,7 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/changelog.d/9352-mysql2-json-fold.md
+++ b/changelog.d/9352-mysql2-json-fold.md
@@ -1,0 +1,8 @@
+### Internal
+
+- **Folds the JSON array arm in `json_value_to_jsvalue`.** #9350's decoder
+  recurses, so `js_array_push(arr, json_value_to_jsvalue(item))` read the array
+  pointer as an argument *before* a call that allocates and can move it. The
+  fold keeps the array out of a named local, matching the row and field
+  builders alongside it, and returns `perry-ext-mysql2` to its unrooted-local
+  ceiling of 9.

--- a/crates/perry-ext-mysql2/src/lib.rs
+++ b/crates/perry-ext-mysql2/src/lib.rs
@@ -400,15 +400,13 @@ fn json_value_to_jsvalue(value: &serde_json::Value) -> JsValue {
         // Every JSON number becomes an f64, which is what JSON.parse does too.
         serde_json::Value::Number(n) => JsValue::from_number(n.as_f64().unwrap_or(f64::NAN)),
         serde_json::Value::String(s) => JsValue::from_string_ptr(alloc_string(s).as_raw()),
-        serde_json::Value::Array(items) => {
-            let mut arr = unsafe { js_array_alloc(items.len() as u32) };
-            for item in items {
-                // Reassigned, never reused: the push may reallocate and move
-                // the array, exactly as the row and field builders below do.
-                arr = unsafe { js_array_push(arr, json_value_to_jsvalue(item)) };
-            }
-            JsValue::from_object_ptr(arr)
-        }
+        // Folded so the array is never a named local carried across the
+        // pushes and nested conversions that can move it -- the same shape the
+        // row and field builders below use.
+        serde_json::Value::Array(items) => JsValue::from_object_ptr(items.iter().fold(
+            unsafe { js_array_alloc(items.len() as u32) },
+            |acc, item| unsafe { js_array_push(acc, json_value_to_jsvalue(item)) },
+        )),
         serde_json::Value::Object(map) => {
             let names: Vec<&str> = map.keys().map(|k| k.as_str()).collect();
             let (packed, shape_id) = build_object_shape(&names);


### PR DESCRIPTION
Follow-up to #9350, which takes `perry-ext-mysql2` to 10 unrooted-local findings against its ceiling of 9.

The new `json_value_to_jsvalue` decoder recurses, and its array arm was:

```rust
arr = unsafe { js_array_push(arr, json_value_to_jsvalue(item)) };
```

Rust evaluates `arr` before the recursive call, and that call allocates — so a collection inside it leaves the already-read pointer stale. That is the #8217 shape rather than a checker artifact, and the recursion makes it likelier to actually happen than in the flat row builders.

Folding removes the named local, which is what the row and field builders alongside it already do, and returns the file to its ceiling with no baseline change.

**Worth saying plainly:** this reduces the window, it does not eliminate the exposure. `perry-ext-mysql2` deliberately depends on `perry-ffi` only — `perry-runtime` is a dev-dependency, so there is no `RuntimeHandleScope` available in its production code — and building any nested JS structure without roots keeps a live JS pointer across allocations somewhere. Every builder in this crate has that property today and is carried as accepted debt. The fold matches existing practice; it is not a claim that the crate is rooting-safe. Giving these builders real roots would need the crate to take a `perry-runtime` dependency, which is a design decision beyond this fix.

**Validation:** `perry-runtime --lib` 2905/0 and `perry-ext-mysql2` green under `RUST_TEST_THREADS=1`; release build clean with no warnings; file-size, raw-handle, unrooted-local (`--check`, `--self-test`, `--no-raise-vs`), root-holder, shape-census and fmt gates all pass with no baseline touched.
