### PR TITLE
fix(release): make the musl static-libs check non-vacuous

### DIFF
--- a/scripts/linux-musl-llvm22.Dockerfile
+++ b/scripts/linux-musl-llvm22.Dockerfile
@@ -31,14 +31,46 @@ RUN apk add --no-cache \
   && /usr/lib/llvm22/bin/llvm-config --version | grep -q '^22\.' \
      || { echo "alpine llvm is not 22.x ($(/usr/lib/llvm22/bin/llvm-config --version 2>&1))" >&2; exit 1; }
 
-# llvm-sys links LLVM statically, so every library `llvm-config --system-libs`
-# names must exist as a `.a` here. Alpine's `-dev` packages carry only the
-# shared object, so a missing `-static` package surfaces ~20 minutes into the
-# cargo build as `could not find native static library 'z'` rather than at
-# image-build time. Assert it up front instead: resolve each `-lNAME` to a
-# `libNAME.a`, skipping the names musl folds into libc.a (which ships stubs,
-# not standalone archives).
-RUN set -eu;     libdirs="$(/usr/lib/llvm22/bin/llvm-config --libdir) /usr/lib /usr/lib/gcc";     missing="";     for flag in $(/usr/lib/llvm22/bin/llvm-config --system-libs); do       name="${flag#-l}";       [ "$name" != "$flag" ] || continue;       case " c m rt dl pthread util xnet " in *" $name "*) continue ;; esac;       found="";       for d in $libdirs; do         [ -e "$d/lib$name.a" ] && { found=1; break; };       done;       [ -n "$found" ] || missing="$missing $name";     done;     if [ -n "$missing" ]; then       echo "missing static system libs for llvm-sys:$missing" >&2;       echo "(llvm-config --system-libs: $(/usr/lib/llvm22/bin/llvm-config --system-libs))" >&2;       exit 1;     fi;     echo "static system libs OK: $(/usr/lib/llvm22/bin/llvm-config --system-libs)"
+# llvm-sys links LLVM statically, so the static system libs it pulls in must
+# exist here as `.a`. Alpine's `-dev` packages carry only the shared object, so
+# a missing `-static` package surfaces ~20 minutes into the cargo build as
+# `could not find native static library 'z'` rather than at image-build time.
+#
+# `llvm-config --system-libs` is EMPTY on this image (Alpine builds LLVM so it
+# reports no system libs), so iterating it alone is a vacuous check that passes
+# having verified nothing -- llvm-sys still demands `z`, which is what broke the
+# musl legs in the first place. So: verify an explicit REQUIRED floor, and union
+# it with whatever llvm-config does report.
+RUN set -eu; \
+    REQUIRED="z zstd"; \
+    libdirs="$(/usr/lib/llvm22/bin/llvm-config --libdir) /usr/lib /usr/lib/gcc"; \
+    reported="$(/usr/lib/llvm22/bin/llvm-config --system-libs || true)"; \
+    names="$REQUIRED"; \
+    for flag in $reported; do \
+      name="${flag#-l}"; \
+      [ "$name" != "$flag" ] || continue; \
+      case " c m rt dl pthread util xnet " in *" $name "*) continue ;; esac; \
+      names="$names $name"; \
+    done; \
+    checked=0; missing=""; \
+    for name in $names; do \
+      found=""; \
+      for d in $libdirs; do \
+        if [ -e "$d/lib$name.a" ]; then found=1; break; fi; \
+      done; \
+      checked=$((checked + 1)); \
+      [ -n "$found" ] || missing="$missing $name"; \
+    done; \
+    if [ -n "$missing" ]; then \
+      echo "missing static system libs for llvm-sys:$missing" >&2; \
+      echo "(llvm-config --system-libs: '$reported')" >&2; \
+      exit 1; \
+    fi; \
+    if [ "$checked" -lt 2 ]; then \
+      echo "static-libs check verified only $checked lib(s) -- it is not testing anything" >&2; \
+      exit 1; \
+    fi; \
+    echo "static system libs OK: checked $checked ($names)"
 
 ENV LLVM_SYS_221_PREFIX=/usr/lib/llvm22
 ENV RUSTUP_HOME=/opt/rustup


### PR DESCRIPTION
## What

Rewrites the musl image's static-system-libs check so it actually verifies
something. Dockerfile-only; no package or behaviour change to the image
contents.

## Why

This landed in #9357 but was **dropped by the squash-merge** — that PR had two
commits and only the first was taken, so the fix below is not on `main`.

The x86_64 musl leg of run 33467410646 printed:

```
#7 0.101 static system libs OK:
```

The value is empty. `llvm-config --system-libs` reports nothing on Alpine's
LLVM 22 build, so #9353's check iterated an empty list, found nothing missing,
and reported OK having verified **zero** libraries — while `llvm-sys` still
demanded `z`, the very library that check was added to guard.

That is the "gate runs but its subject never did" pattern from CLAUDE.md. The
packages #9353 added were correct and did fix the build; only the assertion
around them was inert.

## Fix

- Verify an explicit `REQUIRED="z zstd"` floor rather than trusting
  `llvm-config` to name anything.
- Union that with whatever `llvm-config --system-libs` does report, so a future
  addition is still covered.
- Fail if fewer than 2 libraries were checked — a liveness guard, so the check
  cannot silently go inert again.

## Verification

Against a stub `llvm-config`, checked in both directions:

| case | before | after |
|---|---|---|
| empty system-libs, no static libs (**the real bug**) | **passed** | fails (`MISSING: z zstd`) |
| empty system-libs, only `libz.a` | passed | fails (`MISSING: zstd`) |
| empty system-libs, `z`+`zstd` present | passed | passes (`checked=2`) |
| reports `-lxml2`, absent | passed | fails (`MISSING: xml2`) |

Row 1 is the exact shape that shipped green, so a green build now means the
check ran.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of system libraries in the Linux musl build environment.
  * Builds now fail when required compression libraries are missing or insufficiently verified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->