### PR TITLE
test(codegen): cover conditional Buffer index stores

### DIFF
--- a/changelog.d/9380-buffer-conditional-index.md
+++ b/changelog.d/9380-buffer-conditional-index.md
@@ -1,0 +1,3 @@
+Fixed and locked in module-global `Buffer` stores when the source index flows
+through a ternary or conditionally reassigned local; both forms now match Node
+instead of silently leaving the destination zeroed (#9278).

--- a/crates/perry/tests/issue_9278_buffer_conditional_index.rs
+++ b/crates/perry/tests/issue_9278_buffer_conditional_index.rs
@@ -1,0 +1,52 @@
+//! #9278: a byte read indexed through a conditionally assigned local must not
+//! make a subsequent store into another module-global Buffer disappear.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonicalize workspace root")
+}
+
+#[test]
+fn module_global_buffer_stores_survive_conditional_source_indices() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = workspace_root().join("test-files/test_issue_9278_buffer_conditional_index.ts");
+    let output = dir.path().join("main_bin");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-auto-optimize")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled program failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "ternary=522240\nif=522240\n"
+    );
+}

--- a/test-files/test_issue_9278_buffer_conditional_index.ts
+++ b/test-files/test_issue_9278_buffer_conditional_index.ts
@@ -1,0 +1,43 @@
+const W = 64;
+const H = 64;
+const N = W * H;
+const src = Buffer.alloc(N);
+const ternaryDst = Buffer.alloc(N);
+const ifDst = Buffer.alloc(N);
+
+for (let i = 0; i < N; i++) {
+  src[i] = (i * 7 + 13) & 0xff;
+}
+
+function writeTernary(y: number, x: number): void {
+  const yy = y < 0 ? 0 : y > H - 1 ? H - 1 : y;
+  ternaryDst[y * W + x] = src[yy * W + x] & 0xff;
+}
+
+function writeIf(y: number, x: number): void {
+  let yy = y;
+  if (yy < 0) {
+    yy = 0;
+  }
+  if (yy > H - 1) {
+    yy = H - 1;
+  }
+  ifDst[y * W + x] = src[yy * W + x] & 0xff;
+}
+
+for (let y = 0; y < H; y++) {
+  for (let x = 0; x < W; x++) {
+    writeTernary(y, x);
+    writeIf(y, x);
+  }
+}
+
+let ternarySum = 0;
+let ifSum = 0;
+for (let i = 0; i < N; i++) {
+  ternarySum += ternaryDst[i];
+  ifSum += ifDst[i];
+}
+
+console.log("ternary=" + ternarySum);
+console.log("if=" + ifSum);


### PR DESCRIPTION
## Summary

- add an end-to-end regression for writing one module-global Buffer from another when the read index flows through a ternary-assigned local
- cover the equivalent if-reassignment form reported in the issue
- pin the current-main behavior against the Node checksum so the silent store loss cannot return

## Context

The report was made against v0.5.1220 and noted that main had not been checked. Current main already produces the correct checksum for both reported forms, so no compiler code change is needed; this PR locks in that corrected behavior.

## Test plan

- cargo test --profile perry-dev -p perry --test issue_9278_buffer_conditional_index
- node test-files/test_issue_9278_buffer_conditional_index.ts
- source-built Perry compile and run of the same fixture

Closes #9278

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed conditional buffer writes so module-level buffers retain the correct values when indexes are calculated through ternary expressions or conditionally reassigned variables.
  * Improved compatibility with Node.js behavior, preventing destination buffers from being incorrectly zeroed.

* **Tests**
  * Added coverage for clamped buffer indexes using both ternary expressions and explicit conditional statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->