### PR TITLE
fix(runtime): name the subject in "is not iterable"; resolve ws clients for an untyped receiver (#9324)

### DIFF
--- a/changelog.d/9324-hono-close-path.md
+++ b/changelog.d/9324-hono-close-path.md
@@ -1,0 +1,66 @@
+### Fixed
+
+- **A `TypeError: is not iterable` now names its subject, and `WebSocketServer.clients` resolves for an untyped receiver (#9324).**
+
+  A Hono service on `@hono/node-server` exited every 30 seconds under systemd
+  with an unhandled
+
+  ```text
+  TypeError: is not iterable
+      at node_modules/@hono/node-server/dist/index.mjs:595
+  ```
+
+  Line 595 is the adapter's response `"close"` handler, so the report — and the
+  issue title — blamed the close path. It was not the close path. Two separate
+  defects combined to hide the real line:
+
+  **1. The TypeError named nothing.** Node *never* throws a subject-less
+  `is not iterable`; it always names the receiver (`undefined is not iterable`,
+  `null is not iterable`, `37 is not iterable`). Perry's synchronous
+  `GetIterator` threw the bare string, so the message carried no information at
+  all about what had failed, and the only frame available pointed somewhere
+  else. `crates/perry-runtime/src/symbol/iterator.rs` now builds the message
+  from the value, using the same `null` / `undefined` / `value` label scheme the
+  async twin (`array::iterator::throw_not_iterable`) has always used. Three of
+  the four shapes below were bare before; `null`, the array destructure and the
+  spread now match Node byte for byte:
+
+  | expression | before | after | Node 26.5.1 |
+  |---|---|---|---|
+  | `for (… of holder.clients)` (missing) | `is not iterable` | `undefined is not iterable` | `holder.clients is not iterable` |
+  | `for (… of null)` | `is not iterable` | `null is not iterable` | `null is not iterable` |
+  | `const [a] = undefined` | `is not iterable` | `undefined is not iterable` | `undefined is not iterable` |
+  | `[...undefined]` | `undefined is not iterable` | `undefined is not iterable` | `undefined is not iterable` |
+
+  **2. The actual throw was `for (const ws of wss.clients)`** in a 30-second
+  `setInterval` WebSocket heartbeat — which is why the journal shows the exit
+  exactly 30 s after every `listening on :3000`, on a fixed period, with no
+  load correlation at all. #9325/#9335 made `clients` a real `Set`, but only
+  through the statically-typed lowering, which needs the receiver's class at
+  compile time. Every *untyped* read still produced `undefined`: an `any` alias,
+  a computed `wss[key]`, a helper taking the server as an untyped parameter, and
+  — the case that matters — every compiled npm package, since a published
+  bundle carries no types. Neither ws provider registered any handle-property
+  surface, so both are fixed: `perry-stdlib`'s bundled twin gains a `clients`
+  arm in `js_handle_property_dispatch`, and `perry-ext-ws` (which the
+  workspace-rebuild flip routes to) gains a handle-property dispatch extension
+  alongside its GC root scanner. Both return "not handled" for any other
+  property and for any handle that is not a live `WsServerHandle`, so every
+  other handle family falls through unchanged.
+
+  Verified on Linux x86_64 against the exact reported dependency tree
+  (`@hono/node-server` 1.19.17, hono 4.13.4, the reporting service's
+  `new WebSocketServer({ noServer: true })` shape). On the build the issue was
+  filed against the heartbeat reproducer exits 1 with the bare message; after
+  the fix it survives on *both* ws providers. The `@hono/node-server` response
+  close path — the frame the issue named — needed no change: instrumenting the
+  adapter's own `"close"` listener under rapid POST and early-client-disconnect
+  load showed it firing 30/30 times on completed responses with
+  `writableFinished === true`, taking neither `abort()` branch and throwing
+  nothing.
+
+  Regression coverage: `crates/perry/tests/issue_9324_not_iterable_names_its_subject.rs`
+  (both halves end to end; the dynamic-read half failed on this very test before
+  the `perry-ext-ws` change landed), plus always-on unit tests for the message
+  label (`perry-runtime`) and the dispatch extension (`perry-ext-ws`, including
+  that a dropped server handle is *not* claimed).

--- a/crates/perry-ext-ws/src/lib.rs
+++ b/crates/perry-ext-ws/src/lib.rs
@@ -133,12 +133,67 @@ lazy_static! {
 }
 
 static WS_ACTIVE_SERVERS: AtomicI32 = AtomicI32::new(0);
-static WS_GC_REGISTERED: std::sync::Once = std::sync::Once::new();
+static WS_RUNTIME_HOOKS_REGISTERED: std::sync::Once = std::sync::Once::new();
 
-fn ensure_gc_scanner_registered() {
-    WS_GC_REGISTERED.call_once(|| {
+extern "C" {
+    fn js_register_handle_property_dispatch_extension(
+        f: unsafe extern "C" fn(i64, *const u8, usize, *mut f64) -> i32,
+    );
+}
+
+/// Install the crate's runtime hooks once: the mutable-root scanner, and the
+/// handle-property dispatch extension that answers dynamic reads on ws
+/// handles (#9324).
+fn ensure_runtime_hooks_registered() {
+    WS_RUNTIME_HOOKS_REGISTERED.call_once(|| {
         gc_register_mutable_root_scanner_named("perry-ext-ws", scan_ws_roots);
+        unsafe {
+            js_register_handle_property_dispatch_extension(js_ext_ws_handle_property_dispatch)
+        };
     });
+}
+
+/// Resolve `WebSocketServer.clients` for an UNTYPED receiver (#9324).
+///
+/// #9325/#9335 made `clients` a real `Set`, but only through the statically
+/// typed lowering (`native_dispatch.rs` needs to know the receiver's class).
+/// Every other read lands in the runtime's handle-property dispatcher, and
+/// `perry-ext-ws` registered no property surface there at all — so an `any`
+/// alias, a computed `wss[key]`, a helper taking the server as an untyped
+/// parameter, and every compiled npm package (a published bundle carries no
+/// types) all read `undefined`. `for (const ws of wss.clients)` over that
+/// `undefined` threw `TypeError: is not iterable` from inside a `setInterval`
+/// heartbeat — uncatchable by application code, so the process exited every
+/// 30 seconds.
+///
+/// Returns 0 (not handled) for every other property and for any handle that is
+/// not a live `WsServerHandle`, so the composite dispatcher falls through to
+/// the primary stdlib dispatcher unchanged.
+///
+/// # Safety
+/// FFI entry; `property_name_ptr` must be valid for `property_name_len` bytes,
+/// and `out` must be writable when non-null.
+#[no_mangle]
+pub unsafe extern "C" fn js_ext_ws_handle_property_dispatch(
+    handle: i64,
+    property_name_ptr: *const u8,
+    property_name_len: usize,
+    out: *mut f64,
+) -> i32 {
+    if property_name_ptr.is_null() || property_name_len != b"clients".len() {
+        return 0;
+    }
+    if std::slice::from_raw_parts(property_name_ptr, property_name_len) != b"clients" {
+        return 0;
+    }
+    let clients = js_ws_server_clients(handle);
+    if clients.to_bits() == JsValue::UNDEFINED.bits() {
+        return 0;
+    }
+    if !out.is_null() {
+        *out = clients;
+    }
+    1
 }
 
 fn scan_ws_roots(visitor: &mut GcRootVisitor<'_>) {
@@ -223,7 +278,7 @@ fn untrack_server_client(ws_id: usize) -> Option<Handle> {
 /// `url_ptr` must be null or a Perry-runtime `StringHeader`.
 #[no_mangle]
 pub unsafe extern "C" fn js_ws_connect(url_ptr: *const StringHeader) -> *mut perry_ffi::Promise {
-    ensure_gc_scanner_registered();
+    ensure_runtime_hooks_registered();
     ensure_tls_crypto_provider();
     let promise = perry_ffi::JsPromise::new();
     let raw = promise.as_raw();
@@ -253,7 +308,7 @@ pub unsafe extern "C" fn js_ws_connect(url_ptr: *const StringHeader) -> *mut per
 /// codegen sites that don't expect a Promise return.
 #[no_mangle]
 pub extern "C" fn js_ws_connect_start(url_nanboxed: f64) -> f64 {
-    ensure_gc_scanner_registered();
+    ensure_runtime_hooks_registered();
     ensure_tls_crypto_provider();
     let bits = url_nanboxed.to_bits();
     let mask = TAG_MASK;
@@ -499,7 +554,7 @@ pub unsafe extern "C" fn js_ws_on_client_i64(
     event_name_ptr: *const StringHeader,
     callback_ptr: i64,
 ) -> i64 {
-    ensure_gc_scanner_registered();
+    ensure_runtime_hooks_registered();
     let Some(event_name) = read_str(event_name_ptr) else {
         return handle;
     };
@@ -664,7 +719,7 @@ pub unsafe extern "C" fn js_ws_on(
     event_name_ptr: *const StringHeader,
     callback_ptr: i64,
 ) -> i64 {
-    ensure_gc_scanner_registered();
+    ensure_runtime_hooks_registered();
     let Some(event_name) = read_str(event_name_ptr) else {
         return handle;
     };
@@ -744,7 +799,7 @@ pub unsafe extern "C" fn js_ws_on(
 /// has-active gate — `js_fastify_has_active` — does that).
 #[no_mangle]
 pub extern "C" fn js_ws_server_new(opts_f64: f64) -> Handle {
-    ensure_gc_scanner_registered();
+    ensure_runtime_hooks_registered();
     let port = extract_port(opts_f64);
     let no_server = extract_no_server(opts_f64);
     let clients_bits = alloc_set(4).bits();
@@ -1079,7 +1134,7 @@ pub fn register_external_ws_stream<S>(ws_stream: tokio_tungstenite::WebSocketStr
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
 {
-    ensure_gc_scanner_registered();
+    ensure_runtime_hooks_registered();
     let mut id_guard = NEXT_WS_ID.lock().unwrap();
     let ws_id = *id_guard;
     *id_guard += 1;
@@ -1148,7 +1203,7 @@ pub unsafe extern "C" fn js_ws_handle_upgrade(
     _head_f64: f64,
     cb: i64,
 ) -> i64 {
-    ensure_gc_scanner_registered();
+    ensure_runtime_hooks_registered();
     // `ws_id_f64` is POINTER_TAG-boxed (the host upgrade path encodes
     // it as `POINTER_TAG | (ws_id & POINTER_MASK)` so codegen's
     // unbox_to_i64 round-trips it). Extract the low-48 bits.
@@ -1414,8 +1469,8 @@ mod tests {
 
     #[test]
     fn gc_scanner_registration_idempotent() {
-        ensure_gc_scanner_registered();
-        ensure_gc_scanner_registered();
+        ensure_runtime_hooks_registered();
+        ensure_runtime_hooks_registered();
     }
 
     #[test]
@@ -1458,6 +1513,69 @@ mod tests {
         }
         WS_CLIENT_LISTENERS.lock().unwrap().remove(&client_id);
         drop_handle(server_handle);
+    }
+
+    /// #9324: the DYNAMIC read must reach the same live `Set` the typed read
+    /// gets. Pre-fix this dispatcher did not exist, every untyped
+    /// `wss.clients` read `undefined`, and iterating it killed the process.
+    #[test]
+    fn handle_property_dispatch_answers_clients_for_an_untyped_read() {
+        let _lock = GC_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let undefined = f64::from_bits(JsValue::UNDEFINED.bits());
+        let server_handle = js_ws_server_new(undefined);
+
+        let mut out = f64::NAN;
+        let handled = unsafe {
+            js_ext_ws_handle_property_dispatch(
+                server_handle,
+                b"clients".as_ptr(),
+                b"clients".len(),
+                &mut out,
+            )
+        };
+        assert_eq!(handled, 1, "the dispatcher must claim `clients`");
+        assert_eq!(
+            out.to_bits(),
+            js_ws_server_clients(server_handle).to_bits(),
+            "the dynamic read must return the SAME Set as the typed read"
+        );
+        let set = JsValue::from_bits(out.to_bits()).as_pointer::<perry_runtime::set::SetHeader>();
+        assert!(!set.is_null());
+        assert_eq!(perry_runtime::set::js_set_size(set), 0);
+
+        // Every other property stays unhandled so the composite dispatcher
+        // falls through to the primary stdlib dispatcher.
+        let mut other = f64::NAN;
+        assert_eq!(
+            unsafe {
+                js_ext_ws_handle_property_dispatch(
+                    server_handle,
+                    b"readyState".as_ptr(),
+                    b"readyState".len(),
+                    &mut other,
+                )
+            },
+            0
+        );
+
+        drop_handle(server_handle);
+
+        // A handle that is no longer a live server must NOT be claimed —
+        // otherwise this arm would shadow whatever id gets recycled into it.
+        let mut dead = f64::NAN;
+        assert_eq!(
+            unsafe {
+                js_ext_ws_handle_property_dispatch(
+                    server_handle,
+                    b"clients".as_ptr(),
+                    b"clients".len(),
+                    &mut dead,
+                )
+            },
+            0
+        );
     }
 
     #[test]

--- a/crates/perry-runtime/src/symbol/iterator.rs
+++ b/crates/perry-runtime/src/symbol/iterator.rs
@@ -132,8 +132,28 @@ fn throw_iterator_result_not_object() -> ! {
     crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64));
 }
 
-fn throw_value_not_iterable() -> ! {
-    let msg = b"is not iterable";
+/// The word Node puts in front of `is not iterable`.
+///
+/// Node NEVER throws a subject-less `TypeError: is not iterable` — it names
+/// the value (`undefined is not iterable`, `null is not iterable`). Perry's
+/// sync GetIterator threw the bare message, and #9324 is what that costs: a
+/// service died every 30 s inside a `setInterval` on
+/// `for (const ws of wss.clients)` where `wss.clients` read `undefined`, and
+/// because the TypeError named nothing the report attributed it to an
+/// unrelated frame in a dependency. Same label scheme as the async twin,
+/// `array::iterator::throw_not_iterable`.
+fn not_iterable_label(value: f64) -> &'static str {
+    if value.to_bits() == crate::value::TAG_NULL {
+        "null"
+    } else if value.to_bits() == TAG_UNDEFINED {
+        "undefined"
+    } else {
+        "value"
+    }
+}
+
+fn throw_value_not_iterable(value: f64) -> ! {
+    let msg = format!("{} is not iterable", not_iterable_label(value));
     let msg_str = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
     let err = crate::error::js_typeerror_new(msg_str);
     crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64));
@@ -239,7 +259,7 @@ pub extern "C" fn js_get_iterator(val_f64: f64) -> f64 {
                 let fn_ptr = crate::value::js_nanbox_get_pointer(iter_fn)
                     as *const crate::closure::ClosureHeader;
                 if iter_fn.to_bits() == TAG_UNDEFINED || fn_ptr.is_null() {
-                    throw_value_not_iterable();
+                    throw_value_not_iterable(val_f64);
                 }
                 let prev_this = crate::object::js_implicit_this_set(val_f64);
                 let rebound = crate::closure::clone_closure_rebind_this(iter_fn.to_bits(), val_f64);
@@ -384,7 +404,7 @@ pub extern "C" fn js_get_iterator(val_f64: f64) -> f64 {
         if !jsv.is_pointer() && !jsv.is_any_string() {
             is_registered_class_ref = crate::object::class_ref_id(val_f64).is_some();
             if !is_registered_class_ref {
-                throw_value_not_iterable();
+                throw_value_not_iterable(val_f64);
             }
         }
     }
@@ -468,7 +488,7 @@ pub extern "C" fn js_get_iterator(val_f64: f64) -> f64 {
         if jsv.is_pointer()
             && crate::value::addr_class::is_handle_band(jsv.as_pointer::<u8>() as usize)
         {
-            throw_value_not_iterable();
+            throw_value_not_iterable(val_f64);
         }
     }
     // #6454: the class ref admitted past the primitive guard above resolved no
@@ -479,7 +499,7 @@ pub extern "C" fn js_get_iterator(val_f64: f64) -> f64 {
     // "next is not a function" later; throw here, exactly as before #6454 for
     // every non-pointer value.
     if is_registered_class_ref {
-        throw_value_not_iterable();
+        throw_value_not_iterable(val_f64);
     }
     let async_iter_wk = well_known_symbol("asyncIterator");
     if !async_iter_wk.is_null() {
@@ -489,7 +509,7 @@ pub extern "C" fn js_get_iterator(val_f64: f64) -> f64 {
         if async_iter_fn.to_bits() != TAG_UNDEFINED
             && async_iter_fn.to_bits() != crate::value::TAG_NULL
         {
-            throw_value_not_iterable();
+            throw_value_not_iterable(val_f64);
         }
     }
     val_f64
@@ -637,4 +657,37 @@ pub unsafe extern "C" fn js_to_primitive(value: f64, hint: i32) -> f64 {
     let result = crate::closure::js_closure_call1(closure_ptr, hint_f64);
     crate::object::js_implicit_this_set(prev_this);
     result
+}
+
+#[cfg(test)]
+mod not_iterable_message_tests {
+    use super::*;
+
+    /// #9324: the sync GetIterator TypeError must NAME its subject the way
+    /// Node does. A bare `is not iterable` is unattributable — that is the
+    /// whole reason #9324 was filed against the wrong file.
+    #[test]
+    fn label_names_the_receiver_like_node() {
+        assert_eq!(
+            not_iterable_label(f64::from_bits(TAG_UNDEFINED)),
+            "undefined"
+        );
+        assert_eq!(
+            not_iterable_label(f64::from_bits(crate::value::TAG_NULL)),
+            "null"
+        );
+        // Anything else keeps Perry's long-standing generic subject rather
+        // than inventing a type word the async twin does not use.
+        assert_eq!(not_iterable_label(37.0), "value");
+    }
+
+    /// The label is never empty: an empty subject is exactly the bare
+    /// message this fix removes, so guard the property directly.
+    #[test]
+    fn label_is_never_empty() {
+        for bits in [TAG_UNDEFINED, crate::value::TAG_NULL] {
+            assert!(!not_iterable_label(f64::from_bits(bits)).is_empty());
+        }
+        assert!(!not_iterable_label(0.0).is_empty());
+    }
 }

--- a/crates/perry-stdlib/src/common/dispatch/property_dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch/property_dispatch.rs
@@ -67,6 +67,26 @@ pub unsafe extern "C" fn js_handle_property_dispatch(
         return crate::streams::dispatch_stream_property(handle as f64, property_name);
     }
 
+    // #9324: `WebSocketServer.clients` must resolve on the DYNAMIC path too.
+    // The statically-typed read lowers to a NativeMethodCall (#9325/#9335), but
+    // an UNTYPED receiver lands here instead — a compiled npm package (no types
+    // at all), an `any` alias, a computed `wss[key]`, or a helper that takes the
+    // server as a parameter. ws registers no handle-property surface, so every
+    // one of those read `undefined`, and `for (const c of wss.clients)` over
+    // that `undefined` threw `TypeError: is not iterable` from a timer callback
+    // — uncatchable by application code, so the process exited.
+    //
+    // `js_ws_server_clients` returns `undefined` for any handle that is not a
+    // live `WsServerHandle`, so this arm is inert for every other handle family
+    // and falls through to the dispatchers below.
+    #[cfg(all(feature = "bundled-ws", not(target_os = "ios")))]
+    if property_name == "clients" {
+        let clients = crate::ws::js_ws_server_clients(handle);
+        if !perry_runtime::JSValue::from_bits(clients.to_bits()).is_undefined() {
+            return clients;
+        }
+    }
+
     if let Some(value) =
         super::super::net_socket_bridge::bind_net_socket_property(handle, property_name)
     {

--- a/crates/perry/tests/issue_9324_not_iterable_names_its_subject.rs
+++ b/crates/perry/tests/issue_9324_not_iterable_names_its_subject.rs
@@ -1,0 +1,162 @@
+//! Regression test for #9324.
+//!
+//! Two halves of one production failure. A Hono service on
+//! `@hono/node-server` exited every 30 seconds with
+//!
+//! ```text
+//! TypeError: is not iterable
+//! ```
+//!
+//! The throw was `for (const ws of wss.clients)` inside a `setInterval`
+//! heartbeat, where the `clients` read produced `undefined`. Because the
+//! TypeError named no subject at all, the report attributed it to an unrelated
+//! frame inside the adapter (`@hono/node-server`'s response `close` handler)
+//! and the real line was never found.
+//!
+//! 1. Every `is not iterable` TypeError must NAME its subject, the way Node
+//!    does (`undefined is not iterable`, `null is not iterable`). A bare,
+//!    subject-less message is unattributable — that is the whole defect.
+//! 2. `WebSocketServer.clients` must be the live `Set` on the DYNAMIC property
+//!    path too: an `any` alias, a computed key, or a helper taking the server
+//!    as an untyped parameter — which is how every compiled npm package reads
+//!    it, since a published bundle carries no types. #9335 exposed `clients`
+//!    only for a statically-typed receiver.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonicalize workspace root")
+}
+
+fn compile_and_run(dir: &Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-cache")
+        .env_remove("PERRY_NO_AUTO_OPTIMIZE")
+        .env("PERRY_WORKSPACE_ROOT", workspace_root())
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+/// Pre-fix EVERY line below read `is not iterable` with nothing in front of
+/// it. `null`, the array destructure and the spread now match Node's message
+/// byte for byte; the member read names the VALUE (`undefined`) where Node
+/// names the source text (`holder.clients`) — both identify the receiver,
+/// which is what a bare message could not do.
+#[test]
+fn not_iterable_typeerror_names_its_subject() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+function message(f: () => void): string {
+  try {
+    f();
+    return "NO THROW";
+  } catch (e) {
+    return (e as Error).message;
+  }
+}
+
+// The exact #9324 shape: a member read that resolves to nothing, iterated.
+const holder: { clients?: unknown } = {};
+console.log(message(() => { for (const _x of holder.clients as any) void _x; }));
+console.log(message(() => { for (const _x of null as any) void _x; }));
+console.log(message(() => { const [_a] = undefined as any; void _a; }));
+console.log(message(() => { void [...(undefined as any)]; }));
+"#,
+    );
+
+    assert_eq!(
+        stdout,
+        "undefined is not iterable\n\
+         null is not iterable\n\
+         undefined is not iterable\n\
+         undefined is not iterable\n"
+    );
+    // Guard the defect itself, not just the current wording: a subject-less
+    // message must never come back.
+    assert!(
+        !stdout.lines().any(|line| line.trim() == "is not iterable"),
+        "a bare, subject-less 'is not iterable' survived:\n{stdout}"
+    );
+}
+
+/// #9335 exposed `clients` only for a statically-typed receiver. MB24's own
+/// heartbeat is typed and stopped crashing, but any untyped read — which is
+/// what a compiled npm package emits — still produced `undefined` and put the
+/// 30-second crash straight back.
+#[test]
+fn websocket_server_clients_resolves_on_the_dynamic_path() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+import { WebSocketServer } from "ws";
+
+// `{ noServer: true }` is the shape the reporting service uses (#9324);
+// #9335's own test covers the `{ port: 0 }` arm.
+const wss = new WebSocketServer({ noServer: true });
+
+const anyAlias: any = wss;
+const key = "clients";
+function viaUntypedParam(server: any): any {
+  return server.clients;
+}
+
+console.log(Object.prototype.toString.call(wss.clients));
+console.log(Object.prototype.toString.call(anyAlias.clients));
+console.log(Object.prototype.toString.call((wss as any)[key]));
+console.log(Object.prototype.toString.call(viaUntypedParam(wss)));
+
+// The heartbeat loop that killed the process. Iterating the dynamic read
+// must not throw.
+let count = 0;
+for (const _client of anyAlias.clients) count += 1;
+console.log("iterated " + count);
+
+// A `noServer` WebSocketServer still holds the event loop open.
+process.exit(0);
+"#,
+    );
+
+    assert_eq!(
+        stdout,
+        "[object Set]\n[object Set]\n[object Set]\n[object Set]\niterated 0\n"
+    );
+}


### PR DESCRIPTION
Fixes #9324

## It was not the close handler

The report is a Hono service on `@hono/node-server` 1.19.17 exiting under load with

```
TypeError: is not iterable
    at node_modules/@hono/node-server/dist/index.mjs:595
```

Line 595 is inside the adapter's response `"close"` listener, so the issue was filed against the close path. The journal on the reporting host says otherwise — the exit is **exactly 30 s after every `listening on :3000`, on a fixed period, 84 restarts in a row**, with no load correlation at all:

```
22:00:34  mb24-api listening on :3000
22:01:04  TypeError: is not iterable          ← +30s
22:01:04  systemd: Main process exited, code=exited, status=1/FAILURE
22:01:09  systemd: Scheduled restart job, restart counter is at 84.
```

30 s is the service's WebSocket heartbeat (`apps/api/src/ws/attach.ts`):

```ts
const heartbeatMs = options.heartbeatMs ?? 30_000;
const heartbeat = setInterval(() => {
  for (const ws of wss.clients) {   // ← the actual throw
    …
  }
}, heartbeatMs);
```

`wss.clients` read `undefined`, `for…of` over it threw, and because the throw happens inside a timer callback no application code can catch it — the process exits mid-request. Two defects kept this pointing at the wrong file.

## 1. The TypeError named nothing

Node **never** throws a subject-less `is not iterable` — it always names the receiver. Perry's synchronous `GetIterator` threw a bare `b"is not iterable"`, so the message carried no information about what had failed, and the single available frame pointed elsewhere. That is the whole reason this was reported as a `@hono/node-server` close-handler bug.

`symbol/iterator.rs` now builds the message from the value, using the same `null` / `undefined` / `value` label scheme the async twin (`array::iterator::throw_not_iterable`) has always used:

| expression | before | after | Node 26.5.1 |
|---|---|---|---|
| `for (… of holder.clients)` (missing) | `is not iterable` | `undefined is not iterable` | `holder.clients is not iterable` |
| `for (… of null)` | `is not iterable` | `null is not iterable` | ✅ `null is not iterable` |
| `const [a] = undefined` | `is not iterable` | `undefined is not iterable` | ✅ `undefined is not iterable` |
| `[...undefined]` | `undefined is not iterable` | `undefined is not iterable` | ✅ |

Three bare messages become named; two now match Node byte for byte that did not before.

## 2. `wss.clients` was still `undefined` for an untyped receiver

#9325/#9335 made `clients` a real `Set` — but only through the statically-typed lowering, which needs the receiver's class at compile time. Every *untyped* read still produced `undefined`, on **current `main`**:

```
typed:      [object Set]
any-alias:  [object Undefined]      ← const s: any = wss; s.clients
computed:   [object Undefined]      ← wss[key]
via-helper: [object Undefined]      ← function f(s: any) { return s.clients }
```

The reporting service's own heartbeat is typed, so #9335 stopped its crash — but the same read from a compiled npm package hits the dynamic path, because a published bundle carries no types. Neither ws provider registered any handle-property surface, so both are fixed:

- **`perry-stdlib`** (bundled twin, what a prebuilt release links) — a `clients` arm in `js_handle_property_dispatch`.
- **`perry-ext-ws`** (what the workspace-rebuild flip routes to) — a handle-property dispatch extension, registered alongside the existing GC root scanner, following the `perry-ext-net` template.

Both return "not handled" for every other property and for any handle that is not a live `WsServerHandle`, so all other handle families fall through unchanged.

## Reproduction — before / after

The exact production shape, read the way a compiled bundle reads it:

```ts
import { WebSocketServer } from "ws";
const wss = new WebSocketServer({ noServer: true });   // the service's shape
const server: any = wss;
setInterval(() => { for (const ws of server.clients) void ws; }, 50);
```

| build | result |
|---|---|
| the build the issue was filed against (`6dfa24b2f`) | `TypeError: is not iterable`, **exit 1** |
| this branch, bundled-stdlib ws provider | 3/3 ticks, `SERVICE STILL ALIVE`, exit 0 |
| this branch, `perry-ext-ws` provider | 3/3 ticks, `SERVICE STILL ALIVE`, exit 0 |

## The close handler needed no change

Verified rather than assumed. I vendored a copy of the exact adapter (`@hono/node-server` 1.19.17 + hono 4.13.4 from the reporting host's own `node_modules`) and instrumented its `"close"` listener to record which branch it reaches. Under rapid POSTs, early client disconnects, and aborted streamed responses:

```
completed requests:  close=30/30  wfFalse=0  adapterAborts=0  throws=[]
```

It fires once per completed response with `writableFinished === true`, takes **neither** `abort()` branch, and throws nothing. (Separately: Perry never fires the response's `close` on client disconnect at all — only from `res.end()` — so the `!outgoing.writableFinished` branch the issue quotes is not even reachable there. Worth its own issue; it is not this crash.)

## Testing

On Linux x86_64, against the reporting host's exact dependency tree.

- `crates/perry/tests/issue_9324_not_iterable_names_its_subject.rs` — both halves end to end. **Non-vacuous by observation**: the dynamic-read half *failed on this very test* (`[object Undefined]` ×3) before the `perry-ext-ws` change landed, and passed after.
- Always-on unit tests: the message label (`perry-runtime`) and the dispatch extension (`perry-ext-ws`) — including that a **dropped** server handle is *not* claimed, so the arm can never shadow a recycled id.
- `cargo test -p perry-ext-ws`, `-p perry-stdlib`, `-p perry-runtime` (`RUST_TEST_THREADS=1`).
- `scripts/run_lint_gates.sh` — all gates green, script and compile tiers.
- `@hono/node-server` smoke (routing, middleware, JSON body, streaming, 404): `ALL_OK`.
- Hono stress: 90 aborted POSTs, 60 completed POSTs, 60 aborted streamed responses — server alive through all three.

One note for reviewers: pinning `PERRY_RUNTIME_DIR` without a workspace source links the prebuilt full stdlib, and in *that* configuration the Hono smoke fails with `Cannot read properties of undefined (reading 'listen')`. I A/B'd it against a pristine `origin/main` build with the identical package set — **same 41.0 MB binary, same failure** — so it is pre-existing and unrelated to this change, not a regression here.

No version bump, per the contributor flow; changelog fragment in `changelog.d/9324-hono-close-path.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed intermittent service exits caused by WebSocket server client collection access.
  * WebSocket server `clients` now works reliably through dynamic and untyped property access.
  * Improved “is not iterable” errors to identify the value that caused the problem, matching Node.js behavior.

* **Tests**
  * Added regression coverage for iterator error messages and WebSocket client collection access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->