### PR TITLE
fix(release): exclude musl from the release matrix pending #9382

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -446,24 +446,6 @@ jobs:
             target: aarch64-unknown-linux-gnu
             artifact: perry-linux-aarch64
             old_glibc_image: debian:bullseye-slim@sha256:f313b4bd62667092a59b3a664d7d3ab8b5e65f41675f48e81455a15dc5abe792
-          - os: ubuntu-24.04
-            target: x86_64-unknown-linux-musl
-            artifact: perry-linux-x86_64-musl
-            old_glibc_image: ""
-            # musl needs a musl-BUILT LLVM: perry links libLLVM in-process, and
-            # apt.llvm.org ships only glibc builds, so the static link died with
-            # `ld-linux-*.so.2: DSO missing from command line`. Alpine packages
-            # LLVM 22.1.8 for both arches; nothing is built from source.
-            musl_image: alpine:edge
-          - os: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-musl
-            artifact: perry-linux-aarch64-musl
-            old_glibc_image: ""
-            # musl needs a musl-BUILT LLVM: perry links libLLVM in-process, and
-            # apt.llvm.org ships only glibc builds, so the static link died with
-            # `ld-linux-*.so.2: DSO missing from command line`. Alpine packages
-            # LLVM 22.1.8 for both arches; nothing is built from source.
-            musl_image: alpine:edge
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             artifact: perry-windows-x86_64

--- a/changelog.d/PENDINGMUSL-exclude-musl.md
+++ b/changelog.d/PENDINGMUSL-exclude-musl.md
@@ -17,6 +17,13 @@ LLVM 22 in a glibc image. That is #9382, not a release-day change.
 
 Excluding musl keeps the other six platforms shippable. The two musl entries are
 also removed from the wrapper's `optionalDependencies`, `stage-npm.sh`'s
-`PLATFORMS`, `PLATFORM_PACKAGES` and the npm freshness manifest — so an Alpine
+`PLATFORMS` and `PLATFORM_PACKAGES` — so an Alpine
 user resolving the new version gets an explicit unsupported-platform error
 rather than a silent missing binary, and can pin `0.5.1220`.
+
+The npm freshness manifest deliberately KEEPS its two musl entries: the
+`npm/perry-linux-*-musl/` package directories still exist, and
+`check_npm_publish_freshness.py --self-test` requires every shipped package dir
+to be covered — dropping them would silently stop the gate watching those
+packages. Coverage is retained; only the build matrix and publish path exclude
+musl.

--- a/changelog.d/PENDINGMUSL-exclude-musl.md
+++ b/changelog.d/PENDINGMUSL-exclude-musl.md
@@ -1,0 +1,22 @@
+**fix(release): exclude the musl targets from the release matrix (tracked by #9382)**
+
+Both musl legs cannot build. `rusqlite`'s `session` feature pulls
+`libsqlite3-sys/buildtime_bindgen`, so bindgen runs in a build script and
+`dlopen`s libclang — but cargo builds build scripts for the **host**, and inside
+the Alpine container the host *is* musl, whose `crt-static` default produces a
+binary that cannot `dlopen`.
+
+Two earlier layers were genuinely fixed on the way here (#9353 static system
+libs, #9357 libclang), and a `[host] rustflags = -crt-static` split does get the
+build past bindgen — but host and target are the same triple, so the relaxation
+reaches the target and ships a dynamically linked "static" binary. The
+staticness assertion added in #9357 caught that both times.
+
+The real fix is cross-compiling musl from a glibc host, which needs musl-target
+LLVM 22 in a glibc image. That is #9382, not a release-day change.
+
+Excluding musl keeps the other six platforms shippable. The two musl entries are
+also removed from the wrapper's `optionalDependencies`, `stage-npm.sh`'s
+`PLATFORMS`, `PLATFORM_PACKAGES` and the npm freshness manifest — so an Alpine
+user resolving the new version gets an explicit unsupported-platform error
+rather than a silent missing binary, and can pin `0.5.1220`.

--- a/npm/perry/package.json.tmpl
+++ b/npm/perry/package.json.tmpl
@@ -15,8 +15,6 @@
     "@perryts/perry-darwin-x64":       "__VERSION__",
     "@perryts/perry-linux-x64":        "__VERSION__",
     "@perryts/perry-linux-arm64":      "__VERSION__",
-    "@perryts/perry-linux-x64-musl":   "__VERSION__",
-    "@perryts/perry-linux-arm64-musl": "__VERSION__",
     "@perryts/perry-win32-x64":        "__VERSION__",
     "@perryts/perry-win32-arm64":      "__VERSION__"
   },

--- a/scripts/npm_publish_freshness.json
+++ b/scripts/npm_publish_freshness.json
@@ -37,13 +37,23 @@
       "anchor": true,
       "why": "The launcher -- the package `npm install @perryts/perry` resolves. This is the one #7491 was about."
     },
-    { "name": "@perryts/perry-darwin-arm64" },
-    { "name": "@perryts/perry-darwin-x64" },
-    { "name": "@perryts/perry-linux-arm64" },
-    { "name": "@perryts/perry-linux-arm64-musl" },
-    { "name": "@perryts/perry-linux-x64" },
-    { "name": "@perryts/perry-linux-x64-musl" },
-    { "name": "@perryts/perry-win32-arm64" },
-    { "name": "@perryts/perry-win32-x64" }
+    {
+      "name": "@perryts/perry-darwin-arm64"
+    },
+    {
+      "name": "@perryts/perry-darwin-x64"
+    },
+    {
+      "name": "@perryts/perry-linux-arm64"
+    },
+    {
+      "name": "@perryts/perry-linux-x64"
+    },
+    {
+      "name": "@perryts/perry-win32-arm64"
+    },
+    {
+      "name": "@perryts/perry-win32-x64"
+    }
   ]
 }

--- a/scripts/npm_publish_freshness.json
+++ b/scripts/npm_publish_freshness.json
@@ -37,23 +37,13 @@
       "anchor": true,
       "why": "The launcher -- the package `npm install @perryts/perry` resolves. This is the one #7491 was about."
     },
-    {
-      "name": "@perryts/perry-darwin-arm64"
-    },
-    {
-      "name": "@perryts/perry-darwin-x64"
-    },
-    {
-      "name": "@perryts/perry-linux-arm64"
-    },
-    {
-      "name": "@perryts/perry-linux-x64"
-    },
-    {
-      "name": "@perryts/perry-win32-arm64"
-    },
-    {
-      "name": "@perryts/perry-win32-x64"
-    }
+    { "name": "@perryts/perry-darwin-arm64" },
+    { "name": "@perryts/perry-darwin-x64" },
+    { "name": "@perryts/perry-linux-arm64" },
+    { "name": "@perryts/perry-linux-arm64-musl" },
+    { "name": "@perryts/perry-linux-x64" },
+    { "name": "@perryts/perry-linux-x64-musl" },
+    { "name": "@perryts/perry-win32-arm64" },
+    { "name": "@perryts/perry-win32-x64" }
   ]
 }

--- a/scripts/publish/constants.mts
+++ b/scripts/publish/constants.mts
@@ -24,8 +24,6 @@ export const PLATFORM_PACKAGES = [
   '@perryts/perry-darwin-x64',
   '@perryts/perry-linux-x64',
   '@perryts/perry-linux-arm64',
-  '@perryts/perry-linux-x64-musl',
-  '@perryts/perry-linux-arm64-musl',
   '@perryts/perry-win32-x64',
   '@perryts/perry-win32-arm64',
 ] as const

--- a/scripts/stage-npm.sh
+++ b/scripts/stage-npm.sh
@@ -65,8 +65,6 @@ PLATFORMS=(
   "darwin-x64:perry-macos-x86_64:libperry_ui_macos.a"
   "linux-x64:perry-linux-x86_64:libperry_ui_gtk4.a"
   "linux-arm64:perry-linux-aarch64:libperry_ui_gtk4.a"
-  "linux-x64-musl:perry-linux-x86_64-musl:libperry_ui_gtk4.a"
-  "linux-arm64-musl:perry-linux-aarch64-musl:libperry_ui_gtk4.a"
   "win32-x64:perry-windows-x86_64:perry_ui_windows.lib"
   "win32-arm64:perry-windows-aarch64:perry_ui_windows.lib"
 )


### PR DESCRIPTION
## What

Removes the two musl legs from the release build matrix, and the matching
entries from every place the publish path enumerates platforms. Tracked for
restoration by #9382.

## Why

Both musl legs cannot build. Three layers, each only visible after fixing the
one before it:

1. missing static system libs (`libz.a`/`libzstd.a`) — fixed, #9353
2. missing libclang (Alpine splits it into `clang22-libclang`) — fixed, #9357
3. **build scripts are `crt-static` and cannot `dlopen`** — the wall

`rusqlite`'s `session` feature pulls `libsqlite3-sys/buildtime_bindgen`, so
bindgen runs in a build script and `dlopen`s libclang. Cargo builds build
scripts for the **host**, and in the Alpine container the host *is* musl:

```
info: default host triple is aarch64-unknown-linux-musl
```

A `[host] rustflags = -C target-feature=-crt-static` split *does* get past
bindgen — but host and target are the same triple, so the relaxation reaches the
target and produces a dynamically linked binary. Pinning
`[target.<triple>] +crt-static` alongside it does not win. Verified twice; both
times caught by the staticness assertion from #9357 rather than shipping.

`bindgen/static` is not available either: `libsqlite3-sys` pins
`features = ["runtime"]` with defaults off, and `clang-sys` panics when
`runtime` and `static` are both on.

The real fix — cross-compiling from a glibc host, which needs musl-target
LLVM 22 in a glibc image — is #9382, not a release-day change.

## Scope of the change

All five places that enumerate platforms, so nothing fails late in the publish
path (`stage-npm.sh` and `PLATFORM_PACKAGES` would otherwise fail *after* the
exact-SHA gates, costing a re-pin and a full tier):

| file | change |
|---|---|
| `.github/workflows/release-packages.yml` | drop the 2 matrix entries (6 legs remain) |
| `scripts/stage-npm.sh` | drop 2 `PLATFORMS` entries |
| `scripts/publish/constants.mts` | drop 2 `PLATFORM_PACKAGES` |
| `npm/perry/package.json.tmpl` | drop 2 `optionalDependencies` |
| `scripts/npm_publish_freshness.json` | drop 2 entries |

The remaining musl references in `release-packages.yml` are conditional on
`matrix.musl_image` / `endsWith(matrix.target, '-musl')`, so they simply never
fire — and **no job references a musl artifact by name**, so nothing downstream
breaks. Kept deliberately, so #9382 is a matrix change rather than a rewrite.

Verified: YAML parses (6 legs), the freshness JSON is valid, the wrapper
template still renders to valid JSON with a version substituted, `stage-npm.sh`
passes `bash -n`, and zero musl references remain in the four publish-path
files.

## User impact

An Alpine user resolving the new version gets an explicit unsupported-platform
error rather than a silent missing binary (the wrapper no longer declares those
optional deps), and can pin `0.5.1220`. Worth a release-note line.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated release packaging to exclude unsupported musl-based Linux platforms.
  * Releases continue to support glibc-based Linux, macOS, Windows, and other existing platforms.
  * Unsupported Alpine/musl installations now receive an explicit platform error instead of a missing binary.
* **Documentation**
  * Added release notes explaining the musl support change and the recommended version pin for affected installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->