### PR TITLE
fix(runtime): support class constructors in util.inherits

### DIFF
--- a/changelog.d/9388-util-inherits-class.md
+++ b/changelog.d/9388-util-inherits-class.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **util.inherits now accepts declared classes in either constructor slot.**
+  Perry class constructors are tagged class references rather than closure or
+  object pointers; the runtime now stores the Node-compatible super_ property
+  on that representation instead of rejecting it as a non-object.
+
+  The prototype link installed by util.inherits is now observable from class
+  instances as well: inherited methods resolve through it, and instanceof
+  follows the linked prototype chain without creating an incorrect static
+  inheritance edge between the constructor objects. Regression coverage spans
+  all four function/class constructor pairings. (#9362)

--- a/crates/perry-runtime/src/object/field_get_set/accessors.rs
+++ b/crates/perry-runtime/src/object/field_get_set/accessors.rs
@@ -374,6 +374,27 @@ pub(crate) unsafe fn ordinary_object_prototype_property_value(
             // The guard drops with this branch; let the ordinary final
             // fallback consult Object.prototype on a genuine Error miss.
         }
+
+        // #9362: Object.setPrototypeOf(C.prototype, parentPrototype) changes
+        // the inherited surface of C instances. util.inherits(C, Parent) uses
+        // exactly that operation after materializing C.prototype. Class
+        // instance lookup normally uses the vtable and then jumps straight to
+        // Object.prototype, so a user-selected parent on the declaration
+        // prototype was skipped. Walk the materialized declaration prototype
+        // on a vtable miss, preserving the instance as the accessor receiver.
+        let decl_proto = super::super::class_decl_prototype_object(class_id);
+        if !decl_proto.is_null()
+            && super::super::prototype_chain::object_has_user_prototype_override(
+                decl_proto as usize,
+            )
+        {
+            let _guard = object_prototype_lookup_guard()?;
+            if let Some(value) =
+                prototype_property_value_with_guard(decl_proto as usize, obj as usize, key)
+            {
+                return Some(value);
+            }
+        }
     }
     default_object_prototype_property_value(obj as usize, key)
 }

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -1106,6 +1106,29 @@ pub extern "C" fn js_instanceof(value: f64, class_id: u32) -> f64 {
                     if class_chain_reaches(cur, class_id) {
                         return true_val;
                     }
+
+                    // #9362: util.inherits(DerivedClass, BaseClass) links
+                    // DerivedClass.prototype to BaseClass.prototype at
+                    // runtime; it does not (and must not) create an extends
+                    // edge between the constructor objects. The class-id fast
+                    // path above therefore misses even though the observable
+                    // prototype chain contains BaseClass.prototype. Only pay
+                    // for the spec prototype walk when the candidate class's
+                    // declaration prototype has a user-selected parent.
+                    let candidate_proto = super::class_registry::class_decl_prototype_object(cur);
+                    let target_proto = super::class_registry::class_decl_prototype_object(class_id);
+                    if !candidate_proto.is_null()
+                        && !target_proto.is_null()
+                        && super::prototype_chain::object_has_user_prototype_override(
+                            candidate_proto as usize,
+                        )
+                        && ordinary_has_instance_prototype_walk(
+                            value,
+                            super::class_constructor_ref_value(class_id),
+                        )
+                    {
+                        return true_val;
+                    }
                 }
             }
         }

--- a/crates/perry-runtime/src/util_inherits.rs
+++ b/crates/perry-runtime/src/util_inherits.rs
@@ -120,6 +120,16 @@ fn ensure_function_prototype(value: f64) -> f64 {
 }
 
 fn set_super_property(ctor: f64, super_ctor: f64) {
+    // Declared classes are INT32-tagged constructor refs rather than closure
+    // or ObjectHeader pointers. Store super_ in the constructor-side static
+    // property table, matching Object.defineProperty(C, "super_", ...).
+    if let Some(class_id) = crate::object::class_ref_id(ctor) {
+        if crate::object::class_prototype_ref_id(ctor).is_none() {
+            crate::object::class_dynamic_prop_root_store(class_id, "super_", super_ctor);
+            crate::object::class_static_set_defined_attrs(class_id, "super_", true, false, true);
+            return;
+        }
+    }
     let key = named_key(b"super_");
     let attrs = PropertyAttrs::new(true, false, true);
     let ctor_closure = closure_ptr(ctor);

--- a/crates/perry/tests/issue_9362_util_inherits_class.rs
+++ b/crates/perry/tests/issue_9362_util_inherits_class.rs
@@ -1,0 +1,56 @@
+//! #9362: util.inherits accepts declared classes in either constructor slot.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonicalize workspace root")
+}
+
+#[test]
+fn util_inherits_supports_function_and_class_constructor_pairs() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = workspace_root().join("test-files/test_issue_9362_util_inherits_class.ts");
+    let output = dir.path().join("main_bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-auto-optimize")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "function/function super: function true true false true\n\
+function/function chain: true true true function/function\n\
+function/class super: function true true false true\n\
+function/class chain: true true true function/class\n\
+class/function super: function true true false true\n\
+class/function chain: true true true class/function\n\
+class/class super: function true true false true\n\
+class/class chain: true true true class/class\n"
+    );
+}

--- a/test-files/test_issue_9362_util_inherits_class.ts
+++ b/test-files/test_issue_9362_util_inherits_class.ts
@@ -1,0 +1,117 @@
+// #9362: util.inherits must support all function/class constructor pairings.
+import util from "node:util";
+
+function FunctionFunctionBase() {}
+(FunctionFunctionBase.prototype as any).baseKind = function () {
+  return "function/function";
+};
+function FunctionFunctionDerived() {}
+util.inherits(FunctionFunctionDerived, FunctionFunctionBase);
+const ffSuper = (FunctionFunctionDerived as any).super_;
+const ffDescriptor = Object.getOwnPropertyDescriptor(FunctionFunctionDerived, "super_")!;
+const ffInstance = new FunctionFunctionDerived();
+console.log(
+  "function/function super:",
+  typeof ffSuper,
+  ffSuper === FunctionFunctionBase,
+  ffDescriptor.writable,
+  ffDescriptor.enumerable,
+  ffDescriptor.configurable,
+);
+console.log(
+  "function/function chain:",
+  Object.getPrototypeOf(FunctionFunctionDerived.prototype) ===
+    FunctionFunctionBase.prototype,
+  ffInstance instanceof FunctionFunctionDerived,
+  ffInstance instanceof FunctionFunctionBase,
+  (ffInstance as any).baseKind(),
+);
+
+class FunctionClassBase {
+  baseKind() {
+    return "function/class";
+  }
+}
+function FunctionClassDerived() {}
+util.inherits(FunctionClassDerived, FunctionClassBase);
+const fcSuper = (FunctionClassDerived as any).super_;
+const fcDescriptor = Object.getOwnPropertyDescriptor(
+  FunctionClassDerived,
+  "super_",
+)!;
+const fcInstance = new FunctionClassDerived();
+console.log(
+  "function/class super:",
+  typeof fcSuper,
+  fcSuper === FunctionClassBase,
+  fcDescriptor.writable,
+  fcDescriptor.enumerable,
+  fcDescriptor.configurable,
+);
+console.log(
+  "function/class chain:",
+  Object.getPrototypeOf(FunctionClassDerived.prototype) ===
+    FunctionClassBase.prototype,
+  fcInstance instanceof FunctionClassDerived,
+  fcInstance instanceof FunctionClassBase,
+  (fcInstance as any).baseKind(),
+);
+
+function ClassFunctionBase() {}
+(ClassFunctionBase.prototype as any).baseKind = function () {
+  return "class/function";
+};
+class ClassFunctionDerived {}
+util.inherits(ClassFunctionDerived, ClassFunctionBase);
+const cfSuper = (ClassFunctionDerived as any).super_;
+const cfDescriptor = Object.getOwnPropertyDescriptor(
+  ClassFunctionDerived,
+  "super_",
+)!;
+const cfInstance = new ClassFunctionDerived();
+console.log(
+  "class/function super:",
+  typeof cfSuper,
+  cfSuper === ClassFunctionBase,
+  cfDescriptor.writable,
+  cfDescriptor.enumerable,
+  cfDescriptor.configurable,
+);
+console.log(
+  "class/function chain:",
+  Object.getPrototypeOf(ClassFunctionDerived.prototype) ===
+    ClassFunctionBase.prototype,
+  cfInstance instanceof ClassFunctionDerived,
+  cfInstance instanceof ClassFunctionBase,
+  (cfInstance as any).baseKind(),
+);
+
+class ClassClassBase {
+  baseKind() {
+    return "class/class";
+  }
+}
+class ClassClassDerived {}
+util.inherits(ClassClassDerived, ClassClassBase);
+const ccSuper = (ClassClassDerived as any).super_;
+const ccDescriptor = Object.getOwnPropertyDescriptor(
+  ClassClassDerived,
+  "super_",
+)!;
+const ccInstance = new ClassClassDerived();
+console.log(
+  "class/class super:",
+  typeof ccSuper,
+  ccSuper === ClassClassBase,
+  ccDescriptor.writable,
+  ccDescriptor.enumerable,
+  ccDescriptor.configurable,
+);
+console.log(
+  "class/class chain:",
+  Object.getPrototypeOf(ClassClassDerived.prototype) ===
+    ClassClassBase.prototype,
+  ccInstance instanceof ClassClassDerived,
+  ccInstance instanceof ClassClassBase,
+  ccInstance.baseKind(),
+);


### PR DESCRIPTION
Fixes #9362

## Summary

- store super_ on declared-class constructor refs with Node-compatible descriptor attributes
- honor a user-selected parent on a declared class prototype for inherited reads
- use the observable prototype chain for instanceof when util.inherits links two declared classes
- cover all function/class constructor pairings with a byte-for-byte Node fixture

## Testing

- node --experimental-strip-types test-files/test_issue_9362_util_inherits_class.ts
- cargo test -p perry --test issue_9362_util_inherits_class
- adjacent setPrototypeOf, prototype replacement, descriptor, and Symbol.hasInstance integration tests
- cargo test --lib -p perry-runtime (2890 passed, 4 ignored)
- scripts/pre-tag-check.sh --quick