### PR TITLE
fix(release): give bindgen libclang in the musl builder image

### DIFF
--- a/scripts/linux-musl-llvm22.Dockerfile
+++ b/scripts/linux-musl-llvm22.Dockerfile
@@ -23,7 +23,7 @@ RUN apk add --no-cache \
       build-base clang22 cmake curl git \
       llvm22 llvm22-dev llvm22-static llvm22-libs \
       libffi-dev openssl-dev zlib-dev zstd-dev xz-dev \
-      zlib-static zstd-static libxml2-static ncurses-static \
+      zlib-static zstd-static libxml2-static ncurses-static clang22-libclang \
       musl-dev pkgconf perl python3 \
   # Alpine installs LLVM 22 under /usr/lib/llvm22 and does NOT put its
   # llvm-config on PATH (the bare name is unversioned and absent), so the
@@ -44,6 +44,21 @@ ENV LLVM_SYS_221_PREFIX=/usr/lib/llvm22
 ENV RUSTUP_HOME=/opt/rustup
 ENV CARGO_HOME=/opt/cargo
 ENV PATH=/opt/cargo/bin:/usr/lib/llvm22/bin:$PATH
+
+# `libsqlite3-sys` runs bindgen, which dlopens libclang at BUILD time. Alpine
+# ships the shared library in `clang22-libclang` (plain `clang22` is the driver
+# only) and does not put it on the default search path, so bindgen needs both
+# the package and this variable. Declared AFTER the other ENVs and asserted
+# below, so an Alpine layout change fails here instead of ~8 minutes into the
+# cargo build with "Unable to find libclang".
+ENV LIBCLANG_PATH=/usr/lib/llvm22/lib
+RUN set -eu; \
+    for c in "$LIBCLANG_PATH"/libclang.so "$LIBCLANG_PATH"/libclang.so.*; do \
+      if [ -e "$c" ]; then echo "libclang OK: $c"; exit 0; fi; \
+    done; \
+    echo "no libclang.so under $LIBCLANG_PATH (bindgen would fail)" >&2; \
+    ls -la "$LIBCLANG_PATH" >&2 2>&1 || true; \
+    exit 1
 
 ARG RUST_TOOLCHAIN=nightly-2026-08-20
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \


### PR DESCRIPTION
## What

Installs `clang22-libclang` in the musl builder image, sets `LIBCLANG_PATH`,
and asserts at image-build time that the library is actually there.

## Why

With #9353's static-libs fix in place the musl legs get ~8 minutes further and
then die in `libsqlite3-sys`:

```
error: failed to run custom build command for `libsqlite3-sys v0.37.0`
  Unable to find libclang: "couldn't find any valid shared libraries matching:
  ['libclang.so', 'libclang-*.so', 'libclang.so.*', 'libclang-*.so.*'],
  set the `LIBCLANG_PATH` environment variable ... (invalid: [])"
```

`libsqlite3-sys` runs bindgen, which dlopens libclang at build time. Alpine's
`clang22` package is the driver only — the shared library lives in
`clang22-libclang`, and it is not on the default search path, so bindgen needs
both the package and the variable.

Confirmed `clang22-libclang` exists on Alpine `edge` for `x86_64` and
`aarch64`.

## The assertion

Same reasoning as #9353's static-libs check: this failure costs a full ~8
minute CI round trip to observe, so the image should refuse to build instead.
`LIBCLANG_PATH` is declared **after** the other `ENV`s and the check runs after
it — under `set -eu` an unset variable would fail the layer outright.

Verified against a stub layout, both directions:

| case | expected | got |
|---|---|---|
| empty dir | fail | fail |
| `libclang.so` | pass | pass |
| `libclang.so.22.1` (versioned only) | pass | pass |
| nonexistent dir | fail | fail |

Row 1 is this bug's exact shape, so a green image build means the check ran.

## Note

This is the second defect in the same layer, found only because the first fix
unblocked it. Both musl legs are `create-release` requirements, so neither
could ship a release. The assertions are there so a third one — if the image
grows another build-time native dependency — fails in seconds rather than
minutes.

## Also fixes a vacuous assertion from #9353

The x86_64 musl log shows `static system libs OK:` with an **empty** value —
`llvm-config --system-libs` returns nothing on this image, so #9353's check
iterated an empty list and reported success having verified nothing. The
packages it added were right; the assertion was not testing them.

This PR rewrites it: an explicit `REQUIRED="z zstd"` floor, unioned with
whatever llvm-config reports, plus a liveness guard that fails if fewer than
2 libraries were actually checked.

| case | #9353 | this PR |
|---|---|---|
| empty system-libs, no static libs | **passed** | fails (`MISSING: z zstd`) |
| empty system-libs, only `libz.a` | passed | fails (`MISSING: zstd`) |
| empty system-libs, `z`+`zstd` present | passed | passes (`checked=2`) |
| reports `-lxml2`, absent | passed | fails (`MISSING: xml2`) |
