### PR TITLE
test(ws): add test-only perry_ffi async shims so cargo test -p perry-ext-ws links

### DIFF
--- a/crates/perry-ext-ws/src/lib.rs
+++ b/crates/perry-ext-ws/src/lib.rs
@@ -33,6 +33,9 @@
 /// reference and validated by a property test.
 pub mod mask;
 
+#[cfg(test)]
+mod test_async_shims;
+
 use futures_util::{SinkExt, StreamExt};
 use lazy_static::lazy_static;
 use perry_ffi::{

--- a/crates/perry-ext-ws/src/test_async_shims.rs
+++ b/crates/perry-ext-ws/src/test_async_shims.rs
@@ -1,0 +1,23 @@
+// Unit-test binaries for `perry-ext-ws` do not link the host stdlib/runtime
+// archive that normally provides the perry_ffi async bridge (the real symbols
+// live in `perry-stdlib::perry_ffi_async`, only linked into the final user
+// program). Provide synchronous, test-only shims for the `perry_ffi_*` async
+// externs this crate references so `cargo test -p perry-ext-ws` links — same
+// pattern as `perry-ext-http` / `perry-ext-net`.
+
+use std::ffi::c_void;
+
+#[no_mangle]
+pub extern "C" fn perry_ffi_spawn_blocking_with_reactor(
+    ctx: *mut c_void,
+    invoke: extern "C" fn(*mut c_void),
+) {
+    invoke(ctx);
+}
+
+// The server accept loop and the per-client IO pump reach this through
+// `perry_ffi::async_runtime::spawn_async`. Running the future is not the point
+// of these unit tests (they cover framing/masking and the clients-set surface),
+// so the shim is a no-op rather than a runtime spin-up.
+#[no_mangle]
+pub extern "C" fn perry_ffi_spawn_async(_ctx: *mut c_void) {}

--- a/crates/perry-stdlib/src/crypto/random.rs
+++ b/crates/perry-stdlib/src/crypto/random.rs
@@ -724,7 +724,6 @@ pub(super) unsafe fn object_field_u128(obj_bits: u64, name: &[u8]) -> Option<u12
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::os::raw::c_int;
 
     fn boxed_ptr(ptr: *const u8) -> f64 {
         f64::from_bits(perry_runtime::JSValue::pointer(ptr).bits())


### PR DESCRIPTION
## What

Adds `crates/perry-ext-ws/src/test_async_shims.rs` (test-only, `#[cfg(test)]`),
matching the existing `perry-ext-http` / `perry-ext-net` / `perry-ext-mysql2` /
`perry-ext-qs` pattern.

## Why

`cargo-test` is red on `main`:

```
error: linking with `cc` failed: exit status: 1
  undefined reference to `perry_ffi_spawn_async'
  undefined reference to `perry_ffi_spawn_blocking_with_reactor'
error: could not compile `perry-ext-ws` (lib test) due to 1 previous error
```

Those two symbols are the complete undefined set (confirmed against the job
log, not assumed). The real ones live in `perry-stdlib::perry_ffi_async` and
are only linked into a final user program, so a unit-test binary has nothing to
resolve them against.

`perry-ext-ws` had no lib tests until #9335 added the WebSocketServer
clients-set coverage, which is what pulled the crate into `cargo-test`'s scope
and exposed the missing shim. The crate's dev-dependencies were already correct
(`perry-ffi` with `runtime-link`, `perry-runtime` with `default` + `stdlib`) —
only the module was missing.

`spawn_async` is a no-op here rather than a runtime spin-up: these tests cover
framing/masking and the clients-set surface, not the accept loop.

## Verification

Not just "it links" — the tests actually run:

```
$ RUST_TEST_THREADS=1 cargo test -p perry-ext-ws
test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test support for the WebSocket extension.
  * Enabled the WebSocket package’s test suite to run successfully without the usual runtime environment.
  * Added synchronous test behavior for asynchronous operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->