### PR TITLE
gc: give the copied minor the liveness probes it never had

### DIFF
--- a/changelog.d/9359-copied-minor-liveness-probes.md
+++ b/changelog.d/9359-copied-minor-liveness-probes.md
@@ -1,0 +1,42 @@
+`PERRY_GC_VERIFY_MARK` already owns the direct signature of a dropped old→young
+edge: `verify_minor_unmarked_young_children_report` walks every old parent and
+reports a child slot naming a sweep-eligible object that is UNMARKED — about to
+be freed while its parent survives. It was wired only into `cycle.rs`'s
+non-copying minor. The **copied** minor is the operative cycle on every workload
+that reaches that path, and it is the collector that does the moving; it ran
+without one. So on exactly the cycle where a dropped edge matters it was
+invisible, and the first observable was a garbage `GcHeader` hundreds of
+collections later, in an unrelated function.
+
+Wires it there, and adds a second check for an invariant nothing was asking.
+`verify_array_pointer_slots_enumerated`: the collector's own slot enumeration
+must reach every array element that holds a heap reference.
+`heap_payload_slot_selection` answers with a full scan, an all-pointer claim, or
+a per-object mask — the first two cannot under-report, the mask can. When it
+does, the omitted element is a live edge that marking never marks and the
+evacuation rewrite never rewrites; the child is swept while its owner still
+names it, and the collector reads the recycled bytes as a header one or more
+cycles later.
+
+Arrays only, deliberately: an array's payload is `length` elements at a known
+offset, so "which words are supposed to be reachable" needs no layout
+interpretation, and the check cannot inherit the bug it is looking for. Both
+probes report their own subject counts, so a cycle on which they had nothing to
+check says so rather than reading as a clean bill.
+
+This is the instrument, not the fix. On the claude-code bundle under
+`PERRY_GC_SCHEDULE_SEED=1 PERRY_GC_SCHEDULE_RATE=1` it names the defect behind
+#9261 in one run — an object's spill (overflow-field) buffer whose mask covered
+every `POINTER_TAG` element and omitted three live `STRING_TAG` ones
+(`mask=0xc7fc live=0xfffc missing=0x3800`) — where the bare abort was
+`[gc-pin-latch] FATAL … obj_type=10 size=1347565393`, i.e. the ASCII `QTLP`,
+string payload bytes read as a header, ~200 collections downstream.
+
+Tests are a sabotage pair: a mask-described array is verified clean and the
+clean verdict is required to have examined at least one pointer element, so it
+cannot pass vacuously; then a pointer is published at the append position
+WITHOUT the layout note every store path performs — the exact state found in the
+wild — and the check must see it, at the right index, naming the right child.
+
+Nothing runs outside `PERRY_GC_VERIFY_MARK`: no new knob, no production path
+touched.

--- a/crates/perry-runtime/src/gc/copying.rs
+++ b/crates/perry-runtime/src/gc/copying.rs
@@ -1516,6 +1516,17 @@ pub(super) fn run_copied_minor_attempt(
     // being swept. Non-fatal; logs parent/child obj_types.
     if crate::gc::gc_verify_mark_enabled() {
         super::verify::verify_marked_heap_report_nonfatal("copying-minor");
+        // #9261: the copied minor is the OPERATIVE cycle on every workload that
+        // reaches this path, and it was the one collector with no sweep-live-
+        // child probe — `verify_minor_unmarked_young_children_report` was wired
+        // only into `cycle.rs`'s non-copying minor. So the direct signature of a
+        // dropped old→young edge (a live old parent naming a young child that is
+        // about to be swept) was invisible here, and the first thing anyone saw
+        // was a garbage `GcHeader` hundreds of collections later. Both probes
+        // report their own subject counts, so a cycle on which they had nothing
+        // to check says so rather than reading as a clean bill.
+        super::verify::verify_minor_unmarked_young_children_report("copying-minor");
+        super::verify::verify_array_pointer_slots_enumerated_report("copying-minor");
     }
 
     // #7035: whole-heap from-space scan. MUST run here — after the rewrite

--- a/crates/perry-runtime/src/gc/tests/array_pointer_slot_enumeration.rs
+++ b/crates/perry-runtime/src/gc/tests/array_pointer_slot_enumeration.rs
@@ -1,0 +1,118 @@
+//! #9261: the collector's slot enumeration must reach every array element that
+//! holds a heap reference.
+
+use super::super::*;
+use super::support::*;
+
+use crate::gc::verify::{
+    verify_array_pointer_slots_enumerated, verify_array_pointer_slots_enumerated_for,
+    ArraySlotEnumerationStats,
+};
+
+/// Build a mask-described array: one numeric element, then one pointer.
+///
+/// The numeric element first is load-bearing. An EMPTY array's first pointer
+/// append publishes `GC_LAYOUT_ALL_POINTERS` ("its sole element is the pointer
+/// we just classified"), and under that state every element is enumerated by
+/// construction — the omission this file is about cannot be expressed. With a
+/// numeric prefix the append takes the per-object mask instead, which is the
+/// state that can under-report.
+fn mask_described_array() -> *mut crate::array::ArrayHeader {
+    let arr = crate::array::js_array_alloc(8);
+    let arr = crate::array::js_array_push_f64(arr, 1.0);
+    let child = young_leaf();
+    let arr = crate::array::js_array_push_f64(arr, f64::from_bits(ptr_bits(child)));
+    let header = unsafe { header_from_user_ptr(arr as *const u8) };
+    assert_eq!(
+        unsafe { (*header)._reserved } & crate::gc::GC_LAYOUT_STATE_MASK,
+        crate::gc::GC_LAYOUT_SIDE_MASK,
+        "fixture must be described by a per-object pointer mask, or the \
+         sabotage below is not expressible and every verdict here is vacuous"
+    );
+    arr
+}
+
+unsafe fn stats_for(arr: *mut crate::array::ArrayHeader) -> ArraySlotEnumerationStats {
+    let mut stats = ArraySlotEnumerationStats::default();
+    verify_array_pointer_slots_enumerated_for(&mut stats, header_from_user_ptr(arr as *const u8));
+    stats
+}
+
+/// Publish a pointer at the append position WITHOUT the layout note every
+/// store path performs. This is the state #9261 found in the wild on an
+/// object's spill buffer: `mask=0xc7fc live=0xfffc`, three live `STRING_TAG`
+/// elements the mask omitted. The check must SEE it — a checker that cannot
+/// fail is documentation.
+#[test]
+fn array_slot_enumeration_reports_a_pointer_element_the_layout_omits() {
+    let _isolation = copying_nursery_isolation_lock();
+    let _trigger = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+
+    let arr = mask_described_array();
+
+    // The fixture itself must be clean, and must have LOOKED at something.
+    let clean = unsafe { stats_for(arr) };
+    assert_eq!(
+        clean.unenumerated_slots, 0,
+        "a correctly-noted array must not be reported"
+    );
+    assert_eq!(clean.checked_arrays, 1);
+    assert!(
+        clean.checked_pointer_slots >= 1,
+        "no pointer element was examined, so the clean verdict above is vacuous"
+    );
+
+    let planted = young_leaf();
+    let index = unsafe { (*arr).length } as usize;
+    unsafe {
+        let elements =
+            (arr as *mut u8).add(std::mem::size_of::<crate::array::ArrayHeader>()) as *mut u64;
+        std::ptr::write(elements.add(index), ptr_bits(planted));
+        (*arr).length = index as u32 + 1;
+    }
+
+    let broken = unsafe { stats_for(arr) };
+    assert_eq!(
+        broken.unenumerated_slots, 1,
+        "the planted element is a live heap edge the collector cannot reach"
+    );
+    let missing = broken
+        .first
+        .expect("the first offending element is recorded");
+    assert_eq!(missing.index, index);
+    assert_eq!(missing.child, planted);
+    assert_eq!(missing.array, arr as usize);
+
+    clear_marks();
+    remembered_set_clear();
+}
+
+/// The whole-heap form is what the copied minor calls, so it must actually
+/// walk arrays rather than return an empty verdict.
+#[test]
+fn array_slot_enumeration_walks_the_heap() {
+    let _isolation = copying_nursery_isolation_lock();
+    let _trigger = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+
+    let arr = mask_described_array();
+    // The walk skips unmarked nursery objects (they are this cycle's garbage,
+    // and their elements are the previous tenant's bytes). Nothing has marked
+    // anything here, so pin the fixture to make it a live subject.
+    let header = unsafe { header_from_user_ptr(arr as *const u8) };
+    unsafe {
+        crate::gc::pin_object(header);
+    }
+
+    let stats = verify_array_pointer_slots_enumerated();
+    assert!(
+        stats.checked_arrays >= 1 && stats.checked_pointer_slots >= 1,
+        "the heap walk examined no array element ({stats:?}), so a clean \
+         verdict from it would mean nothing"
+    );
+
+    unsafe {
+        crate::gc::unpin_object(header);
+    }
+    clear_marks();
+    remembered_set_clear();
+}

--- a/crates/perry-runtime/src/gc/tests/mod.rs
+++ b/crates/perry-runtime/src/gc/tests/mod.rs
@@ -1,4 +1,5 @@
 mod alloc;
+mod array_pointer_slot_enumeration;
 mod barrier;
 mod barrier_arming;
 mod barrier_decoded_parent;

--- a/crates/perry-runtime/src/gc/verify.rs
+++ b/crates/perry-runtime/src/gc/verify.rs
@@ -731,6 +731,168 @@ pub(super) unsafe fn verify_marked_object_child_marks(
     });
 }
 
+/// One array element the collector's own slot enumeration does not reach,
+/// even though the element holds a heap reference.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(super) struct UnenumeratedArraySlot {
+    pub(super) array: usize,
+    pub(super) index: usize,
+    pub(super) length: u32,
+    pub(super) reserved: u16,
+    pub(super) child: usize,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(super) struct ArraySlotEnumerationStats {
+    pub(super) checked_arrays: usize,
+    pub(super) checked_pointer_slots: usize,
+    pub(super) unenumerated_slots: usize,
+    pub(super) first: Option<UnenumeratedArraySlot>,
+}
+
+/// Does the collector's own slot enumeration reach every element of `header`
+/// that holds a heap reference?
+///
+/// This is the invariant the per-object pointer LAYOUT rests on, asked of the
+/// one walk that consumes it. `heap_payload_slot_selection` may answer with a
+/// full scan, an all-pointer claim, or a per-object mask; the first two cannot
+/// under-report, the mask can — and when it does, the omitted element is a live
+/// edge that marking never marks and the evacuation rewrite never rewrites. The
+/// child is then swept while its owner still names it, and the collector reads
+/// the recycled bytes as a `GcHeader` one or more cycles later.
+///
+/// That is #9261: an object's spill (overflow-field) buffer whose mask covered
+/// every `POINTER_TAG` element and omitted three live `STRING_TAG` ones
+/// (`mask=0xc7fc live=0xfffc missing=0x3800`), surfacing ~200 collections later
+/// as `[gc-pin-latch] FATAL … obj_type=10 size=1347565393` — payload bytes read
+/// as a header. Nothing between the store and that abort could see it: the
+/// store paths all note the layout correctly, and no runtime GC probe asks this
+/// question. So ask it directly.
+///
+/// Arrays only, deliberately: an array's payload is `length` elements at a
+/// known offset, so "which words are supposed to be reachable" needs no layout
+/// interpretation and the check cannot inherit the bug it is looking for.
+pub(super) unsafe fn verify_array_pointer_slots_enumerated_for(
+    stats: &mut ArraySlotEnumerationStats,
+    header: *mut GcHeader,
+) {
+    if header.is_null() || (*header).obj_type != GC_TYPE_ARRAY {
+        return;
+    }
+    let flags = (*header).gc_flags;
+    // A FORWARDED array is a growth stub or an evacuation original: its first
+    // payload word is a forwarding pointer, not an element.
+    if flags & GC_FLAG_FORWARDED != 0 {
+        return;
+    }
+    let user = (header as *mut u8).add(GC_HEADER_SIZE) as usize;
+    let arr = user as *const crate::array::ArrayHeader;
+    let length = (*arr).length as usize;
+    let capacity = (*arr).capacity as usize;
+    // The same admission gate `array::gc_element_slot_range` applies: outside
+    // it the collector enumerates nothing, and neither should this.
+    if length == 0 || length > capacity || length > 16_000_000 {
+        return;
+    }
+    let elements = (user as *const u8).add(std::mem::size_of::<crate::array::ArrayHeader>());
+    let elements_addr = elements as usize;
+    let words = elements as *const u64;
+
+    let mut reached = vec![0u64; length.div_ceil(64)];
+    visit_gc_rewrite_slots(header, |slot| {
+        let addr = slot.slot as usize;
+        if addr < elements_addr {
+            return;
+        }
+        let index = (addr - elements_addr) / std::mem::size_of::<u64>();
+        if index < length {
+            reached[index / 64] |= 1u64 << (index % 64);
+        }
+    });
+
+    stats.checked_arrays += 1;
+    for index in 0..length {
+        let bits = *words.add(index);
+        if !super::layout::layout_pointer_bearing_bits(bits) {
+            continue;
+        }
+        stats.checked_pointer_slots += 1;
+        if reached[index / 64] & (1u64 << (index % 64)) != 0 {
+            continue;
+        }
+        stats.unenumerated_slots += 1;
+        if stats.first.is_none() {
+            stats.first = Some(UnenumeratedArraySlot {
+                array: user,
+                index,
+                length: (*arr).length,
+                reserved: (*header)._reserved,
+                child: (bits & POINTER_MASK) as usize,
+            });
+        }
+    }
+}
+
+/// Is this array dead this cycle, so that its elements are whatever the
+/// previous tenant of the address left behind rather than live edges?
+///
+/// Mirrors `verify_heap_objects`' gate exactly. It belongs to the heap WALK
+/// and not to the per-object check: liveness is only decidable while marks are
+/// final, and the per-object form is also asked about a specific array by
+/// tests, where nothing has marked anything.
+unsafe fn array_is_sweep_eligible(header: *mut GcHeader) -> bool {
+    let flags = (*header).gc_flags;
+    flags & (GC_FLAG_MARKED | GC_FLAG_PINNED) == 0
+        && crate::arena::pointer_in_nursery((header as *mut u8).add(GC_HEADER_SIZE) as usize)
+}
+
+/// [`verify_array_pointer_slots_enumerated_for`] over every live array.
+pub(super) fn verify_array_pointer_slots_enumerated() -> ArraySlotEnumerationStats {
+    let mut stats = ArraySlotEnumerationStats::default();
+    crate::arena::arena_walk_objects(|hp| unsafe {
+        let header = hp as *mut GcHeader;
+        if array_is_sweep_eligible(header) {
+            return;
+        }
+        verify_array_pointer_slots_enumerated_for(&mut stats, header);
+    });
+    MALLOC_STATE.with(|s| {
+        let s = s.borrow();
+        for &header in s.objects.iter() {
+            unsafe {
+                verify_array_pointer_slots_enumerated_for(&mut stats, header);
+            }
+        }
+    });
+    stats
+}
+
+/// `PERRY_GC_VERIFY_MARK` report form. Non-fatal, like its two siblings: the
+/// point is to name the array, the element and the child at the cycle the
+/// invariant breaks, instead of leaving a garbage-header abort hundreds of
+/// collections downstream.
+pub(super) fn verify_array_pointer_slots_enumerated_report(phase: &str) {
+    let stats = verify_array_pointer_slots_enumerated();
+    match stats.first {
+        Some(missing) => eprintln!(
+            "[gc-array-slots:{}] UNENUMERATED slots={} arrays={} pointer_slots={} | first array=0x{:x} index={} length={} reserved=0x{:x} child=0x{:x}",
+            phase,
+            stats.unenumerated_slots,
+            stats.checked_arrays,
+            stats.checked_pointer_slots,
+            missing.array,
+            missing.index,
+            missing.length,
+            missing.reserved,
+            missing.child,
+        ),
+        None => eprintln!(
+            "[gc-array-slots:{}] OK arrays={} pointer_slots={}",
+            phase, stats.checked_arrays, stats.checked_pointer_slots,
+        ),
+    }
+}
+
 #[allow(dead_code)] // GC heap-invariant verifier exercised by cfg(test) suite in gc/tests/barrier.rs
 pub(super) fn verify_marked_heap_no_unmarked_children() -> MarkInvariantVerifyStats {
     let mut stats = MarkInvariantVerifyStats::default();


### PR DESCRIPTION
## What this is

An instrument, not a fix. It does not close #9261 — it is what found the defect behind it, and what would have found this class years earlier.

## The gap

`PERRY_GC_VERIFY_MARK` already owns the direct signature of a dropped old→young edge: `verify_minor_unmarked_young_children_report` walks every old parent and reports a child slot naming a sweep-eligible object that is **unmarked**, i.e. about to be freed while its parent survives.

It was wired only into `cycle.rs`'s non-copying minor. The **copied** minor — the operative cycle on every workload that reaches that path, and the collector that does the moving — ran without one. So on exactly the cycle where a dropped edge matters, it was invisible, and the first observable was a garbage `GcHeader` hundreds of collections later, in an unrelated function.

This wires it there, and adds a second check for an invariant nothing was asking.

## The new check

`verify_array_pointer_slots_enumerated`: the collector's own slot enumeration must reach every array element that holds a heap reference.

`heap_payload_slot_selection` answers with a full scan, an all-pointer claim, or a per-object mask. The first two cannot under-report; the mask can. When it does, the omitted element is a live edge that marking never marks and the evacuation rewrite never rewrites — the child is swept while its owner still names it, and the collector reads the recycled bytes as a header one or more cycles later.

Arrays only, deliberately: an array's payload is `length` elements at a known offset, so *which words are supposed to be reachable* needs no layout interpretation and the check cannot inherit the bug it is looking for.

Both probes report their own subject counts (`checked_arrays` / `pointer_slots`, `parents` / `young_edges`), so a cycle on which they had nothing to check says so rather than reading as a clean bill.

## What it found

On the claude-code bundle under `PERRY_GC_SCHEDULE_SEED=1 PERRY_GC_SCHEDULE_RATE=1`, in one run:

```
[gc-array-slots:copying-minor] UNENUMERATED slots=3 ...
  first array=0x385bf225728 index=11 length=16 reserved=0x8000
```

An object's spill (overflow-field) buffer, `SIDE_MASK`-described, whose mask covered every `POINTER_TAG` element and omitted three live `STRING_TAG` ones — `mask=0xc7fc live=0xfffc missing=0x3800`. Those three strings are swept while the object still names them.

The bare abort for the same defect is:

```
[gc-pin-latch] FATAL: copying minor is about to relocate a PINNED young object
header=0x20d7ee22440 obj_type=10 (buffer) size=1347565393 flags=0x76
```

`1347565393` is `0x504C5451`, the ASCII `QTLP` — string payload bytes read as a header, ~200 collections downstream of the store that mattered.

## Tests

A sabotage pair, per the "a gate must assert its subject was live" rule:

* a mask-described array is verified clean, **and** the clean verdict is required to have examined at least one pointer element, so it cannot pass vacuously;
* a pointer is then published at the append position **without** the layout note every store path performs — the exact state found in the wild — and the check must see it, at the right index, naming the right child.

The fixture asserts it is actually `GC_LAYOUT_SIDE_MASK` first; an empty array's first pointer append publishes `GC_LAYOUT_ALL_POINTERS`, where every element is enumerated by construction and the omission is not expressible.

## Cost

Nothing outside `PERRY_GC_VERIFY_MARK`. No new knob, no production path touched.

## Validation

* `RUST_TEST_THREADS=1 cargo test --release -p perry-runtime` — 2890 passed, 0 failed
* `scripts/run_lint_gates.sh` — all 60 gates passed, 2 CI-only skipped

Refs #9261.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved garbage-collection diagnostics for copied and non-copied minor collection paths.
  - Added checks to detect heap references in arrays that may be missed during collection.
  - Reports now identify affected array elements and provide clearer counts, including when no items require checking.

- **Tests**
  - Added regression coverage for array pointer-slot enumeration and missed references.
  - Verified detection of incorrectly published pointers and complete traversal of live arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->