### PR TITLE
perf(runtime): memoize short concat results (bench_object_property 36 -> 25 ms alone; 13 ms stacked, beating node)

### DIFF
--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -1017,6 +1017,7 @@ pub fn gc_init() {
     // the thread-local slot is the only place the new address can be recorded.
     reg_scanner!(crate::iter_result::scan_iter_result_keys_roots_mut);
     reg_scanner!(small_int_cache_mutable_root_scanner);
+    reg_scanner!(concat_memo_mutable_root_scanner);
     reg_scanner!(crate::builtins::scan_console_log_singleton_roots_mut);
     reg_scanner!(crate::builtins::scan_structured_clone_memo_roots_mut);
     // #8282/#8294: process EventEmitter listener closures live as raw

--- a/crates/perry-runtime/src/gc/roots.rs
+++ b/crates/perry-runtime/src/gc/roots.rs
@@ -26,11 +26,12 @@ pub(crate) use runtime_handles::{
 pub use runtime_handles::{RuntimeHandle, RuntimeHandleScope};
 pub use scanner_shims::{
     async_context_mutable_root_scanner, async_context_root_scanner,
-    async_hooks_mutable_root_scanner, async_hooks_root_scanner, exception_mutable_root_scanner,
-    exception_root_scanner, intern_table_mutable_root_scanner, intern_table_root_scanner,
-    json_parse_mutable_root_scanner, json_parse_root_scanner, overflow_fields_mutable_root_scanner,
-    overflow_fields_root_scanner, promise_mutable_root_scanner, promise_root_scanner,
-    shadow_stack_root_scanner, shape_cache_mutable_root_scanner, shape_cache_root_scanner,
+    async_hooks_mutable_root_scanner, async_hooks_root_scanner, concat_memo_mutable_root_scanner,
+    concat_memo_root_scanner, exception_mutable_root_scanner, exception_root_scanner,
+    intern_table_mutable_root_scanner, intern_table_root_scanner, json_parse_mutable_root_scanner,
+    json_parse_root_scanner, overflow_fields_mutable_root_scanner, overflow_fields_root_scanner,
+    promise_mutable_root_scanner, promise_root_scanner, shadow_stack_root_scanner,
+    shape_cache_mutable_root_scanner, shape_cache_root_scanner,
     small_int_cache_mutable_root_scanner, small_int_cache_root_scanner, timer_mutable_root_scanner,
     timer_root_scanner, transition_cache_mutable_root_scanner, transition_cache_root_scanner,
 };

--- a/crates/perry-runtime/src/gc/roots/scanner_shims.rs
+++ b/crates/perry-runtime/src/gc/roots/scanner_shims.rs
@@ -114,3 +114,11 @@ pub fn small_int_cache_root_scanner(mark: &mut dyn FnMut(f64)) {
 pub fn small_int_cache_mutable_root_scanner(visitor: &mut RuntimeRootVisitor<'_>) {
     crate::string::scan_small_int_cache_roots_mut(visitor);
 }
+
+pub fn concat_memo_root_scanner(mark: &mut dyn FnMut(f64)) {
+    crate::string::scan_concat_memo_roots(mark);
+}
+
+pub fn concat_memo_mutable_root_scanner(visitor: &mut RuntimeRootVisitor<'_>) {
+    crate::string::scan_concat_memo_roots_mut(visitor);
+}

--- a/crates/perry-runtime/src/registry_latch_probes.rs
+++ b/crates/perry-runtime/src/registry_latch_probes.rs
@@ -344,6 +344,14 @@ fn uint8array_probe_rejects_an_out_of_window_address_without_touching_the_regist
 /// first half able to fail.
 #[test]
 fn symbol_probe_rejects_a_filtered_address_without_touching_the_registry() {
+    // `RegistryAddrFilter` is a Bloom filter, so "this one address is
+    // rejected" depends on which symbols every EARLIER test in the binary
+    // happened to register — three bits set by unrelated addresses are enough
+    // to admit `FAR_OUTSIDE_ANY_WINDOW` and fail this assertion for no reason
+    // of its own. Start from an empty filter (taken before the allocation
+    // below, so the symbol this test registers is still admitted) and the
+    // rejection becomes a property of the filter rather than of test order.
+    let _range = crate::symbol::SymbolAddrRangeGuard::reset();
     let sym = unsafe { crate::symbol::alloc_symbol(std::ptr::null_mut(), false) } as usize;
     assert!(sym != 0, "test premise: the symbol allocated");
 

--- a/crates/perry-runtime/src/string/concat.rs
+++ b/crates/perry-runtime/src/string/concat.rs
@@ -235,6 +235,107 @@ pub extern "C" fn js_string_concat_box(l_value: f64, r_value: f64) -> f64 {
     unsafe { crate::value::js_dynamic_string_or_number_add(l_value, r_value) }
 }
 
+/// Memo for short ASCII concat results (`"field_" + j`, `"row" + i`, slug and
+/// id building — the shape that dominates computed property keys).
+///
+/// A result of 6..=`CONCAT_MEMO_MAX_BYTES` bytes is past SSO's 5-byte ceiling,
+/// so today every one of them heap-allocates. In a build-then-key loop that is
+/// pure garbage: measured on `bench_object_property`, 200k such allocations per
+/// run, whose only consumer is the property-key lookup that reads their bytes
+/// and drops them. They cost a young collection, and that collection costs far
+/// more than the allocations themselves (a scavenge copying 248 KB takes ~7 ms,
+/// most of it fixed per-collection work).
+///
+/// Returning the SAME string object for equal bytes is unobservable: JS strings
+/// are primitives, `===` compares by value, and a concat result is born
+/// `refcount = 0` (shared), which is exactly the marker that forbids the
+/// in-place `+=` append — so a memo hit can never be mutated under its other
+/// holders. That the results are already shared is what makes this sound
+/// without any new discipline at the call sites.
+///
+/// Bounded and evicting on collision, so it can never grow: entries are strong
+/// GC roots (`scan_concat_memo_roots_mut`) rather than pinned, so an evicted
+/// string becomes collectable immediately. Pinning would have made a long
+/// program's distinct short concats accumulate forever — a memory-parity
+/// regression traded for wall time, which is the wrong trade
+/// (`memory-parity-directive`).
+const CONCAT_MEMO_SIZE: usize = 512;
+const CONCAT_MEMO_MAX_BYTES: u32 = 12;
+
+thread_local! {
+    static CONCAT_MEMO: std::cell::UnsafeCell<[*mut StringHeader; CONCAT_MEMO_SIZE]> =
+        const { std::cell::UnsafeCell::new([std::ptr::null_mut(); CONCAT_MEMO_SIZE]) };
+}
+
+#[inline]
+fn concat_memo_slot(bytes: &[u8]) -> usize {
+    // FNV-1a over the result bytes. Content-addressed, so two different
+    // operand splits that produce the same string share one entry.
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for &b in bytes {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x100_0000_01b3);
+    }
+    (h as usize) & (CONCAT_MEMO_SIZE - 1)
+}
+
+/// A cached string with exactly these bytes, or null. The byte compare makes
+/// a hash collision a miss, never a wrong answer.
+#[inline]
+fn concat_memo_lookup(slot: usize, bytes: &[u8]) -> *mut StringHeader {
+    let cached = CONCAT_MEMO.with(|c| unsafe { (*c.get())[slot] });
+    if cached.is_null() {
+        return std::ptr::null_mut();
+    }
+    unsafe {
+        if (*cached).byte_len as usize != bytes.len() {
+            return std::ptr::null_mut();
+        }
+        let data = crate::string::string_data(cached);
+        if std::slice::from_raw_parts(data, bytes.len()) != bytes {
+            return std::ptr::null_mut();
+        }
+    }
+    cached
+}
+
+#[inline]
+fn concat_memo_insert(slot: usize, ptr: *mut StringHeader) {
+    CONCAT_MEMO.with(|c| unsafe {
+        // GC_STORE_AUDIT(ROOT): CONCAT_MEMO is scanned by scan_concat_memo_roots_mut.
+        crate::gc::runtime_store_root_raw_mut_ptr_slot(&raw mut (*c.get())[slot], ptr);
+    });
+}
+
+/// GC root scanner for [`CONCAT_MEMO`]. Same contract as the small-int cache:
+/// the entries are strong roots, so evacuation rewrites them rather than
+/// leaving the memo holding freed strings.
+pub fn scan_concat_memo_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    CONCAT_MEMO.with(|c| unsafe {
+        for slot in (*c.get()).iter_mut() {
+            let mut addr = *slot as usize;
+            if visitor.visit_tagged_usize_slot(&mut addr, crate::value::STRING_TAG) {
+                *slot = addr as *mut StringHeader;
+            }
+        }
+    });
+}
+
+pub fn scan_concat_memo_roots(mark: &mut dyn FnMut(f64)) {
+    let mut visitor = crate::gc::RuntimeRootVisitor::for_copy(mark);
+    scan_concat_memo_roots_mut(&mut visitor);
+}
+
+#[cfg(test)]
+pub(crate) fn test_clear_concat_memo() {
+    CONCAT_MEMO.with(|c| unsafe {
+        for slot in (*c.get()).iter_mut() {
+            // GC_STORE_AUDIT(ROOT): test cleanup clears CONCAT_MEMO roots.
+            crate::gc::runtime_store_root_raw_mut_ptr_slot(&raw mut *slot, std::ptr::null_mut());
+        }
+    });
+}
+
 /// Shared tail of [`js_string_concat_box`]: assemble two raw byte slices
 /// (each a real string's payload or an itoa'd integer) into an SSO immediate
 /// when the total fits five ASCII bytes, a heap `StringHeader` otherwise.
@@ -262,6 +363,35 @@ fn concat_byte_parts(l: (*const u8, u32), r: (*const u8, u32)) -> f64 {
             }
             let len_bits = (total_blen as u64) << crate::value::SHORT_STRING_LEN_SHIFT;
             return f64::from_bits(crate::value::SHORT_STRING_TAG | len_bits | payload);
+        }
+    }
+
+    // Memo probe, ahead of the allocation: assemble the result into a stack
+    // buffer and look it up by content. Restricted to short ASCII results, so
+    // `flags`/`utf16_len` are trivially `0`/`total_blen` and the surrogate
+    // canonicalization below is a no-op — the cached string is bit-identical
+    // to what the heap path would have built.
+    let memoizable = both_ascii && total_blen <= CONCAT_MEMO_MAX_BYTES;
+    let mut memo_buf = [0u8; CONCAT_MEMO_MAX_BYTES as usize];
+    let mut memo_slot = 0usize;
+    if memoizable {
+        unsafe {
+            if l.1 > 0 {
+                std::ptr::copy_nonoverlapping(l.0, memo_buf.as_mut_ptr(), l.1 as usize);
+            }
+            if r.1 > 0 {
+                std::ptr::copy_nonoverlapping(
+                    r.0,
+                    memo_buf.as_mut_ptr().add(l.1 as usize),
+                    r.1 as usize,
+                );
+            }
+        }
+        let bytes = &memo_buf[..total_blen as usize];
+        memo_slot = concat_memo_slot(bytes);
+        let hit = concat_memo_lookup(memo_slot, bytes);
+        if !hit.is_null() {
+            return f64::from_bits(crate::value::JSValue::string_ptr(hit).bits());
         }
     }
 
@@ -319,6 +449,11 @@ fn concat_byte_parts(l: (*const u8, u32), r: (*const u8, u32)) -> f64 {
         // Merge any surrogate pair newly formed across the join boundary
         // (no-op unless the result carries the lone-surrogate flag).
         let ptr = canonicalize_surrogate_pairs(ptr);
+        if memoizable {
+            // Publish only after the header and payload are fully written:
+            // the memo is a GC root, so a half-built entry would be traced.
+            concat_memo_insert(memo_slot, ptr);
+        }
         // NaN-box as STRING_TAG.
         f64::from_bits(crate::value::JSValue::string_ptr(ptr).bits())
     }
@@ -504,6 +639,44 @@ pub extern "C" fn js_string_concat_value(
         // so the incoming `prefix` may have moved — re-read it from its
         // handle before touching the header or copying the payload (#6655).
         let total_blen = prefix_blen as usize + num_len;
+
+        // Memo probe, ahead of the allocation. This is the `"prefix" + i`
+        // shape (computed property keys, id building) and it is where the
+        // allocations actually come from: `js_string_concat_value_box`'s SSO
+        // arm handles results up to 5 bytes, so everything longer lands here
+        // and heap-allocates. Restricted to a plain ASCII prefix so the cached
+        // string is bit-identical to what the block below would build
+        // (flags == 0, utf16_len == byte_len).
+        let memoizable = total_blen <= CONCAT_MEMO_MAX_BYTES as usize
+            && is_valid_string_ptr(prefix)
+            && prefix_u16 == prefix_blen
+            && unsafe { (*prefix).flags == 0 }
+            && unsafe { bytes_all_ascii(string_data(prefix), prefix_blen) };
+        let mut memo_buf = [0u8; CONCAT_MEMO_MAX_BYTES as usize];
+        let mut memo_slot = 0usize;
+        if memoizable {
+            unsafe {
+                if prefix_blen > 0 {
+                    copy_bytes_small(
+                        string_data(prefix),
+                        memo_buf.as_mut_ptr(),
+                        prefix_blen as usize,
+                    );
+                }
+                copy_bytes_small(
+                    num_buf.as_ptr(),
+                    memo_buf.as_mut_ptr().add(prefix_blen as usize),
+                    num_len,
+                );
+            }
+            let bytes = &memo_buf[..total_blen];
+            memo_slot = concat_memo_slot(bytes);
+            let hit = concat_memo_lookup(memo_slot, bytes);
+            if !hit.is_null() {
+                return hit;
+            }
+        }
+
         let (ptr, data_ptr, prefix) =
             match crate::string::string_storage_alloc_no_collect(total_blen as u32) {
                 Some((ptr, data_ptr)) => (ptr, data_ptr, prefix),
@@ -545,6 +718,11 @@ pub extern "C" fn js_string_concat_value(
             );
         }
 
+        if memoizable {
+            // Publish only after header and payload are written: the memo is a
+            // GC root, so a half-built entry would be traced.
+            concat_memo_insert(memo_slot, ptr);
+        }
         return ptr;
     }
 

--- a/crates/perry-runtime/src/string/mod.rs
+++ b/crates/perry-runtime/src/string/mod.rs
@@ -105,7 +105,7 @@ mod append;
 mod base64_codec;
 mod char_ops;
 mod compare;
-mod concat;
+pub(crate) mod concat;
 mod format;
 mod html;
 mod intern;
@@ -157,6 +157,7 @@ pub(crate) use compare::{
 pub use concat::{
     js_string_add_value, js_string_append_chain, js_string_concat, js_string_concat_box,
     js_string_concat_chain, js_string_concat_value, js_value_add_string, js_value_concat_string,
+    scan_concat_memo_roots, scan_concat_memo_roots_mut,
 };
 pub(crate) use format::fix_exponent_format;
 pub(crate) use format::js_format_f64;

--- a/crates/perry-runtime/src/string/tests.rs
+++ b/crates/perry-runtime/src/string/tests.rs
@@ -961,3 +961,87 @@ mod concat_chain_no_collect {
         }
     }
 }
+
+/// The short-concat memo: `"prefix" + smallint` results are content-addressed,
+/// so two evaluations producing the same bytes share one string object.
+///
+/// This asserts OBJECT IDENTITY, not equality. Equality would pass whether or
+/// not the memo fires, which would make it a test that cannot fail — the whole
+/// point is proving the allocation was skipped.
+#[test]
+fn concat_memo_returns_one_object_for_equal_results() {
+    let _lock = crate::gc::global_side_table_test_lock();
+    crate::string::concat::test_clear_concat_memo();
+
+    let prefix = crate::string::js_string_from_bytes(b"field_".as_ptr(), 6);
+    let first = crate::string::js_string_concat_value(prefix, 7.0);
+    // A DIFFERENT prefix object with the same bytes must still reach the entry:
+    // the memo is keyed on result content, not on operand identity.
+    let other_prefix = crate::string::js_string_from_bytes(b"field_".as_ptr(), 6);
+    assert_ne!(prefix as usize, other_prefix as usize);
+    let second = crate::string::js_string_concat_value(other_prefix, 7.0);
+
+    assert_eq!(
+        first as usize, second as usize,
+        "equal concat results must share one memoized string"
+    );
+    unsafe {
+        assert_eq!((*first).byte_len, 7);
+        // Shared, so the in-place `+=` append can never mutate it under a
+        // second holder — the property that makes sharing sound at all.
+        assert_eq!((*first).refcount, 0);
+        let bytes = std::slice::from_raw_parts(crate::string::string_data(first), 7);
+        assert_eq!(bytes, b"field_7");
+    }
+}
+
+/// Distinct results must not alias, including across the memo's hash: a
+/// collision has to degrade to a miss, never to a wrong string.
+#[test]
+fn concat_memo_never_aliases_distinct_results() {
+    let _lock = crate::gc::global_side_table_test_lock();
+    crate::string::concat::test_clear_concat_memo();
+
+    let prefix = crate::string::js_string_from_bytes(b"field_".as_ptr(), 6);
+    let mut seen: Vec<(usize, String)> = Vec::new();
+    for n in 0..40u32 {
+        let s = crate::string::js_string_concat_value(prefix, n as f64);
+        let text = unsafe {
+            let b =
+                std::slice::from_raw_parts(crate::string::string_data(s), (*s).byte_len as usize);
+            String::from_utf8_lossy(b).into_owned()
+        };
+        assert_eq!(text, format!("field_{n}"));
+        for (other_ptr, other_text) in &seen {
+            if *other_text != text {
+                assert_ne!(
+                    *other_ptr, s as usize,
+                    "distinct results {other_text} and {text} must not share an object"
+                );
+            }
+        }
+        seen.push((s as usize, text));
+    }
+}
+
+/// A non-ASCII prefix is excluded: its `utf16_len` differs from `byte_len`, so
+/// a memoized result would carry the wrong `.length`.
+#[test]
+fn concat_memo_declines_non_ascii_prefixes() {
+    let _lock = crate::gc::global_side_table_test_lock();
+    crate::string::concat::test_clear_concat_memo();
+
+    let prefix = crate::string::js_string_from_bytes("é_".as_bytes().as_ptr(), 3);
+    let a = crate::string::js_string_concat_value(prefix, 1.0);
+    let b = crate::string::js_string_concat_value(prefix, 1.0);
+    assert_ne!(
+        a as usize, b as usize,
+        "a non-ASCII prefix must not be memoized"
+    );
+    unsafe {
+        // "é_1" is 4 bytes but 3 UTF-16 units; the memo path would have
+        // asserted byte_len == utf16_len.
+        assert_eq!((*a).byte_len, 4);
+        assert_eq!((*a).utf16_len, 3);
+    }
+}


### PR DESCRIPTION
`bench_object_property` is the suite's last row above Node. This is one of the two halves that fix it.

## What the gap actually was

Not the object path. With precomputed keys perry already beat Node on the identical workload — **10 ms vs 11** — and transition-IC hit counts were the same either way. What differed is that `o["field_" + j] = v` builds 200k key strings per run: `"field_" + j` is 7 bytes, past SSO's 5-byte ceiling, so every one heap-allocates. Their only consumer reads the bytes and drops them, and that garbage buys a young collection costing ~7 ms — far more than the allocations themselves.

So don't allocate them.

## The change

`js_string_concat_value`'s integer arm consults a bounded, content-addressed memo before allocating: 512 entries, direct-mapped, evicting on collision, keyed on the result bytes with an **exact byte compare**, so a hash collision degrades to a miss and never to a wrong string.

Handing the same object to two holders is sound because of an invariant that predates this change rather than one it adds: concat results are born `refcount = 0`, which is exactly the marker that forbids the in-place `+=` append, so a memo hit can never be mutated under another holder. JS string identity is unobservable besides — `===` compares by value. Entries are restricted to short ASCII results so the cached string is bit-identical to what the allocating path would have built (`flags == 0`, `utf16_len == byte_len`).

Entries are **strong GC roots** (`scan_concat_memo_roots_mut`), not pinned. Pinning would let a long program's distinct short concats accumulate forever — trading RSS for wall time, the wrong side of the memory-parity directive. Eviction drops the root and the string becomes collectable immediately.

## Numbers

| | perry | node |
|---|---|---|
| `bench_object_property`, main | ~36 ms | 14 ms |
| **this PR alone** | **25 ms** | 14 ms |
| this PR + #9367 (transition IC) | **13 ms** | 14 ms |

The two are independent and compose: #9367 removes the per-write miss call, this removes the allocation that forces the collection. Together the row goes from the board's largest loser to a win.

Interleaved A/B, same box, min-of-12. Output byte-identical to Node, including under `PERRY_GC_FORCE_EVACUATE=1 PERRY_GC_VERIFY_EVACUATION=1`.

**No regressions** (perry/node): string_heavy 46/57, gc_pressure 19/31, object_create 5/16, int_arithmetic 56/70, json_roundtrip 364/453 — all wins.

**Adversarial case measured, not assumed:** a fixture whose concat results are all distinct (100% miss, pure probe overhead, zero benefit) runs **7 ms against Node's 8**. The probe is cheap even where it can never help.

## Identity, the thing worth checking hardest

A content-addressed memo hands out shared objects, so anything keying by address rather than value would leak that. Verified against Node on `Map`/`Set` keying, object property identity, cross-construction-route equality (`"field_" + 9 === "field_9"`), and `+=` mutation safety — identical output, and identical again under forced evacuation.

## Tests

- `concat_memo_returns_one_object_for_equal_results` — asserts **object identity**, not equality. Equality would pass whether or not the memo fires, which would make it a test that cannot fail; the point is proving the allocation was skipped. Also checks a *different* prefix object with the same bytes reaches the entry, since the memo is keyed on result content, not operand identity.
- `concat_memo_never_aliases_distinct_results` — 40 distinct results, none may share an object.
- `concat_memo_declines_non_ascii_prefixes` — a memoized non-ASCII result would carry the wrong `.length`.

## Unrelated test fix, included because this PR exposed it

`symbol_probe_rejects_a_filtered_address_without_touching_the_registry` now takes the existing `SymbolAddrRangeGuard::reset()`. `RegistryAddrFilter` is a Bloom filter, so whether one constant address is rejected depended on which symbols earlier tests in the binary happened to register — adding three tests anywhere in the crate could flip it, which is what happened here. The guard makes the rejection a property of the filter rather than of test order. The test's own doc already anticipated this ("a Bloom filter has false positives"); it simply lacked the isolation one sibling test already uses.

## Gates

perry-runtime 2911 passed (`--test-threads=1`), perry-codegen 1379 passed, `cargo fmt --check` clean, all five static `gc_root_dominance_check.py` audits pass, GC store-site inventory passes.

https://claude.ai/code/session_01Pcq6j6y57TdKSR2Zx2D187

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved short ASCII string concatenation by reusing previously created results, reducing repeated allocations.
  - Preserved distinct results for different content and excluded unsupported non-ASCII cases.

- **Reliability**
  - Ensured cached strings remain valid during garbage collection and memory evacuation.

- **Tests**
  - Added coverage for result reuse, distinct-content handling, collision safety, and non-ASCII behavior.
  - Improved test isolation for symbol address filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->