### PR TITLE
fix: symbol-filter isolation (#9383) + CONCAT_MEMO thread-local

### DIFF
--- a/changelog.d/9383-symbol-filter-test-isolation.md
+++ b/changelog.d/9383-symbol-filter-test-isolation.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- **The symbol Bloom-filter probe test no longer depends on unrelated tests'
+  filter population.** Test builds now isolate `SYMBOL_ADDR_FILTER` with the
+  per-test `SYMBOL_POINTERS` registry it guards, while production keeps the
+  same process-global filter. A deterministic worker-thread false-positive
+  regression keeps the cross-test leak from returning.

--- a/changelog.d/9390-filter-isolation-and-thread-local.md
+++ b/changelog.d/9390-filter-isolation-and-thread-local.md
@@ -1,0 +1,15 @@
+### Internal
+
+- **Lands #9383's symbol Bloom-filter isolation**, resolving its conflict with
+  the `SymbolAddrRangeGuard::reset()` workaround already on `main` in favour of
+  the stronger form: `per_test_global!` isolates `SYMBOL_ADDR_FILTER` alongside
+  the `SYMBOL_POINTERS` registry it guards, and the test plants the exact false
+  positive on a worker thread. The planted admission leaks through a
+  process-global filter and not through the isolated one, so the assertion has
+  a subject rather than merely not flaking (#9344).
+
+- **Uses `perry_thread_local!` for `CONCAT_MEMO`.** #9373 declared this hot
+  512-entry cache with a raw `thread_local!`, which `check_thread_locals.py`
+  rejects — the address should land in the thread's hot cache instead of
+  costing a `_tlv_get_addr` call (#7469). Its GC root scanner
+  (`scan_concat_memo_roots_mut`) is unaffected.

--- a/crates/perry-runtime/src/registry_latch_probes.rs
+++ b/crates/perry-runtime/src/registry_latch_probes.rs
@@ -342,18 +342,21 @@ fn uint8array_probe_rejects_an_out_of_window_address_without_touching_the_regist
 /// address" is not by itself a proof that it can reject: the probe counter is,
 /// and the second half — an address the filter must ADMIT — is what makes the
 /// first half able to fail.
+///
+/// The worker below is a deterministic stand-in for an unrelated test: it
+/// admits this exact address as a false positive in its own filter. Test builds
+/// must isolate that filter alongside `SYMBOL_POINTERS`; a process-global
+/// filter carries the worker's admission here and reproduces #9344.
 #[test]
 fn symbol_probe_rejects_a_filtered_address_without_touching_the_registry() {
-    // `RegistryAddrFilter` is a Bloom filter, so "this one address is
-    // rejected" depends on which symbols every EARLIER test in the binary
-    // happened to register — three bits set by unrelated addresses are enough
-    // to admit `FAR_OUTSIDE_ANY_WINDOW` and fail this assertion for no reason
-    // of its own. Start from an empty filter (taken before the allocation
-    // below, so the symbol this test registers is still admitted) and the
-    // rejection becomes a property of the filter rather than of test order.
-    let _range = crate::symbol::SymbolAddrRangeGuard::reset();
-    let sym = unsafe { crate::symbol::alloc_symbol(std::ptr::null_mut(), false) } as usize;
-    assert!(sym != 0, "test premise: the symbol allocated");
+    std::thread::spawn(|| {
+        let unrelated_sym =
+            unsafe { crate::symbol::alloc_symbol(std::ptr::null_mut(), false) } as usize;
+        assert!(unrelated_sym != 0, "test premise: the symbol allocated");
+        crate::symbol::admit_symbol_pointer(FAR_OUTSIDE_ANY_WINDOW);
+    })
+    .join()
+    .expect("the unrelated symbol registration must finish");
 
     let before = crate::symbol::test_symbol_filter_admitted_probe_count();
     assert!(!crate::symbol::is_registered_symbol(FAR_OUTSIDE_ANY_WINDOW));
@@ -363,6 +366,8 @@ fn symbol_probe_rejects_a_filtered_address_without_touching_the_registry() {
         "the address filter must answer without reaching SYMBOL_POINTERS"
     );
 
+    let sym = unsafe { crate::symbol::alloc_symbol(std::ptr::null_mut(), false) } as usize;
+    assert!(sym != 0, "test premise: the symbol allocated");
     assert!(
         crate::symbol::is_registered_symbol(sym),
         "the filter must not hide a registered symbol"

--- a/crates/perry-runtime/src/string/concat.rs
+++ b/crates/perry-runtime/src/string/concat.rs
@@ -262,7 +262,7 @@ pub extern "C" fn js_string_concat_box(l_value: f64, r_value: f64) -> f64 {
 const CONCAT_MEMO_SIZE: usize = 512;
 const CONCAT_MEMO_MAX_BYTES: u32 = 12;
 
-thread_local! {
+crate::perry_thread_local! {
     static CONCAT_MEMO: std::cell::UnsafeCell<[*mut StringHeader; CONCAT_MEMO_SIZE]> =
         const { std::cell::UnsafeCell::new([std::ptr::null_mut(); CONCAT_MEMO_SIZE]) };
 }

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -448,6 +448,7 @@ pub(crate) fn test_disable_symbol_magic_screen(disabled: bool) -> bool {
     TEST_DISABLE_SYMBOL_MAGIC_SCREEN.with(|c| c.replace(disabled))
 }
 
+per_test_global! {
 /// Which pointers have ever been registered as a Symbol — a conservative
 /// filter in front of the process-global registry mutex.
 ///
@@ -485,8 +486,15 @@ pub(crate) fn test_disable_symbol_magic_screen(disabled: bool) -> bool {
 /// inserter widens"), and this file no longer relies on one: `debug_assertions`
 /// builds re-derive every rejection from `SYMBOL_POINTERS` itself, so an
 /// inserter added without admitting panics in the first test that touches it.
-static SYMBOL_ADDR_FILTER: crate::registry_latch::RegistryAddrFilter =
-    crate::registry_latch::RegistryAddrFilter::new();
+///
+/// In test builds the filter has the same per-test lifetime as
+/// [`SYMBOL_POINTERS`]. Sharing it between tests would accumulate unrelated
+/// admissions, so a Bloom false positive — including #9344's fixed probe —
+/// would depend on test order. `per_test_global!` still expands to this exact
+/// plain `static` in production.
+    static SYMBOL_ADDR_FILTER: crate::registry_latch::RegistryAddrFilter =
+        crate::registry_latch::RegistryAddrFilter::new();
+}
 
 /// Admit `ptr` into [`SYMBOL_ADDR_FILTER`].
 ///
@@ -519,11 +527,9 @@ pub(crate) fn insert_symbol_pointer_in_set(set: &mut PtrHashSet<usize>, ptr: usi
 #[cfg(test)]
 pub(crate) const SYMBOL_FILTER_WORDS: usize = crate::registry_latch::RegistryAddrFilter::words();
 
-/// Save/restore the address filter around a test that needs to observe a
-/// NEARLY-EMPTY filter. It is process-global and only ever gains bits in
-/// production, so a test that clears it must put back at least what it found —
-/// otherwise a later test in the same binary gets a filter that no longer holds
-/// symbols registered before it ran, and fails for no reason of its own.
+/// Save/restore this test's address filter around a fixture that needs to
+/// observe a NEARLY-EMPTY filter. A reset must put back at least what it found,
+/// so symbols registered earlier in the same test remain admitted afterwards.
 #[cfg(test)]
 pub(crate) struct SymbolAddrRangeGuard([u64; SYMBOL_FILTER_WORDS]);
 


### PR DESCRIPTION
Two things.

**#9383's filter isolation, conflict resolved.** That PR conflicts with the `SymbolAddrRangeGuard::reset()` workaround that reached `main` separately. I resolved in #9383's favour, and the difference matters: the reset guard stops the flake, but `per_test_global!` isolation *plus* planting the exact false positive on a worker thread means the assertion fails if the isolation regresses. A test that merely stopped flaking would still be unable to detect the condition it exists to check. Original commit and authorship preserved.

**`check_thread_locals.py` is red on `main`.** #9373 declared `CONCAT_MEMO` — a hot 512-entry cache — with a raw `thread_local!`; the gate wants `perry_thread_local!` so the address lands in the thread's hot cache rather than costing a `_tlv_get_addr` call (#7469). Drop-in change; its GC root scanner (`scan_concat_memo_roots_mut`) is untouched, and I confirmed the root-holder gate still passes — that cache holds 512 `*mut StringHeader`, so the scanner is what keeps it sound.

**Validation:** `perry-runtime --lib` 2915 passed / 0 failed under `RUST_TEST_THREADS=1`, with the previously-flaky probe green in a *full* run — the configuration the flake actually needed. File-size, thread-local, root-holder, census, raw-handle and fmt gates all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test isolation for symbol filtering, preventing false positives caused by filter state leaking between tests.
  * Added deterministic coverage to prevent regressions in symbol probe behavior.
* **Performance**
  * Optimized thread-local storage for string concatenation memoization, reducing overhead when accessing cached values.
* **Documentation**
  * Updated changelog entries describing the filter-isolation and thread-local storage improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->