### PR TITLE
test(runtime): isolate symbol Bloom filter state

### DIFF
--- a/changelog.d/9383-symbol-filter-test-isolation.md
+++ b/changelog.d/9383-symbol-filter-test-isolation.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- **The symbol Bloom-filter probe test no longer depends on unrelated tests'
+  filter population.** Test builds now isolate `SYMBOL_ADDR_FILTER` with the
+  per-test `SYMBOL_POINTERS` registry it guards, while production keeps the
+  same process-global filter. A deterministic worker-thread false-positive
+  regression keeps the cross-test leak from returning.

--- a/crates/perry-runtime/src/registry_latch_probes.rs
+++ b/crates/perry-runtime/src/registry_latch_probes.rs
@@ -342,10 +342,21 @@ fn uint8array_probe_rejects_an_out_of_window_address_without_touching_the_regist
 /// address" is not by itself a proof that it can reject: the probe counter is,
 /// and the second half — an address the filter must ADMIT — is what makes the
 /// first half able to fail.
+///
+/// The worker below is a deterministic stand-in for an unrelated test: it
+/// admits this exact address as a false positive in its own filter. Test builds
+/// must isolate that filter alongside `SYMBOL_POINTERS`; a process-global
+/// filter carries the worker's admission here and reproduces #9344.
 #[test]
 fn symbol_probe_rejects_a_filtered_address_without_touching_the_registry() {
-    let sym = unsafe { crate::symbol::alloc_symbol(std::ptr::null_mut(), false) } as usize;
-    assert!(sym != 0, "test premise: the symbol allocated");
+    std::thread::spawn(|| {
+        let unrelated_sym =
+            unsafe { crate::symbol::alloc_symbol(std::ptr::null_mut(), false) } as usize;
+        assert!(unrelated_sym != 0, "test premise: the symbol allocated");
+        crate::symbol::admit_symbol_pointer(FAR_OUTSIDE_ANY_WINDOW);
+    })
+    .join()
+    .expect("the unrelated symbol registration must finish");
 
     let before = crate::symbol::test_symbol_filter_admitted_probe_count();
     assert!(!crate::symbol::is_registered_symbol(FAR_OUTSIDE_ANY_WINDOW));
@@ -355,6 +366,8 @@ fn symbol_probe_rejects_a_filtered_address_without_touching_the_registry() {
         "the address filter must answer without reaching SYMBOL_POINTERS"
     );
 
+    let sym = unsafe { crate::symbol::alloc_symbol(std::ptr::null_mut(), false) } as usize;
+    assert!(sym != 0, "test premise: the symbol allocated");
     assert!(
         crate::symbol::is_registered_symbol(sym),
         "the filter must not hide a registered symbol"

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -448,6 +448,7 @@ pub(crate) fn test_disable_symbol_magic_screen(disabled: bool) -> bool {
     TEST_DISABLE_SYMBOL_MAGIC_SCREEN.with(|c| c.replace(disabled))
 }
 
+per_test_global! {
 /// Which pointers have ever been registered as a Symbol — a conservative
 /// filter in front of the process-global registry mutex.
 ///
@@ -485,8 +486,15 @@ pub(crate) fn test_disable_symbol_magic_screen(disabled: bool) -> bool {
 /// inserter widens"), and this file no longer relies on one: `debug_assertions`
 /// builds re-derive every rejection from `SYMBOL_POINTERS` itself, so an
 /// inserter added without admitting panics in the first test that touches it.
-static SYMBOL_ADDR_FILTER: crate::registry_latch::RegistryAddrFilter =
-    crate::registry_latch::RegistryAddrFilter::new();
+///
+/// In test builds the filter has the same per-test lifetime as
+/// [`SYMBOL_POINTERS`]. Sharing it between tests would accumulate unrelated
+/// admissions, so a Bloom false positive — including #9344's fixed probe —
+/// would depend on test order. `per_test_global!` still expands to this exact
+/// plain `static` in production.
+    static SYMBOL_ADDR_FILTER: crate::registry_latch::RegistryAddrFilter =
+        crate::registry_latch::RegistryAddrFilter::new();
+}
 
 /// Admit `ptr` into [`SYMBOL_ADDR_FILTER`].
 ///
@@ -519,11 +527,9 @@ pub(crate) fn insert_symbol_pointer_in_set(set: &mut PtrHashSet<usize>, ptr: usi
 #[cfg(test)]
 pub(crate) const SYMBOL_FILTER_WORDS: usize = crate::registry_latch::RegistryAddrFilter::words();
 
-/// Save/restore the address filter around a test that needs to observe a
-/// NEARLY-EMPTY filter. It is process-global and only ever gains bits in
-/// production, so a test that clears it must put back at least what it found —
-/// otherwise a later test in the same binary gets a filter that no longer holds
-/// symbols registered before it ran, and fails for no reason of its own.
+/// Save/restore this test's address filter around a fixture that needs to
+/// observe a NEARLY-EMPTY filter. A reset must put back at least what it found,
+/// so symbols registered earlier in the same test remain admitted afterwards.
 #[cfg(test)]
 pub(crate) struct SymbolAddrRangeGuard([u64; SYMBOL_FILTER_WORDS]);
 


### PR DESCRIPTION
## Summary

Makes the symbol Bloom-filter probe regression independent of process-wide test order and population. Test builds now isolate the filter with the `SYMBOL_POINTERS` registry it guards, while production keeps the same process-global static.

## Changes

- Declare `SYMBOL_ADDR_FILTER` with `per_test_global!`, which preserves the existing static in non-test builds.
- Make the regression deterministic by priming the exact false-positive address on an unrelated worker thread; the old global filter leaks that admission, while the isolated test filter does not.
- Keep the positive assertion that a registered symbol is admitted and reaches `SYMBOL_POINTERS`.
- Add the required changelog fragment without changing the workspace version.

## Related issue

Fixes #9344

## Test plan

- [ ] `cargo build --release` clean (not run; targeted production-mode `cargo check` passed)
- [ ] Full host-compatible workspace test command (not run; full affected runtime library suite passed)
- [x] Added or updated a `#[test]` in the affected crate
- [x] Documentation update not required; test-only behavior changed
- [x] Platform UI backends not touched

Additional checks run:

- `cargo fmt --all -- --check`
- `cargo check --release -p perry-runtime --lib`
- `cargo test --release -p perry-runtime --lib` — 2,890 passed, 4 ignored, 0 failed
- `python3 scripts/global_sink_isolation.py --self-test`
- `python3 scripts/global_sink_isolation.py`
- `cargo clippy --release -p perry-runtime --lib`

## Screenshots / output

Not applicable.

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of symbol-address filtering by preventing stale state from leaking between test runs.
  - Added coverage for false-positive symbol matches in worker-thread scenarios.

- **Tests**
  - Strengthened test isolation and determinism for runtime symbol registry checks.
  - Production behavior remains unchanged; these updates improve confidence in internal validation without affecting end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->