### PR TITLE
docs: regenerate API reference after manifest change

### DIFF
--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 3019 entries across 138 modules.
+Total: 3020 entries across 138 modules.
 
 ## Modules
 
@@ -4102,6 +4102,7 @@ Total: 3019 entries across 138 modules.
 - `Server` — module
 - `WebSocket` — module
 - `addListener` — instance *(class: `Client`)*
+- `clients` — instance
 - `close` — instance
 - `close` — instance *(class: `Client`)*
 - `closeClient` — module


### PR DESCRIPTION
The `check` job fails with:

```
API docs drift detected. The compile-time manifest in
crates/perry-api-manifest/src/entries.rs changed but the
generated artifacts under docs/ weren't regenerated.
```

This is the output of `./scripts/regen_api_docs.sh` — the exact command the gate names in its own failure message. The resulting diff matches what CI reported byte for byte (`docs/src/api/reference.md | 3 ++-`).

No source change; regenerated artifact only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the API reference with the latest entry and module counts.
  * Documented the `clients` instance method in the `ws` module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->