### PR TITLE
fix(release): install Alpine static system libs for llvm-sys musl builds

### DIFF
--- a/scripts/linux-musl-llvm22.Dockerfile
+++ b/scripts/linux-musl-llvm22.Dockerfile
@@ -23,12 +23,22 @@ RUN apk add --no-cache \
       build-base clang22 cmake curl git \
       llvm22 llvm22-dev llvm22-static llvm22-libs \
       libffi-dev openssl-dev zlib-dev zstd-dev xz-dev \
+      zlib-static zstd-static libxml2-static ncurses-static \
       musl-dev pkgconf perl python3 \
   # Alpine installs LLVM 22 under /usr/lib/llvm22 and does NOT put its
   # llvm-config on PATH (the bare name is unversioned and absent), so the
   # check has to name the prefix explicitly.
   && /usr/lib/llvm22/bin/llvm-config --version | grep -q '^22\.' \
      || { echo "alpine llvm is not 22.x ($(/usr/lib/llvm22/bin/llvm-config --version 2>&1))" >&2; exit 1; }
+
+# llvm-sys links LLVM statically, so every library `llvm-config --system-libs`
+# names must exist as a `.a` here. Alpine's `-dev` packages carry only the
+# shared object, so a missing `-static` package surfaces ~20 minutes into the
+# cargo build as `could not find native static library 'z'` rather than at
+# image-build time. Assert it up front instead: resolve each `-lNAME` to a
+# `libNAME.a`, skipping the names musl folds into libc.a (which ships stubs,
+# not standalone archives).
+RUN set -eu;     libdirs="$(/usr/lib/llvm22/bin/llvm-config --libdir) /usr/lib /usr/lib/gcc";     missing="";     for flag in $(/usr/lib/llvm22/bin/llvm-config --system-libs); do       name="${flag#-l}";       [ "$name" != "$flag" ] || continue;       case " c m rt dl pthread util xnet " in *" $name "*) continue ;; esac;       found="";       for d in $libdirs; do         [ -e "$d/lib$name.a" ] && { found=1; break; };       done;       [ -n "$found" ] || missing="$missing $name";     done;     if [ -n "$missing" ]; then       echo "missing static system libs for llvm-sys:$missing" >&2;       echo "(llvm-config --system-libs: $(/usr/lib/llvm22/bin/llvm-config --system-libs))" >&2;       exit 1;     fi;     echo "static system libs OK: $(/usr/lib/llvm22/bin/llvm-config --system-libs)"
 
 ENV LLVM_SYS_221_PREFIX=/usr/lib/llvm22
 ENV RUSTUP_HOME=/opt/rustup


### PR DESCRIPTION
## What

Adds `zlib-static zstd-static libxml2-static ncurses-static` to the musl
builder image, and asserts at image-build time that every library
`llvm-config --system-libs` names resolves to a `.a`.

## Why

Both musl legs of `release-packages.yml` fail:

```
error: could not find native static library `z`, perhaps an -L flag is missing?
error: could not compile `llvm-sys` (lib) due to 1 previous error
```

`llvm-sys` links LLVM statically, so it needs static `z`/`zstd`/etc. Alpine's
`-dev` packages ship only the shared object and headers; the archives live in
separate `-static` packages, which the image never installed.

This blocks the release outright: `create-release` requires
`needs.build.result == 'success'` for **every** matrix leg, so two red musl
legs mean no release.

## The assertion

Adding the four packages fixes today's error, but the failure mode is the
problem: a missing static lib surfaces ~20 minutes into the cargo build, on CI,
as a link error naming one library at a time — so each missing package costs a
full round trip and only ever reveals the *next* one.

The new `RUN` resolves each `-lNAME` from `llvm-config --system-libs` to a
`libNAME.a`, skipping the names musl folds into `libc.a` (`c m rt dl pthread
util xnet`), and fails the image build listing **all** missing libs at once.

Verified the logic against a stub `llvm-config` — it is checked for both
directions, not just the green one:

| case | `--system-libs` | expected | got |
|---|---|---|---|
| libc-folded only | `-lrt -ldl -lm -lpthread` | OK | OK |
| **`z` present, `zstd` absent** | `-lz -lzstd -lm` | **`MISSING: zstd`** | **`MISSING: zstd`** |
| all present | `-lz -lzstd -lxml2 -lrt` | OK | OK |
| empty | *(none)* | OK | OK |

Row 2 is this bug's exact shape, so a green image build now means the check
ran and passed rather than that it silently matched nothing.

All four package names confirmed present on Alpine `edge` for both `x86_64`
and `aarch64`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux musl build reliability by including required static libraries.
  * Added validation during image creation to identify missing LLVM system libraries early, with clearer build errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->