### PR TITLE
fix(bench): reject zero-time benchmark false greens

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,20 +56,20 @@ We publish *everything*, including the workloads where V8's JIT still beats us â
 <summary><b>The full published suite, generated from the artifact â€” including the rows we lose</b></summary>
 
 <!-- public-node-bun:start -->
-Generated from [`benchmarks/results/public-node-bun-v1.json`](benchmarks/results/public-node-bun-v1.json) at Perry commit `38ff7eccc2aa`.
+Generated from [`benchmarks/results/public-node-bun-v1.json`](benchmarks/results/public-node-bun-v1.json) at Perry commit `827a92bad5a5`.
 Lower wall-clock median is better; every row includes complete raw samples and passed correctness checks.
 
 | Benchmark | Perry | Node.js | Bun | Result | What it tests |
 |---|---:|---:|---:|---|---|
-| factorial | 94 ms | 95 ms | 95 ms | win vs both | Modular accumulation |
-| method_calls | 9 ms | 10 ms | 8 ms | mixed | Class method dispatch |
-| closure | 47 ms | 49 ms | 49 ms | win vs both | Closure creation and invocation |
-| binary_trees | 4 ms | 6 ms | 6 ms | win vs both | Tree allocation and traversal |
-| string_concat | 2 ms | 4 ms | 1 ms | mixed | String append loop |
-| prime_sieve | 28 ms | 6 ms | 5 ms | loss vs both | Sieve of Eratosthenes |
-| mandelbrot | 22 ms | 24 ms | 28 ms | win vs both | Complex-number iteration |
-| matrix_multiply | 85 ms | 33 ms | 33 ms | loss vs both | Matrix multiplication |
-| json_roundtrip | 184 ms | 380 ms | 220 ms | win vs both | Parse and stringify ~1 MB JSON |
+| factorial | 59 ms | 95 ms | 61 ms | win vs both | Modular accumulation |
+| method_calls | 6 ms | 9 ms | 4 ms | mixed | Class method dispatch |
+| closure | 29 ms | 30 ms | 29 ms | mixed | Closure creation and invocation |
+| binary_trees | 6 ms | 5 ms | 9 ms | mixed | Tree allocation and traversal |
+| string_concat | 5 ms | 37 ms | 12 ms | win vs both | String append loop |
+| prime_sieve | 4 ms | 4 ms | 5 ms | mixed | Sieve of Eratosthenes |
+| mandelbrot | 15 ms | 17 ms | 16 ms | win vs both | Complex-number iteration |
+| matrix_multiply | 22 ms | 24 ms | 22 ms | mixed | Matrix multiplication |
+| json_roundtrip | 186 ms | 407 ms | 189 ms | win vs both | Parse and stringify ~1 MB JSON |
 
 <!-- public-node-bun:end -->
 

--- a/benchmarks/app-patterns/results/matrix-20260901-135936.md
+++ b/benchmarks/app-patterns/results/matrix-20260901-135936.md
@@ -1,0 +1,27 @@
+# App-pattern bench matrix — 2026-09-01 13:59:36
+
+Each cell is mean ms (min ms). Lower is better.
+Final column is **perry/bun ratio** — > 2× is a real gap, < 1.5× is fine.
+
+| Kernel | Perry | Bun | Node | perry/bun | perry/node |
+|---|---:|---:|---:|---:|---:|
+| batch | 60.6 (60.0) | 22.8 (21.6) | 62.9 (61.5) | 2.66x ✗ slow | 0.96x |
+| buffer_transcode | 51.9 (51.1) | 47.4 (43.5) | 68.4 (67.2) | 1.09x ✓ ok | 0.76x |
+| date_format_parse | 28.2 (27.8) | 42.9 (39.5) | 81.0 (79.7) | 0.66x ✅ win | 0.35x |
+| json_parse_1mb | 84.7 (83.9) | 72.5 (71.1) | 115.8 (112.2) | 1.17x ✓ ok | 0.73x |
+| json_stringify_1mb | 75.9 (74.9) | 33.5 (31.3) | 81.6 (79.5) | 2.27x ✗ slow | 0.93x |
+| map_1m | 165.7 (152.3) | 267.1 (247.8) | 248.4 (216.4) | 0.62x ✅ win | 0.67x |
+| object_deep_clone | 17.1 (16.6) | 16.6 (15.3) | 42.6 (40.2) | 1.03x ✓ ok | 0.40x |
+| promise_all_chains | 81.9 (79.9) | 22.8 (21.7) | 48.8 (45.7) | 3.59x ✗ slow | 1.68x |
+| regex_replace | 54.0 (53.3) | 40.1 (37.4) | 72.4 (71.3) | 1.35x ✓ ok | 0.75x |
+| string_concat_csv | 28.7 (28.2) | 30.5 (29.5) | 76.4 (75.2) | 0.94x ✅ win | 0.38x |
+| string_split_map_join | 34.1 (33.6) | 56.1 (51.4) | 70.8 (69.2) | 0.61x ✅ win | 0.48x |
+| string_template_interp | 47.2 (46.4) | 55.3 (53.1) | 92.4 (90.4) | 0.85x ✅ win | 0.51x |
+
+## Summary
+
+- Perry-faster-than-Bun kernels: **5**
+- Borderline (1.5–2× slower): **0**
+- Slow (≥ 2× slower): **3**
+
+**Priority backlog:** the ✗ slow rows are the gaps. Each one is a focused workstream.

--- a/benchmarks/benchmark_gate.py
+++ b/benchmarks/benchmark_gate.py
@@ -159,6 +159,12 @@ def build_artifact(
                 raise ArtifactError(f"{name}: {runtime_name} has an invalid zero RSS sample")
             if any(_number(value, f"{name}: {runtime_name} wall sample") < 0 for value in wall_samples):
                 raise ArtifactError(f"{name}: {runtime_name} has an invalid negative wall sample")
+            if runtime_name == "perry" and statistics.median(
+                _number(value, f"{name}: Perry wall sample") for value in wall_samples
+            ) == 0:
+                raise ArtifactError(
+                    f"{name}: Perry median is 0 ms (measures-nothing); refusing to compute ratios"
+                )
             runtime_results[runtime_name] = {
                 "wall_ms": distribution(wall_samples),
                 "rss_kb": distribution(rss_samples),
@@ -331,6 +337,15 @@ def validate_artifact(payload: Mapping[str, Any]) -> None:
                     _number(value, f"{name}: {runtime_name} wall sample") < 0 for value in samples
                 ):
                     raise ArtifactError(f"{name}: {runtime_name} has a negative wall sample")
+                if (
+                    runtime_name == "perry"
+                    and metric_name == "wall_ms"
+                    and recalculated["median"] == 0
+                ):
+                    raise ArtifactError(
+                        f"{name}: Perry median is 0 ms (measures-nothing); "
+                        "refusing to compute ratios"
+                    )
         correctness = _mapping(entry.get("correctness"), f"{name}: correctness")
         correctness_status = correctness.get("status")
         if correctness_status not in ("pass", "fail", "unchecked"):

--- a/benchmarks/compare.sh
+++ b/benchmarks/compare.sh
@@ -408,12 +408,17 @@ for bench in $BENCHMARKS; do
   speed_ratio="-"
   bun_speed_ratio="-"
   mem_ratio="-"
-  if [[ "$perry_ms" != "ERR" && "$node_ms" != "-" ]]; then
+  perry_display="${perry_ms}ms"
+  if [[ "$perry_ms" == "0" ]]; then
+    perry_display="MEASURES-NOTHING"
+    speed_ratio="MEASURES-NOTHING"
+    bun_speed_ratio="MEASURES-NOTHING"
+  elif [[ "$perry_ms" != "ERR" && "$node_ms" != "-" ]]; then
     if [[ "$node_ms" -gt 0 ]] 2>/dev/null; then
       speed_ratio=$(python3 -c "print(f'{int(\"$perry_ms\")/int(\"$node_ms\"):.2f}')" 2>/dev/null || echo "-")
     fi
   fi
-  if [[ "$perry_ms" != "ERR" && "$bun_ms" != "-" ]]; then
+  if [[ "$perry_ms" != "0" && "$perry_ms" != "ERR" && "$bun_ms" != "-" ]]; then
     if [[ "$bun_ms" -gt 0 ]] 2>/dev/null; then
       bun_speed_ratio=$(python3 -c "print(f'{int(\"$perry_ms\")/int(\"$bun_ms\"):.2f}')" 2>/dev/null || echo "-")
     fi
@@ -512,7 +517,7 @@ PY
   correctness_status=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['status'])" "$correctness_json")
 
   printf "%-20s %10s %10s %10s %10s %10s %10s %10s\n" \
-    "$display" "${perry_ms}ms" "${node_ms}ms" "${bun_ms}ms" "$speed_ratio" "$bun_speed_ratio" "${perry_rss}KB" "$correctness_status"
+    "$display" "$perry_display" "${node_ms}ms" "${bun_ms}ms" "$speed_ratio" "$bun_speed_ratio" "${perry_rss}KB" "$correctness_status"
 
   # Save raw samples as JSONL. The artifact builder rejects any available
   # runtime that did not produce exactly RUNS timing and RSS samples.

--- a/benchmarks/honest_bench/REPORT.md
+++ b/benchmarks/honest_bench/REPORT.md
@@ -34,15 +34,15 @@ Charts: [image convolution](charts/image_convolution.png),
 
 | | |
 |---|---|
-| CPU | Apple M1 (8 cores, arm64) |
-| RAM | 8.0 GB |
-| OS  | macOS 26.5.1 (Darwin) |
-| Rust | `rustc 1.97.1 (8bab26f4f 2026-07-14)` |
+| CPU | x86_64 (16 cores, x86_64) |
+| RAM | 61.9 GB |
+| OS  | Ubuntu 24.04.4 LTS (Linux) |
+| Rust | `rustc 1.100.0-nightly (f7d782a3b 2026-08-19)` |
 | Zig | `0.15.2` |
-| Perry | `perry 0.5.1355` |
-| Python | `Python 3.9.6` |
+| Perry | `perry 0.5.1519` |
+| Python | `Python 3.12.3` |
 | Runs | 5 warmup + 20 measured, median reported |
-| Generated | 2026-08-08T11:37:01.892278+00:00 |
+| Generated | 2026-09-01T14:14:47.564994+00:00 |
 
 ## 3. Image convolution (5×5 Gaussian, 3840×2160 RGB)
 
@@ -50,13 +50,13 @@ _In-memory input + output checksum (no PPM I/O) — see the workload README for 
 
 | Language | Wall median (ms) | Wall σ | Peak RSS | Binary size | Source LoC | Runs OK |
 |---|---:|---:|---:|---:|---:|---:|
-| rust | -0.0 | 0.0 | 48.9 MB | 295.5 KB | 112 | 20/20 |
-| zig | 0.0 | 0.0 | 48.8 MB | 227.0 KB | 113 | 20/20 |
-| perry | -0.0 | 0.1 | 56.1 MB | 4.6 MB | 92 | 20/20 |
-| node | 0.0 | 0.1 | 117.6 MB | — | 86 | 20/20 |
-| bun | 0.0 | 0.1 | 83.0 MB | — | 86 | 20/20 |
+| rust | 321.6 | 1.9 | 49.2 MB | 288.9 KB | 112 | 20/20 |
+| zig | 173.5 | 1.1 | 48.7 MB | 1.3 MB | 113 | 20/20 |
+| perry | 1,204.4 | 282.4 | 79.1 MB | 8.7 MB | 92 | 20/20 |
+| node | 975.0 | 78.6 | 115.7 MB | — | 86 | 20/20 |
+| bun | 544.0 | 37.0 | 91.5 MB | — | 86 | 20/20 |
 
-_Ratios vs fastest: zig = 1.40×, node = 1.20×, bun = 1.00×_
+_Ratios vs fastest: rust = 1.85×, zig = 1.00×, perry = 6.94×, node = 5.62×, bun = 3.14×_
 
 ## 1a. JSON pipeline — small fixture (100 records, 21 KB)
 
@@ -64,13 +64,13 @@ _All three languages produce byte-identical output at this scale (hash `7fc66fa8
 
 | Language | Wall median (ms) | Wall σ | Peak RSS | Binary size | Source LoC | Runs OK |
 |---|---:|---:|---:|---:|---:|---:|
-| rust | 0.0 | 0.0 | 1.7 MB | 360.2 KB | 99 | 20/20 |
-| zig | 0.0 | 0.0 | 1.9 MB | 309.2 KB | 112 | 20/20 |
-| perry | 0.0 | 0.0 | 8.5 MB | 4.7 MB | 52 | 20/20 |
-| node | 0.0 | 0.1 | 64.0 MB | — | 40 | 20/20 |
-| bun | 0.0 | 0.1 | 30.1 MB | — | 40 | 20/20 |
+| rust | 14.7 | 0.6 | 2.2 MB | 368.9 KB | 99 | 20/20 |
+| zig | 14.4 | 4.8 | 1.6 MB | 2.5 MB | 112 | 20/20 |
+| perry | 19.6 | 0.4 | 35.1 MB | 8.7 MB | 52 | 20/20 |
+| node | 53.0 | 1.3 | 59.5 MB | — | 40 | 20/20 |
+| bun | 27.9 | 0.4 | 39.5 MB | — | 40 | 20/20 |
 
-_Ratios vs fastest: rust = 18.48×, zig = 1.00×, perry = 40.67×, node = 2.30×, bun = 15.89×_
+_Ratios vs fastest: rust = 1.03×, zig = 1.00×, perry = 1.36×, node = 3.68×, bun = 1.94×_
 
 ## 1b. JSON pipeline — full fixture (500k records, 108 MB)
 
@@ -78,13 +78,13 @@ _All five implementations complete this workload against the same 108 MB fixture
 
 | Language | Wall median (ms) | Wall σ | Peak RSS | Binary size | Source LoC | Runs OK |
 |---|---:|---:|---:|---:|---:|---:|
-| rust | -0.0 | 0.1 | 426.9 MB | 360.2 KB | 99 | 20/20 |
-| zig | -0.0 | 0.1 | 576.8 MB | 309.2 KB | 112 | 20/20 |
-| perry | 0.0 | 0.1 | 1,055.2 MB | 4.7 MB | 52 | 20/20 |
-| node | 0.0 | 0.1 | 774.7 MB | — | 40 | 20/20 |
-| bun | -0.0 | 0.1 | 579.5 MB | — | 40 | 20/20 |
+| rust | 733.6 | 17.9 | 427.8 MB | 368.9 KB | 99 | 20/20 |
+| zig | 850.5 | 89.7 | 547.5 MB | 2.5 MB | 112 | 20/20 |
+| perry | 1,831.2 | 29.3 | 775.9 MB | 8.7 MB | 52 | 20/20 |
+| node | 1,183.5 | 65.6 | 567.2 MB | — | 40 | 20/20 |
+| bun | 624.2 | 4.2 | 589.4 MB | — | 40 | 20/20 |
 
-_Ratios vs fastest: perry = 1.00×, node = 8.75×_
+_Ratios vs fastest: rust = 1.18×, zig = 1.36×, perry = 2.93×, node = 1.90×, bun = 1.00×_
 
 ## Honest findings — Perry gaps surfaced by this benchmark
 

--- a/benchmarks/honest_bench/results/metadata.json
+++ b/benchmarks/honest_bench/results/metadata.json
@@ -1,28 +1,28 @@
 {
-  "generated_at": "2026-08-08T11:37:01.892278+00:00",
-  "commit": "38ff7eccc2aa0b59629bed548daf8ac56bd9fb03",
+  "generated_at": "2026-09-01T14:14:47.564994+00:00",
+  "commit": "827a92bad5a589e94e1630994185693ada903fe2",
   "host": {
-    "os_version": "26.5.1",
-    "kernel": "Darwin perry-macos.fritz.box 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:38:00 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T8103 arm64",
-    "arch": "arm64",
-    "cpu": "Apple M1",
-    "ncpu": "8",
-    "ram_gb": 8.0
+    "os_version": "Ubuntu 24.04.4 LTS",
+    "kernel": "Linux ideal-mastodon 6.17.0-23-generic #23~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC Tue Apr 14 16:11:48 UTC 2 x86_64 x86_64 x86_64 GNU/Linux",
+    "arch": "x86_64",
+    "cpu": "x86_64",
+    "ncpu": "16",
+    "ram_gb": 61.9
   },
   "toolchains": {
-    "rustc": "rustc 1.97.1 (8bab26f4f 2026-07-14)",
-    "cargo": "cargo 1.97.1 (c980f4866 2026-06-30)",
+    "rustc": "rustc 1.100.0-nightly (f7d782a3b 2026-08-19)",
+    "cargo": "cargo 1.100.0-nightly (514c56dd7 2026-08-19)",
     "zig": "0.15.2",
-    "python": "Python 3.9.6",
+    "python": "Python 3.12.3",
     "node": "v22.23.1",
     "bun": "1.3.14",
     "oha": "",
-    "perry": "perry 0.5.1355"
+    "perry": "perry 0.5.1519"
   },
   "executables": {
-    "perry": "/Users/perry/projects/perry/baseline-1355/target/release/perry",
-    "node": "/Users/perry/.cache/perry-bench-tools/bin/node",
-    "bun": "/Users/perry/.cache/perry-bench-tools/bin/bun"
+    "perry": "/root/perry-issue-9338-public-827a92b/target/release/perry",
+    "node": "/root/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
+    "bun": "/root/.cache/perry-bench-tools/bun-1.3.14/bun"
   },
   "harness": {
     "warmup": 5,
@@ -36,18 +36,18 @@
       "<compiled-workload>"
     ],
     "perry_compile": [
-      "/Users/perry/projects/perry/baseline-1355/target/release/perry",
+      "/root/perry-issue-9338-public-827a92b/target/release/perry",
       "<source.ts>",
       "-o",
       "<compiled-workload>"
     ],
     "node": [
-      "/Users/perry/.cache/perry-bench-tools/bin/node",
+      "/root/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "--experimental-strip-types",
       "<source.ts>"
     ],
     "bun": [
-      "/Users/perry/.cache/perry-bench-tools/bin/bun",
+      "/root/.cache/perry-bench-tools/bun-1.3.14/bun",
       "run",
       "<source.ts>"
     ],
@@ -55,7 +55,7 @@
       "<compiled-kernel>"
     ],
     "perry_http_compile": [
-      "/Users/perry/projects/perry/baseline-1355/target/release/perry",
+      "/root/perry-issue-9338-public-827a92b/target/release/perry",
       "<kernel.ts>",
       "-o",
       "<compiled-kernel>"

--- a/benchmarks/honest_bench/results/results.json
+++ b/benchmarks/honest_bench/results/results.json
@@ -8,8 +8,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/rust/target/release/image_conv"
       ],
       "run": 1,
-      "wall_ms": -0.108458,
-      "max_rss_kb": 50064,
+      "wall_ms": 319.912246,
+      "max_rss_kb": 50344,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -24,8 +24,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/rust/target/release/image_conv"
       ],
       "run": 2,
-      "wall_ms": -0.032792,
-      "max_rss_kb": 50064,
+      "wall_ms": 320.809311,
+      "max_rss_kb": 50228,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -40,8 +40,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/rust/target/release/image_conv"
       ],
       "run": 3,
-      "wall_ms": 0.044667,
-      "max_rss_kb": 50048,
+      "wall_ms": 323.089118,
+      "max_rss_kb": 50420,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -56,8 +56,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/rust/target/release/image_conv"
       ],
       "run": 4,
-      "wall_ms": 0.021875,
-      "max_rss_kb": 50064,
+      "wall_ms": 319.492573,
+      "max_rss_kb": 50164,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -72,8 +72,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/rust/target/release/image_conv"
       ],
       "run": 5,
-      "wall_ms": -0.014084,
-      "max_rss_kb": 50064,
+      "wall_ms": 318.944048,
+      "max_rss_kb": 50304,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -88,8 +88,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/rust/target/release/image_conv"
       ],
       "run": 6,
-      "wall_ms": 0.004583,
-      "max_rss_kb": 50064,
+      "wall_ms": 320.191458,
+      "max_rss_kb": 50332,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -104,8 +104,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/rust/target/release/image_conv"
       ],
       "run": 7,
-      "wall_ms": -0.00975,
-      "max_rss_kb": 50064,
+      "wall_ms": 325.011939,
+      "max_rss_kb": 50440,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -120,8 +120,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/rust/target/release/image_conv"
       ],
       "run": 8,
-      "wall_ms": 0.013042,
-      "max_rss_kb": 50064,
+      "wall_ms": 324.331027,
+      "max_rss_kb": 50320,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -136,8 +136,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/rust/target/release/image_conv"
       ],
       "run": 9,
-      "wall_ms": -0.070291,
-      "max_rss_kb": 50064,
+      "wall_ms": 318.817783,
+      "max_rss_kb": 50276,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -152,8 +152,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/rust/target/release/image_conv"
       ],
       "run": 10,
-      "wall_ms": 0.031625,
-      "max_rss_kb": 50064,
+      "wall_ms": 319.406442,
+      "max_rss_kb": 50300,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -168,8 +168,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/rust/target/release/image_conv"
       ],
       "run": 11,
-      "wall_ms": -0.063333,
-      "max_rss_kb": 50064,
+      "wall_ms": 319.293461,
+      "max_rss_kb": 50360,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -184,8 +184,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/rust/target/release/image_conv"
       ],
       "run": 12,
-      "wall_ms": 0.023958,
-      "max_rss_kb": 50064,
+      "wall_ms": 323.677247,
+      "max_rss_kb": 50288,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -200,8 +200,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/rust/target/release/image_conv"
       ],
       "run": 13,
-      "wall_ms": -0.016208,
-      "max_rss_kb": 50064,
+      "wall_ms": 322.53786,
+      "max_rss_kb": 50444,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -216,8 +216,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/rust/target/release/image_conv"
       ],
       "run": 14,
-      "wall_ms": -0.007125,
-      "max_rss_kb": 50064,
+      "wall_ms": 323.488394,
+      "max_rss_kb": 49960,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -232,8 +232,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/rust/target/release/image_conv"
       ],
       "run": 15,
-      "wall_ms": 0.023291,
-      "max_rss_kb": 50048,
+      "wall_ms": 322.14779,
+      "max_rss_kb": 50332,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -248,8 +248,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/rust/target/release/image_conv"
       ],
       "run": 16,
-      "wall_ms": 0.01275,
-      "max_rss_kb": 50064,
+      "wall_ms": 321.894577,
+      "max_rss_kb": 50476,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -264,8 +264,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/rust/target/release/image_conv"
       ],
       "run": 17,
-      "wall_ms": -0.057916,
-      "max_rss_kb": 50064,
+      "wall_ms": 321.234956,
+      "max_rss_kb": 50304,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -280,8 +280,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/rust/target/release/image_conv"
       ],
       "run": 18,
-      "wall_ms": -0.024417,
-      "max_rss_kb": 50064,
+      "wall_ms": 322.809666,
+      "max_rss_kb": 50328,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -296,8 +296,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/rust/target/release/image_conv"
       ],
       "run": 19,
-      "wall_ms": 0.03975,
-      "max_rss_kb": 50064,
+      "wall_ms": 322.066128,
+      "max_rss_kb": 50380,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -312,8 +312,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/rust/target/release/image_conv"
       ],
       "run": 20,
-      "wall_ms": 0.009041,
-      "max_rss_kb": 50064,
+      "wall_ms": 320.183813,
+      "max_rss_kb": 50452,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -328,8 +328,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/zig/zig-out/bin/image_conv"
       ],
       "run": 1,
-      "wall_ms": 0.094833,
-      "max_rss_kb": 49984,
+      "wall_ms": 173.182451,
+      "max_rss_kb": 49760,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -344,8 +344,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/zig/zig-out/bin/image_conv"
       ],
       "run": 2,
-      "wall_ms": -0.022459,
-      "max_rss_kb": 49984,
+      "wall_ms": 173.259385,
+      "max_rss_kb": 50016,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -360,8 +360,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/zig/zig-out/bin/image_conv"
       ],
       "run": 3,
-      "wall_ms": -0.018375,
-      "max_rss_kb": 49984,
+      "wall_ms": 172.255951,
+      "max_rss_kb": 50016,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -376,8 +376,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/zig/zig-out/bin/image_conv"
       ],
       "run": 4,
-      "wall_ms": -0.006833,
-      "max_rss_kb": 49984,
+      "wall_ms": 172.856774,
+      "max_rss_kb": 49888,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -392,8 +392,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/zig/zig-out/bin/image_conv"
       ],
       "run": 5,
-      "wall_ms": 0.047625,
-      "max_rss_kb": 49984,
+      "wall_ms": 172.869126,
+      "max_rss_kb": 50016,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -408,8 +408,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/zig/zig-out/bin/image_conv"
       ],
       "run": 6,
-      "wall_ms": -0.023,
-      "max_rss_kb": 49984,
+      "wall_ms": 173.957178,
+      "max_rss_kb": 49760,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -424,8 +424,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/zig/zig-out/bin/image_conv"
       ],
       "run": 7,
-      "wall_ms": 0.019708,
-      "max_rss_kb": 49984,
+      "wall_ms": 173.667758,
+      "max_rss_kb": 49632,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -440,8 +440,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/zig/zig-out/bin/image_conv"
       ],
       "run": 8,
-      "wall_ms": -0.027959,
-      "max_rss_kb": 49984,
+      "wall_ms": 172.14263,
+      "max_rss_kb": 49760,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -456,8 +456,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/zig/zig-out/bin/image_conv"
       ],
       "run": 9,
-      "wall_ms": 0.08325,
-      "max_rss_kb": 49984,
+      "wall_ms": 175.56484,
+      "max_rss_kb": 49760,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -472,8 +472,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/zig/zig-out/bin/image_conv"
       ],
       "run": 10,
-      "wall_ms": 0.072292,
-      "max_rss_kb": 49984,
+      "wall_ms": 172.970095,
+      "max_rss_kb": 49888,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -488,8 +488,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/zig/zig-out/bin/image_conv"
       ],
       "run": 11,
-      "wall_ms": 0.031417,
-      "max_rss_kb": 49984,
+      "wall_ms": 173.755641,
+      "max_rss_kb": 49888,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -504,8 +504,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/zig/zig-out/bin/image_conv"
       ],
       "run": 12,
-      "wall_ms": -0.024125,
-      "max_rss_kb": 49984,
+      "wall_ms": 175.647044,
+      "max_rss_kb": 49888,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -520,8 +520,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/zig/zig-out/bin/image_conv"
       ],
       "run": 13,
-      "wall_ms": 0.021334,
-      "max_rss_kb": 49984,
+      "wall_ms": 172.046951,
+      "max_rss_kb": 50016,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -536,8 +536,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/zig/zig-out/bin/image_conv"
       ],
       "run": 14,
-      "wall_ms": -0.000417,
-      "max_rss_kb": 49984,
+      "wall_ms": 175.088721,
+      "max_rss_kb": 49888,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -552,8 +552,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/zig/zig-out/bin/image_conv"
       ],
       "run": 15,
-      "wall_ms": -0.033542,
-      "max_rss_kb": 49984,
+      "wall_ms": 174.832622,
+      "max_rss_kb": 50016,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -568,8 +568,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/zig/zig-out/bin/image_conv"
       ],
       "run": 16,
-      "wall_ms": -0.031042,
-      "max_rss_kb": 49984,
+      "wall_ms": 175.06681,
+      "max_rss_kb": 49888,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -584,8 +584,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/zig/zig-out/bin/image_conv"
       ],
       "run": 17,
-      "wall_ms": -0.007208,
-      "max_rss_kb": 49984,
+      "wall_ms": 173.134621,
+      "max_rss_kb": 49888,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -600,8 +600,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/zig/zig-out/bin/image_conv"
       ],
       "run": 18,
-      "wall_ms": 0.051125,
-      "max_rss_kb": 49984,
+      "wall_ms": 173.996952,
+      "max_rss_kb": 49888,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -616,8 +616,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/zig/zig-out/bin/image_conv"
       ],
       "run": 19,
-      "wall_ms": 0.058417,
-      "max_rss_kb": 49984,
+      "wall_ms": 173.241381,
+      "max_rss_kb": 49884,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -632,8 +632,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/zig/zig-out/bin/image_conv"
       ],
       "run": 20,
-      "wall_ms": 0.029625,
-      "max_rss_kb": 49984,
+      "wall_ms": 174.518806,
+      "max_rss_kb": 49888,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -648,8 +648,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/perry/image_conv"
       ],
       "run": 1,
-      "wall_ms": 0.028083,
-      "max_rss_kb": 57488,
+      "wall_ms": 1203.29221,
+      "max_rss_kb": 80800,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -664,8 +664,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/perry/image_conv"
       ],
       "run": 2,
-      "wall_ms": 0.022917,
-      "max_rss_kb": 57472,
+      "wall_ms": 1203.576601,
+      "max_rss_kb": 80764,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -680,8 +680,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/perry/image_conv"
       ],
       "run": 3,
-      "wall_ms": 0.045084,
-      "max_rss_kb": 57488,
+      "wall_ms": 1202.635374,
+      "max_rss_kb": 80788,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -696,8 +696,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/perry/image_conv"
       ],
       "run": 4,
-      "wall_ms": 0.01775,
-      "max_rss_kb": 57472,
+      "wall_ms": 1205.451492,
+      "max_rss_kb": 81076,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -712,8 +712,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/perry/image_conv"
       ],
       "run": 5,
-      "wall_ms": -0.020917,
-      "max_rss_kb": 57472,
+      "wall_ms": 1204.519432,
+      "max_rss_kb": 80992,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -728,8 +728,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/perry/image_conv"
       ],
       "run": 6,
-      "wall_ms": -0.008625,
-      "max_rss_kb": 57472,
+      "wall_ms": 1203.465042,
+      "max_rss_kb": 80684,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -744,8 +744,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/perry/image_conv"
       ],
       "run": 7,
-      "wall_ms": 0.090417,
-      "max_rss_kb": 57472,
+      "wall_ms": 1202.606922,
+      "max_rss_kb": 81084,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -760,8 +760,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/perry/image_conv"
       ],
       "run": 8,
-      "wall_ms": 0.007792,
-      "max_rss_kb": 57488,
+      "wall_ms": 1203.688289,
+      "max_rss_kb": 81108,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -776,8 +776,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/perry/image_conv"
       ],
       "run": 9,
-      "wall_ms": 0.047958,
-      "max_rss_kb": 57472,
+      "wall_ms": 1203.786463,
+      "max_rss_kb": 80944,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -792,8 +792,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/perry/image_conv"
       ],
       "run": 10,
-      "wall_ms": -0.04175,
-      "max_rss_kb": 57472,
+      "wall_ms": 1202.470486,
+      "max_rss_kb": 80764,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -808,8 +808,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/perry/image_conv"
       ],
       "run": 11,
-      "wall_ms": -0.009959,
-      "max_rss_kb": 57488,
+      "wall_ms": 1204.333425,
+      "max_rss_kb": 80964,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -824,8 +824,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/perry/image_conv"
       ],
       "run": 12,
-      "wall_ms": -0.082416,
-      "max_rss_kb": 57488,
+      "wall_ms": 1203.61874,
+      "max_rss_kb": 81092,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -840,8 +840,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/perry/image_conv"
       ],
       "run": 13,
-      "wall_ms": 0.008,
-      "max_rss_kb": 57488,
+      "wall_ms": 1205.85694,
+      "max_rss_kb": 80840,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -856,8 +856,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/perry/image_conv"
       ],
       "run": 14,
-      "wall_ms": -0.018125,
-      "max_rss_kb": 57488,
+      "wall_ms": 1204.794987,
+      "max_rss_kb": 81080,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -872,8 +872,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/perry/image_conv"
       ],
       "run": 15,
-      "wall_ms": -0.183959,
-      "max_rss_kb": 57472,
+      "wall_ms": 1205.210102,
+      "max_rss_kb": 80676,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -888,8 +888,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/perry/image_conv"
       ],
       "run": 16,
-      "wall_ms": -0.002334,
-      "max_rss_kb": 57488,
+      "wall_ms": 1205.37002,
+      "max_rss_kb": 80888,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -904,8 +904,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/perry/image_conv"
       ],
       "run": 17,
-      "wall_ms": -0.059916,
-      "max_rss_kb": 57488,
+      "wall_ms": 1205.074649,
+      "max_rss_kb": 80676,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -920,8 +920,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/perry/image_conv"
       ],
       "run": 18,
-      "wall_ms": -0.064875,
-      "max_rss_kb": 57488,
+      "wall_ms": 1941.538199,
+      "max_rss_kb": 81072,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -936,8 +936,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/perry/image_conv"
       ],
       "run": 19,
-      "wall_ms": -0.054416,
-      "max_rss_kb": 57488,
+      "wall_ms": 2014.706841,
+      "max_rss_kb": 81092,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -952,8 +952,8 @@
         "benchmarks/honest_bench/workloads/3_image_convolution/perry/image_conv"
       ],
       "run": 20,
-      "wall_ms": 0.094791,
-      "max_rss_kb": 57472,
+      "wall_ms": 1966.355061,
+      "max_rss_kb": 81008,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -963,16 +963,16 @@
     {
       "workload": "image_convolution",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 1,
-      "wall_ms": -0.018416,
-      "max_rss_kb": 120384,
+      "wall_ms": 973.375217,
+      "max_rss_kb": 118424,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -982,16 +982,16 @@
     {
       "workload": "image_convolution",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 2,
-      "wall_ms": -0.136083,
-      "max_rss_kb": 120480,
+      "wall_ms": 971.447546,
+      "max_rss_kb": 118636,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1001,16 +1001,16 @@
     {
       "workload": "image_convolution",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 3,
-      "wall_ms": -0.073292,
-      "max_rss_kb": 120432,
+      "wall_ms": 972.381591,
+      "max_rss_kb": 118372,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1020,16 +1020,16 @@
     {
       "workload": "image_convolution",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 4,
-      "wall_ms": 0.062875,
-      "max_rss_kb": 120464,
+      "wall_ms": 975.271227,
+      "max_rss_kb": 118236,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1039,16 +1039,16 @@
     {
       "workload": "image_convolution",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 5,
-      "wall_ms": 0.02525,
-      "max_rss_kb": 120592,
+      "wall_ms": 969.634,
+      "max_rss_kb": 118656,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1058,16 +1058,16 @@
     {
       "workload": "image_convolution",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 6,
-      "wall_ms": 0.0625,
-      "max_rss_kb": 120448,
+      "wall_ms": 972.660041,
+      "max_rss_kb": 118508,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1077,16 +1077,16 @@
     {
       "workload": "image_convolution",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 7,
-      "wall_ms": 0.004416,
-      "max_rss_kb": 120592,
+      "wall_ms": 977.805128,
+      "max_rss_kb": 118720,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1096,16 +1096,16 @@
     {
       "workload": "image_convolution",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 8,
-      "wall_ms": -0.037958,
-      "max_rss_kb": 120352,
+      "wall_ms": 975.870926,
+      "max_rss_kb": 118632,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1115,16 +1115,16 @@
     {
       "workload": "image_convolution",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 9,
-      "wall_ms": -0.027125,
-      "max_rss_kb": 120464,
+      "wall_ms": 986.876377,
+      "max_rss_kb": 118076,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1134,16 +1134,16 @@
     {
       "workload": "image_convolution",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 10,
-      "wall_ms": -0.075917,
-      "max_rss_kb": 120608,
+      "wall_ms": 979.976894,
+      "max_rss_kb": 118484,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1153,16 +1153,16 @@
     {
       "workload": "image_convolution",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 11,
-      "wall_ms": 0.040542,
-      "max_rss_kb": 120448,
+      "wall_ms": 977.929181,
+      "max_rss_kb": 118592,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1172,16 +1172,16 @@
     {
       "workload": "image_convolution",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 12,
-      "wall_ms": -0.027166,
-      "max_rss_kb": 120448,
+      "wall_ms": 979.803641,
+      "max_rss_kb": 118364,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1191,16 +1191,16 @@
     {
       "workload": "image_convolution",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 13,
-      "wall_ms": 0.027459,
-      "max_rss_kb": 120576,
+      "wall_ms": 1183.670039,
+      "max_rss_kb": 118432,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1210,16 +1210,16 @@
     {
       "workload": "image_convolution",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 14,
-      "wall_ms": -0.030167,
-      "max_rss_kb": 120432,
+      "wall_ms": 974.71618,
+      "max_rss_kb": 117956,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1229,16 +1229,16 @@
     {
       "workload": "image_convolution",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 15,
-      "wall_ms": 0.052375,
-      "max_rss_kb": 120384,
+      "wall_ms": 1093.290109,
+      "max_rss_kb": 117988,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1248,16 +1248,16 @@
     {
       "workload": "image_convolution",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 16,
-      "wall_ms": 0.062916,
-      "max_rss_kb": 120512,
+      "wall_ms": 1252.292942,
+      "max_rss_kb": 118280,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1267,16 +1267,16 @@
     {
       "workload": "image_convolution",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 17,
-      "wall_ms": 0.006792,
-      "max_rss_kb": 120640,
+      "wall_ms": 974.618267,
+      "max_rss_kb": 118532,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1286,16 +1286,16 @@
     {
       "workload": "image_convolution",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 18,
-      "wall_ms": 0.035958,
-      "max_rss_kb": 120432,
+      "wall_ms": 966.695012,
+      "max_rss_kb": 118420,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1305,16 +1305,16 @@
     {
       "workload": "image_convolution",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 19,
-      "wall_ms": 0.01625,
-      "max_rss_kb": 120464,
+      "wall_ms": 967.978879,
+      "max_rss_kb": 118116,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1324,16 +1324,16 @@
     {
       "workload": "image_convolution",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 20,
-      "wall_ms": 0.00975,
-      "max_rss_kb": 120448,
+      "wall_ms": 965.920996,
+      "max_rss_kb": 118492,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1343,15 +1343,15 @@
     {
       "workload": "image_convolution",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 1,
-      "wall_ms": 0.060959,
-      "max_rss_kb": 84976,
+      "wall_ms": 523.357448,
+      "max_rss_kb": 93436,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1361,15 +1361,15 @@
     {
       "workload": "image_convolution",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 2,
-      "wall_ms": 0.0165,
-      "max_rss_kb": 84912,
+      "wall_ms": 523.303468,
+      "max_rss_kb": 93540,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1379,15 +1379,15 @@
     {
       "workload": "image_convolution",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 3,
-      "wall_ms": 0.014875,
-      "max_rss_kb": 85040,
+      "wall_ms": 544.101685,
+      "max_rss_kb": 93848,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1397,15 +1397,15 @@
     {
       "workload": "image_convolution",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 4,
-      "wall_ms": 0.024042,
-      "max_rss_kb": 85008,
+      "wall_ms": 538.859747,
+      "max_rss_kb": 93348,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1415,15 +1415,15 @@
     {
       "workload": "image_convolution",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 5,
-      "wall_ms": -0.040542,
-      "max_rss_kb": 84976,
+      "wall_ms": 557.809563,
+      "max_rss_kb": 94300,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1433,15 +1433,15 @@
     {
       "workload": "image_convolution",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 6,
-      "wall_ms": -0.203416,
-      "max_rss_kb": 84864,
+      "wall_ms": 544.497604,
+      "max_rss_kb": 93380,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1451,15 +1451,15 @@
     {
       "workload": "image_convolution",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 7,
-      "wall_ms": 0.027625,
-      "max_rss_kb": 84944,
+      "wall_ms": 543.87429,
+      "max_rss_kb": 93796,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1469,15 +1469,15 @@
     {
       "workload": "image_convolution",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 8,
-      "wall_ms": 0.007208,
-      "max_rss_kb": 84848,
+      "wall_ms": 543.083173,
+      "max_rss_kb": 93912,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1487,15 +1487,15 @@
     {
       "workload": "image_convolution",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 9,
-      "wall_ms": -0.048458,
-      "max_rss_kb": 85056,
+      "wall_ms": 553.869625,
+      "max_rss_kb": 94216,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1505,15 +1505,15 @@
     {
       "workload": "image_convolution",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 10,
-      "wall_ms": 0.005708,
-      "max_rss_kb": 84944,
+      "wall_ms": 550.315568,
+      "max_rss_kb": 93928,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1523,15 +1523,15 @@
     {
       "workload": "image_convolution",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 11,
-      "wall_ms": 0.507625,
-      "max_rss_kb": 85024,
+      "wall_ms": 544.095113,
+      "max_rss_kb": 93572,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1541,15 +1541,15 @@
     {
       "workload": "image_convolution",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 12,
-      "wall_ms": -0.275625,
-      "max_rss_kb": 84944,
+      "wall_ms": 522.549449,
+      "max_rss_kb": 93488,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1559,15 +1559,15 @@
     {
       "workload": "image_convolution",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 13,
-      "wall_ms": -0.057833,
-      "max_rss_kb": 84880,
+      "wall_ms": 539.650903,
+      "max_rss_kb": 93024,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1577,15 +1577,15 @@
     {
       "workload": "image_convolution",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 14,
-      "wall_ms": 0.047042,
-      "max_rss_kb": 84944,
+      "wall_ms": 519.266388,
+      "max_rss_kb": 93736,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1595,15 +1595,15 @@
     {
       "workload": "image_convolution",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 15,
-      "wall_ms": 0.064834,
-      "max_rss_kb": 85056,
+      "wall_ms": 671.222823,
+      "max_rss_kb": 93384,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1613,15 +1613,15 @@
     {
       "workload": "image_convolution",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 16,
-      "wall_ms": -0.011,
-      "max_rss_kb": 84944,
+      "wall_ms": 566.700675,
+      "max_rss_kb": 94040,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1631,15 +1631,15 @@
     {
       "workload": "image_convolution",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 17,
-      "wall_ms": 0.018083,
-      "max_rss_kb": 84896,
+      "wall_ms": 521.688942,
+      "max_rss_kb": 93236,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1649,15 +1649,15 @@
     {
       "workload": "image_convolution",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 18,
-      "wall_ms": -0.048875,
-      "max_rss_kb": 84944,
+      "wall_ms": 630.710774,
+      "max_rss_kb": 93852,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1667,15 +1667,15 @@
     {
       "workload": "image_convolution",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 19,
-      "wall_ms": 0.006542,
-      "max_rss_kb": 85008,
+      "wall_ms": 559.09371,
+      "max_rss_kb": 93788,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1685,15 +1685,15 @@
     {
       "workload": "image_convolution",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
       ],
       "run": 20,
-      "wall_ms": -0.02425,
-      "max_rss_kb": 85024,
+      "wall_ms": 541.397535,
+      "max_rss_kb": 93456,
       "exit_code": 0,
       "stdout_first": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
       "stdout_last": "checksum=2ba2e053 dims=3840x2160 bytes=24883200",
@@ -1707,11 +1707,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 1,
-      "wall_ms": -0.015542,
-      "max_rss_kb": 1680,
+      "wall_ms": 14.945068,
+      "max_rss_kb": 2212,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -1725,11 +1725,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 2,
-      "wall_ms": -0.05,
-      "max_rss_kb": 1696,
+      "wall_ms": 15.108022,
+      "max_rss_kb": 2300,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -1743,11 +1743,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 3,
-      "wall_ms": -0.023708,
-      "max_rss_kb": 1680,
+      "wall_ms": 14.435717,
+      "max_rss_kb": 2316,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -1761,11 +1761,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 4,
-      "wall_ms": 0.022708,
-      "max_rss_kb": 1696,
+      "wall_ms": 14.211408,
+      "max_rss_kb": 2308,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -1779,11 +1779,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 5,
-      "wall_ms": -0.021375,
-      "max_rss_kb": 1696,
+      "wall_ms": 15.158516,
+      "max_rss_kb": 2268,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -1797,11 +1797,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 6,
-      "wall_ms": 0.003583,
-      "max_rss_kb": 1696,
+      "wall_ms": 14.701934,
+      "max_rss_kb": 2180,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -1815,11 +1815,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 7,
-      "wall_ms": 0.042041,
-      "max_rss_kb": 1696,
+      "wall_ms": 14.396253,
+      "max_rss_kb": 2164,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -1833,11 +1833,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 8,
-      "wall_ms": -0.03675,
-      "max_rss_kb": 1680,
+      "wall_ms": 15.309018,
+      "max_rss_kb": 2232,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -1851,11 +1851,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 9,
-      "wall_ms": -0.008583,
-      "max_rss_kb": 1696,
+      "wall_ms": 14.878213,
+      "max_rss_kb": 2316,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -1869,11 +1869,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 10,
-      "wall_ms": 0.014666,
-      "max_rss_kb": 1696,
+      "wall_ms": 14.927054,
+      "max_rss_kb": 2184,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -1887,11 +1887,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 11,
-      "wall_ms": 0.032125,
-      "max_rss_kb": 1696,
+      "wall_ms": 15.015399,
+      "max_rss_kb": 2196,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -1905,11 +1905,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 12,
-      "wall_ms": -0.063083,
-      "max_rss_kb": 1696,
+      "wall_ms": 14.797642,
+      "max_rss_kb": 2180,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -1923,11 +1923,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 13,
-      "wall_ms": -0.04075,
-      "max_rss_kb": 1696,
+      "wall_ms": 15.218698,
+      "max_rss_kb": 2164,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -1941,11 +1941,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 14,
-      "wall_ms": 0.082084,
-      "max_rss_kb": 1680,
+      "wall_ms": 13.892162,
+      "max_rss_kb": 2312,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -1959,11 +1959,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 15,
-      "wall_ms": 0.023458,
-      "max_rss_kb": 1696,
+      "wall_ms": 15.093024,
+      "max_rss_kb": 2260,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -1977,11 +1977,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 16,
-      "wall_ms": 0.030209,
-      "max_rss_kb": 1696,
+      "wall_ms": 13.694572,
+      "max_rss_kb": 2184,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -1995,11 +1995,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 17,
-      "wall_ms": -0.060542,
-      "max_rss_kb": 1696,
+      "wall_ms": 13.707957,
+      "max_rss_kb": 2296,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2013,11 +2013,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 18,
-      "wall_ms": 0.1065,
-      "max_rss_kb": 1680,
+      "wall_ms": 13.770654,
+      "max_rss_kb": 2268,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2031,11 +2031,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 19,
-      "wall_ms": 0.028125,
-      "max_rss_kb": 1696,
+      "wall_ms": 13.68269,
+      "max_rss_kb": 2220,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2049,11 +2049,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 20,
-      "wall_ms": 0.0095,
-      "max_rss_kb": 1696,
+      "wall_ms": 14.384951,
+      "max_rss_kb": 2176,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2067,11 +2067,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 1,
-      "wall_ms": 0.031291,
-      "max_rss_kb": 1984,
+      "wall_ms": 14.441698,
+      "max_rss_kb": 1660,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2085,11 +2085,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 2,
-      "wall_ms": -0.047542,
-      "max_rss_kb": 1984,
+      "wall_ms": 14.928536,
+      "max_rss_kb": 1660,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2103,11 +2103,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 3,
-      "wall_ms": -0.060959,
-      "max_rss_kb": 1984,
+      "wall_ms": 14.291848,
+      "max_rss_kb": 1660,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2121,11 +2121,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 4,
-      "wall_ms": 0.002125,
-      "max_rss_kb": 1984,
+      "wall_ms": 36.047543,
+      "max_rss_kb": 1660,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2139,11 +2139,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 5,
-      "wall_ms": 0.057333,
-      "max_rss_kb": 1984,
+      "wall_ms": 14.202712,
+      "max_rss_kb": 1660,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2157,11 +2157,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 6,
-      "wall_ms": 0.008917,
-      "max_rss_kb": 1984,
+      "wall_ms": 15.152645,
+      "max_rss_kb": 1660,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2175,11 +2175,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 7,
-      "wall_ms": 0.040042,
-      "max_rss_kb": 1984,
+      "wall_ms": 14.457247,
+      "max_rss_kb": 1788,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2193,11 +2193,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 8,
-      "wall_ms": 0.008667,
-      "max_rss_kb": 1984,
+      "wall_ms": 14.21848,
+      "max_rss_kb": 1660,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2211,11 +2211,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 9,
-      "wall_ms": 0.0045,
-      "max_rss_kb": 1984,
+      "wall_ms": 13.938659,
+      "max_rss_kb": 1660,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2229,11 +2229,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 10,
-      "wall_ms": -0.02825,
-      "max_rss_kb": 1984,
+      "wall_ms": 15.14959,
+      "max_rss_kb": 1660,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2247,11 +2247,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 11,
-      "wall_ms": -0.046625,
-      "max_rss_kb": 1984,
+      "wall_ms": 14.162957,
+      "max_rss_kb": 1660,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2265,11 +2265,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 12,
-      "wall_ms": 0.063292,
-      "max_rss_kb": 1984,
+      "wall_ms": 14.61432,
+      "max_rss_kb": 1660,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2283,11 +2283,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 13,
-      "wall_ms": 0.004334,
-      "max_rss_kb": 1984,
+      "wall_ms": 14.203613,
+      "max_rss_kb": 1660,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2301,11 +2301,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 14,
-      "wall_ms": -0.006083,
-      "max_rss_kb": 1984,
+      "wall_ms": 14.372388,
+      "max_rss_kb": 1660,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2319,11 +2319,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 15,
-      "wall_ms": -0.122291,
-      "max_rss_kb": 1984,
+      "wall_ms": 14.317636,
+      "max_rss_kb": 1660,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2337,11 +2337,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 16,
-      "wall_ms": -0.0075,
-      "max_rss_kb": 1984,
+      "wall_ms": 14.554468,
+      "max_rss_kb": 1660,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2355,11 +2355,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 17,
-      "wall_ms": -0.001417,
-      "max_rss_kb": 1984,
+      "wall_ms": 14.36279,
+      "max_rss_kb": 1660,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2373,11 +2373,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 18,
-      "wall_ms": 0.076833,
-      "max_rss_kb": 1984,
+      "wall_ms": 15.128571,
+      "max_rss_kb": 1660,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2391,11 +2391,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 19,
-      "wall_ms": -0.009333,
-      "max_rss_kb": 1984,
+      "wall_ms": 13.942005,
+      "max_rss_kb": 1660,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2409,11 +2409,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 20,
-      "wall_ms": -0.021458,
-      "max_rss_kb": 1984,
+      "wall_ms": 14.407654,
+      "max_rss_kb": 1660,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2427,11 +2427,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 1,
-      "wall_ms": 0.041375,
-      "max_rss_kb": 8720,
+      "wall_ms": 19.778593,
+      "max_rss_kb": 35832,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2445,11 +2445,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 2,
-      "wall_ms": 0.025458,
-      "max_rss_kb": 8608,
+      "wall_ms": 19.461461,
+      "max_rss_kb": 35920,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2463,11 +2463,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 3,
-      "wall_ms": -0.03025,
-      "max_rss_kb": 8720,
+      "wall_ms": 19.82479,
+      "max_rss_kb": 35836,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2481,11 +2481,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 4,
-      "wall_ms": 0.010292,
-      "max_rss_kb": 8720,
+      "wall_ms": 19.624095,
+      "max_rss_kb": 36124,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2499,11 +2499,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 5,
-      "wall_ms": 0.057375,
-      "max_rss_kb": 8720,
+      "wall_ms": 19.053189,
+      "max_rss_kb": 35916,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2517,11 +2517,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 6,
-      "wall_ms": -0.047333,
-      "max_rss_kb": 8720,
+      "wall_ms": 19.859093,
+      "max_rss_kb": 36056,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2535,11 +2535,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 7,
-      "wall_ms": 0.0185,
-      "max_rss_kb": 8720,
+      "wall_ms": 19.576235,
+      "max_rss_kb": 36000,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2553,11 +2553,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 8,
-      "wall_ms": 0.05975,
-      "max_rss_kb": 8720,
+      "wall_ms": 19.538775,
+      "max_rss_kb": 35884,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2571,11 +2571,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 9,
-      "wall_ms": 0.099333,
-      "max_rss_kb": 8720,
+      "wall_ms": 20.551216,
+      "max_rss_kb": 35756,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2589,11 +2589,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 10,
-      "wall_ms": 0.079667,
-      "max_rss_kb": 8720,
+      "wall_ms": 19.78725,
+      "max_rss_kb": 35920,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2607,11 +2607,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 11,
-      "wall_ms": 0.026084,
-      "max_rss_kb": 8736,
+      "wall_ms": 20.096217,
+      "max_rss_kb": 35916,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2625,11 +2625,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 12,
-      "wall_ms": 0.007917,
-      "max_rss_kb": 8736,
+      "wall_ms": 19.569043,
+      "max_rss_kb": 35568,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2643,11 +2643,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 13,
-      "wall_ms": 0.005333,
-      "max_rss_kb": 8720,
+      "wall_ms": 18.936972,
+      "max_rss_kb": 36080,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2661,11 +2661,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 14,
-      "wall_ms": -0.033541,
-      "max_rss_kb": 8608,
+      "wall_ms": 19.509411,
+      "max_rss_kb": 35992,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2679,11 +2679,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 15,
-      "wall_ms": -0.054084,
-      "max_rss_kb": 8720,
+      "wall_ms": 19.145902,
+      "max_rss_kb": 35880,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2697,11 +2697,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 16,
-      "wall_ms": 0.022875,
-      "max_rss_kb": 8720,
+      "wall_ms": 19.995809,
+      "max_rss_kb": 35928,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2715,11 +2715,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 17,
-      "wall_ms": -0.021875,
-      "max_rss_kb": 8592,
+      "wall_ms": 19.759357,
+      "max_rss_kb": 36116,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2733,11 +2733,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 18,
-      "wall_ms": -0.05075,
-      "max_rss_kb": 8736,
+      "wall_ms": 19.237503,
+      "max_rss_kb": 35992,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2751,11 +2751,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 19,
-      "wall_ms": 0.035458,
-      "max_rss_kb": 8720,
+      "wall_ms": 19.449729,
+      "max_rss_kb": 36028,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2769,11 +2769,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 20,
-      "wall_ms": -0.013583,
-      "max_rss_kb": 8720,
+      "wall_ms": 19.568782,
+      "max_rss_kb": 35884,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2783,18 +2783,18 @@
     {
       "workload": "json_pipeline_small",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 1,
-      "wall_ms": -0.025542,
-      "max_rss_kb": 65536,
+      "wall_ms": 54.736041,
+      "max_rss_kb": 60952,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2804,18 +2804,18 @@
     {
       "workload": "json_pipeline_small",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 2,
-      "wall_ms": -0.1445,
-      "max_rss_kb": 65488,
+      "wall_ms": 53.614096,
+      "max_rss_kb": 60724,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2825,18 +2825,18 @@
     {
       "workload": "json_pipeline_small",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 3,
-      "wall_ms": 0.018875,
-      "max_rss_kb": 65632,
+      "wall_ms": 53.743457,
+      "max_rss_kb": 60800,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2846,18 +2846,18 @@
     {
       "workload": "json_pipeline_small",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 4,
-      "wall_ms": -0.044625,
-      "max_rss_kb": 65504,
+      "wall_ms": 51.094371,
+      "max_rss_kb": 61004,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2867,18 +2867,18 @@
     {
       "workload": "json_pipeline_small",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 5,
-      "wall_ms": -0.109416,
-      "max_rss_kb": 65264,
+      "wall_ms": 53.587717,
+      "max_rss_kb": 60952,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2888,18 +2888,18 @@
     {
       "workload": "json_pipeline_small",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 6,
-      "wall_ms": 0.008667,
-      "max_rss_kb": 65504,
+      "wall_ms": 52.98934,
+      "max_rss_kb": 60796,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2909,18 +2909,18 @@
     {
       "workload": "json_pipeline_small",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 7,
-      "wall_ms": -0.011625,
-      "max_rss_kb": 65424,
+      "wall_ms": 51.670737,
+      "max_rss_kb": 60640,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2930,18 +2930,18 @@
     {
       "workload": "json_pipeline_small",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 8,
-      "wall_ms": 0.02225,
-      "max_rss_kb": 65568,
+      "wall_ms": 53.009598,
+      "max_rss_kb": 61096,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2951,18 +2951,18 @@
     {
       "workload": "json_pipeline_small",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 9,
-      "wall_ms": 0.039375,
-      "max_rss_kb": 65584,
+      "wall_ms": 54.034882,
+      "max_rss_kb": 60976,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2972,18 +2972,18 @@
     {
       "workload": "json_pipeline_small",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 10,
-      "wall_ms": 0.028542,
-      "max_rss_kb": 65536,
+      "wall_ms": 50.515881,
+      "max_rss_kb": 60880,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -2993,18 +2993,18 @@
     {
       "workload": "json_pipeline_small",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 11,
-      "wall_ms": -0.009666,
-      "max_rss_kb": 65552,
+      "wall_ms": 51.521488,
+      "max_rss_kb": 61228,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -3014,18 +3014,18 @@
     {
       "workload": "json_pipeline_small",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 12,
-      "wall_ms": -0.093292,
-      "max_rss_kb": 65552,
+      "wall_ms": 52.47569,
+      "max_rss_kb": 60968,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -3035,18 +3035,18 @@
     {
       "workload": "json_pipeline_small",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 13,
-      "wall_ms": 0.017125,
-      "max_rss_kb": 65600,
+      "wall_ms": 54.06073,
+      "max_rss_kb": 60752,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -3056,18 +3056,18 @@
     {
       "workload": "json_pipeline_small",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 14,
-      "wall_ms": -0.144125,
-      "max_rss_kb": 65616,
+      "wall_ms": 52.984821,
+      "max_rss_kb": 61016,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -3077,18 +3077,18 @@
     {
       "workload": "json_pipeline_small",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 15,
-      "wall_ms": -0.0405,
-      "max_rss_kb": 65664,
+      "wall_ms": 50.570152,
+      "max_rss_kb": 60676,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -3098,18 +3098,18 @@
     {
       "workload": "json_pipeline_small",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 16,
-      "wall_ms": 0.031209,
-      "max_rss_kb": 65568,
+      "wall_ms": 51.398459,
+      "max_rss_kb": 60852,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -3119,18 +3119,18 @@
     {
       "workload": "json_pipeline_small",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 17,
-      "wall_ms": 0.034791,
-      "max_rss_kb": 65504,
+      "wall_ms": 50.739238,
+      "max_rss_kb": 60984,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -3140,18 +3140,18 @@
     {
       "workload": "json_pipeline_small",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 18,
-      "wall_ms": -0.001666,
-      "max_rss_kb": 65504,
+      "wall_ms": 53.55204,
+      "max_rss_kb": 60932,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -3161,18 +3161,18 @@
     {
       "workload": "json_pipeline_small",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 19,
-      "wall_ms": 0.00975,
-      "max_rss_kb": 65616,
+      "wall_ms": 51.235835,
+      "max_rss_kb": 60868,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -3182,18 +3182,18 @@
     {
       "workload": "json_pipeline_small",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 20,
-      "wall_ms": 0.003292,
-      "max_rss_kb": 65520,
+      "wall_ms": 53.238073,
+      "max_rss_kb": 60856,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -3203,17 +3203,17 @@
     {
       "workload": "json_pipeline_small",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 1,
-      "wall_ms": 0.0055,
-      "max_rss_kb": 30832,
+      "wall_ms": 28.31262,
+      "max_rss_kb": 40356,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -3223,17 +3223,17 @@
     {
       "workload": "json_pipeline_small",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 2,
-      "wall_ms": -0.099792,
-      "max_rss_kb": 30896,
+      "wall_ms": 28.22738,
+      "max_rss_kb": 40516,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -3243,17 +3243,17 @@
     {
       "workload": "json_pipeline_small",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 3,
-      "wall_ms": 0.00575,
-      "max_rss_kb": 30816,
+      "wall_ms": 28.310285,
+      "max_rss_kb": 40448,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -3263,17 +3263,17 @@
     {
       "workload": "json_pipeline_small",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 4,
-      "wall_ms": -0.032167,
-      "max_rss_kb": 30816,
+      "wall_ms": 27.132165,
+      "max_rss_kb": 40516,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -3283,17 +3283,17 @@
     {
       "workload": "json_pipeline_small",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 5,
-      "wall_ms": 0.066125,
-      "max_rss_kb": 30800,
+      "wall_ms": 27.774024,
+      "max_rss_kb": 40156,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -3303,17 +3303,17 @@
     {
       "workload": "json_pipeline_small",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 6,
-      "wall_ms": -0.094916,
-      "max_rss_kb": 30816,
+      "wall_ms": 28.230075,
+      "max_rss_kb": 40516,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -3323,17 +3323,17 @@
     {
       "workload": "json_pipeline_small",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 7,
-      "wall_ms": -0.01225,
-      "max_rss_kb": 30864,
+      "wall_ms": 28.373233,
+      "max_rss_kb": 40524,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -3343,17 +3343,17 @@
     {
       "workload": "json_pipeline_small",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 8,
-      "wall_ms": 0.040917,
-      "max_rss_kb": 30816,
+      "wall_ms": 27.872147,
+      "max_rss_kb": 40516,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -3363,17 +3363,17 @@
     {
       "workload": "json_pipeline_small",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 9,
-      "wall_ms": 0.007417,
-      "max_rss_kb": 30800,
+      "wall_ms": 27.858562,
+      "max_rss_kb": 40624,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -3383,17 +3383,17 @@
     {
       "workload": "json_pipeline_small",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 10,
-      "wall_ms": -0.035041,
-      "max_rss_kb": 30784,
+      "wall_ms": 27.619265,
+      "max_rss_kb": 40580,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -3403,17 +3403,17 @@
     {
       "workload": "json_pipeline_small",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 11,
-      "wall_ms": 0.04775,
-      "max_rss_kb": 30800,
+      "wall_ms": 27.803158,
+      "max_rss_kb": 40456,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -3423,17 +3423,17 @@
     {
       "workload": "json_pipeline_small",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 12,
-      "wall_ms": -0.038042,
-      "max_rss_kb": 30816,
+      "wall_ms": 27.550486,
+      "max_rss_kb": 40388,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -3443,17 +3443,17 @@
     {
       "workload": "json_pipeline_small",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 13,
-      "wall_ms": 0.090458,
-      "max_rss_kb": 30784,
+      "wall_ms": 27.177049,
+      "max_rss_kb": 40336,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -3463,17 +3463,17 @@
     {
       "workload": "json_pipeline_small",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 14,
-      "wall_ms": 0.060041,
-      "max_rss_kb": 30816,
+      "wall_ms": 28.768351,
+      "max_rss_kb": 40512,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -3483,17 +3483,17 @@
     {
       "workload": "json_pipeline_small",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 15,
-      "wall_ms": -0.117959,
-      "max_rss_kb": 30848,
+      "wall_ms": 27.808929,
+      "max_rss_kb": 40140,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -3503,17 +3503,17 @@
     {
       "workload": "json_pipeline_small",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 16,
-      "wall_ms": -0.015625,
-      "max_rss_kb": 30832,
+      "wall_ms": 27.868961,
+      "max_rss_kb": 40484,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -3523,17 +3523,17 @@
     {
       "workload": "json_pipeline_small",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 17,
-      "wall_ms": 0.027417,
-      "max_rss_kb": 30800,
+      "wall_ms": 27.561156,
+      "max_rss_kb": 40704,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -3543,17 +3543,17 @@
     {
       "workload": "json_pipeline_small",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 18,
-      "wall_ms": 0.030875,
-      "max_rss_kb": 30832,
+      "wall_ms": 27.903646,
+      "max_rss_kb": 40368,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -3563,17 +3563,17 @@
     {
       "workload": "json_pipeline_small",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 19,
-      "wall_ms": 0.099917,
-      "max_rss_kb": 30800,
+      "wall_ms": 27.75583,
+      "max_rss_kb": 40332,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -3583,17 +3583,17 @@
     {
       "workload": "json_pipeline_small",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input_small.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 20,
-      "wall_ms": -0.02275,
-      "max_rss_kb": 30864,
+      "wall_ms": 28.159423,
+      "max_rss_kb": 40536,
       "exit_code": 0,
       "stdout_first": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
       "stdout_last": "input_bytes=21671 records_in=100 records_out=56 output_bytes=14841 hash=7fc66fa8",
@@ -3607,11 +3607,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 1,
-      "wall_ms": -0.030667,
-      "max_rss_kb": 441136,
+      "wall_ms": 780.246288,
+      "max_rss_kb": 437764,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -3625,11 +3625,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 2,
-      "wall_ms": -0.042792,
-      "max_rss_kb": 437184,
+      "wall_ms": 724.024203,
+      "max_rss_kb": 438072,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -3643,11 +3643,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 3,
-      "wall_ms": -0.008625,
-      "max_rss_kb": 437184,
+      "wall_ms": 735.70822,
+      "max_rss_kb": 438048,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -3661,11 +3661,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 4,
-      "wall_ms": 0.06075,
-      "max_rss_kb": 437168,
+      "wall_ms": 730.830552,
+      "max_rss_kb": 437720,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -3679,11 +3679,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 5,
-      "wall_ms": -0.041666,
-      "max_rss_kb": 437184,
+      "wall_ms": 764.484826,
+      "max_rss_kb": 438108,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -3697,11 +3697,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 6,
-      "wall_ms": -0.036667,
-      "max_rss_kb": 437184,
+      "wall_ms": 751.676368,
+      "max_rss_kb": 437984,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -3715,11 +3715,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 7,
-      "wall_ms": -0.029459,
-      "max_rss_kb": 441136,
+      "wall_ms": 758.893324,
+      "max_rss_kb": 438112,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -3733,11 +3733,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 8,
-      "wall_ms": 0.08375,
-      "max_rss_kb": 441136,
+      "wall_ms": 731.030445,
+      "max_rss_kb": 438136,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -3751,11 +3751,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 9,
-      "wall_ms": -0.024833,
-      "max_rss_kb": 441136,
+      "wall_ms": 758.487091,
+      "max_rss_kb": 438024,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -3769,11 +3769,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 10,
-      "wall_ms": -0.089708,
-      "max_rss_kb": 441136,
+      "wall_ms": 752.708215,
+      "max_rss_kb": 437952,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -3787,11 +3787,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 11,
-      "wall_ms": -0.0145,
-      "max_rss_kb": 441136,
+      "wall_ms": 726.7061,
+      "max_rss_kb": 438220,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -3805,11 +3805,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 12,
-      "wall_ms": 0.009708,
-      "max_rss_kb": 437184,
+      "wall_ms": 727.261337,
+      "max_rss_kb": 438056,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -3823,11 +3823,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 13,
-      "wall_ms": 0.102458,
-      "max_rss_kb": 437168,
+      "wall_ms": 721.825737,
+      "max_rss_kb": 437932,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -3841,11 +3841,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 14,
-      "wall_ms": -0.067708,
-      "max_rss_kb": 437168,
+      "wall_ms": 720.916529,
+      "max_rss_kb": 438148,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -3859,11 +3859,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 15,
-      "wall_ms": -0.04625,
-      "max_rss_kb": 437184,
+      "wall_ms": 730.570116,
+      "max_rss_kb": 437916,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -3877,11 +3877,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 16,
-      "wall_ms": 0.080833,
-      "max_rss_kb": 441120,
+      "wall_ms": 754.059609,
+      "max_rss_kb": 438088,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -3895,11 +3895,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 17,
-      "wall_ms": -0.090125,
-      "max_rss_kb": 441120,
+      "wall_ms": 772.093184,
+      "max_rss_kb": 438044,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -3913,11 +3913,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 18,
-      "wall_ms": -0.001625,
-      "max_rss_kb": 437184,
+      "wall_ms": 738.742316,
+      "max_rss_kb": 438140,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -3931,11 +3931,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 19,
-      "wall_ms": 0.122792,
-      "max_rss_kb": 441120,
+      "wall_ms": 731.545337,
+      "max_rss_kb": 438140,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -3949,11 +3949,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/rust/target/release/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_rust.json"
+        "/tmp/out_rust.json"
       ],
       "run": 20,
-      "wall_ms": -0.008792,
-      "max_rss_kb": 437168,
+      "wall_ms": 730.659613,
+      "max_rss_kb": 438140,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -3967,11 +3967,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 1,
-      "wall_ms": -0.050291,
-      "max_rss_kb": 590640,
+      "wall_ms": 898.487655,
+      "max_rss_kb": 560588,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -3985,11 +3985,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 2,
-      "wall_ms": 0.001291,
-      "max_rss_kb": 590640,
+      "wall_ms": 865.061978,
+      "max_rss_kb": 560716,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4003,11 +4003,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 3,
-      "wall_ms": -0.03525,
-      "max_rss_kb": 590640,
+      "wall_ms": 834.68861,
+      "max_rss_kb": 560496,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4021,11 +4021,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 4,
-      "wall_ms": 0.020959,
-      "max_rss_kb": 590640,
+      "wall_ms": 906.976717,
+      "max_rss_kb": 560460,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4039,11 +4039,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 5,
-      "wall_ms": -0.020709,
-      "max_rss_kb": 590640,
+      "wall_ms": 1082.379775,
+      "max_rss_kb": 560588,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4057,11 +4057,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 6,
-      "wall_ms": 0.060917,
-      "max_rss_kb": 590640,
+      "wall_ms": 865.624098,
+      "max_rss_kb": 560716,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4075,11 +4075,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 7,
-      "wall_ms": 0.083333,
-      "max_rss_kb": 590640,
+      "wall_ms": 858.045697,
+      "max_rss_kb": 560892,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4093,11 +4093,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 8,
-      "wall_ms": -0.075458,
-      "max_rss_kb": 590640,
+      "wall_ms": 832.086993,
+      "max_rss_kb": 560716,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4111,11 +4111,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 9,
-      "wall_ms": -0.069125,
-      "max_rss_kb": 590640,
+      "wall_ms": 1168.563791,
+      "max_rss_kb": 560716,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4129,11 +4129,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 10,
-      "wall_ms": 0.001,
-      "max_rss_kb": 590640,
+      "wall_ms": 897.903204,
+      "max_rss_kb": 560764,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4147,11 +4147,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 11,
-      "wall_ms": -0.012083,
-      "max_rss_kb": 590640,
+      "wall_ms": 840.900581,
+      "max_rss_kb": 560588,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4165,11 +4165,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 12,
-      "wall_ms": -0.077125,
-      "max_rss_kb": 590640,
+      "wall_ms": 837.919734,
+      "max_rss_kb": 560584,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4183,11 +4183,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 13,
-      "wall_ms": 0.014208,
-      "max_rss_kb": 590640,
+      "wall_ms": 809.718403,
+      "max_rss_kb": 560712,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4201,11 +4201,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 14,
-      "wall_ms": -0.095709,
-      "max_rss_kb": 590640,
+      "wall_ms": 825.860045,
+      "max_rss_kb": 560588,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4219,11 +4219,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 15,
-      "wall_ms": -0.103167,
-      "max_rss_kb": 590640,
+      "wall_ms": 847.379428,
+      "max_rss_kb": 560588,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4237,11 +4237,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 16,
-      "wall_ms": -0.017,
-      "max_rss_kb": 590640,
+      "wall_ms": 853.606036,
+      "max_rss_kb": 561020,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4255,11 +4255,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 17,
-      "wall_ms": 0.039417,
-      "max_rss_kb": 590640,
+      "wall_ms": 822.33384,
+      "max_rss_kb": 560588,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4273,11 +4273,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 18,
-      "wall_ms": -0.008,
-      "max_rss_kb": 590640,
+      "wall_ms": 873.950576,
+      "max_rss_kb": 560716,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4291,11 +4291,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 19,
-      "wall_ms": -0.00925,
-      "max_rss_kb": 590640,
+      "wall_ms": 823.37809,
+      "max_rss_kb": 560460,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4309,11 +4309,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/zig/zig-out/bin/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_zig.json"
+        "/tmp/out_zig.json"
       ],
       "run": 20,
-      "wall_ms": 0.0355,
-      "max_rss_kb": 590640,
+      "wall_ms": 831.018397,
+      "max_rss_kb": 560716,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4327,11 +4327,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 1,
-      "wall_ms": 0.040125,
-      "max_rss_kb": 1071648,
+      "wall_ms": 1835.684334,
+      "max_rss_kb": 794516,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4345,11 +4345,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 2,
-      "wall_ms": 0.089875,
-      "max_rss_kb": 1080544,
+      "wall_ms": 1830.917012,
+      "max_rss_kb": 794448,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4363,11 +4363,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 3,
-      "wall_ms": -0.001917,
-      "max_rss_kb": 1083120,
+      "wall_ms": 1820.831388,
+      "max_rss_kb": 794688,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4381,11 +4381,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 4,
-      "wall_ms": 0.138167,
-      "max_rss_kb": 1080560,
+      "wall_ms": 1902.209639,
+      "max_rss_kb": 790400,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4399,11 +4399,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 5,
-      "wall_ms": -0.069708,
-      "max_rss_kb": 1083136,
+      "wall_ms": 1896.768158,
+      "max_rss_kb": 794476,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4417,11 +4417,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 6,
-      "wall_ms": -0.030166,
-      "max_rss_kb": 1080544,
+      "wall_ms": 1902.603285,
+      "max_rss_kb": 802608,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4435,11 +4435,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 7,
-      "wall_ms": -0.044208,
-      "max_rss_kb": 1080560,
+      "wall_ms": 1831.581021,
+      "max_rss_kb": 794492,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4453,11 +4453,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 8,
-      "wall_ms": 0.004417,
-      "max_rss_kb": 1080560,
+      "wall_ms": 1808.209619,
+      "max_rss_kb": 802804,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4471,11 +4471,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 9,
-      "wall_ms": -0.028458,
-      "max_rss_kb": 1080544,
+      "wall_ms": 1828.928679,
+      "max_rss_kb": 794380,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4489,11 +4489,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 10,
-      "wall_ms": 0.004958,
-      "max_rss_kb": 1080544,
+      "wall_ms": 1813.872353,
+      "max_rss_kb": 794476,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4507,11 +4507,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 11,
-      "wall_ms": -0.003958,
-      "max_rss_kb": 1083120,
+      "wall_ms": 1829.227837,
+      "max_rss_kb": 794412,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4525,11 +4525,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 12,
-      "wall_ms": 0.015667,
-      "max_rss_kb": 1083136,
+      "wall_ms": 1843.676358,
+      "max_rss_kb": 802628,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4543,11 +4543,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 13,
-      "wall_ms": 0.02375,
-      "max_rss_kb": 1080560,
+      "wall_ms": 1839.095554,
+      "max_rss_kb": 802696,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4561,11 +4561,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 14,
-      "wall_ms": 0.005333,
-      "max_rss_kb": 1080544,
+      "wall_ms": 1813.338195,
+      "max_rss_kb": 790556,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4579,11 +4579,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 15,
-      "wall_ms": 0.157542,
-      "max_rss_kb": 1080560,
+      "wall_ms": 1831.451449,
+      "max_rss_kb": 794812,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4597,11 +4597,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 16,
-      "wall_ms": 0.00575,
-      "max_rss_kb": 1080544,
+      "wall_ms": 1841.129201,
+      "max_rss_kb": 794464,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4615,11 +4615,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 17,
-      "wall_ms": -0.036417,
-      "max_rss_kb": 1080544,
+      "wall_ms": 1815.767993,
+      "max_rss_kb": 794468,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4633,11 +4633,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 18,
-      "wall_ms": -0.023584,
-      "max_rss_kb": 1080560,
+      "wall_ms": 1814.921954,
+      "max_rss_kb": 802672,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4651,11 +4651,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 19,
-      "wall_ms": -0.021458,
-      "max_rss_kb": 1083120,
+      "wall_ms": 1843.768319,
+      "max_rss_kb": 794480,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4669,11 +4669,11 @@
       "command": [
         "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_perry.json"
+        "/tmp/out_perry.json"
       ],
       "run": 20,
-      "wall_ms": -0.0235,
-      "max_rss_kb": 1080560,
+      "wall_ms": 1809.612619,
+      "max_rss_kb": 802876,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4683,18 +4683,18 @@
     {
       "workload": "json_pipeline_full",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 1,
-      "wall_ms": 0.026375,
-      "max_rss_kb": 793296,
+      "wall_ms": 1329.248393,
+      "max_rss_kb": 579536,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4704,18 +4704,18 @@
     {
       "workload": "json_pipeline_full",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 2,
-      "wall_ms": -0.035917,
-      "max_rss_kb": 793376,
+      "wall_ms": 1227.612324,
+      "max_rss_kb": 578028,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4725,18 +4725,18 @@
     {
       "workload": "json_pipeline_full",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 3,
-      "wall_ms": 0.048709,
-      "max_rss_kb": 793360,
+      "wall_ms": 1220.61599,
+      "max_rss_kb": 579748,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4746,18 +4746,18 @@
     {
       "workload": "json_pipeline_full",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 4,
-      "wall_ms": -0.024084,
-      "max_rss_kb": 793280,
+      "wall_ms": 1248.038698,
+      "max_rss_kb": 581364,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4767,18 +4767,18 @@
     {
       "workload": "json_pipeline_full",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 5,
-      "wall_ms": 0.033625,
-      "max_rss_kb": 793520,
+      "wall_ms": 1252.098939,
+      "max_rss_kb": 581292,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4788,18 +4788,18 @@
     {
       "workload": "json_pipeline_full",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 6,
-      "wall_ms": 0.034041,
-      "max_rss_kb": 793424,
+      "wall_ms": 1284.885363,
+      "max_rss_kb": 579344,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4809,18 +4809,18 @@
     {
       "workload": "json_pipeline_full",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 7,
-      "wall_ms": -0.025208,
-      "max_rss_kb": 792640,
+      "wall_ms": 1343.372498,
+      "max_rss_kb": 579840,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4830,18 +4830,18 @@
     {
       "workload": "json_pipeline_full",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 8,
-      "wall_ms": -0.048917,
-      "max_rss_kb": 793280,
+      "wall_ms": 1214.058725,
+      "max_rss_kb": 581136,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4851,18 +4851,18 @@
     {
       "workload": "json_pipeline_full",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 9,
-      "wall_ms": 0.017791,
-      "max_rss_kb": 793488,
+      "wall_ms": 1172.592754,
+      "max_rss_kb": 580952,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4872,18 +4872,18 @@
     {
       "workload": "json_pipeline_full",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 10,
-      "wall_ms": 0.042292,
-      "max_rss_kb": 793216,
+      "wall_ms": 1194.454026,
+      "max_rss_kb": 580956,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4893,18 +4893,18 @@
     {
       "workload": "json_pipeline_full",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 11,
-      "wall_ms": 0.315166,
-      "max_rss_kb": 793472,
+      "wall_ms": 1160.372635,
+      "max_rss_kb": 579660,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4914,18 +4914,18 @@
     {
       "workload": "json_pipeline_full",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 12,
-      "wall_ms": -0.003167,
-      "max_rss_kb": 793072,
+      "wall_ms": 1310.195014,
+      "max_rss_kb": 579420,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4935,18 +4935,18 @@
     {
       "workload": "json_pipeline_full",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 13,
-      "wall_ms": -0.03875,
-      "max_rss_kb": 792816,
+      "wall_ms": 1137.366935,
+      "max_rss_kb": 580764,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4956,18 +4956,18 @@
     {
       "workload": "json_pipeline_full",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 14,
-      "wall_ms": -0.027167,
-      "max_rss_kb": 793312,
+      "wall_ms": 1134.893957,
+      "max_rss_kb": 579800,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4977,18 +4977,18 @@
     {
       "workload": "json_pipeline_full",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 15,
-      "wall_ms": 0.007,
-      "max_rss_kb": 793424,
+      "wall_ms": 1156.61586,
+      "max_rss_kb": 581292,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -4998,18 +4998,18 @@
     {
       "workload": "json_pipeline_full",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 16,
-      "wall_ms": -0.046583,
-      "max_rss_kb": 793216,
+      "wall_ms": 1156.097962,
+      "max_rss_kb": 580600,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -5019,18 +5019,18 @@
     {
       "workload": "json_pipeline_full",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 17,
-      "wall_ms": 0.051,
-      "max_rss_kb": 792928,
+      "wall_ms": 1161.174972,
+      "max_rss_kb": 580776,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -5040,18 +5040,18 @@
     {
       "workload": "json_pipeline_full",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 18,
-      "wall_ms": 0.0275,
-      "max_rss_kb": 792992,
+      "wall_ms": 1158.708467,
+      "max_rss_kb": 581368,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -5061,18 +5061,18 @@
     {
       "workload": "json_pipeline_full",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 19,
-      "wall_ms": 0.014875,
-      "max_rss_kb": 793312,
+      "wall_ms": 1170.386123,
+      "max_rss_kb": 580820,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -5082,18 +5082,18 @@
     {
       "workload": "json_pipeline_full",
       "language": "node",
-      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+      "binary": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
       "command": [
-        "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+        "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
         "--experimental-strip-types",
         "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_node.json"
+        "/tmp/out_node.json"
       ],
       "run": 20,
-      "wall_ms": -0.041792,
-      "max_rss_kb": 793536,
+      "wall_ms": 1155.237786,
+      "max_rss_kb": 581160,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -5103,17 +5103,17 @@
     {
       "workload": "json_pipeline_full",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 1,
-      "wall_ms": -0.006458,
-      "max_rss_kb": 594016,
+      "wall_ms": 624.340689,
+      "max_rss_kb": 603524,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -5123,17 +5123,17 @@
     {
       "workload": "json_pipeline_full",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 2,
-      "wall_ms": 0.016834,
-      "max_rss_kb": 593456,
+      "wall_ms": 625.109945,
+      "max_rss_kb": 603600,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -5143,17 +5143,17 @@
     {
       "workload": "json_pipeline_full",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 3,
-      "wall_ms": -0.021375,
-      "max_rss_kb": 592688,
+      "wall_ms": 624.264216,
+      "max_rss_kb": 603804,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -5163,17 +5163,17 @@
     {
       "workload": "json_pipeline_full",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 4,
-      "wall_ms": 0.021667,
-      "max_rss_kb": 593424,
+      "wall_ms": 626.066722,
+      "max_rss_kb": 603488,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -5183,17 +5183,17 @@
     {
       "workload": "json_pipeline_full",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 5,
-      "wall_ms": -0.114917,
-      "max_rss_kb": 591520,
+      "wall_ms": 619.589467,
+      "max_rss_kb": 603620,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -5203,17 +5203,17 @@
     {
       "workload": "json_pipeline_full",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 6,
-      "wall_ms": -0.03925,
-      "max_rss_kb": 594336,
+      "wall_ms": 633.374158,
+      "max_rss_kb": 603596,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -5223,17 +5223,17 @@
     {
       "workload": "json_pipeline_full",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 7,
-      "wall_ms": -0.092291,
-      "max_rss_kb": 593312,
+      "wall_ms": 619.003492,
+      "max_rss_kb": 603300,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -5243,17 +5243,17 @@
     {
       "workload": "json_pipeline_full",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 8,
-      "wall_ms": 0.08675,
-      "max_rss_kb": 593232,
+      "wall_ms": 624.229,
+      "max_rss_kb": 603464,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -5263,17 +5263,17 @@
     {
       "workload": "json_pipeline_full",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 9,
-      "wall_ms": -0.038625,
-      "max_rss_kb": 594400,
+      "wall_ms": 621.666075,
+      "max_rss_kb": 603580,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -5283,17 +5283,17 @@
     {
       "workload": "json_pipeline_full",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 10,
-      "wall_ms": -0.017041,
-      "max_rss_kb": 593328,
+      "wall_ms": 618.004186,
+      "max_rss_kb": 603688,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -5303,17 +5303,17 @@
     {
       "workload": "json_pipeline_full",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 11,
-      "wall_ms": -0.0405,
-      "max_rss_kb": 593536,
+      "wall_ms": 624.870768,
+      "max_rss_kb": 604032,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -5323,17 +5323,17 @@
     {
       "workload": "json_pipeline_full",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 12,
-      "wall_ms": -0.055875,
-      "max_rss_kb": 594160,
+      "wall_ms": 627.110832,
+      "max_rss_kb": 603720,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -5343,17 +5343,17 @@
     {
       "workload": "json_pipeline_full",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 13,
-      "wall_ms": -0.053875,
-      "max_rss_kb": 591888,
+      "wall_ms": 623.766186,
+      "max_rss_kb": 603484,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -5363,17 +5363,17 @@
     {
       "workload": "json_pipeline_full",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 14,
-      "wall_ms": -0.026417,
-      "max_rss_kb": 593856,
+      "wall_ms": 621.193932,
+      "max_rss_kb": 603712,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -5383,17 +5383,17 @@
     {
       "workload": "json_pipeline_full",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 15,
-      "wall_ms": 0.039708,
-      "max_rss_kb": 593792,
+      "wall_ms": 624.222899,
+      "max_rss_kb": 603436,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -5403,17 +5403,17 @@
     {
       "workload": "json_pipeline_full",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 16,
-      "wall_ms": -0.031042,
-      "max_rss_kb": 591360,
+      "wall_ms": 622.828896,
+      "max_rss_kb": 603716,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -5423,17 +5423,17 @@
     {
       "workload": "json_pipeline_full",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 17,
-      "wall_ms": 0.101708,
-      "max_rss_kb": 593424,
+      "wall_ms": 626.464414,
+      "max_rss_kb": 603520,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -5443,17 +5443,17 @@
     {
       "workload": "json_pipeline_full",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 18,
-      "wall_ms": 0.085542,
-      "max_rss_kb": 593520,
+      "wall_ms": 623.176665,
+      "max_rss_kb": 603468,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -5463,17 +5463,17 @@
     {
       "workload": "json_pipeline_full",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 19,
-      "wall_ms": -0.15075,
-      "max_rss_kb": 593488,
+      "wall_ms": 621.693646,
+      "max_rss_kb": 603244,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
@@ -5483,17 +5483,17 @@
     {
       "workload": "json_pipeline_full",
       "language": "bun",
-      "binary": "~/.cache/perry-bench-tools/bun/bun",
+      "binary": "~/.cache/perry-bench-tools/bun-1.3.14/bun",
       "command": [
-        "~/.cache/perry-bench-tools/bun/bun",
+        "~/.cache/perry-bench-tools/bun-1.3.14/bun",
         "run",
         "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
         "benchmarks/honest_bench/assets/input.json",
-        "/private/tmp/out_bun.json"
+        "/tmp/out_bun.json"
       ],
       "run": 20,
-      "wall_ms": 0.025542,
-      "max_rss_kb": 593312,
+      "wall_ms": 635.261472,
+      "max_rss_kb": 603968,
       "exit_code": 0,
       "stdout_first": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",
       "stdout_last": "input_bytes=112695869 records_in=500000 records_out=249976 output_bytes=68140794 hash=b7e8a588",

--- a/benchmarks/honest_bench/results/summary.txt
+++ b/benchmarks/honest_bench/results/summary.txt
@@ -3,21 +3,21 @@
 # expected.json: present
 
 ## PERF — output verified to match Bun reference
-image_convolution        bun         0.0 ms  runs=20  match=20/20
-image_convolution        node        0.0 ms  runs=20  match=20/20
-image_convolution        perry      -0.0 ms  runs=20  match=20/20
-image_convolution        rust       -0.0 ms  runs=20  match=20/20
-image_convolution        zig         0.0 ms  runs=20  match=20/20
-json_pipeline_full       bun        -0.0 ms  runs=20  match=20/20
-json_pipeline_full       node        0.0 ms  runs=20  match=20/20
-json_pipeline_full       perry       0.0 ms  runs=20  match=20/20
-json_pipeline_full       rust       -0.0 ms  runs=20  match=20/20
-json_pipeline_full       zig        -0.0 ms  runs=20  match=20/20
-json_pipeline_small      bun         0.0 ms  runs=20  match=20/20
-json_pipeline_small      node        0.0 ms  runs=20  match=20/20
-json_pipeline_small      perry       0.0 ms  runs=20  match=20/20
-json_pipeline_small      rust        0.0 ms  runs=20  match=20/20
-json_pipeline_small      zig         0.0 ms  runs=20  match=20/20
+image_convolution        bun       544.0 ms  runs=20  match=20/20
+image_convolution        node      975.0 ms  runs=20  match=20/20
+image_convolution        perry    1204.4 ms  runs=20  match=20/20
+image_convolution        rust      321.6 ms  runs=20  match=20/20
+image_convolution        zig       173.5 ms  runs=20  match=20/20
+json_pipeline_full       bun       624.2 ms  runs=20  match=20/20
+json_pipeline_full       node     1183.5 ms  runs=20  match=20/20
+json_pipeline_full       perry    1831.2 ms  runs=20  match=20/20
+json_pipeline_full       rust      733.6 ms  runs=20  match=20/20
+json_pipeline_full       zig       850.5 ms  runs=20  match=20/20
+json_pipeline_small      bun        27.9 ms  runs=20  match=20/20
+json_pipeline_small      node       53.0 ms  runs=20  match=20/20
+json_pipeline_small      perry      19.6 ms  runs=20  match=20/20
+json_pipeline_small      rust       14.7 ms  runs=20  match=20/20
+json_pipeline_small      zig        14.4 ms  runs=20  match=20/20
 
 # To turn mismatches into a hard CI failure: ./run.sh --strict-output
 # To refresh the reference (only when output semantics intentionally change):

--- a/benchmarks/honest_bench/run.sh
+++ b/benchmarks/honest_bench/run.sh
@@ -65,6 +65,23 @@ def system_profiler_hardware():
     except (IndexError, json.JSONDecodeError):
         return {}
 
+def os_version():
+    system = platform.system()
+    if system == "Darwin":
+        return run(["sw_vers", "-productVersion"])
+    if system == "Linux":
+        try:
+            with open("/etc/os-release", encoding="utf-8") as handle:
+                values = dict(
+                    line.rstrip().split("=", 1)
+                    for line in handle
+                    if "=" in line
+                )
+            return values.get("PRETTY_NAME", "").strip('"') or platform.release()
+        except OSError:
+            return platform.release()
+    return platform.platform()
+
 hardware = system_profiler_hardware()
 cpu = run(["sysctl", "-n", "machdep.cpu.brand_string"]) or hardware.get("chip_type") or platform.processor()
 ncpu = run(["sysctl", "-n", "hw.ncpu"]) or str(os.cpu_count() or "")
@@ -80,7 +97,7 @@ meta = {
     "generated_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
     "commit": run(["git", "-C", "$PERRY_ROOT", "rev-parse", "HEAD"]),
     "host": {
-        "os_version": run(["sw_vers", "-productVersion"]),
+        "os_version": os_version(),
         "kernel":     run(["uname", "-a"]),
         "arch":       platform.machine(),
         "cpu":        cpu,

--- a/benchmarks/honest_bench/scripts/report.py
+++ b/benchmarks/honest_bench/scripts/report.py
@@ -193,11 +193,14 @@ Charts: [image convolution](charts/image_convolution.png),
     h = meta.get("host", {})
     t = meta.get("toolchains", {})
     harn = meta.get("harness", {})
+    kernel_name = str(h.get("kernel", "?")).split()[0]
+    os_version = str(h.get("os_version", "?") or "?")
+    os_label = f"macOS {os_version}" if kernel_name == "Darwin" else os_version
     lines.append("| | |")
     lines.append("|---|---|")
     lines.append(f"| CPU | {h.get('cpu','?')} ({h.get('ncpu','?')} cores, {h.get('arch','?')}) |")
     lines.append(f"| RAM | {h.get('ram_gb','?')} GB |")
-    lines.append(f"| OS  | macOS {h.get('os_version','?')} ({h.get('kernel','?').split()[0]}) |")
+    lines.append(f"| OS  | {os_label} ({kernel_name}) |")
     lines.append(f"| Rust | `{t.get('rustc','?')}` |")
     lines.append(f"| Zig | `{t.get('zig','?')}` |")
     lines.append(f"| Perry | `{t.get('perry','?')}` |")

--- a/benchmarks/honest_bench/workloads/1_json_pipeline/zig/build.sh
+++ b/benchmarks/honest_bench/workloads/1_json_pipeline/zig/build.sh
@@ -10,9 +10,14 @@ export ZIG_GLOBAL_CACHE_DIR="$zig_cache/global"
 export ZIG_LOCAL_CACHE_DIR="$zig_cache/json_pipeline"
 
 mkdir -p zig-out/bin
+target_args=()
+if [[ "$(uname)" == "Darwin" ]]; then
+  # Zig 0.15.2 does not recognize macOS 26 as a deployment target.
+  target_args=(-target aarch64-macos.14.0)
+fi
 zig build-exe src/main.zig \
   -O ReleaseFast \
-  -target aarch64-macos.14.0 \
+  "${target_args[@]}" \
   -lc \
   --name json_pipeline \
   -femit-bin=zig-out/bin/json_pipeline

--- a/benchmarks/honest_bench/workloads/3_image_convolution/zig/build.sh
+++ b/benchmarks/honest_bench/workloads/3_image_convolution/zig/build.sh
@@ -13,9 +13,13 @@ export ZIG_GLOBAL_CACHE_DIR="$zig_cache/global"
 export ZIG_LOCAL_CACHE_DIR="$zig_cache/image_conv"
 
 mkdir -p zig-out/bin
+target_args=()
+if [[ "$(uname)" == "Darwin" ]]; then
+  target_args=(-target aarch64-macos.14.0)
+fi
 zig build-exe src/main.zig \
   -O ReleaseFast \
-  -target aarch64-macos.14.0 \
+  "${target_args[@]}" \
   -lc \
   --name image_conv \
   -femit-bin=zig-out/bin/image_conv

--- a/benchmarks/json_polyglot/RESULTS.md
+++ b/benchmarks/json_polyglot/RESULTS.md
@@ -1,8 +1,8 @@
 # JSON Polyglot Benchmark Results
 
-**Runs per cell:** 11 · **Pinning:** macOS scheduler hint (taskpolicy -t 0 -l 0 — P-core preferred via throughput/latency tiers, NOT strict affinity)
-**Hardware:** Darwin 25.5.0 arm64 on perry-macos.
-**Date:** 2026-08-08.
+**Runs per cell:** 11 · **Pinning:** Linux strict (taskset -c 0)
+**Hardware:** Linux 6.17.0-23-generic x86_64 on ideal-mastodon.
+**Date:** 2026-09-01.
 
 Two workloads, each language listed twice (idiomatic / optimized flag profile).
 Median wall-clock time is the headline number; p95, σ (population stddev),
@@ -18,15 +18,13 @@ low — the lazy path can avoid materializing the parse tree entirely.
 
 | Implementation | Profile | Median (ms) | p95 (ms) | σ | Min | Max | Peak RSS (MB) |
 |---|---|---:|---:|---:|---:|---:|---:|
-| rust serde_json (LTO+1cgu) | optimized | 178 | 194 | 4.6 | 178 | 194 | 10 |
-| perry (gen-gc + lazy tape) | optimized | 184 | 190 | 1.9 | 183 | 190 | 79 |
-| rust serde_json | idiomatic | 188 | 203 | 4.3 | 188 | 203 | 9 |
-| bun (default) | idiomatic | 220 | 232 | 3.5 | 219 | 232 | 83 |
-| node --max-old=4096 | optimized | 380 | 385 | 4.2 | 373 | 385 | 100 |
-| node (default) | idiomatic | 380 | 389 | 3.9 | 373 | 389 | 99 |
-| perry (mark-sweep, no lazy) | idiomatic | 1198 | 1206 | 2.6 | 1196 | 1206 | 62 |
-| swift -O -wmo (Foundation) | optimized | 3461 | 3487 | 10.0 | 3456 | 3487 | 28 |
-| swift -O (Foundation) | idiomatic | 3466 | 3481 | 8.1 | 3452 | 3481 | 28 |
+| perry (gen-gc + lazy tape) | optimized | 186 | 188 | 1.4 | 184 | 188 | 119 |
+| bun (default) | idiomatic | 189 | 195 | 2.3 | 188 | 195 | 87 |
+| rust serde_json (LTO+1cgu) | optimized | 213 | 213 | 0.4 | 212 | 213 | 9 |
+| rust serde_json | idiomatic | 227 | 230 | 1.1 | 226 | 230 | 9 |
+| node --max-old=4096 | optimized | 379 | 409 | 8.8 | 377 | 409 | 114 |
+| node (default) | idiomatic | 407 | 669 | 88.2 | 378 | 669 | 113 |
+| perry (mark-sweep, no lazy) | idiomatic | 514 | 936 | 195.6 | 504 | 936 | 79 |
 
 ## JSON parse-and-iterate
 
@@ -37,12 +35,10 @@ JSON content. 10k records, ~1 MB blob, 50 iterations per run.
 
 | Implementation | Profile | Median (ms) | p95 (ms) | σ | Min | Max | Peak RSS (MB) |
 |---|---|---:|---:|---:|---:|---:|---:|
-| rust serde_json (LTO+1cgu) | optimized | 179 | 198 | 5.4 | 179 | 198 | 10 |
-| rust serde_json | idiomatic | 188 | 203 | 4.3 | 188 | 203 | 9 |
-| bun (default) | idiomatic | 222 | 222 | 0.7 | 220 | 222 | 87 |
-| node --max-old=4096 | optimized | 384 | 389 | 4.4 | 376 | 389 | 95 |
-| node (default) | idiomatic | 385 | 395 | 5.0 | 378 | 395 | 95 |
-| perry (mark-sweep, no lazy) | idiomatic | 1247 | 1250 | 1.9 | 1244 | 1250 | 59 |
-| perry (gen-gc + lazy tape) | optimized | 2030 | 2048 | 69.2 | 1804 | 2048 | 170 |
-| swift -O (Foundation) | idiomatic | 3451 | 3477 | 11.8 | 3441 | 3477 | 28 |
-| swift -O -wmo (Foundation) | optimized | 3474 | 3502 | 14.0 | 3450 | 3502 | 28 |
+| bun (default) | idiomatic | 198 | 206 | 3.1 | 198 | 206 | 104 |
+| rust serde_json (LTO+1cgu) | optimized | 212 | 217 | 1.4 | 212 | 217 | 9 |
+| rust serde_json | idiomatic | 227 | 227 | 0.5 | 226 | 227 | 9 |
+| node --max-old=4096 | optimized | 380 | 383 | 1.2 | 379 | 383 | 114 |
+| node (default) | idiomatic | 382 | 385 | 2.4 | 377 | 385 | 115 |
+| perry (mark-sweep, no lazy) | idiomatic | 513 | 521 | 3.1 | 510 | 521 | 79 |
+| perry (gen-gc + lazy tape) | optimized | 758 | 1013 | 175.4 | 548 | 1013 | 396 |

--- a/benchmarks/polyglot/METHODOLOGY.md
+++ b/benchmarks/polyglot/METHODOLOGY.md
@@ -125,7 +125,7 @@ everything else.
 | Benchmark           | Iterations | Array size  | Notes                                            |
 |---------------------|-----------:|------------:|-------------------------------------------------|
 | fibonacci           | recursion  |           — | `fib(40)` — ~2 billion calls                    |
-| loop_overhead       |       100M |           — | `sum += 1.0` — trivially foldable               |
+| loop_overhead       |       100M |           — | 32-bit FNV recurrence with a sequential carry   |
 | loop_data_dependent |       100M |          64 | `sum = sum*x[i%64] + x[(i*7)%64]` on `[0.5,1)`  |
 | array_write         |        10M |         10M | write `arr[i] = i`                              |
 | array_read          |        10M |         10M | sum array elements                              |
@@ -182,15 +182,16 @@ full rationale and divergence numbers.
 
 Rust, C++, Go, and Swift all default to IEEE 754 strict. Under IEEE rules,
 `(a + b) + c ≠ a + (b + c)` in general — because a single `inf` or `nan` in
-the chain makes reordering observably change the result. The compiler
-must preserve original associativity, so every `fadd` in
-`for (...) sum += 1.0` has a 3-cycle latency dependency on the previous
-`fadd`. That's why Rust/C++/Go/Swift cluster at ~95-98 ms on
-`loop_overhead`: they're hitting the `fadd` latency wall, all running
-the same IEEE-strict serialized loop. **Perry default also sits at 95
-ms here**, in the same boat — bit-exact-with-Node by default, no
-reassoc permission. Perry `--fast-math` reaches 12 ms by giving the
-optimizer the same permission `-ffast-math` gives clang.
+the chain makes reordering observably change the result. The compiler must
+therefore preserve original associativity on the floating-point accumulator
+probes such as `math_intensive` and `accumulate`; `--fast-math` permits Perry
+to vectorize those chains in the same way `-ffast-math` permits clang.
+
+`loop_overhead` is intentionally no longer one of those foldability probes.
+As of #9338 it carries a 32-bit FNV-style recurrence whose final value escapes,
+so an optimizer cannot turn the timed region into a 0 ms false green. Results
+from before that change used `sum += 1.0` and are not comparable to the current
+row.
 
 The full rationale for which FMFs Perry emits even under `--fast-math`
 is in `block.rs:113-160` — Perry deliberately does not emit the full
@@ -298,15 +299,13 @@ recursive call more aggressively than any of the AOT compilers here
 manage to do at module scope. This is a JIT-vs-AOT story, not a
 Perry story.
 
-## `loop_data_dependent` — what happens when the compiler *can't* fold
+## `loop_data_dependent` — the floating-point data-dependent companion
 
-Added at v0.5.271 in direct response to the most-common skeptic
-objection to the optimization-probe cells: "your `loop_overhead`
-12 ms vs C++ 98 ms isn't 'Perry beats C++' — it's 'Perry's defaults
-fold the loop and C++'s don't.'" That objection is correct, and
-this benchmark answers the natural follow-up: *what does Perry do
-on a kernel where the compiler can't fold, regardless of flag
-posture?*
+Added at v0.5.271 in response to the old, trivially foldable
+`loop_overhead` kernel. #9338 later replaced that kernel with an observable
+integer recurrence, but this benchmark remains the floating-point companion:
+it adds runtime-loaded data and exposes FP-contraction behavior while retaining
+a true sequential carry.
 
 ### Kernel design
 
@@ -324,9 +323,9 @@ Two properties make this kernel resistant to optimization:
 1. **Multiplicative carry.** The next iteration's `sum` depends on
    the previous via `*` then `+`. LLVM's autovectorizer can't break
    this dependency into parallel accumulators — the closed-form
-   collapse `(sum + 1.0) × N → integer induction variable` that
-   `loop_overhead` admits requires accumulator reordering, which
-   `reassoc` allows but `contract` (FMA fusion) does not change.
+   collapse that the pre-#9338 `sum += 1.0` loop admitted requires accumulator
+   reordering, which `reassoc` allows but `contract` (FMA fusion) does not
+   change.
 2. **Runtime-loaded array reads.** `x[i%64]` and `x[(i*7)%64]` are
    loaded from memory on every step. Even though `x` is constant
    after init, LLVM's loop-invariant code motion can't hoist
@@ -403,8 +402,9 @@ the no-contract pack alongside Bun.
 
 ### What this benchmark answers
 
-The "Perry is 7× faster than C++ on `loop_overhead`" headline does
-not generalize to all f64 compute. On a kernel where the compiler
+The historical "Perry is 7× faster than C++ on `loop_overhead`" headline was
+based on the pre-#9338 foldability probe and does not describe the current
+integer-carry kernel. On a floating-point kernel where the compiler
 *cannot* fold (because the inner loop has a true sequential
 multiplicative dependency on a memory-loaded value), Perry is
 **competitive with the no-contract compiled pack** — Rust default,
@@ -415,19 +415,18 @@ be.
 
 This is the kind of kernel — multiplicative carry, runtime-loaded
 data, contracting domain — that real numerical workloads (signal
-processing, IIR filters, Markov-chain reductions, numerical
-integration) actually look like. The optimization-probe kernels
-(`loop_overhead`, `math_intensive`, `accumulate`) are *probes*, not
-workload simulators — they are diagnostic tools for measuring
-compiler flag posture, and we report them on those terms.
+processing, IIR filters, Markov-chain reductions, numerical integration)
+actually look like. The remaining floating-point optimization probes
+(`math_intensive`, `accumulate`) are diagnostic tools for measuring compiler
+flag posture, not workload simulators.
 
-## Optimization probes (`loop_overhead`, `math_intensive`, `accumulate`, `array_read`, `array_write`)
+## Optimization probes (`math_intensive`, `accumulate`, `array_read`, `array_write`)
 
-These five cells are flag-aggressiveness probes, not runtime perf
-comparisons. They measure whether the compiler applied
-**reassoc + IndVarSimplify + autovectorize** to a trivially-foldable
-accumulator, NOT how fast the resulting loop computes under load
-(which the previous section's `loop_data_dependent` answers honestly).
+These four cells are flag-aggressiveness probes, not runtime performance
+comparisons. They measure whether the compiler applied reassociation,
+induction-variable simplification, or autovectorization to simple accumulator
+and array loops. `loop_overhead` is excluded because its observable integer
+recurrence deliberately measures executed work instead of foldability.
 
 **Two Perry columns since v0.5.585:**
 - `Perry default` (no `--fast-math`) sits at 95-50 ms on these probes,
@@ -443,10 +442,9 @@ accumulator, NOT how fast the resulting loop computes under load
   randomly-generated FP programs at the *program* level (the residual
   6% in default mode comes from the SLP vectorizer).
 
-LLVM's IndVarSimplify rewrites `sum + 1.0 × N` as an integer induction
-variable and the autovectorizer generates `<2 x double>` parallel-
-accumulator reductions with interleave count 4 only when `reassoc` is
-on. **C++ closes every one of these gaps with `clang++ -O3
+LLVM's autovectorizer generates parallel-accumulator reductions for the
+floating-point probes only when `reassoc` is on. **C++ closes these gaps with
+`clang++ -O3
 -ffast-math`** — same LLVM pipeline, one flag — see
 [`RESULTS_OPT.md`](./RESULTS_OPT.md). They are reported here for
 diagnostic completeness; treating Perry's `--fast-math` numbers as
@@ -458,6 +456,9 @@ Perry columns next to each other.
 
 This methodology will drift as the Perry codegen changes. Key moments:
 
+- **2026-09-01 (#9338):** Replaced `loop_overhead`'s foldable floating-point
+  induction with an observable 32-bit recurrence, aligned every native
+  implementation, and fingerprinted the native sources as baseline inputs.
 - **2026-04-25 (v0.5.249 → v0.5.283):** Compiler-version table refreshed
   to actually-installed versions (rustc 1.94.1, Apple clang 21.0.0,
   swift 6.3.1, Bun 1.3.12, Node 25.8.0, Python 3.14.3); added

--- a/benchmarks/polyglot/RESULTS_AUTO.md
+++ b/benchmarks/polyglot/RESULTS_AUTO.md
@@ -1,22 +1,22 @@
 # Polyglot Compute-Microbench Results (auto-generated)
 
-**Runs per cell:** 11 · **Pinning:** macOS scheduler hint (taskpolicy -t 0 -l 0 — P-core preferred via throughput/latency tiers, NOT strict affinity)
-**Hardware:** Darwin 25.5.0 arm64 on perry-macos · **Date:** 2026-08-08
-**Perry version:** v0.5.1355
+**Runs per cell:** 11 · **Pinning:** Linux strict (taskset -c 0)
+**Hardware:** Linux 6.17.0-23-generic x86_64 on ideal-mastodon · **Date:** 2026-09-01
+**Perry version:** v0.5.1519
 
 Headline = median wall-clock ms. Lower is better.
 
 | Benchmark           | Perry |  Rust |   C++ |    Go | Swift |  Java |  Node |   Bun | Hermes |  Python |
 |---------------------|-------|-------|-------|-------|-------|-------|-------|-------|--------|---------|
-| fibonacci           |   390 |   308 |   300 |     - |   389 |   271 |   912 |   500 |      - |   24432 |
-| loop_overhead       |    94 |    93 |    93 |     - |    93 |    95 |    63 |    39 |      - |    2599 |
-| loop_data_dependent |   219 |   218 |   125 |     - |   218 |   221 |   221 |   221 |      - |   12630 |
-| array_write         |     1 |     8 |     1 |     - |     1 |     5 |     7 |     5 |      - |     696 |
-| array_read          |    22 |     9 |     9 |     - |     9 |    11 |    11 |    14 |      - |     323 |
-| math_intensive      |    49 |    46 |    49 |     - |    47 |    49 |    49 |    49 |      - |    2272 |
-| object_create       |     3 |     0 |     0 |     - |     0 |     5 |     5 |     5 |      - |     303 |
-| nested_loops        |    40 |     8 |     8 |     - |     8 |    10 |    18 |    19 |      - |     559 |
-| accumulate          |    94 |    93 |    93 |     - |    93 |    95 |    94 |    95 |      - |    4556 |
+| fibonacci           |   323 |   189 |   103 |     - |     - |     - |   708 |   469 |      - |    8579 |
+| loop_overhead       |    74 |    77 |    75 |     - |     - |     - |    76 |    83 |      - |    5629 |
+| loop_data_dependent |   112 |   112 |   112 |     - |     - |     - |   115 |   124 |      - |    5425 |
+| array_write         |     4 |     4 |     2 |     - |     - |     - |     5 |     9 |      - |     339 |
+| array_read          |     6 |     6 |    12 |     - |     - |     - |     7 |    17 |      - |     193 |
+| math_intensive      |    51 |    44 |    51 |     - |     - |     - |    44 |    55 |      - |    1240 |
+| object_create       |     4 |     2 |     0 |     - |     - |     - |     7 |    20 |      - |     121 |
+| nested_loops        |    26 |     5 |    10 |     - |     - |     - |    15 |    26 |      - |     330 |
+| accumulate          |    58 |    63 |    56 |     - |     - |     - |   162 |    72 |      - |    3369 |
 
 ## Per-cell full stats
 
@@ -24,93 +24,93 @@ Format: median (p95: X, σ: S, min: Y, max: Z) ms
 
 | Benchmark | Runtime | Stats (ms) |
 |---|---|---|
-| fibonacci | perry | 390 (p95: 391, σ: 0.4, min: 389, max: 391) |
-| fibonacci | rust | 308 (p95: 350, σ: 12.1, min: 308, max: 350) |
-| fibonacci | cpp | 300 (p95: 348, σ: 13.9, min: 299, max: 348) |
+| fibonacci | perry | 323 (p95: 325, σ: 0.8, min: 322, max: 325) |
+| fibonacci | rust | 189 (p95: 194, σ: 2.0, min: 188, max: 194) |
+| fibonacci | cpp | 103 (p95: 104, σ: 0.4, min: 103, max: 104) |
 | fibonacci | go | - |
-| fibonacci | swift | 389 (p95: 430, σ: 11.7, min: 389, max: 430) |
-| fibonacci | java | 271 (p95: 272, σ: 0.4, min: 270, max: 272) |
-| fibonacci | node | 912 (p95: 913, σ: 0.5, min: 912, max: 913) |
-| fibonacci | bun | 500 (p95: 504, σ: 1.7, min: 499, max: 504) |
+| fibonacci | swift | - |
+| fibonacci | java | - |
+| fibonacci | node | 708 (p95: 713, σ: 1.7, min: 706, max: 713) |
+| fibonacci | bun | 469 (p95: 694, σ: 99.4, min: 440, max: 694) |
 | fibonacci | hermes | - |
-| fibonacci | python | 24432 (p95: 24445, σ: 8.8, min: 24414, max: 24445) |
-| loop_overhead | perry | 94 (p95: 94, σ: 0.5, min: 93, max: 94) |
-| loop_overhead | rust | 93 (p95: 94, σ: 0.3, min: 93, max: 94) |
-| loop_overhead | cpp | 93 (p95: 93, σ: 0.0, min: 93, max: 93) |
+| fibonacci | python | 8579 (p95: 8853, σ: 110.8, min: 8484, max: 8853) |
+| loop_overhead | perry | 74 (p95: 75, σ: 0.4, min: 74, max: 75) |
+| loop_overhead | rust | 77 (p95: 80, σ: 2.4, min: 74, max: 80) |
+| loop_overhead | cpp | 75 (p95: 75, σ: 0.3, min: 74, max: 75) |
 | loop_overhead | go | - |
-| loop_overhead | swift | 93 (p95: 94, σ: 0.3, min: 93, max: 94) |
-| loop_overhead | java | 95 (p95: 96, σ: 0.3, min: 95, max: 96) |
-| loop_overhead | node | 63 (p95: 64, σ: 0.4, min: 63, max: 64) |
-| loop_overhead | bun | 39 (p95: 40, σ: 0.4, min: 39, max: 40) |
+| loop_overhead | swift | - |
+| loop_overhead | java | - |
+| loop_overhead | node | 76 (p95: 79, σ: 0.9, min: 76, max: 79) |
+| loop_overhead | bun | 83 (p95: 84, σ: 1.2, min: 81, max: 84) |
 | loop_overhead | hermes | - |
-| loop_overhead | python | 2599 (p95: 2603, σ: 2.0, min: 2598, max: 2603) |
-| loop_data_dependent | perry | 219 (p95: 220, σ: 0.3, min: 219, max: 220) |
-| loop_data_dependent | rust | 218 (p95: 219, σ: 0.5, min: 218, max: 219) |
-| loop_data_dependent | cpp | 125 (p95: 125, σ: 0.0, min: 125, max: 125) |
+| loop_overhead | python | 5629 (p95: 6106, σ: 194.1, min: 5511, max: 6106) |
+| loop_data_dependent | perry | 112 (p95: 112, σ: 0.3, min: 111, max: 112) |
+| loop_data_dependent | rust | 112 (p95: 118, σ: 2.4, min: 111, max: 118) |
+| loop_data_dependent | cpp | 112 (p95: 113, σ: 0.6, min: 111, max: 113) |
 | loop_data_dependent | go | - |
-| loop_data_dependent | swift | 218 (p95: 219, σ: 0.5, min: 218, max: 219) |
-| loop_data_dependent | java | 221 (p95: 221, σ: 0.5, min: 220, max: 221) |
-| loop_data_dependent | node | 221 (p95: 225, σ: 1.5, min: 221, max: 225) |
-| loop_data_dependent | bun | 221 (p95: 221, σ: 0.0, min: 221, max: 221) |
+| loop_data_dependent | swift | - |
+| loop_data_dependent | java | - |
+| loop_data_dependent | node | 115 (p95: 116, σ: 0.5, min: 115, max: 116) |
+| loop_data_dependent | bun | 124 (p95: 127, σ: 1.4, min: 122, max: 127) |
 | loop_data_dependent | hermes | - |
-| loop_data_dependent | python | 12630 (p95: 12646, σ: 6.0, min: 12625, max: 12646) |
-| array_write | perry | 1 (p95: 2, σ: 0.5, min: 1, max: 2) |
-| array_write | rust | 8 (p95: 8, σ: 0.8, min: 6, max: 8) |
-| array_write | cpp | 1 (p95: 2, σ: 0.4, min: 1, max: 2) |
+| loop_data_dependent | python | 5425 (p95: 5869, σ: 180.7, min: 5375, max: 5869) |
+| array_write | perry | 4 (p95: 4, σ: 0.5, min: 3, max: 4) |
+| array_write | rust | 4 (p95: 5, σ: 0.9, min: 3, max: 5) |
+| array_write | cpp | 2 (p95: 3, σ: 0.3, min: 2, max: 3) |
 | array_write | go | - |
-| array_write | swift | 1 (p95: 2, σ: 0.5, min: 1, max: 2) |
-| array_write | java | 5 (p95: 6, σ: 0.5, min: 5, max: 6) |
-| array_write | node | 7 (p95: 7, σ: 0.0, min: 7, max: 7) |
-| array_write | bun | 5 (p95: 5, σ: 0.0, min: 5, max: 5) |
+| array_write | swift | - |
+| array_write | java | - |
+| array_write | node | 5 (p95: 5, σ: 0.5, min: 4, max: 5) |
+| array_write | bun | 9 (p95: 11, σ: 0.8, min: 9, max: 11) |
 | array_write | hermes | - |
-| array_write | python | 696 (p95: 722, σ: 13.7, min: 672, max: 722) |
-| array_read | perry | 22 (p95: 23, σ: 0.4, min: 22, max: 23) |
-| array_read | rust | 9 (p95: 9, σ: 0.0, min: 9, max: 9) |
-| array_read | cpp | 9 (p95: 9, σ: 0.0, min: 9, max: 9) |
+| array_write | python | 339 (p95: 342, σ: 1.2, min: 338, max: 342) |
+| array_read | perry | 6 (p95: 6, σ: 0.5, min: 5, max: 6) |
+| array_read | rust | 6 (p95: 6, σ: 0.0, min: 6, max: 6) |
+| array_read | cpp | 12 (p95: 13, σ: 0.3, min: 12, max: 13) |
 | array_read | go | - |
-| array_read | swift | 9 (p95: 9, σ: 0.0, min: 9, max: 9) |
-| array_read | java | 11 (p95: 11, σ: 0.4, min: 10, max: 11) |
-| array_read | node | 11 (p95: 11, σ: 0.5, min: 10, max: 11) |
-| array_read | bun | 14 (p95: 14, σ: 0.4, min: 13, max: 14) |
+| array_read | swift | - |
+| array_read | java | - |
+| array_read | node | 7 (p95: 8, σ: 0.4, min: 7, max: 8) |
+| array_read | bun | 17 (p95: 18, σ: 0.7, min: 16, max: 18) |
 | array_read | hermes | - |
-| array_read | python | 323 (p95: 329, σ: 2.6, min: 322, max: 329) |
-| math_intensive | perry | 49 (p95: 49, σ: 0.0, min: 49, max: 49) |
-| math_intensive | rust | 46 (p95: 47, σ: 0.3, min: 46, max: 47) |
-| math_intensive | cpp | 49 (p95: 49, σ: 0.5, min: 48, max: 49) |
+| array_read | python | 193 (p95: 325, σ: 59.1, min: 179, max: 325) |
+| math_intensive | perry | 51 (p95: 55, σ: 4.1, min: 44, max: 55) |
+| math_intensive | rust | 44 (p95: 45, σ: 0.5, min: 44, max: 45) |
+| math_intensive | cpp | 51 (p95: 54, σ: 2.3, min: 48, max: 54) |
 | math_intensive | go | - |
-| math_intensive | swift | 47 (p95: 47, σ: 0.0, min: 47, max: 47) |
-| math_intensive | java | 49 (p95: 49, σ: 0.4, min: 48, max: 49) |
-| math_intensive | node | 49 (p95: 49, σ: 0.5, min: 48, max: 49) |
-| math_intensive | bun | 49 (p95: 49, σ: 0.3, min: 48, max: 49) |
+| math_intensive | swift | - |
+| math_intensive | java | - |
+| math_intensive | node | 44 (p95: 45, σ: 0.6, min: 43, max: 45) |
+| math_intensive | bun | 55 (p95: 56, σ: 1.3, min: 52, max: 56) |
 | math_intensive | hermes | - |
-| math_intensive | python | 2272 (p95: 2316, σ: 16.1, min: 2254, max: 2316) |
-| object_create | perry | 3 (p95: 3, σ: 0.4, min: 2, max: 3) |
-| object_create | rust | 0 (p95: 0, σ: 0.0, min: 0, max: 0) |
+| math_intensive | python | 1240 (p95: 1978, σ: 332.2, min: 1110, max: 1978) |
+| object_create | perry | 4 (p95: 4, σ: 0.4, min: 3, max: 4) |
+| object_create | rust | 2 (p95: 2, σ: 0.0, min: 2, max: 2) |
 | object_create | cpp | 0 (p95: 0, σ: 0.0, min: 0, max: 0) |
 | object_create | go | - |
-| object_create | swift | 0 (p95: 0, σ: 0.0, min: 0, max: 0) |
-| object_create | java | 5 (p95: 5, σ: 0.4, min: 4, max: 5) |
-| object_create | node | 5 (p95: 5, σ: 0.4, min: 4, max: 5) |
-| object_create | bun | 5 (p95: 6, σ: 0.5, min: 5, max: 6) |
+| object_create | swift | - |
+| object_create | java | - |
+| object_create | node | 7 (p95: 8, σ: 1.2, min: 5, max: 8) |
+| object_create | bun | 20 (p95: 21, σ: 1.7, min: 15, max: 21) |
 | object_create | hermes | - |
-| object_create | python | 303 (p95: 311, σ: 3.5, min: 300, max: 311) |
-| nested_loops | perry | 40 (p95: 40, σ: 0.4, min: 39, max: 40) |
-| nested_loops | rust | 8 (p95: 8, σ: 0.0, min: 8, max: 8) |
-| nested_loops | cpp | 8 (p95: 8, σ: 0.0, min: 8, max: 8) |
+| object_create | python | 121 (p95: 187, σ: 19.4, min: 118, max: 187) |
+| nested_loops | perry | 26 (p95: 26, σ: 0.5, min: 25, max: 26) |
+| nested_loops | rust | 5 (p95: 5, σ: 0.0, min: 5, max: 5) |
+| nested_loops | cpp | 10 (p95: 11, σ: 0.4, min: 10, max: 11) |
 | nested_loops | go | - |
-| nested_loops | swift | 8 (p95: 8, σ: 0.0, min: 8, max: 8) |
-| nested_loops | java | 10 (p95: 11, σ: 0.5, min: 10, max: 11) |
-| nested_loops | node | 18 (p95: 18, σ: 0.0, min: 18, max: 18) |
-| nested_loops | bun | 19 (p95: 19, σ: 0.5, min: 18, max: 19) |
+| nested_loops | swift | - |
+| nested_loops | java | - |
+| nested_loops | node | 15 (p95: 18, σ: 1.4, min: 13, max: 18) |
+| nested_loops | bun | 26 (p95: 27, σ: 1.9, min: 22, max: 27) |
 | nested_loops | hermes | - |
-| nested_loops | python | 559 (p95: 566, σ: 3.4, min: 558, max: 566) |
-| accumulate | perry | 94 (p95: 94, σ: 0.4, min: 93, max: 94) |
-| accumulate | rust | 93 (p95: 94, σ: 0.3, min: 93, max: 94) |
-| accumulate | cpp | 93 (p95: 93, σ: 0.0, min: 93, max: 93) |
+| nested_loops | python | 330 (p95: 527, σ: 82.5, min: 319, max: 527) |
+| accumulate | perry | 58 (p95: 62, σ: 1.4, min: 57, max: 62) |
+| accumulate | rust | 63 (p95: 64, σ: 0.5, min: 62, max: 64) |
+| accumulate | cpp | 56 (p95: 57, σ: 0.3, min: 56, max: 57) |
 | accumulate | go | - |
-| accumulate | swift | 93 (p95: 93, σ: 0.0, min: 93, max: 93) |
-| accumulate | java | 95 (p95: 96, σ: 0.4, min: 95, max: 96) |
-| accumulate | node | 94 (p95: 95, σ: 0.5, min: 94, max: 95) |
-| accumulate | bun | 95 (p95: 96, σ: 0.3, min: 95, max: 96) |
+| accumulate | swift | - |
+| accumulate | java | - |
+| accumulate | node | 162 (p95: 172, σ: 25.1, min: 101, max: 172) |
+| accumulate | bun | 72 (p95: 76, σ: 1.7, min: 69, max: 76) |
 | accumulate | hermes | - |
-| accumulate | python | 4556 (p95: 4562, σ: 45.4, min: 4431, max: 4562) |
+| accumulate | python | 3369 (p95: 5661, σ: 862.4, min: 3262, max: 5661) |

--- a/benchmarks/polyglot/bench.cpp
+++ b/benchmarks/polyglot/bench.cpp
@@ -1,4 +1,5 @@
 #include <chrono>
+#include <cstdint>
 #include <cstdio>
 #include <vector>
 
@@ -23,12 +24,12 @@ void bench_fibonacci() {
 
 void bench_loop_overhead() {
     auto start = Clock::now();
-    double sum = 0.0;
-    for (int i = 0; i < 100000000; i++) {
-        sum += 1.0;
+    std::uint32_t checksum = 0x811c9dc5U;
+    for (std::uint32_t i = 0; i < 100000000U; i++) {
+        checksum = (checksum ^ i) * 0x01000193U;
     }
     printf("loop_overhead:%lld\n", elapsed_ms(start));
-    printf("  checksum: %.0f\n", sum);
+    printf("  checksum: %u\n", checksum);
 }
 
 void bench_array_write() {
@@ -108,12 +109,9 @@ void bench_accumulate() {
     printf("  checksum: %.0f\n", sum);
 }
 
-// Data-dependent loop with sequential multiply-carry. Sibling to
-// bench_loop_overhead but genuinely non-foldable: array reads + a
-// multiplicative carry through `sum` defeat reassoc, IV-simplify, and
-// the vectorizer. See bench.rs for the asm-verification dump (the
-// generated loop body is a 4-instruction scalar fmul/fadd chain with
-// two array loads).
+// Floating-point loop with a sequential multiply-carry. Unlike
+// bench_loop_overhead's integer carry, this adds two runtime array reads and
+// exposes FP-contraction behavior. See bench.rs for the asm-verification dump.
 void bench_loop_data_dependent() {
     constexpr int N = 64;
     constexpr long long ITERATIONS = 100000000LL;

--- a/benchmarks/polyglot/bench.go
+++ b/benchmarks/polyglot/bench.go
@@ -23,13 +23,13 @@ func benchFibonacci() {
 
 func benchLoopOverhead() {
 	start := time.Now()
-	sum := 0.0
-	for i := 0; i < 100_000_000; i++ {
-		sum += 1.0
+	checksum := uint32(0x811c9dc5)
+	for i := uint32(0); i < 100_000_000; i++ {
+		checksum = (checksum ^ i) * 0x01000193
 	}
 	elapsed := time.Since(start).Milliseconds()
 	fmt.Printf("loop_overhead:%d\n", elapsed)
-	fmt.Printf("  checksum: %.0f\n", sum)
+	fmt.Printf("  checksum: %d\n", checksum)
 }
 
 func benchArrayWrite() {
@@ -115,12 +115,9 @@ func benchAccumulate() {
 	fmt.Printf("  checksum: %.0f\n", sum)
 }
 
-// Data-dependent loop with sequential multiply-carry. Sibling to
-// benchLoopOverhead but genuinely non-foldable: array reads + a
-// multiplicative carry through `sum` defeat any IV-simplify or
-// reassoc the Go compiler might attempt. (Go's compiler does not
-// have a fast-math flag; this loop runs identically with or without
-// optimization in stock Go.)
+// Floating-point loop with a sequential multiply-carry. Unlike
+// benchLoopOverhead's integer carry, this adds two runtime array reads and
+// exposes FP-contraction behavior. Go has no fast-math flag.
 func benchLoopDataDependent() {
 	const N = 64
 	const ITERATIONS = 100_000_000

--- a/benchmarks/polyglot/bench.java
+++ b/benchmarks/polyglot/bench.java
@@ -15,13 +15,13 @@ public class bench {
 
     static void benchLoopOverhead() {
         long start = System.currentTimeMillis();
-        double sum = 0.0;
+        int checksum = 0x811c9dc5;
         for (int i = 0; i < 100_000_000; i++) {
-            sum += 1.0;
+            checksum = (checksum ^ i) * 0x01000193;
         }
         long elapsed = System.currentTimeMillis() - start;
         System.out.println("loop_overhead:" + elapsed);
-        System.out.printf("  checksum: %.0f%n", sum);
+        System.out.println("  checksum: " + Integer.toUnsignedLong(checksum));
     }
 
     static void benchArrayWrite() {
@@ -112,10 +112,9 @@ public class bench {
         System.out.printf("  checksum: %.0f%n", sum);
     }
 
-    // Data-dependent loop with sequential multiply-carry. Sibling to
-    // benchLoopOverhead but genuinely non-foldable: array reads + a
-    // multiplicative carry through `sum` defeat HotSpot's loop
-    // unrolling and reassoc.
+    // Floating-point loop with a sequential multiply-carry. Unlike
+    // benchLoopOverhead's integer carry, this adds two runtime array reads and
+    // exposes FP-contraction behavior.
     static void benchLoopDataDependent() {
         final int N = 64;
         final long ITERATIONS = 100_000_000L;

--- a/benchmarks/polyglot/bench.py
+++ b/benchmarks/polyglot/bench.py
@@ -16,12 +16,12 @@ def bench_fibonacci():
 
 def bench_loop_overhead():
     start = time.monotonic()
-    sum_val = 0.0
-    for _ in range(100_000_000):
-        sum_val += 1.0
+    checksum = 0x811C9DC5
+    for i in range(100_000_000):
+        checksum = ((checksum ^ i) * 0x01000193) & 0xFFFFFFFF
     elapsed = int((time.monotonic() - start) * 1000)
     print(f"loop_overhead:{elapsed}")
-    print(f"  checksum: {sum_val:.0f}")
+    print(f"  checksum: {checksum}")
 
 
 def bench_array_write():
@@ -98,10 +98,9 @@ def bench_accumulate():
 
 
 def bench_loop_data_dependent():
-    # Data-dependent loop with sequential multiply-carry. Sibling to
-    # bench_loop_overhead but genuinely non-foldable. Python is its own
-    # interpreter, so no asm-level verification applies; the kernel is
-    # identical to the compiled-language versions for fairness.
+    # Floating-point loop with a sequential multiply-carry. Unlike
+    # bench_loop_overhead's integer carry, this adds two runtime array reads
+    # and exposes FP-contraction behavior.
     N = 64
     ITERATIONS = 100_000_000
     seed = 42

--- a/benchmarks/polyglot/bench.rs
+++ b/benchmarks/polyglot/bench.rs
@@ -18,13 +18,13 @@ fn bench_fibonacci() {
 
 fn bench_loop_overhead() {
     let start = Instant::now();
-    let mut sum: f64 = 0.0;
-    for _ in 0..100_000_000 {
-        sum += 1.0;
+    let mut checksum: u32 = 0x811c9dc5;
+    for i in 0..100_000_000_u32 {
+        checksum = (checksum ^ i).wrapping_mul(0x01000193);
     }
     let elapsed = start.elapsed().as_millis();
     println!("loop_overhead:{}", elapsed);
-    println!("  checksum: {:.0}", sum);
+    println!("  checksum: {}", checksum);
 }
 
 fn bench_array_write() {
@@ -167,12 +167,9 @@ fn bench_loop_data_dependent() {
     // the dependency chain on `sum`; the win is one ISA-level fusion,
     // not a fold or a vectorize.
     //
-    // This is the honest companion to bench_loop_overhead. Where
-    // loop_overhead measures whether the compiler applied
-    // reassoc + IV-simplify to a trivially-foldable accumulator
-    // (a flag-aggressiveness probe), this one forces the compiler
-    // to actually execute work — and surfaces FP-contract as a
-    // secondary axis of the same flag-posture story.
+    // This is the floating-point companion to bench_loop_overhead. Both
+    // kernels have a sequential carry; this one additionally performs two
+    // runtime array loads and surfaces FP contraction as a secondary axis.
     const N: usize = 64;
     const ITERATIONS: u64 = 100_000_000;
     let mut seed: u64 = 42;

--- a/benchmarks/polyglot/bench.swift
+++ b/benchmarks/polyglot/bench.swift
@@ -15,13 +15,15 @@ func benchFibonacci() {
 
 func benchLoopOverhead() {
     let start = CFAbsoluteTimeGetCurrent()
-    var sum: Double = 0.0
-    for _ in 0..<100_000_000 {
-        sum += 1.0
+    var checksum: UInt32 = 0x811c9dc5
+    var i: UInt32 = 0
+    while i < 100_000_000 {
+        checksum = (checksum ^ i) &* 0x01000193
+        i &+= 1
     }
     let elapsed = Int((CFAbsoluteTimeGetCurrent() - start) * 1000)
     print("loop_overhead:\(elapsed)")
-    print("  checksum: \(Int(sum))")
+    print("  checksum: \(checksum)")
 }
 
 func benchArrayWrite() {
@@ -107,10 +109,9 @@ func benchAccumulate() {
     print("  checksum: \(Int(sum))")
 }
 
-// Data-dependent loop with sequential multiply-carry. Sibling to
-// benchLoopOverhead but genuinely non-foldable: array reads + a
-// multiplicative carry through `sum` defeat reassoc, IV-simplify,
-// and the vectorizer.
+// Floating-point loop with a sequential multiply-carry. Unlike
+// benchLoopOverhead's integer carry, this adds two runtime array reads and
+// exposes FP-contraction behavior.
 func benchLoopDataDependent() {
     let N = 64
     let ITERATIONS = 100_000_000

--- a/benchmarks/polyglot/bench.zig
+++ b/benchmarks/polyglot/bench.zig
@@ -25,14 +25,14 @@ fn benchFibonacci() void {
 
 fn benchLoopOverhead() void {
     const start = std.time.milliTimestamp();
-    var sum: f64 = 0.0;
-    var i: i32 = 0;
-    while (i < 100_000_000) : (i += 1) {
-        sum += 1.0;
+    var checksum: u32 = 0x811c9dc5;
+    var i: u32 = 0;
+    while (i < 100_000_000) : (i +%= 1) {
+        checksum = (checksum ^ i) *% 0x01000193;
     }
     const elapsed = std.time.milliTimestamp() - start;
     print("loop_overhead:{d}\n", .{elapsed});
-    print("  checksum: {d:.0}\n", .{sum});
+    print("  checksum: {d}\n", .{checksum});
 }
 
 fn benchArrayWrite() void {

--- a/benchmarks/public_baseline.py
+++ b/benchmarks/public_baseline.py
@@ -34,6 +34,7 @@ README_END = "<!-- public-node-bun:end -->"
 SOURCE_PATHS = (
     "Cargo.toml",
     "benchmarks/suite/*.ts",
+    "benchmarks/polyglot/bench.*",
     "benchmarks/json_polyglot/*.ts",
     "benchmarks/app-patterns/kernels/*.ts",
     "benchmarks/honest_bench/scripts/gen_image.py",

--- a/benchmarks/results/public-node-bun-v1.json
+++ b/benchmarks/results/public-node-bun-v1.json
@@ -1,25 +1,25 @@
 {
   "schema_version": 1,
   "kind": "perry-public-node-bun-baseline",
-  "commit": "38ff7eccc2aa0b59629bed548daf8ac56bd9fb03",
-  "perry_version": "perry 0.5.1355",
-  "generated_at": "2026-08-08T11:42:16Z",
+  "commit": "827a92bad5a589e94e1630994185693ada903fe2",
+  "perry_version": "perry 0.5.1519",
+  "generated_at": "2026-09-01T14:19:43Z",
   "freshness": {
-    "source_fingerprint": "65a1218e02c95b4aa8ed22065ca33e4653addcd81a77a4fb1a810e5153e07887",
-    "harness_fingerprint": "28117b86b2bcca9cc4e6f418f156bfcce0b4bf0851698c3e88525737221df49b"
+    "source_fingerprint": "bec8afb6e384640aa9090036e3ad393ac564750a083f6e6c485804b6784c38b8",
+    "harness_fingerprint": "513dba8ff9eaf931edc8a5fc01a0093a1156c31b0b6c9cc1218f710405e315e0"
   },
   "host": {
-    "os_version": "26.5.1",
-    "kernel": "Darwin perry-macos.fritz.box 25.5.0 Darwin Kernel Version 25.5.0: Mon Apr 27 20:38:00 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T8103 arm64",
-    "arch": "arm64",
-    "cpu": "Apple M1",
-    "ncpu": "8",
-    "ram_gb": 8.0
+    "os_version": "Ubuntu 24.04.4 LTS",
+    "kernel": "Linux ideal-mastodon 6.17.0-23-generic #23~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC Tue Apr 14 16:11:48 UTC 2 x86_64 x86_64 x86_64 GNU/Linux",
+    "arch": "x86_64",
+    "cpu": "x86_64",
+    "ncpu": "16",
+    "ram_gb": 61.9
   },
   "runtimes": {
     "perry": {
       "available": true,
-      "version": "perry 0.5.1355",
+      "version": "perry 0.5.1519",
       "command": [
         "<compiled-binary>"
       ],
@@ -38,7 +38,7 @@
         "node",
         "<source.ts>"
       ],
-      "resolved_executable": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node"
+      "resolved_executable": "/usr/bin/node"
     },
     "bun": {
       "available": true,
@@ -48,7 +48,7 @@
         "run",
         "<source.ts>"
       ],
-      "resolved_executable": "~/.cache/perry-bench-tools/bun/bun"
+      "resolved_executable": "bun"
     }
   },
   "policy": {
@@ -69,8 +69,8 @@
   "components": {
     "suite": {
       "schema_version": 2,
-      "commit": "38ff7eccc",
-      "generated_at": "2026-08-08T09:55:40Z",
+      "commit": "827a92bad",
+      "generated_at": "2026-09-01T13:00:03Z",
       "run_config": {
         "requested_samples": 5,
         "expected_benchmarks": [
@@ -104,7 +104,7 @@
       "runtimes": {
         "perry": {
           "available": true,
-          "version": "perry 0.5.1355",
+          "version": "perry 0.5.1519",
           "command": [
             "<compiled-binary>"
           ],
@@ -139,135 +139,135 @@
             "perry": {
               "wall_ms": {
                 "samples": [
-                  136,
-                  94,
-                  94,
-                  93,
-                  94
+                  75,
+                  73,
+                  73,
+                  74,
+                  74
                 ],
                 "sample_count": 5,
-                "median": 94,
-                "p95": 136,
-                "min": 93,
-                "max": 136,
-                "mad": 0,
-                "stdev": 16.904437
+                "median": 74,
+                "p95": 75,
+                "min": 73,
+                "max": 75,
+                "mad": 1,
+                "stdev": 0.748331
               },
               "rss_kb": {
                 "samples": [
-                  3968,
-                  3968,
-                  3968,
-                  3968,
-                  3968
+                  16880,
+                  17092,
+                  17032,
+                  16880,
+                  17052
                 ],
                 "sample_count": 5,
-                "median": 3968,
-                "p95": 3968,
-                "min": 3968,
-                "max": 3968,
-                "mad": 0,
-                "stdev": 0
+                "median": 17032,
+                "p95": 17092,
+                "min": 16880,
+                "max": 17092,
+                "mad": 60,
+                "stdev": 89.635707
               }
             },
             "node": {
               "wall_ms": {
                 "samples": [
-                  63,
-                  64,
-                  64,
-                  64,
-                  64
+                  75,
+                  75,
+                  75,
+                  74,
+                  74
                 ],
                 "sample_count": 5,
-                "median": 64,
-                "p95": 64,
-                "min": 63,
-                "max": 64,
+                "median": 75,
+                "p95": 75,
+                "min": 74,
+                "max": 75,
                 "mad": 0,
-                "stdev": 0.4
+                "stdev": 0.489898
               },
               "rss_kb": {
                 "samples": [
-                  68144,
-                  68208,
-                  68128,
-                  68000,
-                  68272
+                  65728,
+                  65724,
+                  65696,
+                  65656,
+                  65532
                 ],
                 "sample_count": 5,
-                "median": 68144,
-                "p95": 68272,
-                "min": 68000,
-                "max": 68272,
-                "mad": 64,
-                "stdev": 90.848445
+                "median": 65696,
+                "p95": 65728,
+                "min": 65532,
+                "max": 65728,
+                "mad": 32,
+                "stdev": 72.328141
               }
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  39,
-                  39,
-                  40,
-                  39,
-                  39
+                  75,
+                  74,
+                  74,
+                  74,
+                  74
                 ],
                 "sample_count": 5,
-                "median": 39,
-                "p95": 40,
-                "min": 39,
-                "max": 40,
+                "median": 74,
+                "p95": 75,
+                "min": 74,
+                "max": 75,
                 "mad": 0,
                 "stdev": 0.4
               },
               "rss_kb": {
                 "samples": [
-                  30464,
-                  30400,
-                  30400,
-                  30416,
-                  30400
+                  39696,
+                  39792,
+                  39788,
+                  39924,
+                  39792
                 ],
                 "sample_count": 5,
-                "median": 30400,
-                "p95": 30464,
-                "min": 30400,
-                "max": 30464,
-                "mad": 0,
-                "stdev": 24.787093
+                "median": 39792,
+                "p95": 39924,
+                "min": 39696,
+                "max": 39924,
+                "mad": 4,
+                "stdev": 72.734036
               }
             }
           },
           "ratios": {
             "perry_to_node": {
-              "wall_time": 1.46875,
-              "rss": 0.05823
+              "wall_time": 0.986667,
+              "rss": 0.259255
             },
             "perry_to_bun": {
-              "wall_time": 2.410256,
-              "rss": 0.130526
+              "wall_time": 1.0,
+              "rss": 0.428026
             }
           },
           "correctness": {
             "status": "pass",
             "reference": "node",
             "actual_lines": [
-              "sum:100000000"
+              "checksum:3848272069"
             ],
             "expected_lines": [
-              "sum:100000000"
+              "checksum:3848272069"
             ],
             "reason": "all 5 Perry sample(s) matched node semantic output"
           },
-          "perry_ms": 94,
-          "perry_rss_kb": 3968,
-          "node_ms": 64,
-          "node_rss_kb": 68144,
-          "bun_ms": 39,
-          "bun_rss_kb": 30400,
-          "speed_ratio": 1.46875,
-          "memory_ratio": 0.05823
+          "perry_ms": 74,
+          "perry_rss_kb": 17032,
+          "node_ms": 75,
+          "node_rss_kb": 65696,
+          "bun_ms": 74,
+          "bun_rss_kb": 39792,
+          "speed_ratio": 0.986667,
+          "memory_ratio": 0.259255
         },
         "03_array_write": {
           "runtimes": {
@@ -275,581 +275,41 @@
               "wall_ms": {
                 "samples": [
                   3,
-                  1,
-                  1,
-                  1,
-                  1
-                ],
-                "sample_count": 5,
-                "median": 1,
-                "p95": 3,
-                "min": 1,
-                "max": 3,
-                "mad": 0,
-                "stdev": 0.8
-              },
-              "rss_kb": {
-                "samples": [
-                  94848,
-                  94848,
-                  94864,
-                  94848,
-                  94848
-                ],
-                "sample_count": 5,
-                "median": 94848,
-                "p95": 94864,
-                "min": 94848,
-                "max": 94864,
-                "mad": 0,
-                "stdev": 6.4
-              }
-            },
-            "node": {
-              "wall_ms": {
-                "samples": [
-                  7,
-                  7,
-                  7,
-                  7,
-                  7
-                ],
-                "sample_count": 5,
-                "median": 7,
-                "p95": 7,
-                "min": 7,
-                "max": 7,
-                "mad": 0,
-                "stdev": 0
-              },
-              "rss_kb": {
-                "samples": [
-                  374016,
-                  374176,
-                  374048,
-                  374064,
-                  374128
-                ],
-                "sample_count": 5,
-                "median": 374064,
-                "p95": 374176,
-                "min": 374016,
-                "max": 374176,
-                "mad": 48,
-                "stdev": 57.777504
-              }
-            },
-            "bun": {
-              "wall_ms": {
-                "samples": [
-                  5,
-                  5,
-                  5,
-                  5,
-                  5
-                ],
-                "sample_count": 5,
-                "median": 5,
-                "p95": 5,
-                "min": 5,
-                "max": 5,
-                "mad": 0,
-                "stdev": 0
-              },
-              "rss_kb": {
-                "samples": [
-                  291120,
-                  291072,
-                  291056,
-                  287632,
-                  284624
-                ],
-                "sample_count": 5,
-                "median": 291056,
-                "p95": 291120,
-                "min": 284624,
-                "max": 291120,
-                "mad": 64,
-                "stdev": 2607.094812
-              }
-            }
-          },
-          "ratios": {
-            "perry_to_node": {
-              "wall_time": 0.142857,
-              "rss": 0.253561
-            },
-            "perry_to_bun": {
-              "wall_time": 0.2,
-              "rss": 0.325875
-            }
-          },
-          "correctness": {
-            "status": "pass",
-            "reference": "node",
-            "actual_lines": [
-              "checksum:9999999"
-            ],
-            "expected_lines": [
-              "checksum:9999999"
-            ],
-            "reason": "all 5 Perry sample(s) matched node semantic output"
-          },
-          "perry_ms": 1,
-          "perry_rss_kb": 94848,
-          "node_ms": 7,
-          "node_rss_kb": 374064,
-          "bun_ms": 5,
-          "bun_rss_kb": 291056,
-          "speed_ratio": 0.142857,
-          "memory_ratio": 0.253561
-        },
-        "04_array_read": {
-          "runtimes": {
-            "perry": {
-              "wall_ms": {
-                "samples": [
-                  42,
-                  22,
-                  23,
-                  23,
-                  22
-                ],
-                "sample_count": 5,
-                "median": 23,
-                "p95": 42,
-                "min": 22,
-                "max": 42,
-                "mad": 1,
-                "stdev": 7.81281
-              },
-              "rss_kb": {
-                "samples": [
-                  94880,
-                  94880,
-                  94880,
-                  94880,
-                  94880
-                ],
-                "sample_count": 5,
-                "median": 94880,
-                "p95": 94880,
-                "min": 94880,
-                "max": 94880,
-                "mad": 0,
-                "stdev": 0
-              }
-            },
-            "node": {
-              "wall_ms": {
-                "samples": [
-                  11,
-                  11,
-                  11,
-                  11,
-                  10
-                ],
-                "sample_count": 5,
-                "median": 11,
-                "p95": 11,
-                "min": 10,
-                "max": 11,
-                "mad": 0,
-                "stdev": 0.4
-              },
-              "rss_kb": {
-                "samples": [
-                  374336,
-                  374272,
-                  374304,
-                  374320,
-                  374128
-                ],
-                "sample_count": 5,
-                "median": 374304,
-                "p95": 374336,
-                "min": 374128,
-                "max": 374336,
-                "mad": 32,
-                "stdev": 75.046652
-              }
-            },
-            "bun": {
-              "wall_ms": {
-                "samples": [
-                  14,
-                  13,
-                  13,
-                  13,
-                  14
-                ],
-                "sample_count": 5,
-                "median": 13,
-                "p95": 14,
-                "min": 13,
-                "max": 14,
-                "mad": 0,
-                "stdev": 0.489898
-              },
-              "rss_kb": {
-                "samples": [
-                  267888,
-                  246032,
-                  291760,
-                  279520,
-                  267904
-                ],
-                "sample_count": 5,
-                "median": 267904,
-                "p95": 291760,
-                "min": 246032,
-                "max": 291760,
-                "mad": 11616,
-                "stdev": 15136.180633
-              }
-            }
-          },
-          "ratios": {
-            "perry_to_node": {
-              "wall_time": 2.090909,
-              "rss": 0.253484
-            },
-            "perry_to_bun": {
-              "wall_time": 1.769231,
-              "rss": 0.354157
-            }
-          },
-          "correctness": {
-            "status": "pass",
-            "reference": "node",
-            "actual_lines": [
-              "sum:49999995000000"
-            ],
-            "expected_lines": [
-              "sum:49999995000000"
-            ],
-            "reason": "all 5 Perry sample(s) matched node semantic output"
-          },
-          "perry_ms": 23,
-          "perry_rss_kb": 94880,
-          "node_ms": 11,
-          "node_rss_kb": 374304,
-          "bun_ms": 13,
-          "bun_rss_kb": 267904,
-          "speed_ratio": 2.090909,
-          "memory_ratio": 0.253484
-        },
-        "05_fibonacci": {
-          "runtimes": {
-            "perry": {
-              "wall_ms": {
-                "samples": [
-                  435,
-                  389,
-                  390,
-                  390,
-                  390
-                ],
-                "sample_count": 5,
-                "median": 390,
-                "p95": 435,
-                "min": 389,
-                "max": 435,
-                "mad": 0,
-                "stdev": 18.104143
-              },
-              "rss_kb": {
-                "samples": [
-                  4080,
-                  4080,
-                  4080,
-                  4080,
-                  4080
-                ],
-                "sample_count": 5,
-                "median": 4080,
-                "p95": 4080,
-                "min": 4080,
-                "max": 4080,
-                "mad": 0,
-                "stdev": 0
-              }
-            },
-            "node": {
-              "wall_ms": {
-                "samples": [
-                  912,
-                  913,
-                  913,
-                  912,
-                  913
-                ],
-                "sample_count": 5,
-                "median": 913,
-                "p95": 913,
-                "min": 912,
-                "max": 913,
-                "mad": 0,
-                "stdev": 0.489898
-              },
-              "rss_kb": {
-                "samples": [
-                  68304,
-                  68272,
-                  68208,
-                  68256,
-                  68128
-                ],
-                "sample_count": 5,
-                "median": 68256,
-                "p95": 68304,
-                "min": 68128,
-                "max": 68304,
-                "mad": 48,
-                "stdev": 61.219605
-              }
-            },
-            "bun": {
-              "wall_ms": {
-                "samples": [
-                  505,
-                  506,
-                  501,
-                  504,
-                  506
-                ],
-                "sample_count": 5,
-                "median": 505,
-                "p95": 506,
-                "min": 501,
-                "max": 506,
-                "mad": 1,
-                "stdev": 1.854724
-              },
-              "rss_kb": {
-                "samples": [
-                  29392,
-                  29424,
-                  29328,
-                  29376,
-                  29408
-                ],
-                "sample_count": 5,
-                "median": 29392,
-                "p95": 29424,
-                "min": 29328,
-                "max": 29424,
-                "mad": 16,
-                "stdev": 32.946016
-              }
-            }
-          },
-          "ratios": {
-            "perry_to_node": {
-              "wall_time": 0.427163,
-              "rss": 0.059775
-            },
-            "perry_to_bun": {
-              "wall_time": 0.772277,
-              "rss": 0.138813
-            }
-          },
-          "correctness": {
-            "status": "pass",
-            "reference": "node",
-            "actual_lines": [
-              "fib(40):102334155"
-            ],
-            "expected_lines": [
-              "fib(40):102334155"
-            ],
-            "reason": "all 5 Perry sample(s) matched node semantic output"
-          },
-          "perry_ms": 390,
-          "perry_rss_kb": 4080,
-          "node_ms": 913,
-          "node_rss_kb": 68256,
-          "bun_ms": 505,
-          "bun_rss_kb": 29392,
-          "speed_ratio": 0.427163,
-          "memory_ratio": 0.059775
-        },
-        "06_math_intensive": {
-          "runtimes": {
-            "perry": {
-              "wall_ms": {
-                "samples": [
-                  92,
-                  49,
-                  50,
-                  49,
-                  49
-                ],
-                "sample_count": 5,
-                "median": 49,
-                "p95": 92,
-                "min": 49,
-                "max": 92,
-                "mad": 0,
-                "stdev": 17.104385
-              },
-              "rss_kb": {
-                "samples": [
-                  4064,
-                  4064,
-                  4064,
-                  4064,
-                  4064
-                ],
-                "sample_count": 5,
-                "median": 4064,
-                "p95": 4064,
-                "min": 4064,
-                "max": 4064,
-                "mad": 0,
-                "stdev": 0
-              }
-            },
-            "node": {
-              "wall_ms": {
-                "samples": [
-                  49,
-                  49,
-                  48,
-                  49,
-                  48
-                ],
-                "sample_count": 5,
-                "median": 49,
-                "p95": 49,
-                "min": 48,
-                "max": 49,
-                "mad": 0,
-                "stdev": 0.489898
-              },
-              "rss_kb": {
-                "samples": [
-                  70320,
-                  70240,
-                  70432,
-                  70256,
-                  70368
-                ],
-                "sample_count": 5,
-                "median": 70320,
-                "p95": 70432,
-                "min": 70240,
-                "max": 70432,
-                "mad": 64,
-                "stdev": 71.123554
-              }
-            },
-            "bun": {
-              "wall_ms": {
-                "samples": [
-                  49,
-                  48,
-                  48,
-                  48,
-                  48
-                ],
-                "sample_count": 5,
-                "median": 48,
-                "p95": 49,
-                "min": 48,
-                "max": 49,
-                "mad": 0,
-                "stdev": 0.4
-              },
-              "rss_kb": {
-                "samples": [
-                  30672,
-                  30672,
-                  30672,
-                  30672,
-                  30672
-                ],
-                "sample_count": 5,
-                "median": 30672,
-                "p95": 30672,
-                "min": 30672,
-                "max": 30672,
-                "mad": 0,
-                "stdev": 0
-              }
-            }
-          },
-          "ratios": {
-            "perry_to_node": {
-              "wall_time": 1.0,
-              "rss": 0.057793
-            },
-            "perry_to_bun": {
-              "wall_time": 1.020833,
-              "rss": 0.132499
-            }
-          },
-          "correctness": {
-            "status": "pass",
-            "reference": "node",
-            "actual_lines": [
-              "result:19.30474921829397"
-            ],
-            "expected_lines": [
-              "result:19.30474921829397"
-            ],
-            "reason": "all 5 Perry sample(s) matched node semantic output"
-          },
-          "perry_ms": 49,
-          "perry_rss_kb": 4064,
-          "node_ms": 49,
-          "node_rss_kb": 70320,
-          "bun_ms": 48,
-          "bun_rss_kb": 30672,
-          "speed_ratio": 1.0,
-          "memory_ratio": 0.057793
-        },
-        "07_object_create": {
-          "runtimes": {
-            "perry": {
-              "wall_ms": {
-                "samples": [
-                  10,
-                  3,
-                  2,
-                  3,
-                  2
-                ],
-                "sample_count": 5,
-                "median": 3,
-                "p95": 10,
-                "min": 2,
-                "max": 10,
-                "mad": 1,
-                "stdev": 3.03315
-              },
-              "rss_kb": {
-                "samples": [
-                  4704,
-                  4688,
-                  4688,
-                  4688,
-                  4688
-                ],
-                "sample_count": 5,
-                "median": 4688,
-                "p95": 4704,
-                "min": 4688,
-                "max": 4704,
-                "mad": 0,
-                "stdev": 6.4
-              }
-            },
-            "node": {
-              "wall_ms": {
-                "samples": [
                   4,
+                  4,
+                  3,
+                  4
+                ],
+                "sample_count": 5,
+                "median": 4,
+                "p95": 4,
+                "min": 3,
+                "max": 4,
+                "mad": 0,
+                "stdev": 0.489898
+              },
+              "rss_kb": {
+                "samples": [
+                  127384,
+                  127764,
+                  127576,
+                  127636,
+                  127912
+                ],
+                "sample_count": 5,
+                "median": 127636,
+                "p95": 127912,
+                "min": 127384,
+                "max": 127912,
+                "mad": 128,
+                "stdev": 177.747686
+              }
+            },
+            "node": {
+              "wall_ms": {
+                "samples": [
                   5,
+                  4,
                   5,
                   5,
                   4
@@ -864,123 +324,494 @@
               },
               "rss_kb": {
                 "samples": [
-                  70832,
-                  70880,
-                  70784,
-                  70784,
-                  70848
+                  369704,
+                  369516,
+                  369356,
+                  369492,
+                  369160
                 ],
                 "sample_count": 5,
-                "median": 70832,
-                "p95": 70880,
-                "min": 70784,
-                "max": 70880,
-                "mad": 48,
-                "stdev": 37.318092
+                "median": 369492,
+                "p95": 369704,
+                "min": 369160,
+                "max": 369704,
+                "mad": 136,
+                "stdev": 180.817698
               }
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  7,
                   5,
                   5,
-                  6,
+                  5,
+                  5,
                   5
                 ],
                 "sample_count": 5,
                 "median": 5,
-                "p95": 7,
+                "p95": 5,
                 "min": 5,
-                "max": 7,
+                "max": 5,
                 "mad": 0,
-                "stdev": 0.8
+                "stdev": 0
               },
               "rss_kb": {
                 "samples": [
-                  52224,
-                  49040,
-                  48768,
-                  48992,
-                  48960
+                  305344,
+                  305204,
+                  293696,
+                  305076,
+                  305404
                 ],
                 "sample_count": 5,
-                "median": 48992,
-                "p95": 52224,
-                "min": 48768,
-                "max": 52224,
-                "mad": 48,
-                "stdev": 1316.845686
+                "median": 305204,
+                "p95": 305404,
+                "min": 293696,
+                "max": 305404,
+                "mad": 140,
+                "stdev": 4625.799926
               }
             }
           },
           "ratios": {
             "perry_to_node": {
-              "wall_time": 0.6,
-              "rss": 0.066185
+              "wall_time": 0.8,
+              "rss": 0.345436
             },
             "perry_to_bun": {
-              "wall_time": 0.6,
-              "rss": 0.095689
+              "wall_time": 0.8,
+              "rss": 0.418199
             }
           },
           "correctness": {
             "status": "pass",
             "reference": "node",
             "actual_lines": [
-              "sum:1000000000000"
+              "checksum:9999999"
             ],
             "expected_lines": [
-              "sum:1000000000000"
+              "checksum:9999999"
             ],
             "reason": "all 5 Perry sample(s) matched node semantic output"
           },
-          "perry_ms": 3,
-          "perry_rss_kb": 4688,
+          "perry_ms": 4,
+          "perry_rss_kb": 127636,
           "node_ms": 5,
-          "node_rss_kb": 70832,
+          "node_rss_kb": 369492,
           "bun_ms": 5,
-          "bun_rss_kb": 48992,
-          "speed_ratio": 0.6,
-          "memory_ratio": 0.066185
+          "bun_rss_kb": 305204,
+          "speed_ratio": 0.8,
+          "memory_ratio": 0.345436
         },
-        "08_string_concat": {
+        "04_array_read": {
           "runtimes": {
             "perry": {
               "wall_ms": {
                 "samples": [
-                  4,
-                  2,
-                  1,
-                  1,
-                  2
+                  5,
+                  6,
+                  6,
+                  5,
+                  5
                 ],
                 "sample_count": 5,
-                "median": 2,
-                "p95": 4,
-                "min": 1,
-                "max": 4,
-                "mad": 1,
-                "stdev": 1.095445
+                "median": 5,
+                "p95": 6,
+                "min": 5,
+                "max": 6,
+                "mad": 0,
+                "stdev": 0.489898
               },
               "rss_kb": {
                 "samples": [
-                  4384,
-                  4384,
-                  4384,
-                  4384,
-                  4384
+                  127812,
+                  127452,
+                  127508,
+                  127912,
+                  127776
                 ],
                 "sample_count": 5,
-                "median": 4384,
-                "p95": 4384,
-                "min": 4384,
-                "max": 4384,
-                "mad": 0,
-                "stdev": 0
+                "median": 127776,
+                "p95": 127912,
+                "min": 127452,
+                "max": 127912,
+                "mad": 136,
+                "stdev": 179.617371
               }
             },
             "node": {
+              "wall_ms": {
+                "samples": [
+                  8,
+                  7,
+                  7,
+                  8,
+                  7
+                ],
+                "sample_count": 5,
+                "median": 7,
+                "p95": 8,
+                "min": 7,
+                "max": 8,
+                "mad": 0,
+                "stdev": 0.489898
+              },
+              "rss_kb": {
+                "samples": [
+                  370624,
+                  370872,
+                  370704,
+                  370900,
+                  370516
+                ],
+                "sample_count": 5,
+                "median": 370704,
+                "p95": 370900,
+                "min": 370516,
+                "max": 370900,
+                "mad": 168,
+                "stdev": 145.973148
+              }
+            },
+            "bun": {
+              "wall_ms": {
+                "samples": [
+                  9,
+                  9,
+                  9,
+                  9,
+                  10
+                ],
+                "sample_count": 5,
+                "median": 9,
+                "p95": 10,
+                "min": 9,
+                "max": 10,
+                "mad": 0,
+                "stdev": 0.4
+              },
+              "rss_kb": {
+                "samples": [
+                  305792,
+                  305760,
+                  305844,
+                  305800,
+                  305920
+                ],
+                "sample_count": 5,
+                "median": 305800,
+                "p95": 305920,
+                "min": 305760,
+                "max": 305920,
+                "mad": 40,
+                "stdev": 55.333173
+              }
+            }
+          },
+          "ratios": {
+            "perry_to_node": {
+              "wall_time": 0.714286,
+              "rss": 0.344685
+            },
+            "perry_to_bun": {
+              "wall_time": 0.555556,
+              "rss": 0.417842
+            }
+          },
+          "correctness": {
+            "status": "pass",
+            "reference": "node",
+            "actual_lines": [
+              "sum:49999995000000"
+            ],
+            "expected_lines": [
+              "sum:49999995000000"
+            ],
+            "reason": "all 5 Perry sample(s) matched node semantic output"
+          },
+          "perry_ms": 5,
+          "perry_rss_kb": 127776,
+          "node_ms": 7,
+          "node_rss_kb": 370704,
+          "bun_ms": 9,
+          "bun_rss_kb": 305800,
+          "speed_ratio": 0.714286,
+          "memory_ratio": 0.344685
+        },
+        "05_fibonacci": {
+          "runtimes": {
+            "perry": {
+              "wall_ms": {
+                "samples": [
+                  315,
+                  315,
+                  315,
+                  315,
+                  315
+                ],
+                "sample_count": 5,
+                "median": 315,
+                "p95": 315,
+                "min": 315,
+                "max": 315,
+                "mad": 0,
+                "stdev": 0
+              },
+              "rss_kb": {
+                "samples": [
+                  16772,
+                  17324,
+                  16824,
+                  17152,
+                  16988
+                ],
+                "sample_count": 5,
+                "median": 16988,
+                "p95": 17324,
+                "min": 16772,
+                "max": 17324,
+                "mad": 164,
+                "stdev": 205.165299
+              }
+            },
+            "node": {
+              "wall_ms": {
+                "samples": [
+                  698,
+                  698,
+                  699,
+                  696,
+                  697
+                ],
+                "sample_count": 5,
+                "median": 698,
+                "p95": 699,
+                "min": 696,
+                "max": 699,
+                "mad": 1,
+                "stdev": 1.019804
+              },
+              "rss_kb": {
+                "samples": [
+                  65348,
+                  65400,
+                  65216,
+                  65276,
+                  65232
+                ],
+                "sample_count": 5,
+                "median": 65276,
+                "p95": 65400,
+                "min": 65216,
+                "max": 65400,
+                "mad": 60,
+                "stdev": 69.861577
+              }
+            },
+            "bun": {
+              "wall_ms": {
+                "samples": [
+                  426,
+                  426,
+                  426,
+                  426,
+                  426
+                ],
+                "sample_count": 5,
+                "median": 426,
+                "p95": 426,
+                "min": 426,
+                "max": 426,
+                "mad": 0,
+                "stdev": 0
+              },
+              "rss_kb": {
+                "samples": [
+                  39112,
+                  39616,
+                  39548,
+                  39428,
+                  39428
+                ],
+                "sample_count": 5,
+                "median": 39428,
+                "p95": 39616,
+                "min": 39112,
+                "max": 39616,
+                "mad": 120,
+                "stdev": 172.966586
+              }
+            }
+          },
+          "ratios": {
+            "perry_to_node": {
+              "wall_time": 0.451289,
+              "rss": 0.260249
+            },
+            "perry_to_bun": {
+              "wall_time": 0.739437,
+              "rss": 0.430861
+            }
+          },
+          "correctness": {
+            "status": "pass",
+            "reference": "node",
+            "actual_lines": [
+              "fib(40):102334155"
+            ],
+            "expected_lines": [
+              "fib(40):102334155"
+            ],
+            "reason": "all 5 Perry sample(s) matched node semantic output"
+          },
+          "perry_ms": 315,
+          "perry_rss_kb": 16988,
+          "node_ms": 698,
+          "node_rss_kb": 65276,
+          "bun_ms": 426,
+          "bun_rss_kb": 39428,
+          "speed_ratio": 0.451289,
+          "memory_ratio": 0.260249
+        },
+        "06_math_intensive": {
+          "runtimes": {
+            "perry": {
+              "wall_ms": {
+                "samples": [
+                  44,
+                  45,
+                  44,
+                  45,
+                  44
+                ],
+                "sample_count": 5,
+                "median": 44,
+                "p95": 45,
+                "min": 44,
+                "max": 45,
+                "mad": 0,
+                "stdev": 0.489898
+              },
+              "rss_kb": {
+                "samples": [
+                  16824,
+                  16732,
+                  16716,
+                  17160,
+                  16820
+                ],
+                "sample_count": 5,
+                "median": 16820,
+                "p95": 17160,
+                "min": 16716,
+                "max": 17160,
+                "mad": 88,
+                "stdev": 160.969065
+              }
+            },
+            "node": {
+              "wall_ms": {
+                "samples": [
+                  43,
+                  43,
+                  43,
+                  44,
+                  44
+                ],
+                "sample_count": 5,
+                "median": 43,
+                "p95": 44,
+                "min": 43,
+                "max": 44,
+                "mad": 0,
+                "stdev": 0.489898
+              },
+              "rss_kb": {
+                "samples": [
+                  67260,
+                  67204,
+                  67492,
+                  67228,
+                  67232
+                ],
+                "sample_count": 5,
+                "median": 67232,
+                "p95": 67492,
+                "min": 67204,
+                "max": 67492,
+                "mad": 28,
+                "stdev": 105.902597
+              }
+            },
+            "bun": {
+              "wall_ms": {
+                "samples": [
+                  49,
+                  49,
+                  46,
+                  45,
+                  47
+                ],
+                "sample_count": 5,
+                "median": 47,
+                "p95": 49,
+                "min": 45,
+                "max": 49,
+                "mad": 2,
+                "stdev": 1.6
+              },
+              "rss_kb": {
+                "samples": [
+                  40028,
+                  40032,
+                  39812,
+                  40096,
+                  39988
+                ],
+                "sample_count": 5,
+                "median": 40028,
+                "p95": 40096,
+                "min": 39812,
+                "max": 40096,
+                "mad": 40,
+                "stdev": 96.046655
+              }
+            }
+          },
+          "ratios": {
+            "perry_to_node": {
+              "wall_time": 1.023256,
+              "rss": 0.250178
+            },
+            "perry_to_bun": {
+              "wall_time": 0.93617,
+              "rss": 0.420206
+            }
+          },
+          "correctness": {
+            "status": "pass",
+            "reference": "node",
+            "actual_lines": [
+              "result:19.30474921829397"
+            ],
+            "expected_lines": [
+              "result:19.30474921829397"
+            ],
+            "reason": "all 5 Perry sample(s) matched node semantic output"
+          },
+          "perry_ms": 44,
+          "perry_rss_kb": 16820,
+          "node_ms": 43,
+          "node_rss_kb": 67232,
+          "bun_ms": 47,
+          "bun_rss_kb": 40028,
+          "speed_ratio": 1.023256,
+          "memory_ratio": 0.250178
+        },
+        "07_object_create": {
+          "runtimes": {
+            "perry": {
               "wall_ms": {
                 "samples": [
                   4,
@@ -999,167 +830,304 @@
               },
               "rss_kb": {
                 "samples": [
-                  73488,
-                  73568,
-                  73584,
-                  73616,
-                  73728
+                  21244,
+                  21408,
+                  21368,
+                  21444,
+                  21148
                 ],
                 "sample_count": 5,
-                "median": 73584,
-                "p95": 73728,
-                "min": 73488,
-                "max": 73728,
-                "mad": 32,
-                "stdev": 77.990769
+                "median": 21368,
+                "p95": 21444,
+                "min": 21148,
+                "max": 21444,
+                "mad": 76,
+                "stdev": 110.231756
+              }
+            },
+            "node": {
+              "wall_ms": {
+                "samples": [
+                  5,
+                  4,
+                  4,
+                  5,
+                  4
+                ],
+                "sample_count": 5,
+                "median": 4,
+                "p95": 5,
+                "min": 4,
+                "max": 5,
+                "mad": 0,
+                "stdev": 0.489898
+              },
+              "rss_kb": {
+                "samples": [
+                  68108,
+                  67920,
+                  68008,
+                  68020,
+                  67708
+                ],
+                "sample_count": 5,
+                "median": 68008,
+                "p95": 68108,
+                "min": 67708,
+                "max": 68108,
+                "mad": 88,
+                "stdev": 136.127
               }
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  1,
-                  1,
-                  1,
-                  1,
-                  1
+                  7,
+                  8,
+                  7,
+                  8,
+                  7
                 ],
                 "sample_count": 5,
-                "median": 1,
-                "p95": 1,
-                "min": 1,
-                "max": 1,
+                "median": 7,
+                "p95": 8,
+                "min": 7,
+                "max": 8,
                 "mad": 0,
-                "stdev": 0
+                "stdev": 0.489898
               },
               "rss_kb": {
                 "samples": [
-                  30160,
-                  30160,
-                  30128,
-                  30160,
-                  30160
+                  56480,
+                  56296,
+                  55960,
+                  55928,
+                  56044
                 ],
                 "sample_count": 5,
-                "median": 30160,
-                "p95": 30160,
-                "min": 30128,
-                "max": 30160,
-                "mad": 0,
-                "stdev": 12.8
+                "median": 56044,
+                "p95": 56480,
+                "min": 55928,
+                "max": 56480,
+                "mad": 116,
+                "stdev": 212.830073
               }
             }
           },
           "ratios": {
             "perry_to_node": {
-              "wall_time": 0.5,
-              "rss": 0.059578
+              "wall_time": 1.0,
+              "rss": 0.314198
             },
             "perry_to_bun": {
-              "wall_time": 2.0,
-              "rss": 0.145358
+              "wall_time": 0.571429,
+              "rss": 0.381272
             }
           },
           "correctness": {
             "status": "pass",
             "reference": "node",
             "actual_lines": [
-              "length:100000"
+              "sum:1000000000000"
             ],
             "expected_lines": [
-              "length:100000"
+              "sum:1000000000000"
             ],
             "reason": "all 5 Perry sample(s) matched node semantic output"
           },
-          "perry_ms": 2,
-          "perry_rss_kb": 4384,
+          "perry_ms": 4,
+          "perry_rss_kb": 21368,
           "node_ms": 4,
-          "node_rss_kb": 73584,
-          "bun_ms": 1,
-          "bun_rss_kb": 30160,
-          "speed_ratio": 0.5,
-          "memory_ratio": 0.059578
+          "node_rss_kb": 68008,
+          "bun_ms": 7,
+          "bun_rss_kb": 56044,
+          "speed_ratio": 1.0,
+          "memory_ratio": 0.314198
+        },
+        "08_string_concat": {
+          "runtimes": {
+            "perry": {
+              "wall_ms": {
+                "samples": [
+                  4,
+                  5,
+                  4,
+                  5,
+                  5
+                ],
+                "sample_count": 5,
+                "median": 5,
+                "p95": 5,
+                "min": 4,
+                "max": 5,
+                "mad": 0,
+                "stdev": 0.489898
+              },
+              "rss_kb": {
+                "samples": [
+                  27500,
+                  27116,
+                  26992,
+                  26908,
+                  26916
+                ],
+                "sample_count": 5,
+                "median": 26992,
+                "p95": 27500,
+                "min": 26908,
+                "max": 27500,
+                "mad": 84,
+                "stdev": 219.870507
+              }
+            },
+            "node": {
+              "wall_ms": {
+                "samples": [
+                  37,
+                  37,
+                  36,
+                  36,
+                  37
+                ],
+                "sample_count": 5,
+                "median": 37,
+                "p95": 37,
+                "min": 36,
+                "max": 37,
+                "mad": 0,
+                "stdev": 0.489898
+              },
+              "rss_kb": {
+                "samples": [
+                  114624,
+                  114668,
+                  114904,
+                  114668,
+                  114492
+                ],
+                "sample_count": 5,
+                "median": 114668,
+                "p95": 114904,
+                "min": 114492,
+                "max": 114904,
+                "mad": 44,
+                "stdev": 133.084034
+              }
+            },
+            "bun": {
+              "wall_ms": {
+                "samples": [
+                  12,
+                  12,
+                  13,
+                  12,
+                  13
+                ],
+                "sample_count": 5,
+                "median": 12,
+                "p95": 13,
+                "min": 12,
+                "max": 13,
+                "mad": 0,
+                "stdev": 0.489898
+              },
+              "rss_kb": {
+                "samples": [
+                  74020,
+                  74024,
+                  73700,
+                  73860,
+                  73508
+                ],
+                "sample_count": 5,
+                "median": 73860,
+                "p95": 74024,
+                "min": 73508,
+                "max": 74024,
+                "mad": 160,
+                "stdev": 197.449335
+              }
+            }
+          },
+          "ratios": {
+            "perry_to_node": {
+              "wall_time": 0.135135,
+              "rss": 0.235393
+            },
+            "perry_to_bun": {
+              "wall_time": 0.416667,
+              "rss": 0.365448
+            }
+          },
+          "correctness": {
+            "status": "pass",
+            "reference": "node",
+            "actual_lines": [
+              "length:1000000",
+              "checksum:120480"
+            ],
+            "expected_lines": [
+              "length:1000000",
+              "checksum:120480"
+            ],
+            "reason": "all 5 Perry sample(s) matched node semantic output"
+          },
+          "perry_ms": 5,
+          "perry_rss_kb": 26992,
+          "node_ms": 37,
+          "node_rss_kb": 114668,
+          "bun_ms": 12,
+          "bun_rss_kb": 73860,
+          "speed_ratio": 0.135135,
+          "memory_ratio": 0.235393
         },
         "09_method_calls": {
           "runtimes": {
             "perry": {
               "wall_ms": {
                 "samples": [
-                  21,
-                  9,
-                  9,
-                  10,
-                  9
+                  6,
+                  6,
+                  6,
+                  6,
+                  6
                 ],
                 "sample_count": 5,
-                "median": 9,
-                "p95": 21,
-                "min": 9,
-                "max": 21,
+                "median": 6,
+                "p95": 6,
+                "min": 6,
+                "max": 6,
                 "mad": 0,
-                "stdev": 4.71593
+                "stdev": 0
               },
               "rss_kb": {
                 "samples": [
-                  7840,
-                  7840,
-                  7840,
-                  7840,
-                  7856
+                  21508,
+                  21504,
+                  21596,
+                  21648,
+                  21740
                 ],
                 "sample_count": 5,
-                "median": 7840,
-                "p95": 7856,
-                "min": 7840,
-                "max": 7856,
-                "mad": 0,
-                "stdev": 6.4
+                "median": 21596,
+                "p95": 21740,
+                "min": 21504,
+                "max": 21740,
+                "mad": 88,
+                "stdev": 88.990786
               }
             },
             "node": {
               "wall_ms": {
                 "samples": [
-                  11,
-                  10,
-                  10,
-                  10,
-                  11
-                ],
-                "sample_count": 5,
-                "median": 10,
-                "p95": 11,
-                "min": 10,
-                "max": 11,
-                "mad": 0,
-                "stdev": 0.489898
-              },
-              "rss_kb": {
-                "samples": [
-                  68816,
-                  68704,
-                  68704,
-                  68736,
-                  68624
-                ],
-                "sample_count": 5,
-                "median": 68704,
-                "p95": 68816,
-                "min": 68624,
-                "max": 68816,
-                "mad": 32,
-                "stdev": 61.885055
-              }
-            },
-            "bun": {
-              "wall_ms": {
-                "samples": [
-                  8,
                   8,
                   9,
                   9,
-                  8
+                  8,
+                  9
                 ],
                 "sample_count": 5,
-                "median": 8,
+                "median": 9,
                 "p95": 9,
                 "min": 8,
                 "max": 9,
@@ -1168,30 +1136,64 @@
               },
               "rss_kb": {
                 "samples": [
-                  31568,
-                  31584,
-                  31552,
-                  31584,
-                  31616
+                  65280,
+                  65596,
+                  65644,
+                  65380,
+                  65524
                 ],
                 "sample_count": 5,
-                "median": 31584,
-                "p95": 31616,
-                "min": 31552,
-                "max": 31616,
-                "mad": 16,
-                "stdev": 21.226399
+                "median": 65524,
+                "p95": 65644,
+                "min": 65280,
+                "max": 65644,
+                "mad": 120,
+                "stdev": 135.77393
+              }
+            },
+            "bun": {
+              "wall_ms": {
+                "samples": [
+                  4,
+                  5,
+                  5,
+                  4,
+                  4
+                ],
+                "sample_count": 5,
+                "median": 4,
+                "p95": 5,
+                "min": 4,
+                "max": 5,
+                "mad": 0,
+                "stdev": 0.489898
+              },
+              "rss_kb": {
+                "samples": [
+                  41444,
+                  41444,
+                  41596,
+                  41332,
+                  41336
+                ],
+                "sample_count": 5,
+                "median": 41444,
+                "p95": 41596,
+                "min": 41332,
+                "max": 41596,
+                "mad": 108,
+                "stdev": 96.319468
               }
             }
           },
           "ratios": {
             "perry_to_node": {
-              "wall_time": 0.9,
-              "rss": 0.114113
+              "wall_time": 0.666667,
+              "rss": 0.329589
             },
             "perry_to_bun": {
-              "wall_time": 1.125,
-              "rss": 0.248227
+              "wall_time": 1.5,
+              "rss": 0.521089
             }
           },
           "correctness": {
@@ -1205,128 +1207,128 @@
             ],
             "reason": "all 5 Perry sample(s) matched node semantic output"
           },
-          "perry_ms": 9,
-          "perry_rss_kb": 7840,
-          "node_ms": 10,
-          "node_rss_kb": 68704,
-          "bun_ms": 8,
-          "bun_rss_kb": 31584,
-          "speed_ratio": 0.9,
-          "memory_ratio": 0.114113
+          "perry_ms": 6,
+          "perry_rss_kb": 21596,
+          "node_ms": 9,
+          "node_rss_kb": 65524,
+          "bun_ms": 4,
+          "bun_rss_kb": 41444,
+          "speed_ratio": 0.666667,
+          "memory_ratio": 0.329589
         },
         "10_nested_loops": {
           "runtimes": {
             "perry": {
               "wall_ms": {
                 "samples": [
-                  75,
-                  39,
-                  40,
-                  39,
-                  39
+                  26,
+                  25,
+                  25,
+                  25,
+                  25
                 ],
                 "sample_count": 5,
-                "median": 39,
-                "p95": 75,
-                "min": 39,
-                "max": 75,
+                "median": 25,
+                "p95": 26,
+                "min": 25,
+                "max": 26,
                 "mad": 0,
-                "stdev": 14.305244
+                "stdev": 0.4
               },
               "rss_kb": {
                 "samples": [
-                  7824,
-                  7824,
-                  7824,
-                  7824,
-                  7824
+                  33520,
+                  33488,
+                  33184,
+                  33564,
+                  33220
                 ],
                 "sample_count": 5,
-                "median": 7824,
-                "p95": 7824,
-                "min": 7824,
-                "max": 7824,
-                "mad": 0,
-                "stdev": 0
+                "median": 33488,
+                "p95": 33564,
+                "min": 33184,
+                "max": 33564,
+                "mad": 76,
+                "stdev": 159.988
               }
             },
             "node": {
               "wall_ms": {
                 "samples": [
-                  17,
-                  17,
-                  18,
-                  17,
-                  17
+                  12,
+                  12,
+                  12,
+                  11,
+                  11
                 ],
                 "sample_count": 5,
-                "median": 17,
-                "p95": 18,
-                "min": 17,
-                "max": 18,
+                "median": 12,
+                "p95": 12,
+                "min": 11,
+                "max": 12,
                 "mad": 0,
-                "stdev": 0.4
+                "stdev": 0.489898
               },
               "rss_kb": {
                 "samples": [
-                  70480,
-                  70528,
-                  70320,
-                  70496,
-                  70336
+                  67524,
+                  67700,
+                  67396,
+                  67268,
+                  67720
                 ],
                 "sample_count": 5,
-                "median": 70480,
-                "p95": 70528,
-                "min": 70320,
-                "max": 70528,
-                "mad": 48,
-                "stdev": 86.459239
+                "median": 67524,
+                "p95": 67720,
+                "min": 67268,
+                "max": 67720,
+                "mad": 176,
+                "stdev": 173.944359
               }
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  19,
-                  19,
-                  18,
-                  19,
-                  19
+                  12,
+                  12,
+                  12,
+                  13,
+                  13
                 ],
                 "sample_count": 5,
-                "median": 19,
-                "p95": 19,
-                "min": 18,
-                "max": 19,
+                "median": 12,
+                "p95": 13,
+                "min": 12,
+                "max": 13,
                 "mad": 0,
-                "stdev": 0.4
+                "stdev": 0.489898
               },
               "rss_kb": {
                 "samples": [
-                  32896,
-                  32912,
-                  32880,
-                  32896,
-                  32912
+                  42592,
+                  42796,
+                  42648,
+                  42752,
+                  42532
                 ],
                 "sample_count": 5,
-                "median": 32896,
-                "p95": 32912,
-                "min": 32880,
-                "max": 32912,
-                "mad": 16,
-                "stdev": 11.973304
+                "median": 42648,
+                "p95": 42796,
+                "min": 42532,
+                "max": 42796,
+                "mad": 104,
+                "stdev": 98.012244
               }
             }
           },
           "ratios": {
             "perry_to_node": {
-              "wall_time": 2.294118,
-              "rss": 0.11101
+              "wall_time": 2.083333,
+              "rss": 0.495942
             },
             "perry_to_bun": {
-              "wall_time": 2.052632,
-              "rss": 0.23784
+              "wall_time": 2.083333,
+              "rss": 0.785219
             }
           },
           "correctness": {
@@ -1340,83 +1342,83 @@
             ],
             "reason": "all 5 Perry sample(s) matched node semantic output"
           },
-          "perry_ms": 39,
-          "perry_rss_kb": 7824,
-          "node_ms": 17,
-          "node_rss_kb": 70480,
-          "bun_ms": 19,
-          "bun_rss_kb": 32896,
-          "speed_ratio": 2.294118,
-          "memory_ratio": 0.11101
+          "perry_ms": 25,
+          "perry_rss_kb": 33488,
+          "node_ms": 12,
+          "node_rss_kb": 67524,
+          "bun_ms": 12,
+          "bun_rss_kb": 42648,
+          "speed_ratio": 2.083333,
+          "memory_ratio": 0.495942
         },
         "11_prime_sieve": {
           "runtimes": {
             "perry": {
               "wall_ms": {
                 "samples": [
-                  40,
-                  28,
-                  28,
-                  28,
-                  28
-                ],
-                "sample_count": 5,
-                "median": 28,
-                "p95": 40,
-                "min": 28,
-                "max": 40,
-                "mad": 0,
-                "stdev": 4.8
-              },
-              "rss_kb": {
-                "samples": [
-                  26752,
-                  26768,
-                  26768,
-                  26768,
-                  26752
-                ],
-                "sample_count": 5,
-                "median": 26768,
-                "p95": 26768,
-                "min": 26752,
-                "max": 26768,
-                "mad": 0,
-                "stdev": 7.838367
-              }
-            },
-            "node": {
-              "wall_ms": {
-                "samples": [
-                  6,
+                  4,
                   5,
-                  6,
-                  6,
-                  6
+                  4,
+                  4,
+                  4
                 ],
                 "sample_count": 5,
-                "median": 6,
-                "p95": 6,
-                "min": 5,
-                "max": 6,
+                "median": 4,
+                "p95": 5,
+                "min": 4,
+                "max": 5,
                 "mad": 0,
                 "stdev": 0.4
               },
               "rss_kb": {
                 "samples": [
-                  100352,
-                  100192,
-                  100320,
-                  100224,
-                  100304
+                  64168,
+                  64360,
+                  64232,
+                  64120,
+                  64188
                 ],
                 "sample_count": 5,
-                "median": 100304,
-                "p95": 100352,
-                "min": 100192,
-                "max": 100352,
-                "mad": 48,
-                "stdev": 60.377479
+                "median": 64188,
+                "p95": 64360,
+                "min": 64120,
+                "max": 64360,
+                "mad": 44,
+                "stdev": 81.568621
+              }
+            },
+            "node": {
+              "wall_ms": {
+                "samples": [
+                  5,
+                  4,
+                  4,
+                  4,
+                  4
+                ],
+                "sample_count": 5,
+                "median": 4,
+                "p95": 5,
+                "min": 4,
+                "max": 5,
+                "mad": 0,
+                "stdev": 0.4
+              },
+              "rss_kb": {
+                "samples": [
+                  96784,
+                  97096,
+                  96892,
+                  96984,
+                  97056
+                ],
+                "sample_count": 5,
+                "median": 96984,
+                "p95": 97096,
+                "min": 96784,
+                "max": 97096,
+                "mad": 92,
+                "stdev": 113.012566
               }
             },
             "bun": {
@@ -1424,44 +1426,44 @@
                 "samples": [
                   5,
                   5,
-                  6,
+                  5,
                   5,
                   5
                 ],
                 "sample_count": 5,
                 "median": 5,
-                "p95": 6,
+                "p95": 5,
                 "min": 5,
-                "max": 6,
+                "max": 5,
                 "mad": 0,
-                "stdev": 0.4
+                "stdev": 0
               },
               "rss_kb": {
                 "samples": [
-                  62048,
-                  58240,
-                  58624,
-                  58256,
-                  62048
+                  76204,
+                  76232,
+                  76252,
+                  76348,
+                  76016
                 ],
                 "sample_count": 5,
-                "median": 58624,
-                "p95": 62048,
-                "min": 58240,
-                "max": 62048,
-                "mad": 384,
-                "stdev": 1805.446693
+                "median": 76232,
+                "p95": 76348,
+                "min": 76016,
+                "max": 76348,
+                "mad": 28,
+                "stdev": 108.593922
               }
             }
           },
           "ratios": {
             "perry_to_node": {
-              "wall_time": 4.666667,
-              "rss": 0.266869
+              "wall_time": 1.0,
+              "rss": 0.661841
             },
             "perry_to_bun": {
-              "wall_time": 5.6,
-              "rss": 0.456605
+              "wall_time": 0.8,
+              "rss": 0.842009
             }
           },
           "correctness": {
@@ -1475,128 +1477,128 @@
             ],
             "reason": "all 5 Perry sample(s) matched node semantic output"
           },
-          "perry_ms": 28,
-          "perry_rss_kb": 26768,
-          "node_ms": 6,
-          "node_rss_kb": 100304,
+          "perry_ms": 4,
+          "perry_rss_kb": 64188,
+          "node_ms": 4,
+          "node_rss_kb": 96984,
           "bun_ms": 5,
-          "bun_rss_kb": 58624,
-          "speed_ratio": 4.666667,
-          "memory_ratio": 0.266869
+          "bun_rss_kb": 76232,
+          "speed_ratio": 1.0,
+          "memory_ratio": 0.661841
         },
         "12_binary_trees": {
           "runtimes": {
             "perry": {
               "wall_ms": {
                 "samples": [
-                  14,
-                  4,
-                  4,
-                  3,
-                  4
-                ],
-                "sample_count": 5,
-                "median": 4,
-                "p95": 14,
-                "min": 3,
-                "max": 14,
-                "mad": 0,
-                "stdev": 4.118252
-              },
-              "rss_kb": {
-                "samples": [
-                  4624,
-                  4624,
-                  4624,
-                  4624,
-                  4640
-                ],
-                "sample_count": 5,
-                "median": 4624,
-                "p95": 4640,
-                "min": 4624,
-                "max": 4640,
-                "mad": 0,
-                "stdev": 6.4
-              }
-            },
-            "node": {
-              "wall_ms": {
-                "samples": [
                   6,
                   6,
-                  6,
-                  6,
-                  5
-                ],
-                "sample_count": 5,
-                "median": 6,
-                "p95": 6,
-                "min": 5,
-                "max": 6,
-                "mad": 0,
-                "stdev": 0.4
-              },
-              "rss_kb": {
-                "samples": [
-                  70928,
-                  70848,
-                  70912,
-                  70864,
-                  70768
-                ],
-                "sample_count": 5,
-                "median": 70864,
-                "p95": 70928,
-                "min": 70768,
-                "max": 70928,
-                "mad": 48,
-                "stdev": 56.341814
-              }
-            },
-            "bun": {
-              "wall_ms": {
-                "samples": [
-                  6,
-                  7,
                   6,
                   6,
                   6
                 ],
                 "sample_count": 5,
                 "median": 6,
-                "p95": 7,
+                "p95": 6,
                 "min": 6,
-                "max": 7,
+                "max": 6,
                 "mad": 0,
-                "stdev": 0.4
+                "stdev": 0
               },
               "rss_kb": {
                 "samples": [
-                  51424,
-                  51504,
-                  51584,
-                  51472,
-                  51280
+                  21372,
+                  21136,
+                  21392,
+                  21248,
+                  21032
                 ],
                 "sample_count": 5,
-                "median": 51472,
-                "p95": 51584,
-                "min": 51280,
-                "max": 51584,
-                "mad": 48,
-                "stdev": 100.88885
+                "median": 21248,
+                "p95": 21392,
+                "min": 21032,
+                "max": 21392,
+                "mad": 124,
+                "stdev": 137.544175
+              }
+            },
+            "node": {
+              "wall_ms": {
+                "samples": [
+                  5,
+                  5,
+                  4,
+                  5,
+                  4
+                ],
+                "sample_count": 5,
+                "median": 5,
+                "p95": 5,
+                "min": 4,
+                "max": 5,
+                "mad": 0,
+                "stdev": 0.489898
+              },
+              "rss_kb": {
+                "samples": [
+                  67624,
+                  68092,
+                  67832,
+                  68156,
+                  67868
+                ],
+                "sample_count": 5,
+                "median": 67868,
+                "p95": 68156,
+                "min": 67624,
+                "max": 68156,
+                "mad": 224,
+                "stdev": 191.409091
+              }
+            },
+            "bun": {
+              "wall_ms": {
+                "samples": [
+                  8,
+                  8,
+                  9,
+                  9,
+                  9
+                ],
+                "sample_count": 5,
+                "median": 9,
+                "p95": 9,
+                "min": 8,
+                "max": 9,
+                "mad": 0,
+                "stdev": 0.489898
+              },
+              "rss_kb": {
+                "samples": [
+                  58892,
+                  58604,
+                  58792,
+                  59048,
+                  59180
+                ],
+                "sample_count": 5,
+                "median": 58892,
+                "p95": 59180,
+                "min": 58604,
+                "max": 59180,
+                "mad": 156,
+                "stdev": 199.798298
               }
             }
           },
           "ratios": {
             "perry_to_node": {
-              "wall_time": 0.666667,
-              "rss": 0.065252
+              "wall_time": 1.2,
+              "rss": 0.313078
             },
             "perry_to_bun": {
               "wall_time": 0.666667,
-              "rss": 0.089835
+              "rss": 0.360796
             }
           },
           "correctness": {
@@ -1610,49 +1612,49 @@
             ],
             "reason": "all 5 Perry sample(s) matched node semantic output"
           },
-          "perry_ms": 4,
-          "perry_rss_kb": 4624,
-          "node_ms": 6,
-          "node_rss_kb": 70864,
-          "bun_ms": 6,
-          "bun_rss_kb": 51472,
-          "speed_ratio": 0.666667,
-          "memory_ratio": 0.065252
+          "perry_ms": 6,
+          "perry_rss_kb": 21248,
+          "node_ms": 5,
+          "node_rss_kb": 67868,
+          "bun_ms": 9,
+          "bun_rss_kb": 58892,
+          "speed_ratio": 1.2,
+          "memory_ratio": 0.313078
         },
         "13_factorial": {
           "runtimes": {
             "perry": {
               "wall_ms": {
                 "samples": [
-                  141,
-                  94,
-                  94,
-                  94,
-                  94
+                  59,
+                  60,
+                  58,
+                  60,
+                  58
                 ],
                 "sample_count": 5,
-                "median": 94,
-                "p95": 141,
-                "min": 94,
-                "max": 141,
-                "mad": 0,
-                "stdev": 18.8
+                "median": 59,
+                "p95": 60,
+                "min": 58,
+                "max": 60,
+                "mad": 1,
+                "stdev": 0.894427
               },
               "rss_kb": {
                 "samples": [
-                  4000,
-                  4000,
-                  4000,
-                  4000,
-                  4000
+                  16580,
+                  16572,
+                  16824,
+                  16932,
+                  16800
                 ],
                 "sample_count": 5,
-                "median": 4000,
-                "p95": 4000,
-                "min": 4000,
-                "max": 4000,
-                "mad": 0,
-                "stdev": 0
+                "median": 16800,
+                "p95": 16932,
+                "min": 16572,
+                "max": 16932,
+                "mad": 132,
+                "stdev": 142.359545
               }
             },
             "node": {
@@ -1662,76 +1664,76 @@
                   95,
                   95,
                   95,
-                  95
+                  94
                 ],
                 "sample_count": 5,
                 "median": 95,
                 "p95": 95,
-                "min": 95,
+                "min": 94,
                 "max": 95,
                 "mad": 0,
-                "stdev": 0
+                "stdev": 0.4
               },
               "rss_kb": {
                 "samples": [
-                  69616,
-                  69664,
-                  69760,
-                  69808,
-                  69824
+                  66760,
+                  66844,
+                  66536,
+                  66880,
+                  66720
                 ],
                 "sample_count": 5,
-                "median": 69760,
-                "p95": 69824,
-                "min": 69616,
-                "max": 69824,
-                "mad": 64,
-                "stdev": 81.332896
+                "median": 66760,
+                "p95": 66880,
+                "min": 66536,
+                "max": 66880,
+                "mad": 84,
+                "stdev": 120.425911
               }
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  95,
-                  95,
-                  95,
-                  95,
-                  95
+                  61,
+                  60,
+                  60,
+                  61,
+                  61
                 ],
                 "sample_count": 5,
-                "median": 95,
-                "p95": 95,
-                "min": 95,
-                "max": 95,
+                "median": 61,
+                "p95": 61,
+                "min": 60,
+                "max": 61,
                 "mad": 0,
-                "stdev": 0
+                "stdev": 0.489898
               },
               "rss_kb": {
                 "samples": [
-                  31360,
-                  31344,
-                  31344,
-                  31312,
-                  31328
+                  40868,
+                  40640,
+                  40760,
+                  40768,
+                  40552
                 ],
                 "sample_count": 5,
-                "median": 31344,
-                "p95": 31360,
-                "min": 31312,
-                "max": 31360,
-                "mad": 16,
-                "stdev": 16.316862
+                "median": 40760,
+                "p95": 40868,
+                "min": 40552,
+                "max": 40868,
+                "mad": 108,
+                "stdev": 109.911965
               }
             }
           },
           "ratios": {
             "perry_to_node": {
-              "wall_time": 0.989474,
-              "rss": 0.057339
+              "wall_time": 0.621053,
+              "rss": 0.251648
             },
             "perry_to_bun": {
-              "wall_time": 0.989474,
-              "rss": 0.127616
+              "wall_time": 0.967213,
+              "rss": 0.412169
             }
           },
           "correctness": {
@@ -1745,128 +1747,128 @@
             ],
             "reason": "all 5 Perry sample(s) matched node semantic output"
           },
-          "perry_ms": 94,
-          "perry_rss_kb": 4000,
+          "perry_ms": 59,
+          "perry_rss_kb": 16800,
           "node_ms": 95,
-          "node_rss_kb": 69760,
-          "bun_ms": 95,
-          "bun_rss_kb": 31344,
-          "speed_ratio": 0.989474,
-          "memory_ratio": 0.057339
+          "node_rss_kb": 66760,
+          "bun_ms": 61,
+          "bun_rss_kb": 40760,
+          "speed_ratio": 0.621053,
+          "memory_ratio": 0.251648
         },
         "14_closure": {
           "runtimes": {
             "perry": {
               "wall_ms": {
                 "samples": [
-                  93,
-                  46,
-                  47,
-                  47,
-                  47
+                  29,
+                  28,
+                  28,
+                  29,
+                  30
                 ],
                 "sample_count": 5,
-                "median": 47,
-                "p95": 93,
-                "min": 46,
-                "max": 93,
-                "mad": 0,
-                "stdev": 18.504054
+                "median": 29,
+                "p95": 30,
+                "min": 28,
+                "max": 30,
+                "mad": 1,
+                "stdev": 0.748331
               },
               "rss_kb": {
                 "samples": [
-                  4128,
-                  4128,
-                  4128,
-                  4128,
-                  4128
+                  17168,
+                  16988,
+                  16904,
+                  17180,
+                  17068
                 ],
                 "sample_count": 5,
-                "median": 4128,
-                "p95": 4128,
-                "min": 4128,
-                "max": 4128,
-                "mad": 0,
-                "stdev": 0
+                "median": 17068,
+                "p95": 17180,
+                "min": 16904,
+                "max": 17180,
+                "mad": 100,
+                "stdev": 105.484786
               }
             },
             "node": {
               "wall_ms": {
                 "samples": [
-                  50,
-                  48,
-                  49,
-                  49,
-                  49
+                  30,
+                  30,
+                  30,
+                  30,
+                  30
                 ],
                 "sample_count": 5,
-                "median": 49,
-                "p95": 50,
-                "min": 48,
-                "max": 50,
-                "mad": 0,
-                "stdev": 0.632456
-              },
-              "rss_kb": {
-                "samples": [
-                  70720,
-                  70608,
-                  70528,
-                  70544,
-                  70400
-                ],
-                "sample_count": 5,
-                "median": 70544,
-                "p95": 70720,
-                "min": 70400,
-                "max": 70720,
-                "mad": 64,
-                "stdev": 104.674734
-              }
-            },
-            "bun": {
-              "wall_ms": {
-                "samples": [
-                  49,
-                  49,
-                  49,
-                  49,
-                  49
-                ],
-                "sample_count": 5,
-                "median": 49,
-                "p95": 49,
-                "min": 49,
-                "max": 49,
+                "median": 30,
+                "p95": 30,
+                "min": 30,
+                "max": 30,
                 "mad": 0,
                 "stdev": 0
               },
               "rss_kb": {
                 "samples": [
-                  31248,
-                  31248,
-                  31264,
-                  31248,
-                  31264
+                  67512,
+                  67512,
+                  67448,
+                  67400,
+                  67304
                 ],
                 "sample_count": 5,
-                "median": 31248,
-                "p95": 31264,
-                "min": 31248,
-                "max": 31264,
+                "median": 67448,
+                "p95": 67512,
+                "min": 67304,
+                "max": 67512,
+                "mad": 64,
+                "stdev": 77.990769
+              }
+            },
+            "bun": {
+              "wall_ms": {
+                "samples": [
+                  30,
+                  29,
+                  29,
+                  30,
+                  29
+                ],
+                "sample_count": 5,
+                "median": 29,
+                "p95": 30,
+                "min": 29,
+                "max": 30,
                 "mad": 0,
-                "stdev": 7.838367
+                "stdev": 0.489898
+              },
+              "rss_kb": {
+                "samples": [
+                  40240,
+                  40616,
+                  40324,
+                  40296,
+                  40304
+                ],
+                "sample_count": 5,
+                "median": 40304,
+                "p95": 40616,
+                "min": 40240,
+                "max": 40616,
+                "mad": 20,
+                "stdev": 132.954127
               }
             }
           },
           "ratios": {
             "perry_to_node": {
-              "wall_time": 0.959184,
-              "rss": 0.058517
+              "wall_time": 0.966667,
+              "rss": 0.253054
             },
             "perry_to_bun": {
-              "wall_time": 0.959184,
-              "rss": 0.132104
+              "wall_time": 1.0,
+              "rss": 0.423482
             }
           },
           "correctness": {
@@ -1880,83 +1882,353 @@
             ],
             "reason": "all 5 Perry sample(s) matched node semantic output"
           },
-          "perry_ms": 47,
-          "perry_rss_kb": 4128,
-          "node_ms": 49,
-          "node_rss_kb": 70544,
-          "bun_ms": 49,
-          "bun_rss_kb": 31248,
-          "speed_ratio": 0.959184,
-          "memory_ratio": 0.058517
+          "perry_ms": 29,
+          "perry_rss_kb": 17068,
+          "node_ms": 30,
+          "node_rss_kb": 67448,
+          "bun_ms": 29,
+          "bun_rss_kb": 40304,
+          "speed_ratio": 0.966667,
+          "memory_ratio": 0.253054
         },
         "15_mandelbrot": {
           "runtimes": {
             "perry": {
               "wall_ms": {
                 "samples": [
-                  61,
-                  22,
-                  21,
-                  22,
-                  22
+                  15,
+                  15,
+                  14,
+                  15,
+                  14
                 ],
                 "sample_count": 5,
-                "median": 22,
-                "p95": 61,
-                "min": 21,
-                "max": 61,
-                "mad": 0,
-                "stdev": 15.704776
-              },
-              "rss_kb": {
-                "samples": [
-                  3984,
-                  3984,
-                  3984,
-                  3984,
-                  3984
-                ],
-                "sample_count": 5,
-                "median": 3984,
-                "p95": 3984,
-                "min": 3984,
-                "max": 3984,
-                "mad": 0,
-                "stdev": 0
-              }
-            },
-            "node": {
-              "wall_ms": {
-                "samples": [
-                  25,
-                  24,
-                  24,
-                  24,
-                  25
-                ],
-                "sample_count": 5,
-                "median": 24,
-                "p95": 25,
-                "min": 24,
-                "max": 25,
+                "median": 15,
+                "p95": 15,
+                "min": 14,
+                "max": 15,
                 "mad": 0,
                 "stdev": 0.489898
               },
               "rss_kb": {
                 "samples": [
-                  70544,
-                  70320,
-                  70416,
-                  70480,
-                  70464
+                  17040,
+                  16556,
+                  16944,
+                  16876,
+                  16932
                 ],
                 "sample_count": 5,
-                "median": 70464,
-                "p95": 70544,
-                "min": 70320,
-                "max": 70544,
+                "median": 16932,
+                "p95": 17040,
+                "min": 16556,
+                "max": 17040,
+                "mad": 56,
+                "stdev": 165.439536
+              }
+            },
+            "node": {
+              "wall_ms": {
+                "samples": [
+                  17,
+                  17,
+                  17,
+                  16,
+                  17
+                ],
+                "sample_count": 5,
+                "median": 17,
+                "p95": 17,
+                "min": 16,
+                "max": 17,
+                "mad": 0,
+                "stdev": 0.4
+              },
+              "rss_kb": {
+                "samples": [
+                  67452,
+                  67376,
+                  67352,
+                  67324,
+                  67268
+                ],
+                "sample_count": 5,
+                "median": 67352,
+                "p95": 67452,
+                "min": 67268,
+                "max": 67452,
+                "mad": 28,
+                "stdev": 60.6419
+              }
+            },
+            "bun": {
+              "wall_ms": {
+                "samples": [
+                  16,
+                  15,
+                  16,
+                  15,
+                  16
+                ],
+                "sample_count": 5,
+                "median": 16,
+                "p95": 16,
+                "min": 15,
+                "max": 16,
+                "mad": 0,
+                "stdev": 0.489898
+              },
+              "rss_kb": {
+                "samples": [
+                  40832,
+                  40572,
+                  40896,
+                  40600,
+                  40680
+                ],
+                "sample_count": 5,
+                "median": 40680,
+                "p95": 40896,
+                "min": 40572,
+                "max": 40896,
+                "mad": 108,
+                "stdev": 127.549206
+              }
+            }
+          },
+          "ratios": {
+            "perry_to_node": {
+              "wall_time": 0.882353,
+              "rss": 0.251396
+            },
+            "perry_to_bun": {
+              "wall_time": 0.9375,
+              "rss": 0.416224
+            }
+          },
+          "correctness": {
+            "status": "pass",
+            "reference": "node",
+            "actual_lines": [
+              "total_iter:8011148"
+            ],
+            "expected_lines": [
+              "total_iter:8011148"
+            ],
+            "reason": "all 5 Perry sample(s) matched node semantic output"
+          },
+          "perry_ms": 15,
+          "perry_rss_kb": 16932,
+          "node_ms": 17,
+          "node_rss_kb": 67352,
+          "bun_ms": 16,
+          "bun_rss_kb": 40680,
+          "speed_ratio": 0.882353,
+          "memory_ratio": 0.251396
+        },
+        "16_matrix_multiply": {
+          "runtimes": {
+            "perry": {
+              "wall_ms": {
+                "samples": [
+                  22,
+                  23,
+                  23,
+                  21,
+                  21
+                ],
+                "sample_count": 5,
+                "median": 22,
+                "p95": 23,
+                "min": 21,
+                "max": 23,
+                "mad": 1,
+                "stdev": 0.894427
+              },
+              "rss_kb": {
+                "samples": [
+                  31876,
+                  31820,
+                  31784,
+                  31868,
+                  31852
+                ],
+                "sample_count": 5,
+                "median": 31852,
+                "p95": 31876,
+                "min": 31784,
+                "max": 31876,
+                "mad": 24,
+                "stdev": 33.941125
+              }
+            },
+            "node": {
+              "wall_ms": {
+                "samples": [
+                  24,
+                  24,
+                  24,
+                  24,
+                  23
+                ],
+                "sample_count": 5,
+                "median": 24,
+                "p95": 24,
+                "min": 23,
+                "max": 24,
+                "mad": 0,
+                "stdev": 0.4
+              },
+              "rss_kb": {
+                "samples": [
+                  71912,
+                  72052,
+                  71700,
+                  72052,
+                  72100
+                ],
+                "sample_count": 5,
+                "median": 72052,
+                "p95": 72100,
+                "min": 71700,
+                "max": 72100,
                 "mad": 48,
-                "stdev": 74.636184
+                "stdev": 145.863498
+              }
+            },
+            "bun": {
+              "wall_ms": {
+                "samples": [
+                  22,
+                  22,
+                  22,
+                  22,
+                  22
+                ],
+                "sample_count": 5,
+                "median": 22,
+                "p95": 22,
+                "min": 22,
+                "max": 22,
+                "mad": 0,
+                "stdev": 0
+              },
+              "rss_kb": {
+                "samples": [
+                  47088,
+                  46904,
+                  47044,
+                  47020,
+                  46992
+                ],
+                "sample_count": 5,
+                "median": 47020,
+                "p95": 47088,
+                "min": 46904,
+                "max": 47088,
+                "mad": 28,
+                "stdev": 61.480403
+              }
+            }
+          },
+          "ratios": {
+            "perry_to_node": {
+              "wall_time": 0.916667,
+              "rss": 0.44207
+            },
+            "perry_to_bun": {
+              "wall_time": 1.0,
+              "rss": 0.677414
+            }
+          },
+          "correctness": {
+            "status": "pass",
+            "reference": "node",
+            "actual_lines": [
+              "checksum:41079519680"
+            ],
+            "expected_lines": [
+              "checksum:41079519680"
+            ],
+            "reason": "all 5 Perry sample(s) matched node semantic output"
+          },
+          "perry_ms": 22,
+          "perry_rss_kb": 31852,
+          "node_ms": 24,
+          "node_rss_kb": 72052,
+          "bun_ms": 22,
+          "bun_rss_kb": 47020,
+          "speed_ratio": 0.916667,
+          "memory_ratio": 0.44207
+        },
+        "bench_gc_pressure": {
+          "runtimes": {
+            "perry": {
+              "wall_ms": {
+                "samples": [
+                  12,
+                  12,
+                  13,
+                  12,
+                  12
+                ],
+                "sample_count": 5,
+                "median": 12,
+                "p95": 13,
+                "min": 12,
+                "max": 13,
+                "mad": 0,
+                "stdev": 0.4
+              },
+              "rss_kb": {
+                "samples": [
+                  40064,
+                  39784,
+                  39924,
+                  39868,
+                  39924
+                ],
+                "sample_count": 5,
+                "median": 39924,
+                "p95": 40064,
+                "min": 39784,
+                "max": 40064,
+                "mad": 56,
+                "stdev": 91.333236
+              }
+            },
+            "node": {
+              "wall_ms": {
+                "samples": [
+                  15,
+                  15,
+                  15,
+                  16,
+                  15
+                ],
+                "sample_count": 5,
+                "median": 15,
+                "p95": 16,
+                "min": 15,
+                "max": 16,
+                "mad": 0,
+                "stdev": 0.4
+              },
+              "rss_kb": {
+                "samples": [
+                  74660,
+                  74484,
+                  74380,
+                  74680,
+                  74736
+                ],
+                "sample_count": 5,
+                "median": 74660,
+                "p95": 74736,
+                "min": 74380,
+                "max": 74736,
+                "mad": 76,
+                "stdev": 133.889507
               }
             },
             "bun": {
@@ -1978,300 +2250,30 @@
               },
               "rss_kb": {
                 "samples": [
-                  31456,
-                  31456,
-                  31488,
-                  31456,
-                  31472
+                  86652,
+                  86560,
+                  86816,
+                  86728,
+                  86640
                 ],
                 "sample_count": 5,
-                "median": 31456,
-                "p95": 31488,
-                "min": 31456,
-                "max": 31488,
-                "mad": 0,
-                "stdev": 12.8
-              }
-            }
-          },
-          "ratios": {
-            "perry_to_node": {
-              "wall_time": 0.916667,
-              "rss": 0.05654
-            },
-            "perry_to_bun": {
-              "wall_time": 0.785714,
-              "rss": 0.126653
-            }
-          },
-          "correctness": {
-            "status": "pass",
-            "reference": "node",
-            "actual_lines": [
-              "total_iter:8011148"
-            ],
-            "expected_lines": [
-              "total_iter:8011148"
-            ],
-            "reason": "all 5 Perry sample(s) matched node semantic output"
-          },
-          "perry_ms": 22,
-          "perry_rss_kb": 3984,
-          "node_ms": 24,
-          "node_rss_kb": 70464,
-          "bun_ms": 28,
-          "bun_rss_kb": 31456,
-          "speed_ratio": 0.916667,
-          "memory_ratio": 0.05654
-        },
-        "16_matrix_multiply": {
-          "runtimes": {
-            "perry": {
-              "wall_ms": {
-                "samples": [
-                  134,
-                  84,
-                  85,
-                  84,
-                  85
-                ],
-                "sample_count": 5,
-                "median": 85,
-                "p95": 134,
-                "min": 84,
-                "max": 134,
-                "mad": 1,
-                "stdev": 19.80505
-              },
-              "rss_kb": {
-                "samples": [
-                  7792,
-                  7792,
-                  7792,
-                  7792,
-                  7792
-                ],
-                "sample_count": 5,
-                "median": 7792,
-                "p95": 7792,
-                "min": 7792,
-                "max": 7792,
-                "mad": 0,
-                "stdev": 0
-              }
-            },
-            "node": {
-              "wall_ms": {
-                "samples": [
-                  33,
-                  33,
-                  32,
-                  33,
-                  33
-                ],
-                "sample_count": 5,
-                "median": 33,
-                "p95": 33,
-                "min": 32,
-                "max": 33,
-                "mad": 0,
-                "stdev": 0.4
-              },
-              "rss_kb": {
-                "samples": [
-                  74752,
-                  74816,
-                  74576,
-                  74640,
-                  74656
-                ],
-                "sample_count": 5,
-                "median": 74656,
-                "p95": 74816,
-                "min": 74576,
-                "max": 74816,
-                "mad": 80,
-                "stdev": 85.266641
-              }
-            },
-            "bun": {
-              "wall_ms": {
-                "samples": [
-                  33,
-                  33,
-                  33,
-                  33,
-                  33
-                ],
-                "sample_count": 5,
-                "median": 33,
-                "p95": 33,
-                "min": 33,
-                "max": 33,
-                "mad": 0,
-                "stdev": 0
-              },
-              "rss_kb": {
-                "samples": [
-                  37840,
-                  37840,
-                  37840,
-                  37840,
-                  37856
-                ],
-                "sample_count": 5,
-                "median": 37840,
-                "p95": 37856,
-                "min": 37840,
-                "max": 37856,
-                "mad": 0,
-                "stdev": 6.4
-              }
-            }
-          },
-          "ratios": {
-            "perry_to_node": {
-              "wall_time": 2.575758,
-              "rss": 0.104372
-            },
-            "perry_to_bun": {
-              "wall_time": 2.575758,
-              "rss": 0.20592
-            }
-          },
-          "correctness": {
-            "status": "pass",
-            "reference": "node",
-            "actual_lines": [
-              "checksum:41079519680"
-            ],
-            "expected_lines": [
-              "checksum:41079519680"
-            ],
-            "reason": "all 5 Perry sample(s) matched node semantic output"
-          },
-          "perry_ms": 85,
-          "perry_rss_kb": 7792,
-          "node_ms": 33,
-          "node_rss_kb": 74656,
-          "bun_ms": 33,
-          "bun_rss_kb": 37840,
-          "speed_ratio": 2.575758,
-          "memory_ratio": 0.104372
-        },
-        "bench_gc_pressure": {
-          "runtimes": {
-            "perry": {
-              "wall_ms": {
-                "samples": [
-                  64,
-                  21,
-                  21,
-                  21,
-                  21
-                ],
-                "sample_count": 5,
-                "median": 21,
-                "p95": 64,
-                "min": 21,
-                "max": 64,
-                "mad": 0,
-                "stdev": 17.2
-              },
-              "rss_kb": {
-                "samples": [
-                  23440,
-                  23424,
-                  23440,
-                  23424,
-                  23440
-                ],
-                "sample_count": 5,
-                "median": 23440,
-                "p95": 23440,
-                "min": 23424,
-                "max": 23440,
-                "mad": 0,
-                "stdev": 7.838367
-              }
-            },
-            "node": {
-              "wall_ms": {
-                "samples": [
-                  15,
-                  15,
-                  16,
-                  15,
-                  16
-                ],
-                "sample_count": 5,
-                "median": 15,
-                "p95": 16,
-                "min": 15,
-                "max": 16,
-                "mad": 0,
-                "stdev": 0.489898
-              },
-              "rss_kb": {
-                "samples": [
-                  77616,
-                  77488,
-                  77408,
-                  77408,
-                  77584
-                ],
-                "sample_count": 5,
-                "median": 77488,
-                "p95": 77616,
-                "min": 77408,
-                "max": 77616,
-                "mad": 80,
+                "median": 86652,
+                "p95": 86816,
+                "min": 86560,
+                "max": 86816,
+                "mad": 76,
                 "stdev": 86.69579
               }
-            },
-            "bun": {
-              "wall_ms": {
-                "samples": [
-                  20,
-                  20,
-                  20,
-                  20,
-                  20
-                ],
-                "sample_count": 5,
-                "median": 20,
-                "p95": 20,
-                "min": 20,
-                "max": 20,
-                "mad": 0,
-                "stdev": 0
-              },
-              "rss_kb": {
-                "samples": [
-                  77584,
-                  77648,
-                  77632,
-                  77616,
-                  77584
-                ],
-                "sample_count": 5,
-                "median": 77616,
-                "p95": 77648,
-                "min": 77584,
-                "max": 77648,
-                "mad": 32,
-                "stdev": 25.6
-              }
             }
           },
           "ratios": {
             "perry_to_node": {
-              "wall_time": 1.4,
-              "rss": 0.302498
+              "wall_time": 0.8,
+              "rss": 0.534744
             },
             "perry_to_bun": {
-              "wall_time": 1.05,
-              "rss": 0.302
+              "wall_time": 0.428571,
+              "rss": 0.46074
             }
           },
           "correctness": {
@@ -2285,128 +2287,128 @@
             ],
             "reason": "all 5 Perry sample(s) matched node semantic output"
           },
-          "perry_ms": 21,
-          "perry_rss_kb": 23440,
+          "perry_ms": 12,
+          "perry_rss_kb": 39924,
           "node_ms": 15,
-          "node_rss_kb": 77488,
-          "bun_ms": 20,
-          "bun_rss_kb": 77616,
-          "speed_ratio": 1.4,
-          "memory_ratio": 0.302498
+          "node_rss_kb": 74660,
+          "bun_ms": 28,
+          "bun_rss_kb": 86652,
+          "speed_ratio": 0.8,
+          "memory_ratio": 0.534744
         },
         "bench_json_roundtrip": {
           "runtimes": {
             "perry": {
               "wall_ms": {
                 "samples": [
-                  189,
                   184,
+                  185,
+                  185,
                   184,
-                  183,
                   184
                 ],
                 "sample_count": 5,
                 "median": 184,
-                "p95": 189,
-                "min": 183,
-                "max": 189,
+                "p95": 185,
+                "min": 184,
+                "max": 185,
                 "mad": 0,
-                "stdev": 2.135416
+                "stdev": 0.489898
               },
               "rss_kb": {
                 "samples": [
-                  81376,
-                  81376,
-                  81376,
-                  81376,
-                  81376
+                  121624,
+                  121604,
+                  121740,
+                  121620,
+                  121744
                 ],
                 "sample_count": 5,
-                "median": 81376,
-                "p95": 81376,
-                "min": 81376,
-                "max": 81376,
-                "mad": 0,
-                "stdev": 0
+                "median": 121624,
+                "p95": 121744,
+                "min": 121604,
+                "max": 121744,
+                "mad": 20,
+                "stdev": 62.101852
               }
             },
             "node": {
               "wall_ms": {
                 "samples": [
-                  387,
-                  384,
-                  384,
-                  382,
-                  385
+                  378,
+                  394,
+                  380,
+                  378,
+                  381
                 ],
                 "sample_count": 5,
-                "median": 384,
-                "p95": 387,
-                "min": 382,
-                "max": 387,
-                "mad": 1,
-                "stdev": 1.624808
+                "median": 380,
+                "p95": 394,
+                "min": 378,
+                "max": 394,
+                "mad": 2,
+                "stdev": 6.013319
               },
               "rss_kb": {
                 "samples": [
-                  122656,
-                  121568,
-                  121712,
-                  121648,
-                  121888
+                  116492,
+                  116256,
+                  117152,
+                  117424,
+                  116364
                 ],
                 "sample_count": 5,
-                "median": 121712,
-                "p95": 122656,
-                "min": 121568,
-                "max": 122656,
-                "mad": 144,
-                "stdev": 395.11902
+                "median": 116492,
+                "p95": 117424,
+                "min": 116256,
+                "max": 117424,
+                "mad": 236,
+                "stdev": 463.617774
               }
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  219,
-                  219,
-                  219,
-                  220,
-                  219
+                  186,
+                  186,
+                  184,
+                  185,
+                  183
                 ],
                 "sample_count": 5,
-                "median": 219,
-                "p95": 220,
-                "min": 219,
-                "max": 220,
-                "mad": 0,
-                "stdev": 0.4
+                "median": 185,
+                "p95": 186,
+                "min": 183,
+                "max": 186,
+                "mad": 1,
+                "stdev": 1.16619
               },
               "rss_kb": {
                 "samples": [
-                  82304,
-                  84000,
-                  83344,
-                  84560,
-                  83344
+                  90752,
+                  90920,
+                  94180,
+                  94336,
+                  90500
                 ],
                 "sample_count": 5,
-                "median": 83344,
-                "p95": 84560,
-                "min": 82304,
-                "max": 84560,
-                "mad": 656,
-                "stdev": 755.267794
+                "median": 90920,
+                "p95": 94336,
+                "min": 90500,
+                "max": 94336,
+                "mad": 420,
+                "stdev": 1737.154639
               }
             }
           },
           "ratios": {
             "perry_to_node": {
-              "wall_time": 0.479167,
-              "rss": 0.668595
+              "wall_time": 0.484211,
+              "rss": 1.044055
             },
             "perry_to_bun": {
-              "wall_time": 0.840183,
-              "rss": 0.976387
+              "wall_time": 0.994595,
+              "rss": 1.337703
             }
           },
           "correctness": {
@@ -2421,127 +2423,127 @@
             "reason": "all 5 Perry sample(s) matched node semantic output"
           },
           "perry_ms": 184,
-          "perry_rss_kb": 81376,
-          "node_ms": 384,
-          "node_rss_kb": 121712,
-          "bun_ms": 219,
-          "bun_rss_kb": 83344,
-          "speed_ratio": 0.479167,
-          "memory_ratio": 0.668595
+          "perry_rss_kb": 121624,
+          "node_ms": 380,
+          "node_rss_kb": 116492,
+          "bun_ms": 185,
+          "bun_rss_kb": 90920,
+          "speed_ratio": 0.484211,
+          "memory_ratio": 1.044055
         },
         "bench_object_property": {
           "runtimes": {
             "perry": {
               "wall_ms": {
                 "samples": [
-                  164,
-                  129,
-                  128,
-                  129,
-                  128
+                  25,
+                  25,
+                  26,
+                  28,
+                  26
                 ],
                 "sample_count": 5,
-                "median": 129,
-                "p95": 164,
-                "min": 128,
-                "max": 164,
+                "median": 26,
+                "p95": 28,
+                "min": 25,
+                "max": 28,
                 "mad": 1,
-                "stdev": 14.207041
+                "stdev": 1.095445
               },
               "rss_kb": {
                 "samples": [
-                  21632,
-                  21632,
-                  21648,
-                  21648,
-                  21648
+                  57112,
+                  57232,
+                  57028,
+                  56752,
+                  56968
                 ],
                 "sample_count": 5,
-                "median": 21648,
-                "p95": 21648,
-                "min": 21632,
-                "max": 21648,
-                "mad": 0,
-                "stdev": 7.838367
+                "median": 57028,
+                "p95": 57232,
+                "min": 56752,
+                "max": 57232,
+                "mad": 84,
+                "stdev": 159.992
               }
             },
             "node": {
               "wall_ms": {
                 "samples": [
+                  13,
                   15,
-                  16,
-                  15,
-                  15,
-                  16
+                  12,
+                  14,
+                  13
                 ],
                 "sample_count": 5,
-                "median": 15,
-                "p95": 16,
-                "min": 15,
-                "max": 16,
-                "mad": 0,
-                "stdev": 0.489898
+                "median": 13,
+                "p95": 15,
+                "min": 12,
+                "max": 15,
+                "mad": 1,
+                "stdev": 1.019804
               },
               "rss_kb": {
                 "samples": [
-                  70256,
-                  70416,
-                  70624,
-                  70464,
-                  70448
+                  67180,
+                  67360,
+                  67120,
+                  67276,
+                  67280
                 ],
                 "sample_count": 5,
-                "median": 70448,
-                "p95": 70624,
-                "min": 70256,
-                "max": 70624,
-                "mad": 32,
-                "stdev": 117.401192
+                "median": 67276,
+                "p95": 67360,
+                "min": 67120,
+                "max": 67360,
+                "mad": 84,
+                "stdev": 83.958085
               }
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  6,
-                  6,
-                  7,
-                  9,
-                  16
+                  17,
+                  17,
+                  17,
+                  17,
+                  17
                 ],
                 "sample_count": 5,
-                "median": 7,
-                "p95": 16,
-                "min": 6,
-                "max": 16,
-                "mad": 1,
-                "stdev": 3.762978
+                "median": 17,
+                "p95": 17,
+                "min": 17,
+                "max": 17,
+                "mad": 0,
+                "stdev": 0
               },
               "rss_kb": {
                 "samples": [
-                  33632,
-                  33136,
-                  33120,
-                  37120,
-                  46032
+                  55436,
+                  55576,
+                  55324,
+                  55512,
+                  55168
                 ],
                 "sample_count": 5,
-                "median": 33632,
-                "p95": 46032,
-                "min": 33120,
-                "max": 46032,
-                "mad": 512,
-                "stdev": 4942.700153
+                "median": 55436,
+                "p95": 55576,
+                "min": 55168,
+                "max": 55576,
+                "mad": 112,
+                "stdev": 144.474773
               }
             }
           },
           "ratios": {
             "perry_to_node": {
-              "wall_time": 8.6,
-              "rss": 0.30729
+              "wall_time": 2.0,
+              "rss": 0.847672
             },
             "perry_to_bun": {
-              "wall_time": 18.428571,
-              "rss": 0.643673
+              "wall_time": 1.529412,
+              "rss": 1.028718
             }
           },
           "correctness": {
@@ -2555,128 +2557,128 @@
             ],
             "reason": "all 5 Perry sample(s) matched node semantic output"
           },
-          "perry_ms": 129,
-          "perry_rss_kb": 21648,
-          "node_ms": 15,
-          "node_rss_kb": 70448,
-          "bun_ms": 7,
-          "bun_rss_kb": 33632,
-          "speed_ratio": 8.6,
-          "memory_ratio": 0.30729
+          "perry_ms": 26,
+          "perry_rss_kb": 57028,
+          "node_ms": 13,
+          "node_rss_kb": 67276,
+          "bun_ms": 17,
+          "bun_rss_kb": 55436,
+          "speed_ratio": 2.0,
+          "memory_ratio": 0.847672
         },
         "bench_int_arithmetic": {
           "runtimes": {
             "perry": {
               "wall_ms": {
                 "samples": [
-                  399,
-                  367,
-                  366,
-                  367,
-                  367
+                  37,
+                  37,
+                  37,
+                  36,
+                  36
                 ],
                 "sample_count": 5,
-                "median": 367,
-                "p95": 399,
-                "min": 366,
-                "max": 399,
+                "median": 37,
+                "p95": 37,
+                "min": 36,
+                "max": 37,
                 "mad": 0,
-                "stdev": 12.905813
+                "stdev": 0.489898
               },
               "rss_kb": {
                 "samples": [
-                  4272,
-                  4272,
-                  4272,
-                  4272,
-                  4272
+                  19092,
+                  18944,
+                  18732,
+                  19164,
+                  19168
                 ],
                 "sample_count": 5,
-                "median": 4272,
-                "p95": 4272,
-                "min": 4272,
-                "max": 4272,
-                "mad": 0,
-                "stdev": 0
+                "median": 19092,
+                "p95": 19168,
+                "min": 18732,
+                "max": 19168,
+                "mad": 76,
+                "stdev": 165.253744
               }
             },
             "node": {
               "wall_ms": {
                 "samples": [
-                  93,
-                  93,
-                  94,
-                  94,
-                  94
+                  77,
+                  78,
+                  77,
+                  78,
+                  77
                 ],
                 "sample_count": 5,
-                "median": 94,
-                "p95": 94,
-                "min": 93,
-                "max": 94,
+                "median": 77,
+                "p95": 78,
+                "min": 77,
+                "max": 78,
                 "mad": 0,
                 "stdev": 0.489898
               },
               "rss_kb": {
                 "samples": [
-                  68896,
-                  68944,
-                  68992,
-                  68928,
-                  68944
+                  67168,
+                  67252,
+                  67152,
+                  66964,
+                  67296
                 ],
                 "sample_count": 5,
-                "median": 68944,
-                "p95": 68992,
-                "min": 68896,
-                "max": 68992,
-                "mad": 16,
-                "stdev": 31.025151
+                "median": 67168,
+                "p95": 67296,
+                "min": 66964,
+                "max": 67296,
+                "mad": 84,
+                "stdev": 114.279657
               }
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  39,
-                  38,
-                  39,
-                  38,
-                  39
+                  36,
+                  36,
+                  36,
+                  36,
+                  36
                 ],
                 "sample_count": 5,
-                "median": 39,
-                "p95": 39,
-                "min": 38,
-                "max": 39,
+                "median": 36,
+                "p95": 36,
+                "min": 36,
+                "max": 36,
                 "mad": 0,
-                "stdev": 0.489898
+                "stdev": 0
               },
               "rss_kb": {
                 "samples": [
-                  35952,
-                  35984,
-                  35968,
-                  36032,
-                  35984
+                  45032,
+                  44844,
+                  44968,
+                  44856,
+                  45096
                 ],
                 "sample_count": 5,
-                "median": 35984,
-                "p95": 36032,
-                "min": 35952,
-                "max": 36032,
-                "mad": 16,
-                "stdev": 26.773121
+                "median": 44968,
+                "p95": 45096,
+                "min": 44844,
+                "max": 45096,
+                "mad": 112,
+                "stdev": 97.992653
               }
             }
           },
           "ratios": {
             "perry_to_node": {
-              "wall_time": 3.904255,
-              "rss": 0.061963
+              "wall_time": 0.480519,
+              "rss": 0.284242
             },
             "perry_to_bun": {
-              "wall_time": 9.410256,
-              "rss": 0.118719
+              "wall_time": 1.027778,
+              "rss": 0.424569
             }
           },
           "correctness": {
@@ -2690,128 +2692,128 @@
             ],
             "reason": "all 5 Perry sample(s) matched node semantic output"
           },
-          "perry_ms": 367,
-          "perry_rss_kb": 4272,
-          "node_ms": 94,
-          "node_rss_kb": 68944,
-          "bun_ms": 39,
-          "bun_rss_kb": 35984,
-          "speed_ratio": 3.904255,
-          "memory_ratio": 0.061963
+          "perry_ms": 37,
+          "perry_rss_kb": 19092,
+          "node_ms": 77,
+          "node_rss_kb": 67168,
+          "bun_ms": 36,
+          "bun_rss_kb": 44968,
+          "speed_ratio": 0.480519,
+          "memory_ratio": 0.284242
         },
         "bench_buffer_readwrite": {
           "runtimes": {
             "perry": {
               "wall_ms": {
                 "samples": [
-                  133,
-                  94,
-                  94,
-                  94,
-                  95
+                  79,
+                  78,
+                  79,
+                  80,
+                  80
                 ],
                 "sample_count": 5,
-                "median": 94,
-                "p95": 133,
-                "min": 94,
-                "max": 133,
-                "mad": 0,
-                "stdev": 15.504838
+                "median": 79,
+                "p95": 80,
+                "min": 78,
+                "max": 80,
+                "mad": 1,
+                "stdev": 0.748331
               },
               "rss_kb": {
                 "samples": [
-                  5296,
-                  5280,
-                  5280,
-                  5280,
-                  5280
+                  18916,
+                  18936,
+                  19192,
+                  18880,
+                  19116
                 ],
                 "sample_count": 5,
-                "median": 5280,
-                "p95": 5296,
-                "min": 5280,
-                "max": 5296,
-                "mad": 0,
-                "stdev": 6.4
+                "median": 18936,
+                "p95": 19192,
+                "min": 18880,
+                "max": 19192,
+                "mad": 56,
+                "stdev": 122.924367
               }
             },
             "node": {
               "wall_ms": {
                 "samples": [
-                  96,
-                  96,
-                  97,
-                  96,
-                  97
+                  59,
+                  61,
+                  60,
+                  60,
+                  61
                 ],
                 "sample_count": 5,
-                "median": 96,
-                "p95": 97,
-                "min": 96,
-                "max": 97,
-                "mad": 0,
-                "stdev": 0.489898
+                "median": 60,
+                "p95": 61,
+                "min": 59,
+                "max": 61,
+                "mad": 1,
+                "stdev": 0.748331
               },
               "rss_kb": {
                 "samples": [
-                  68688,
-                  68896,
-                  68672,
-                  68688,
-                  68704
+                  67700,
+                  67172,
+                  67304,
+                  67356,
+                  67176
                 ],
                 "sample_count": 5,
-                "median": 68688,
-                "p95": 68896,
-                "min": 68672,
-                "max": 68896,
-                "mad": 16,
-                "stdev": 83.813125
+                "median": 67304,
+                "p95": 67700,
+                "min": 67172,
+                "max": 67700,
+                "mad": 128,
+                "stdev": 193.007357
               }
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  193,
-                  193,
-                  193,
-                  193,
-                  193
+                  150,
+                  151,
+                  76,
+                  72,
+                  72
                 ],
                 "sample_count": 5,
-                "median": 193,
-                "p95": 193,
-                "min": 193,
-                "max": 193,
-                "mad": 0,
-                "stdev": 0
+                "median": 76,
+                "p95": 151,
+                "min": 72,
+                "max": 151,
+                "mad": 4,
+                "stdev": 37.833319
               },
               "rss_kb": {
                 "samples": [
-                  34224,
-                  34176,
-                  34176,
-                  34192,
-                  34224
+                  43304,
+                  43532,
+                  43296,
+                  43052,
+                  43644
                 ],
                 "sample_count": 5,
-                "median": 34192,
-                "p95": 34224,
-                "min": 34176,
-                "max": 34224,
-                "mad": 16,
-                "stdev": 21.703456
+                "median": 43304,
+                "p95": 43644,
+                "min": 43052,
+                "max": 43644,
+                "mad": 228,
+                "stdev": 205.999612
               }
             }
           },
           "ratios": {
             "perry_to_node": {
-              "wall_time": 0.979167,
-              "rss": 0.076869
+              "wall_time": 1.316667,
+              "rss": 0.28135
             },
             "perry_to_bun": {
-              "wall_time": 0.487047,
-              "rss": 0.154422
+              "wall_time": 1.039474,
+              "rss": 0.437281
             }
           },
           "correctness": {
@@ -2825,128 +2827,128 @@
             ],
             "reason": "all 5 Perry sample(s) matched node semantic output"
           },
-          "perry_ms": 94,
-          "perry_rss_kb": 5280,
-          "node_ms": 96,
-          "node_rss_kb": 68688,
-          "bun_ms": 193,
-          "bun_rss_kb": 34192,
-          "speed_ratio": 0.979167,
-          "memory_ratio": 0.076869
+          "perry_ms": 79,
+          "perry_rss_kb": 18936,
+          "node_ms": 60,
+          "node_rss_kb": 67304,
+          "bun_ms": 76,
+          "bun_rss_kb": 43304,
+          "speed_ratio": 1.316667,
+          "memory_ratio": 0.28135
         },
         "bench_array_grow": {
           "runtimes": {
             "perry": {
               "wall_ms": {
                 "samples": [
-                  23,
                   8,
                   7,
                   8,
-                  7
+                  8,
+                  9
                 ],
                 "sample_count": 5,
                 "median": 8,
-                "p95": 23,
+                "p95": 9,
                 "min": 7,
-                "max": 23,
-                "mad": 1,
-                "stdev": 6.216108
+                "max": 9,
+                "mad": 0,
+                "stdev": 0.632456
               },
               "rss_kb": {
                 "samples": [
-                  42416,
-                  42416,
-                  42416,
-                  42400,
-                  42416
+                  79200,
+                  79240,
+                  79124,
+                  79620,
+                  79020
                 ],
                 "sample_count": 5,
-                "median": 42416,
-                "p95": 42416,
-                "min": 42400,
-                "max": 42416,
-                "mad": 0,
-                "stdev": 6.4
+                "median": 79200,
+                "p95": 79620,
+                "min": 79020,
+                "max": 79620,
+                "mad": 76,
+                "stdev": 203.888597
               }
             },
             "node": {
               "wall_ms": {
                 "samples": [
-                  14,
-                  13,
-                  13,
-                  13,
-                  13
+                  29,
+                  28,
+                  28,
+                  28,
+                  29
                 ],
                 "sample_count": 5,
-                "median": 13,
-                "p95": 14,
-                "min": 13,
-                "max": 14,
+                "median": 28,
+                "p95": 29,
+                "min": 28,
+                "max": 29,
                 "mad": 0,
-                "stdev": 0.4
+                "stdev": 0.489898
               },
               "rss_kb": {
                 "samples": [
-                  132528,
-                  132560,
-                  132480,
-                  132640,
-                  132592
+                  128484,
+                  128376,
+                  128144,
+                  128336,
+                  128212
                 ],
                 "sample_count": 5,
-                "median": 132560,
-                "p95": 132640,
-                "min": 132480,
-                "max": 132640,
-                "mad": 32,
-                "stdev": 54.494036
+                "median": 128336,
+                "p95": 128484,
+                "min": 128144,
+                "max": 128484,
+                "mad": 124,
+                "stdev": 120.388704
               }
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  9,
-                  8,
-                  9,
-                  9,
-                  9
+                  19,
+                  16,
+                  21,
+                  19,
+                  19
                 ],
                 "sample_count": 5,
-                "median": 9,
-                "p95": 9,
-                "min": 8,
-                "max": 9,
+                "median": 19,
+                "p95": 21,
+                "min": 16,
+                "max": 21,
                 "mad": 0,
-                "stdev": 0.4
+                "stdev": 1.6
               },
               "rss_kb": {
                 "samples": [
-                  79184,
-                  70896,
-                  75760,
-                  79168,
-                  75728
+                  93464,
+                  79744,
+                  93308,
+                  93328,
+                  93600
                 ],
                 "sample_count": 5,
-                "median": 75760,
-                "p95": 79184,
-                "min": 70896,
-                "max": 79184,
-                "mad": 3408,
-                "stdev": 3041.320134
+                "median": 93328,
+                "p95": 93600,
+                "min": 79744,
+                "max": 93600,
+                "mad": 136,
+                "stdev": 5473.409409
               }
             }
           },
           "ratios": {
             "perry_to_node": {
-              "wall_time": 0.615385,
-              "rss": 0.319976
+              "wall_time": 0.285714,
+              "rss": 0.61713
             },
             "perry_to_bun": {
-              "wall_time": 0.888889,
-              "rss": 0.559873
+              "wall_time": 0.421053,
+              "rss": 0.84862
             }
           },
           "correctness": {
@@ -2963,127 +2965,127 @@
             "reason": "all 5 Perry sample(s) matched node semantic output"
           },
           "perry_ms": 8,
-          "perry_rss_kb": 42416,
-          "node_ms": 13,
-          "node_rss_kb": 132560,
-          "bun_ms": 9,
-          "bun_rss_kb": 75760,
-          "speed_ratio": 0.615385,
-          "memory_ratio": 0.319976
+          "perry_rss_kb": 79200,
+          "node_ms": 28,
+          "node_rss_kb": 128336,
+          "bun_ms": 19,
+          "bun_rss_kb": 93328,
+          "speed_ratio": 0.285714,
+          "memory_ratio": 0.61713
         },
         "bench_string_heavy": {
           "runtimes": {
             "perry": {
               "wall_ms": {
                 "samples": [
-                  100,
-                  49,
-                  50,
-                  50,
-                  49
+                  32,
+                  32,
+                  32,
+                  32,
+                  32
                 ],
                 "sample_count": 5,
-                "median": 50,
-                "p95": 100,
-                "min": 49,
-                "max": 100,
-                "mad": 1,
-                "stdev": 20.20495
-              },
-              "rss_kb": {
-                "samples": [
-                  23616,
-                  23616,
-                  23600,
-                  23600,
-                  23600
-                ],
-                "sample_count": 5,
-                "median": 23600,
-                "p95": 23616,
-                "min": 23600,
-                "max": 23616,
-                "mad": 0,
-                "stdev": 7.838367
-              }
-            },
-            "node": {
-              "wall_ms": {
-                "samples": [
-                  42,
-                  42,
-                  42,
-                  42,
-                  42
-                ],
-                "sample_count": 5,
-                "median": 42,
-                "p95": 42,
-                "min": 42,
-                "max": 42,
+                "median": 32,
+                "p95": 32,
+                "min": 32,
+                "max": 32,
                 "mad": 0,
                 "stdev": 0
               },
               "rss_kb": {
                 "samples": [
-                  68336,
-                  68560,
-                  68304,
-                  68480,
-                  68592
+                  47908,
+                  48020,
+                  47688,
+                  47820,
+                  48044
                 ],
                 "sample_count": 5,
-                "median": 68480,
-                "p95": 68592,
-                "min": 68304,
-                "max": 68592,
+                "median": 47908,
+                "p95": 48044,
+                "min": 47688,
+                "max": 48044,
                 "mad": 112,
-                "stdev": 116.085486
+                "stdev": 131.502091
+              }
+            },
+            "node": {
+              "wall_ms": {
+                "samples": [
+                  37,
+                  37,
+                  37,
+                  35,
+                  36
+                ],
+                "sample_count": 5,
+                "median": 37,
+                "p95": 37,
+                "min": 35,
+                "max": 37,
+                "mad": 0,
+                "stdev": 0.8
+              },
+              "rss_kb": {
+                "samples": [
+                  63828,
+                  64008,
+                  63872,
+                  64040,
+                  63900
+                ],
+                "sample_count": 5,
+                "median": 63900,
+                "p95": 64040,
+                "min": 63828,
+                "max": 64040,
+                "mad": 72,
+                "stdev": 81.057017
               }
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  28,
-                  29,
-                  29,
-                  29,
-                  29
+                  30,
+                  31,
+                  31,
+                  31,
+                  30
                 ],
                 "sample_count": 5,
-                "median": 29,
-                "p95": 29,
-                "min": 28,
-                "max": 29,
+                "median": 31,
+                "p95": 31,
+                "min": 30,
+                "max": 31,
                 "mad": 0,
-                "stdev": 0.4
+                "stdev": 0.489898
               },
               "rss_kb": {
                 "samples": [
-                  62432,
-                  62432,
-                  62432,
-                  62448,
-                  62400
+                  71092,
+                  70932,
+                  70940,
+                  70916,
+                  70892
                 ],
                 "sample_count": 5,
-                "median": 62432,
-                "p95": 62448,
-                "min": 62400,
-                "max": 62448,
-                "mad": 0,
-                "stdev": 15.676734
+                "median": 70932,
+                "p95": 71092,
+                "min": 70892,
+                "max": 71092,
+                "mad": 16,
+                "stdev": 70.726516
               }
             }
           },
           "ratios": {
             "perry_to_node": {
-              "wall_time": 1.190476,
-              "rss": 0.344626
+              "wall_time": 0.864865,
+              "rss": 0.749734
             },
             "perry_to_bun": {
-              "wall_time": 1.724138,
-              "rss": 0.378011
+              "wall_time": 1.032258,
+              "rss": 0.675407
             }
           },
           "correctness": {
@@ -3097,86 +3099,18 @@
             ],
             "reason": "all 5 Perry sample(s) matched node semantic output"
           },
-          "perry_ms": 50,
-          "perry_rss_kb": 23600,
-          "node_ms": 42,
-          "node_rss_kb": 68480,
-          "bun_ms": 29,
-          "bun_rss_kb": 62432,
-          "speed_ratio": 1.190476,
-          "memory_ratio": 0.344626
+          "perry_ms": 32,
+          "perry_rss_kb": 47908,
+          "node_ms": 37,
+          "node_rss_kb": 63900,
+          "bun_ms": 31,
+          "bun_rss_kb": 70932,
+          "speed_ratio": 0.864865,
+          "memory_ratio": 0.749734
         },
         "bench_numeric_array_numeric": {
           "runtimes": {
             "perry": {
-              "wall_ms": {
-                "samples": [
-                  67,
-                  68,
-                  68,
-                  68,
-                  67
-                ],
-                "sample_count": 5,
-                "median": 68,
-                "p95": 68,
-                "min": 67,
-                "max": 68,
-                "mad": 0,
-                "stdev": 0.489898
-              },
-              "rss_kb": {
-                "samples": [
-                  26640,
-                  26624,
-                  26640,
-                  26640,
-                  26640
-                ],
-                "sample_count": 5,
-                "median": 26640,
-                "p95": 26640,
-                "min": 26624,
-                "max": 26640,
-                "mad": 0,
-                "stdev": 6.4
-              }
-            },
-            "node": {
-              "wall_ms": {
-                "samples": [
-                  5,
-                  5,
-                  5,
-                  6,
-                  5
-                ],
-                "sample_count": 5,
-                "median": 5,
-                "p95": 6,
-                "min": 5,
-                "max": 6,
-                "mad": 0,
-                "stdev": 0.4
-              },
-              "rss_kb": {
-                "samples": [
-                  89104,
-                  88896,
-                  88960,
-                  89120,
-                  89168
-                ],
-                "sample_count": 5,
-                "median": 89104,
-                "p95": 89168,
-                "min": 88896,
-                "max": 89168,
-                "mad": 64,
-                "stdev": 103.494154
-              }
-            },
-            "bun": {
               "wall_ms": {
                 "samples": [
                   4,
@@ -3195,30 +3129,98 @@
               },
               "rss_kb": {
                 "samples": [
-                  46496,
-                  46544,
-                  46512,
-                  46512,
-                  46528
+                  54404,
+                  54100,
+                  54352,
+                  54348,
+                  54360
                 ],
                 "sample_count": 5,
-                "median": 46512,
-                "p95": 46544,
-                "min": 46496,
-                "max": 46544,
-                "mad": 16,
-                "stdev": 16.316862
+                "median": 54352,
+                "p95": 54404,
+                "min": 54100,
+                "max": 54404,
+                "mad": 8,
+                "stdev": 108.263383
+              }
+            },
+            "node": {
+              "wall_ms": {
+                "samples": [
+                  5,
+                  6,
+                  5,
+                  5,
+                  6
+                ],
+                "sample_count": 5,
+                "median": 5,
+                "p95": 6,
+                "min": 5,
+                "max": 6,
+                "mad": 0,
+                "stdev": 0.489898
+              },
+              "rss_kb": {
+                "samples": [
+                  85788,
+                  85572,
+                  85724,
+                  85372,
+                  85564
+                ],
+                "sample_count": 5,
+                "median": 85572,
+                "p95": 85788,
+                "min": 85372,
+                "max": 85788,
+                "mad": 152,
+                "stdev": 144.709364
+              }
+            },
+            "bun": {
+              "wall_ms": {
+                "samples": [
+                  3,
+                  4,
+                  3,
+                  3,
+                  3
+                ],
+                "sample_count": 5,
+                "median": 3,
+                "p95": 4,
+                "min": 3,
+                "max": 4,
+                "mad": 0,
+                "stdev": 0.4
+              },
+              "rss_kb": {
+                "samples": [
+                  55680,
+                  55040,
+                  55160,
+                  55208,
+                  55596
+                ],
+                "sample_count": 5,
+                "median": 55208,
+                "p95": 55680,
+                "min": 55040,
+                "max": 55680,
+                "mad": 168,
+                "stdev": 253.341193
               }
             }
           },
           "ratios": {
             "perry_to_node": {
-              "wall_time": 13.6,
-              "rss": 0.298976
+              "wall_time": 0.8,
+              "rss": 0.635161
             },
             "perry_to_bun": {
-              "wall_time": 17.0,
-              "rss": 0.572755
+              "wall_time": 1.333333,
+              "rss": 0.984495
             }
           },
           "correctness": {
@@ -3232,96 +3234,62 @@
             ],
             "reason": "all 5 Perry sample(s) matched node semantic output"
           },
-          "perry_ms": 68,
-          "perry_rss_kb": 26640,
+          "perry_ms": 4,
+          "perry_rss_kb": 54352,
           "node_ms": 5,
-          "node_rss_kb": 89104,
-          "bun_ms": 4,
-          "bun_rss_kb": 46512,
-          "speed_ratio": 13.6,
-          "memory_ratio": 0.298976
+          "node_rss_kb": 85572,
+          "bun_ms": 3,
+          "bun_rss_kb": 55208,
+          "speed_ratio": 0.8,
+          "memory_ratio": 0.635161
         },
         "bench_numeric_array_downgrade": {
           "runtimes": {
             "perry": {
               "wall_ms": {
                 "samples": [
-                  18,
-                  17,
-                  18,
-                  17,
-                  17
+                  4,
+                  5,
+                  4,
+                  5,
+                  4
                 ],
                 "sample_count": 5,
-                "median": 17,
-                "p95": 18,
-                "min": 17,
-                "max": 18,
+                "median": 4,
+                "p95": 5,
+                "min": 4,
+                "max": 5,
                 "mad": 0,
                 "stdev": 0.489898
               },
               "rss_kb": {
                 "samples": [
-                  24080,
-                  24080,
-                  24080,
-                  24080,
-                  24096
+                  54756,
+                  54884,
+                  54784,
+                  54760,
+                  54400
                 ],
                 "sample_count": 5,
-                "median": 24080,
-                "p95": 24096,
-                "min": 24080,
-                "max": 24096,
-                "mad": 0,
-                "stdev": 6.4
+                "median": 54760,
+                "p95": 54884,
+                "min": 54400,
+                "max": 54884,
+                "mad": 24,
+                "stdev": 165.067744
               }
             },
             "node": {
               "wall_ms": {
                 "samples": [
+                  5,
                   6,
                   6,
                   6,
-                  7,
                   6
                 ],
                 "sample_count": 5,
                 "median": 6,
-                "p95": 7,
-                "min": 6,
-                "max": 7,
-                "mad": 0,
-                "stdev": 0.4
-              },
-              "rss_kb": {
-                "samples": [
-                  89280,
-                  89168,
-                  89168,
-                  89136,
-                  89248
-                ],
-                "sample_count": 5,
-                "median": 89168,
-                "p95": 89280,
-                "min": 89136,
-                "max": 89280,
-                "mad": 32,
-                "stdev": 54.494036
-              }
-            },
-            "bun": {
-              "wall_ms": {
-                "samples": [
-                  5,
-                  5,
-                  5,
-                  6,
-                  5
-                ],
-                "sample_count": 5,
-                "median": 5,
                 "p95": 6,
                 "min": 5,
                 "max": 6,
@@ -3330,30 +3298,64 @@
               },
               "rss_kb": {
                 "samples": [
-                  47952,
-                  47968,
-                  48000,
-                  47936,
-                  47968
+                  86244,
+                  86304,
+                  86348,
+                  86404,
+                  86364
                 ],
                 "sample_count": 5,
-                "median": 47968,
-                "p95": 48000,
-                "min": 47936,
-                "max": 48000,
-                "mad": 16,
-                "stdev": 21.226399
+                "median": 86348,
+                "p95": 86404,
+                "min": 86244,
+                "max": 86404,
+                "mad": 44,
+                "stdev": 54.751804
+              }
+            },
+            "bun": {
+              "wall_ms": {
+                "samples": [
+                  5,
+                  5,
+                  5,
+                  5,
+                  4
+                ],
+                "sample_count": 5,
+                "median": 5,
+                "p95": 5,
+                "min": 4,
+                "max": 5,
+                "mad": 0,
+                "stdev": 0.4
+              },
+              "rss_kb": {
+                "samples": [
+                  56444,
+                  56180,
+                  56416,
+                  56424,
+                  56316
+                ],
+                "sample_count": 5,
+                "median": 56416,
+                "p95": 56444,
+                "min": 56180,
+                "max": 56444,
+                "mad": 28,
+                "stdev": 98.533243
               }
             }
           },
           "ratios": {
             "perry_to_node": {
-              "wall_time": 2.833333,
-              "rss": 0.270052
+              "wall_time": 0.666667,
+              "rss": 0.634178
             },
             "perry_to_bun": {
-              "wall_time": 3.4,
-              "rss": 0.502001
+              "wall_time": 0.8,
+              "rss": 0.970647
             }
           },
           "correctness": {
@@ -3367,26 +3369,26 @@
             ],
             "reason": "all 5 Perry sample(s) matched node semantic output"
           },
-          "perry_ms": 17,
-          "perry_rss_kb": 24080,
+          "perry_ms": 4,
+          "perry_rss_kb": 54760,
           "node_ms": 6,
-          "node_rss_kb": 89168,
+          "node_rss_kb": 86348,
           "bun_ms": 5,
-          "bun_rss_kb": 47968,
-          "speed_ratio": 2.833333,
-          "memory_ratio": 0.270052
+          "bun_rss_kb": 56416,
+          "speed_ratio": 0.666667,
+          "memory_ratio": 0.634178
         }
       }
     },
     "polyglot": {
       "schema_version": 1,
       "suite": "polyglot",
-      "commit": "38ff7eccc2aa0b59629bed548daf8ac56bd9fb03",
-      "generated_at": "2026-08-08T11:25:10Z",
+      "commit": "827a92bad5a589e94e1630994185693ada903fe2",
+      "generated_at": "2026-09-01T13:54:18Z",
       "run_config": {
         "warmup": "none beyond benchmark-specific setup",
         "requested_samples": 11,
-        "pinning": "macOS scheduler hint (taskpolicy -t 0 -l 0 \u2014 P-core preferred via throughput/latency tiers, NOT strict affinity)"
+        "pinning": "Linux strict (taskset -c 0)"
       },
       "commands": {
         "perry": [
@@ -3397,11 +3399,11 @@
           "<binary>"
         ],
         "node": [
-          "/Users/perry/.cache/perry-bench-tools/bin/node",
+          "/root/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
           "<precompiled.mjs>"
         ],
         "bun": [
-          "/Users/perry/.cache/perry-bench-tools/bin/bun",
+          "/root/.cache/perry-bench-tools/bun-1.3.14/bun",
           "run",
           "<source.ts>"
         ],
@@ -3412,16 +3414,16 @@
       },
       "runtime_metadata": {
         "perry": {
-          "version": "perry 0.5.1355",
+          "version": "perry 0.5.1519",
           "resolved_executable": "target/release/perry"
         },
         "node": {
           "version": "v22.23.1",
-          "resolved_executable": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node"
+          "resolved_executable": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node"
         },
         "bun": {
           "version": "1.3.14",
-          "resolved_executable": "~/.cache/perry-bench-tools/bun/bun"
+          "resolved_executable": "~/.cache/perry-bench-tools/bun-1.3.14/bun"
         }
       },
       "benchmarks": {
@@ -3435,72 +3437,72 @@
             "perry": {
               "wall_ms": {
                 "samples": [
-                  94.0,
-                  94.0,
-                  94.0,
-                  93.0,
-                  94.0,
-                  94.0,
-                  94.0,
-                  94.0,
-                  94.0,
-                  93.0,
-                  93.0
+                  57.0,
+                  57.0,
+                  57.0,
+                  58.0,
+                  57.0,
+                  58.0,
+                  58.0,
+                  59.0,
+                  58.0,
+                  62.0,
+                  58.0
                 ],
                 "sample_count": 11,
-                "median": 94.0,
-                "p95": 94.0,
-                "min": 93.0,
-                "max": 94.0,
-                "stdev": 0.4453617714151233
+                "median": 58.0,
+                "p95": 62.0,
+                "min": 57.0,
+                "max": 62.0,
+                "stdev": 1.378704626191191
               },
               "output_sha256": "45e7000362b678343915ceae0bbf34e9c236096552f86ca83f6cb91d6b0b5c67"
             },
             "node": {
               "wall_ms": {
                 "samples": [
-                  95.0,
-                  94.0,
-                  94.0,
-                  94.0,
-                  95.0,
-                  95.0,
-                  94.0,
-                  95.0,
-                  94.0,
-                  95.0,
-                  94.0
+                  168.0,
+                  172.0,
+                  164.0,
+                  162.0,
+                  165.0,
+                  157.0,
+                  159.0,
+                  131.0,
+                  166.0,
+                  101.0,
+                  101.0
                 ],
                 "sample_count": 11,
-                "median": 94.0,
-                "p95": 95.0,
-                "min": 94.0,
-                "max": 95.0,
-                "stdev": 0.49792959773196915
+                "median": 162.0,
+                "p95": 172.0,
+                "min": 101.0,
+                "max": 172.0,
+                "stdev": 25.082673220128843
               },
               "output_sha256": "45e7000362b678343915ceae0bbf34e9c236096552f86ca83f6cb91d6b0b5c67"
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  96.0,
-                  95.0,
-                  95.0,
-                  95.0,
-                  95.0,
-                  95.0,
-                  95.0,
-                  95.0,
-                  95.0,
-                  95.0,
-                  95.0
+                  72.0,
+                  72.0,
+                  69.0,
+                  72.0,
+                  76.0,
+                  72.0,
+                  70.0,
+                  72.0,
+                  73.0,
+                  71.0,
+                  72.0
                 ],
                 "sample_count": 11,
-                "median": 95.0,
-                "p95": 96.0,
-                "min": 95.0,
-                "max": 96.0,
-                "stdev": 0.28747978728803447
+                "median": 72.0,
+                "p95": 76.0,
+                "min": 69.0,
+                "max": 76.0,
+                "stdev": 1.6762808104168887
               },
               "output_sha256": "45e7000362b678343915ceae0bbf34e9c236096552f86ca83f6cb91d6b0b5c67"
             }
@@ -3516,72 +3518,72 @@
             "perry": {
               "wall_ms": {
                 "samples": [
-                  22.0,
-                  23.0,
-                  22.0,
-                  22.0,
-                  22.0,
-                  23.0,
-                  22.0,
-                  22.0,
-                  22.0,
-                  22.0,
-                  23.0
+                  6.0,
+                  5.0,
+                  6.0,
+                  6.0,
+                  5.0,
+                  5.0,
+                  6.0,
+                  6.0,
+                  6.0,
+                  5.0,
+                  6.0
                 ],
                 "sample_count": 11,
-                "median": 22.0,
-                "p95": 23.0,
-                "min": 22.0,
-                "max": 23.0,
-                "stdev": 0.4453617714151233
+                "median": 6.0,
+                "p95": 6.0,
+                "min": 5.0,
+                "max": 6.0,
+                "stdev": 0.48104569292083466
               },
               "output_sha256": "9a59b9a771dcc3170ca6608099bc1dbe482831939679e81ae72f7bf4bd249674"
             },
             "node": {
               "wall_ms": {
                 "samples": [
-                  11.0,
-                  11.0,
-                  11.0,
-                  10.0,
-                  11.0,
-                  10.0,
-                  11.0,
-                  11.0,
-                  10.0,
-                  11.0,
-                  10.0
+                  7.0,
+                  7.0,
+                  7.0,
+                  7.0,
+                  7.0,
+                  7.0,
+                  7.0,
+                  7.0,
+                  8.0,
+                  8.0,
+                  7.0
                 ],
                 "sample_count": 11,
-                "median": 11.0,
-                "p95": 11.0,
-                "min": 10.0,
-                "max": 11.0,
-                "stdev": 0.48104569292083466
+                "median": 7.0,
+                "p95": 8.0,
+                "min": 7.0,
+                "max": 8.0,
+                "stdev": 0.38569460791993504
               },
               "output_sha256": "9a59b9a771dcc3170ca6608099bc1dbe482831939679e81ae72f7bf4bd249674"
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  14.0,
-                  14.0,
-                  13.0,
-                  14.0,
-                  14.0,
-                  14.0,
-                  13.0,
-                  14.0,
-                  14.0,
-                  14.0,
-                  13.0
+                  16.0,
+                  17.0,
+                  17.0,
+                  17.0,
+                  16.0,
+                  18.0,
+                  17.0,
+                  17.0,
+                  18.0,
+                  16.0,
+                  18.0
                 ],
                 "sample_count": 11,
-                "median": 14.0,
-                "p95": 14.0,
-                "min": 13.0,
-                "max": 14.0,
-                "stdev": 0.4453617714151233
+                "median": 17.0,
+                "p95": 18.0,
+                "min": 16.0,
+                "max": 18.0,
+                "stdev": 0.7385489458759964
               },
               "output_sha256": "9a59b9a771dcc3170ca6608099bc1dbe482831939679e81ae72f7bf4bd249674"
             }
@@ -3597,60 +3599,36 @@
             "perry": {
               "wall_ms": {
                 "samples": [
-                  1.0,
-                  2.0,
-                  2.0,
-                  1.0,
-                  1.0,
-                  1.0,
-                  2.0,
-                  1.0,
-                  1.0,
-                  1.0,
-                  2.0
+                  3.0,
+                  3.0,
+                  4.0,
+                  4.0,
+                  3.0,
+                  4.0,
+                  4.0,
+                  3.0,
+                  3.0,
+                  4.0,
+                  4.0
                 ],
                 "sample_count": 11,
-                "median": 1.0,
-                "p95": 2.0,
-                "min": 1.0,
-                "max": 2.0,
-                "stdev": 0.48104569292083466
+                "median": 4.0,
+                "p95": 4.0,
+                "min": 3.0,
+                "max": 4.0,
+                "stdev": 0.4979295977319692
               },
               "output_sha256": "a76ae1255a79f86acf51281a91633021374b072ef8c7fc75e6f1adf69e1e9ed4"
             },
             "node": {
               "wall_ms": {
                 "samples": [
-                  7.0,
-                  7.0,
-                  7.0,
-                  7.0,
-                  7.0,
-                  7.0,
-                  7.0,
-                  7.0,
-                  7.0,
-                  7.0,
-                  7.0
-                ],
-                "sample_count": 11,
-                "median": 7.0,
-                "p95": 7.0,
-                "min": 7.0,
-                "max": 7.0,
-                "stdev": 0.0
-              },
-              "output_sha256": "a76ae1255a79f86acf51281a91633021374b072ef8c7fc75e6f1adf69e1e9ed4"
-            },
-            "bun": {
-              "wall_ms": {
-                "samples": [
+                  4.0,
                   5.0,
+                  4.0,
                   5.0,
-                  5.0,
-                  5.0,
-                  5.0,
-                  5.0,
+                  4.0,
+                  4.0,
                   5.0,
                   5.0,
                   5.0,
@@ -3660,9 +3638,33 @@
                 "sample_count": 11,
                 "median": 5.0,
                 "p95": 5.0,
-                "min": 5.0,
+                "min": 4.0,
                 "max": 5.0,
-                "stdev": 0.0
+                "stdev": 0.48104569292083466
+              },
+              "output_sha256": "a76ae1255a79f86acf51281a91633021374b072ef8c7fc75e6f1adf69e1e9ed4"
+            },
+            "bun": {
+              "wall_ms": {
+                "samples": [
+                  9.0,
+                  9.0,
+                  11.0,
+                  9.0,
+                  10.0,
+                  9.0,
+                  9.0,
+                  10.0,
+                  9.0,
+                  11.0,
+                  10.0
+                ],
+                "sample_count": 11,
+                "median": 9.0,
+                "p95": 11.0,
+                "min": 9.0,
+                "max": 11.0,
+                "stdev": 0.7713892158398701
               },
               "output_sha256": "a76ae1255a79f86acf51281a91633021374b072ef8c7fc75e6f1adf69e1e9ed4"
             }
@@ -3678,72 +3680,72 @@
             "perry": {
               "wall_ms": {
                 "samples": [
-                  389.0,
-                  390.0,
-                  391.0,
-                  390.0,
-                  390.0,
-                  390.0,
-                  390.0,
-                  390.0,
-                  390.0,
-                  390.0,
-                  390.0
+                  322.0,
+                  323.0,
+                  323.0,
+                  323.0,
+                  323.0,
+                  325.0,
+                  323.0,
+                  322.0,
+                  322.0,
+                  323.0,
+                  322.0
                 ],
                 "sample_count": 11,
-                "median": 390.0,
-                "p95": 391.0,
-                "min": 389.0,
-                "max": 391.0,
-                "stdev": 0.4264014327112209
+                "median": 323.0,
+                "p95": 325.0,
+                "min": 322.0,
+                "max": 325.0,
+                "stdev": 0.8331955809010618
               },
               "output_sha256": "834774a30aeb60ab0f0a8dac4482efb07689d7b249da0942aa1260a78a3fa77d"
             },
             "node": {
               "wall_ms": {
                 "samples": [
-                  912.0,
-                  913.0,
-                  912.0,
-                  912.0,
-                  913.0,
-                  912.0,
-                  913.0,
-                  912.0,
-                  913.0,
-                  912.0,
-                  913.0
+                  708.0,
+                  709.0,
+                  708.0,
+                  713.0,
+                  709.0,
+                  709.0,
+                  709.0,
+                  708.0,
+                  707.0,
+                  707.0,
+                  706.0
                 ],
                 "sample_count": 11,
-                "median": 912.0,
-                "p95": 913.0,
-                "min": 912.0,
-                "max": 913.0,
-                "stdev": 0.49792959773196915
+                "median": 708.0,
+                "p95": 713.0,
+                "min": 706.0,
+                "max": 713.0,
+                "stdev": 1.7248787237282068
               },
               "output_sha256": "834774a30aeb60ab0f0a8dac4482efb07689d7b249da0942aa1260a78a3fa77d"
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  504.0,
-                  500.0,
-                  499.0,
-                  500.0,
-                  500.0,
-                  504.0,
-                  500.0,
-                  500.0,
-                  499.0,
-                  500.0,
-                  500.0
+                  676.0,
+                  685.0,
+                  694.0,
+                  549.0,
+                  466.0,
+                  442.0,
+                  458.0,
+                  464.0,
+                  469.0,
+                  477.0,
+                  440.0
                 ],
                 "sample_count": 11,
-                "median": 500.0,
-                "p95": 504.0,
-                "min": 499.0,
-                "max": 504.0,
-                "stdev": 1.6713433009863852
+                "median": 469.0,
+                "p95": 694.0,
+                "min": 440.0,
+                "max": 694.0,
+                "stdev": 99.36109952679446
               },
               "output_sha256": "834774a30aeb60ab0f0a8dac4482efb07689d7b249da0942aa1260a78a3fa77d"
             }
@@ -3759,23 +3761,23 @@
             "perry": {
               "wall_ms": {
                 "samples": [
-                  219.0,
-                  219.0,
-                  219.0,
-                  219.0,
-                  219.0,
-                  219.0,
-                  219.0,
-                  219.0,
-                  219.0,
-                  220.0,
-                  219.0
+                  112.0,
+                  111.0,
+                  112.0,
+                  112.0,
+                  112.0,
+                  112.0,
+                  112.0,
+                  112.0,
+                  112.0,
+                  112.0,
+                  112.0
                 ],
                 "sample_count": 11,
-                "median": 219.0,
-                "p95": 220.0,
-                "min": 219.0,
-                "max": 220.0,
+                "median": 112.0,
+                "p95": 112.0,
+                "min": 111.0,
+                "max": 112.0,
                 "stdev": 0.28747978728803447
               },
               "output_sha256": "6cb3a76d1ca7915e12bb42333de96a572ad2f85a93f3d7bb6c2148d08be2bb2d"
@@ -3783,48 +3785,48 @@
             "node": {
               "wall_ms": {
                 "samples": [
-                  221.0,
-                  221.0,
-                  221.0,
-                  225.0,
-                  221.0,
-                  221.0,
-                  221.0,
-                  222.0,
-                  225.0,
-                  221.0,
-                  221.0
+                  116.0,
+                  116.0,
+                  116.0,
+                  115.0,
+                  115.0,
+                  115.0,
+                  115.0,
+                  116.0,
+                  115.0,
+                  115.0,
+                  115.0
                 ],
                 "sample_count": 11,
-                "median": 221.0,
-                "p95": 225.0,
-                "min": 221.0,
-                "max": 225.0,
-                "stdev": 1.526623238522424
+                "median": 115.0,
+                "p95": 116.0,
+                "min": 115.0,
+                "max": 116.0,
+                "stdev": 0.48104569292083466
               },
               "output_sha256": "6cb3a76d1ca7915e12bb42333de96a572ad2f85a93f3d7bb6c2148d08be2bb2d"
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  221.0,
-                  221.0,
-                  221.0,
-                  221.0,
-                  221.0,
-                  221.0,
-                  221.0,
-                  221.0,
-                  221.0,
-                  221.0,
-                  221.0
+                  125.0,
+                  124.0,
+                  124.0,
+                  124.0,
+                  127.0,
+                  125.0,
+                  124.0,
+                  125.0,
+                  123.0,
+                  122.0,
+                  122.0
                 ],
                 "sample_count": 11,
-                "median": 221.0,
-                "p95": 221.0,
-                "min": 221.0,
-                "max": 221.0,
-                "stdev": 0.0
+                "median": 124.0,
+                "p95": 127.0,
+                "min": 122.0,
+                "max": 127.0,
+                "stdev": 1.378704626191191
               },
               "output_sha256": "6cb3a76d1ca7915e12bb42333de96a572ad2f85a93f3d7bb6c2148d08be2bb2d"
             }
@@ -3834,80 +3836,80 @@
           "correctness": {
             "status": "pass",
             "reference": "node+bun",
-            "output_sha256": "d68797a2b161b634fec27feb8b6bc77e100157293c334376792cb0341b9c5f51"
+            "output_sha256": "bbdf35a7b000c5e4255d4405e5c3ea7a863991e0ae764edbdcdb3809dc331b65"
           },
           "runtimes": {
             "perry": {
               "wall_ms": {
                 "samples": [
-                  94.0,
-                  94.0,
-                  93.0,
-                  93.0,
-                  94.0,
-                  94.0,
-                  94.0,
-                  93.0,
-                  94.0,
-                  94.0,
-                  93.0
+                  74.0,
+                  74.0,
+                  74.0,
+                  74.0,
+                  74.0,
+                  74.0,
+                  75.0,
+                  75.0,
+                  74.0,
+                  74.0,
+                  75.0
                 ],
                 "sample_count": 11,
-                "median": 94.0,
-                "p95": 94.0,
-                "min": 93.0,
-                "max": 94.0,
-                "stdev": 0.48104569292083466
+                "median": 74.0,
+                "p95": 75.0,
+                "min": 74.0,
+                "max": 75.0,
+                "stdev": 0.4453617714151233
               },
-              "output_sha256": "d68797a2b161b634fec27feb8b6bc77e100157293c334376792cb0341b9c5f51"
+              "output_sha256": "bbdf35a7b000c5e4255d4405e5c3ea7a863991e0ae764edbdcdb3809dc331b65"
             },
             "node": {
               "wall_ms": {
                 "samples": [
-                  64.0,
-                  63.0,
-                  64.0,
-                  63.0,
-                  63.0,
-                  64.0,
-                  63.0,
-                  63.0,
-                  63.0,
-                  63.0,
-                  63.0
+                  79.0,
+                  77.0,
+                  76.0,
+                  76.0,
+                  77.0,
+                  76.0,
+                  76.0,
+                  76.0,
+                  76.0,
+                  77.0,
+                  76.0
                 ],
                 "sample_count": 11,
-                "median": 63.0,
-                "p95": 64.0,
-                "min": 63.0,
-                "max": 64.0,
-                "stdev": 0.4453617714151233
+                "median": 76.0,
+                "p95": 79.0,
+                "min": 76.0,
+                "max": 79.0,
+                "stdev": 0.8907235428302466
               },
-              "output_sha256": "d68797a2b161b634fec27feb8b6bc77e100157293c334376792cb0341b9c5f51"
+              "output_sha256": "bbdf35a7b000c5e4255d4405e5c3ea7a863991e0ae764edbdcdb3809dc331b65"
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  39.0,
-                  39.0,
-                  39.0,
-                  39.0,
-                  40.0,
-                  39.0,
-                  39.0,
-                  40.0,
-                  39.0,
-                  39.0,
-                  39.0
+                  84.0,
+                  83.0,
+                  83.0,
+                  81.0,
+                  83.0,
+                  81.0,
+                  81.0,
+                  84.0,
+                  81.0,
+                  81.0,
+                  83.0
                 ],
                 "sample_count": 11,
-                "median": 39.0,
-                "p95": 40.0,
-                "min": 39.0,
-                "max": 40.0,
-                "stdev": 0.38569460791993504
+                "median": 83.0,
+                "p95": 84.0,
+                "min": 81.0,
+                "max": 84.0,
+                "stdev": 1.2128785512842122
               },
-              "output_sha256": "d68797a2b161b634fec27feb8b6bc77e100157293c334376792cb0341b9c5f51"
+              "output_sha256": "bbdf35a7b000c5e4255d4405e5c3ea7a863991e0ae764edbdcdb3809dc331b65"
             }
           }
         },
@@ -3921,72 +3923,72 @@
             "perry": {
               "wall_ms": {
                 "samples": [
-                  49.0,
-                  49.0,
-                  49.0,
-                  49.0,
-                  49.0,
-                  49.0,
-                  49.0,
-                  49.0,
-                  49.0,
-                  49.0,
-                  49.0
+                  51.0,
+                  54.0,
+                  55.0,
+                  55.0,
+                  53.0,
+                  53.0,
+                  50.0,
+                  45.0,
+                  44.0,
+                  44.0,
+                  51.0
                 ],
                 "sample_count": 11,
-                "median": 49.0,
-                "p95": 49.0,
-                "min": 49.0,
-                "max": 49.0,
-                "stdev": 0.0
+                "median": 51.0,
+                "p95": 55.0,
+                "min": 44.0,
+                "max": 55.0,
+                "stdev": 4.053363056292355
               },
               "output_sha256": "02dbcc45c8e22eb2287af9c9106f65c992f093273c79f14f5fa49a4fc7ef0289"
             },
             "node": {
               "wall_ms": {
                 "samples": [
-                  49.0,
-                  48.0,
-                  49.0,
-                  48.0,
-                  49.0,
-                  49.0,
-                  48.0,
-                  49.0,
-                  49.0,
-                  49.0,
-                  48.0
+                  43.0,
+                  44.0,
+                  44.0,
+                  44.0,
+                  45.0,
+                  44.0,
+                  45.0,
+                  44.0,
+                  45.0,
+                  44.0,
+                  45.0
                 ],
                 "sample_count": 11,
-                "median": 49.0,
-                "p95": 49.0,
-                "min": 48.0,
-                "max": 49.0,
-                "stdev": 0.48104569292083466
+                "median": 44.0,
+                "p95": 45.0,
+                "min": 43.0,
+                "max": 45.0,
+                "stdev": 0.616575453011388
               },
               "output_sha256": "02dbcc45c8e22eb2287af9c9106f65c992f093273c79f14f5fa49a4fc7ef0289"
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  49.0,
-                  49.0,
-                  49.0,
-                  49.0,
-                  48.0,
-                  49.0,
-                  49.0,
-                  49.0,
-                  49.0,
-                  49.0,
-                  49.0
+                  54.0,
+                  55.0,
+                  52.0,
+                  55.0,
+                  56.0,
+                  56.0,
+                  55.0,
+                  53.0,
+                  56.0,
+                  54.0,
+                  53.0
                 ],
                 "sample_count": 11,
-                "median": 49.0,
-                "p95": 49.0,
-                "min": 48.0,
-                "max": 49.0,
-                "stdev": 0.28747978728803447
+                "median": 55.0,
+                "p95": 56.0,
+                "min": 52.0,
+                "max": 56.0,
+                "stdev": 1.3047909176733932
               },
               "output_sha256": "02dbcc45c8e22eb2287af9c9106f65c992f093273c79f14f5fa49a4fc7ef0289"
             }
@@ -4002,72 +4004,72 @@
             "perry": {
               "wall_ms": {
                 "samples": [
-                  40.0,
-                  40.0,
-                  40.0,
-                  40.0,
-                  40.0,
-                  40.0,
-                  39.0,
-                  39.0,
-                  40.0,
-                  40.0,
-                  39.0
+                  26.0,
+                  26.0,
+                  25.0,
+                  25.0,
+                  26.0,
+                  25.0,
+                  26.0,
+                  26.0,
+                  26.0,
+                  25.0,
+                  26.0
                 ],
                 "sample_count": 11,
-                "median": 40.0,
-                "p95": 40.0,
-                "min": 39.0,
-                "max": 40.0,
-                "stdev": 0.4453617714151233
+                "median": 26.0,
+                "p95": 26.0,
+                "min": 25.0,
+                "max": 26.0,
+                "stdev": 0.48104569292083466
               },
               "output_sha256": "8e77f4e216b88148ae91a1b1fafd99b59948aa3d0a447313af68e39a25cc21e2"
             },
             "node": {
               "wall_ms": {
                 "samples": [
+                  13.0,
+                  14.0,
+                  15.0,
+                  15.0,
                   18.0,
-                  18.0,
-                  18.0,
-                  18.0,
-                  18.0,
-                  18.0,
-                  18.0,
-                  18.0,
-                  18.0,
-                  18.0,
-                  18.0
+                  15.0,
+                  17.0,
+                  14.0,
+                  14.0,
+                  15.0,
+                  14.0
                 ],
                 "sample_count": 11,
-                "median": 18.0,
+                "median": 15.0,
                 "p95": 18.0,
-                "min": 18.0,
+                "min": 13.0,
                 "max": 18.0,
-                "stdev": 0.0
+                "stdev": 1.378704626191191
               },
               "output_sha256": "8e77f4e216b88148ae91a1b1fafd99b59948aa3d0a447313af68e39a25cc21e2"
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  19.0,
-                  18.0,
-                  18.0,
-                  18.0,
-                  18.0,
-                  18.0,
-                  19.0,
-                  19.0,
-                  19.0,
-                  19.0,
-                  19.0
+                  27.0,
+                  26.0,
+                  27.0,
+                  24.0,
+                  26.0,
+                  22.0,
+                  26.0,
+                  22.0,
+                  22.0,
+                  25.0,
+                  26.0
                 ],
                 "sample_count": 11,
-                "median": 19.0,
-                "p95": 19.0,
-                "min": 18.0,
-                "max": 19.0,
-                "stdev": 0.49792959773196915
+                "median": 26.0,
+                "p95": 27.0,
+                "min": 22.0,
+                "max": 27.0,
+                "stdev": 1.8982375470746455
               },
               "output_sha256": "8e77f4e216b88148ae91a1b1fafd99b59948aa3d0a447313af68e39a25cc21e2"
             }
@@ -4083,24 +4085,24 @@
             "perry": {
               "wall_ms": {
                 "samples": [
-                  2.0,
+                  4.0,
+                  4.0,
+                  4.0,
+                  4.0,
+                  4.0,
+                  4.0,
+                  4.0,
                   3.0,
                   3.0,
                   3.0,
-                  3.0,
-                  3.0,
-                  3.0,
-                  3.0,
-                  3.0,
-                  2.0,
-                  3.0
+                  4.0
                 ],
                 "sample_count": 11,
-                "median": 3.0,
-                "p95": 3.0,
-                "min": 2.0,
-                "max": 3.0,
-                "stdev": 0.385694607919935
+                "median": 4.0,
+                "p95": 4.0,
+                "min": 3.0,
+                "max": 4.0,
+                "stdev": 0.4453617714151233
               },
               "output_sha256": "e70c38907b55a22165abecab6fbc7e4901cc69e6aeee9fb0c32635455ec55134"
             },
@@ -4108,47 +4110,47 @@
               "wall_ms": {
                 "samples": [
                   5.0,
-                  4.0,
-                  4.0,
                   5.0,
                   5.0,
+                  7.0,
+                  8.0,
+                  8.0,
+                  7.0,
                   5.0,
-                  5.0,
-                  5.0,
-                  4.0,
-                  5.0,
-                  5.0
+                  7.0,
+                  7.0,
+                  8.0
                 ],
                 "sample_count": 11,
-                "median": 5.0,
-                "p95": 5.0,
-                "min": 4.0,
-                "max": 5.0,
-                "stdev": 0.4453617714151233
+                "median": 7.0,
+                "p95": 8.0,
+                "min": 5.0,
+                "max": 8.0,
+                "stdev": 1.233150906022776
               },
               "output_sha256": "e70c38907b55a22165abecab6fbc7e4901cc69e6aeee9fb0c32635455ec55134"
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  6.0,
-                  6.0,
-                  5.0,
-                  5.0,
-                  5.0,
-                  5.0,
-                  6.0,
-                  6.0,
-                  6.0,
-                  5.0,
-                  5.0
+                  17.0,
+                  20.0,
+                  20.0,
+                  20.0,
+                  20.0,
+                  20.0,
+                  21.0,
+                  20.0,
+                  15.0,
+                  20.0,
+                  20.0
                 ],
                 "sample_count": 11,
-                "median": 5.0,
-                "p95": 6.0,
-                "min": 5.0,
-                "max": 6.0,
-                "stdev": 0.4979295977319692
+                "median": 20.0,
+                "p95": 21.0,
+                "min": 15.0,
+                "max": 21.0,
+                "stdev": 1.6663911618021237
               },
               "output_sha256": "e70c38907b55a22165abecab6fbc7e4901cc69e6aeee9fb0c32635455ec55134"
             }
@@ -4159,27 +4161,27 @@
     "json_polyglot": {
       "schema_version": 1,
       "suite": "json_polyglot",
-      "commit": "38ff7eccc2aa0b59629bed548daf8ac56bd9fb03",
-      "generated_at": "2026-08-08T11:30:48Z",
+      "commit": "827a92bad5a589e94e1630994185693ada903fe2",
+      "generated_at": "2026-09-01T13:56:31Z",
       "run_config": {
         "warmup": "3 untimed iterations inside each benchmark process",
         "requested_samples": 11,
-        "pinning": "macOS scheduler hint (taskpolicy -t 0 -l 0 \u2014 P-core preferred via throughput/latency tiers, NOT strict affinity)"
+        "pinning": "Linux strict (taskset -c 0)"
       },
       "commands": {
         "perry": [
-          "/Users/perry/projects/perry/baseline-1355/target/release/perry",
+          "/root/perry-issue-9338-public-827a92b/target/release/perry",
           "compile",
           "bench.ts",
           "-o",
           "<binary>"
         ],
         "node": [
-          "/Users/perry/.cache/perry-bench-tools/bin/node",
+          "/root/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
           "<precompiled.mjs>"
         ],
         "bun": [
-          "/Users/perry/.cache/perry-bench-tools/bin/bun",
+          "/root/.cache/perry-bench-tools/bun-1.3.14/bun",
           "bench.ts"
         ],
         "runner": [
@@ -4188,16 +4190,16 @@
       },
       "runtime_metadata": {
         "perry": {
-          "version": "perry 0.5.1355",
+          "version": "perry 0.5.1519",
           "resolved_executable": "target/release/perry"
         },
         "node": {
           "version": "v22.23.1",
-          "resolved_executable": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node"
+          "resolved_executable": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node"
         },
         "bun": {
           "version": "1.3.14",
-          "resolved_executable": "~/.cache/perry-bench-tools/bun/bun"
+          "resolved_executable": "~/.cache/perry-bench-tools/bun-1.3.14/bun"
         }
       },
       "benchmarks": {
@@ -4211,70 +4213,70 @@
             "perry": {
               "wall_ms": {
                 "samples": [
-                  190.0,
-                  183.0,
+                  186.0,
+                  185.0,
+                  186.0,
+                  184.0,
+                  186.0,
+                  186.0,
+                  188.0,
+                  188.0,
                   184.0,
                   184.0,
-                  184.0,
-                  184.0,
-                  183.0,
-                  184.0,
-                  183.0,
-                  184.0,
-                  183.0
+                  185.0
                 ],
                 "sample_count": 11,
-                "median": 184.0,
-                "p95": 190.0,
-                "min": 183.0,
-                "max": 190.0,
-                "stdev": 1.8982375470746453
+                "median": 186.0,
+                "p95": 188.0,
+                "min": 184.0,
+                "max": 188.0,
+                "stdev": 1.3666633071248098
               }
             },
             "node": {
               "wall_ms": {
                 "samples": [
-                  389.0,
-                  376.0,
-                  373.0,
-                  380.0,
+                  463.0,
+                  560.0,
+                  383.0,
+                  383.0,
+                  384.0,
+                  407.0,
+                  471.0,
+                  669.0,
+                  447.0,
                   382.0,
-                  380.0,
-                  383.0,
-                  383.0,
-                  380.0,
-                  379.0,
-                  380.0
+                  378.0
                 ],
                 "sample_count": 11,
-                "median": 380.0,
-                "p95": 389.0,
-                "min": 373.0,
-                "max": 389.0,
-                "stdev": 3.8932023827934286
+                "median": 407.0,
+                "p95": 669.0,
+                "min": 378.0,
+                "max": 669.0,
+                "stdev": 88.22641796223103
               }
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  220.0,
-                  220.0,
-                  220.0,
-                  219.0,
-                  232.0,
-                  220.0,
-                  221.0,
-                  220.0,
-                  219.0,
-                  220.0,
-                  220.0
+                  189.0,
+                  189.0,
+                  195.0,
+                  192.0,
+                  189.0,
+                  189.0,
+                  191.0,
+                  190.0,
+                  194.0,
+                  188.0,
+                  188.0
                 ],
                 "sample_count": 11,
-                "median": 220.0,
-                "p95": 232.0,
-                "min": 219.0,
-                "max": 232.0,
-                "stdev": 3.5161962919661303
+                "median": 189.0,
+                "p95": 195.0,
+                "min": 188.0,
+                "max": 195.0,
+                "stdev": 2.2672661660618045
               }
             }
           }
@@ -4289,70 +4291,70 @@
             "perry": {
               "wall_ms": {
                 "samples": [
-                  2035.0,
-                  2009.0,
-                  2024.0,
-                  2022.0,
-                  2040.0,
-                  2048.0,
-                  1804.0,
-                  2046.0,
-                  2034.0,
-                  2030.0,
-                  1937.0
+                  1013.0,
+                  758.0,
+                  885.0,
+                  951.0,
+                  895.0,
+                  880.0,
+                  643.0,
+                  551.0,
+                  550.0,
+                  548.0,
+                  548.0
                 ],
                 "sample_count": 11,
-                "median": 2030.0,
-                "p95": 2048.0,
-                "min": 1804.0,
-                "max": 2048.0,
-                "stdev": 69.24957857078557
+                "median": 758.0,
+                "p95": 1013.0,
+                "min": 548.0,
+                "max": 1013.0,
+                "stdev": 175.38807030870592
               }
             },
             "node": {
               "wall_ms": {
                 "samples": [
+                  385.0,
+                  382.0,
+                  382.0,
+                  377.0,
+                  382.0,
+                  379.0,
                   381.0,
-                  386.0,
-                  378.0,
-                  385.0,
-                  386.0,
-                  379.0,
-                  379.0,
-                  379.0,
-                  395.0,
-                  385.0,
-                  389.0
+                  383.0,
+                  380.0,
+                  383.0,
+                  377.0
                 ],
                 "sample_count": 11,
-                "median": 385.0,
-                "p95": 395.0,
-                "min": 378.0,
-                "max": 395.0,
-                "stdev": 5.005781781067711
+                "median": 382.0,
+                "p95": 385.0,
+                "min": 377.0,
+                "max": 385.0,
+                "stdev": 2.412090756622109
               }
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  222.0,
-                  222.0,
-                  221.0,
-                  220.0,
-                  222.0,
-                  222.0,
-                  221.0,
-                  221.0,
-                  222.0,
-                  221.0,
-                  222.0
+                  204.0,
+                  202.0,
+                  206.0,
+                  203.0,
+                  198.0,
+                  198.0,
+                  198.0,
+                  198.0,
+                  205.0,
+                  198.0,
+                  198.0
                 ],
                 "sample_count": 11,
-                "median": 222.0,
-                "p95": 222.0,
-                "min": 220.0,
-                "max": 222.0,
-                "stdev": 0.6555547773570889
+                "median": 198.0,
+                "p95": 206.0,
+                "min": 198.0,
+                "max": 206.0,
+                "stdev": 3.13603423830188
               }
             }
           }
@@ -4362,8 +4364,8 @@
     "app_patterns": {
       "schema_version": 1,
       "suite": "app_patterns",
-      "commit": "38ff7eccc2aa0b59629bed548daf8ac56bd9fb03",
-      "generated_at": "2026-08-08T11:35:56Z",
+      "commit": "827a92bad5a589e94e1630994185693ada903fe2",
+      "generated_at": "2026-09-01T14:02:47Z",
       "run_config": {
         "warmup": 3,
         "requested_samples": 15,
@@ -4371,18 +4373,18 @@
       },
       "commands": {
         "perry": [
-          "/Users/perry/projects/perry/baseline-1355/target/release/perry",
+          "/root/perry-issue-9338-public-827a92b/target/release/perry",
           "<kernel.ts>",
           "-o",
           "<compiled-kernel>"
         ],
         "node": [
-          "/Users/perry/.cache/perry-bench-tools/bin/node",
+          "/root/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
           "--experimental-strip-types",
           "<kernel.ts>"
         ],
         "bun": [
-          "/Users/perry/.cache/perry-bench-tools/bin/bun",
+          "/root/.cache/perry-bench-tools/bun-1.3.14/bun",
           "run",
           "<kernel.ts>"
         ],
@@ -4396,16 +4398,16 @@
       },
       "runtime_metadata": {
         "perry": {
-          "version": "perry 0.5.1355",
+          "version": "perry 0.5.1519",
           "resolved_executable": "target/release/perry"
         },
         "node": {
           "version": "v22.23.1",
-          "resolved_executable": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node"
+          "resolved_executable": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node"
         },
         "bun": {
           "version": "1.3.14",
-          "resolved_executable": "~/.cache/perry-bench-tools/bun/bun"
+          "resolved_executable": "~/.cache/perry-bench-tools/bun-1.3.14/bun"
         }
       },
       "benchmarks": {
@@ -4419,82 +4421,82 @@
             "perry": {
               "wall_ms": {
                 "samples": [
-                  114.394625,
-                  114.049667,
-                  113.88925,
-                  114.166792,
-                  113.89025,
-                  113.811125,
-                  114.369792,
-                  114.6075,
-                  114.009042,
-                  113.641542,
-                  114.472,
-                  114.486375,
-                  114.749958,
-                  114.483458,
-                  114.158959
+                  60.241799,
+                  60.191896,
+                  60.34418,
+                  60.621277,
+                  60.674898,
+                  60.461308,
+                  60.748054,
+                  60.877936,
+                  60.484351,
+                  60.582014,
+                  60.288216,
+                  62.016833,
+                  60.720603,
+                  59.996601,
+                  60.137985
                 ],
                 "sample_count": 15,
-                "median": 114.166792,
-                "p95": 114.749958,
-                "min": 113.641542,
-                "max": 114.749958,
-                "stdev": 0.31483912596195723
+                "median": 60.484351,
+                "p95": 62.016833,
+                "min": 59.996601,
+                "max": 62.016833,
+                "stdev": 0.45972527311014266
               }
             },
             "node": {
               "wall_ms": {
                 "samples": [
-                  69.831125,
-                  70.245959,
-                  68.8325,
-                  69.855916,
-                  69.103959,
-                  69.29725,
-                  70.579458,
-                  69.482208,
-                  70.601625,
-                  69.107916,
-                  70.076375,
-                  69.527,
-                  69.329041,
-                  69.916417,
-                  69.558834
+                  62.181029,
+                  62.274915,
+                  62.357991,
+                  63.878229,
+                  61.489187,
+                  63.53643,
+                  62.334807,
+                  63.086982,
+                  62.253876,
+                  63.868862,
+                  63.693334,
+                  63.433498,
+                  63.56263,
+                  63.24122,
+                  62.826505
                 ],
                 "sample_count": 15,
-                "median": 69.558834,
-                "p95": 70.601625,
-                "min": 68.8325,
-                "max": 70.601625,
-                "stdev": 0.5143504998438141
+                "median": 63.086982,
+                "p95": 63.878229,
+                "min": 61.489187,
+                "max": 63.878229,
+                "stdev": 0.7174624891472258
               }
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  24.360917,
-                  24.34825,
-                  24.755333,
-                  24.473125,
-                  24.669,
-                  24.557083,
-                  24.623417,
-                  24.488334,
-                  24.6255,
-                  24.54175,
-                  24.464042,
-                  24.492208,
-                  24.589125,
-                  24.676291,
-                  24.777541
+                  26.592804,
+                  22.325065,
+                  22.246278,
+                  23.399131,
+                  22.249424,
+                  25.043612,
+                  21.958521,
+                  22.168903,
+                  22.646976,
+                  21.632702,
+                  21.948442,
+                  22.629343,
+                  22.244054,
+                  21.7922,
+                  23.477577
                 ],
                 "sample_count": 15,
-                "median": 24.557083,
-                "p95": 24.777541,
-                "min": 24.34825,
-                "max": 24.777541,
-                "stdev": 0.12415780675726074
+                "median": 22.249424,
+                "p95": 26.592804,
+                "min": 21.632702,
+                "max": 26.592804,
+                "stdev": 1.3073002848897521
               }
             }
           }
@@ -4509,82 +4511,82 @@
             "perry": {
               "wall_ms": {
                 "samples": [
-                  55.870626,
-                  55.331335,
-                  55.382168,
-                  55.404668,
-                  55.373585,
-                  55.513085,
-                  55.171127,
-                  55.398085,
-                  55.372044,
-                  55.092794,
-                  55.257876,
-                  55.159751,
-                  55.034002,
-                  55.439543,
-                  55.334252
+                  52.029945,
+                  51.346358,
+                  51.903448,
+                  51.694238,
+                  51.710448,
+                  51.388748,
+                  52.280884,
+                  52.248612,
+                  51.741987,
+                  51.391111,
+                  51.094658,
+                  51.815975,
+                  53.223924,
+                  52.042327,
+                  51.907616
                 ],
                 "sample_count": 15,
-                "median": 55.372044,
-                "p95": 55.870626,
-                "min": 55.034002,
-                "max": 55.870626,
-                "stdev": 0.19243082945889955
+                "median": 51.815975,
+                "p95": 53.223924,
+                "min": 51.094658,
+                "max": 53.223924,
+                "stdev": 0.49068163426869205
               }
             },
             "node": {
               "wall_ms": {
                 "samples": [
-                  81.073835,
-                  81.921043,
-                  80.45596,
-                  81.525794,
-                  80.722877,
-                  80.960918,
-                  81.369252,
-                  80.773668,
-                  80.934169,
-                  80.897544,
-                  80.60446,
-                  80.741918,
-                  80.086127,
-                  80.621626,
-                  80.723502
+                  67.838284,
+                  68.682579,
+                  69.308349,
+                  71.346965,
+                  67.95884,
+                  67.157323,
+                  69.001866,
+                  69.119245,
+                  68.109581,
+                  67.329584,
+                  68.154233,
+                  68.426072,
+                  67.387763,
+                  68.087869,
+                  68.472147
                 ],
                 "sample_count": 15,
-                "median": 80.773668,
-                "p95": 81.921043,
-                "min": 80.086127,
-                "max": 81.921043,
-                "stdev": 0.43334435299099217
+                "median": 68.154233,
+                "p95": 71.346965,
+                "min": 67.157323,
+                "max": 71.346965,
+                "stdev": 0.9977410486314237
               }
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  39.99346,
-                  40.279585,
-                  39.959543,
-                  39.987127,
-                  40.299752,
-                  39.978877,
-                  40.044502,
-                  40.042835,
-                  39.932877,
-                  40.140794,
-                  39.961877,
-                  39.983126,
-                  40.074751,
-                  40.287918,
-                  39.928627
+                  48.324264,
+                  43.977257,
+                  47.757206,
+                  47.633875,
+                  48.106368,
+                  48.009226,
+                  48.442136,
+                  47.983999,
+                  48.110135,
+                  47.719786,
+                  43.514784,
+                  48.456972,
+                  48.028112,
+                  47.851462,
+                  47.420046
                 ],
                 "sample_count": 15,
-                "median": 39.99346,
-                "p95": 40.299752,
-                "min": 39.928627,
-                "max": 40.299752,
-                "stdev": 0.12656789697468895
+                "median": 47.983999,
+                "p95": 48.456972,
+                "min": 43.514784,
+                "max": 48.456972,
+                "stdev": 1.4710274022542293
               }
             }
           }
@@ -4599,82 +4601,82 @@
             "perry": {
               "wall_ms": {
                 "samples": [
-                  33.839363,
-                  33.76428,
-                  33.780571,
-                  33.701362,
-                  33.645071,
-                  33.768279,
-                  33.565779,
-                  33.740654,
-                  33.608321,
-                  33.968446,
-                  33.70853,
-                  33.742112,
-                  33.613071,
-                  33.733404,
-                  33.669821
+                  28.394869,
+                  28.445374,
+                  28.009791,
+                  27.788577,
+                  28.185178,
+                  27.989452,
+                  28.001845,
+                  28.596416,
+                  27.843049,
+                  28.000894,
+                  28.130175,
+                  28.650467,
+                  28.228098,
+                  28.542174,
+                  28.326382
                 ],
                 "sample_count": 15,
-                "median": 33.733404,
-                "p95": 33.968446,
-                "min": 33.565779,
-                "max": 33.968446,
-                "stdev": 0.09701182997240915
+                "median": 28.185178,
+                "p95": 28.650467,
+                "min": 27.788577,
+                "max": 28.650467,
+                "stdev": 0.26484151445290194
               }
             },
             "node": {
               "wall_ms": {
                 "samples": [
-                  110.045862,
-                  110.218738,
-                  112.408029,
-                  110.815112,
-                  109.697321,
-                  109.804863,
-                  109.795071,
-                  110.064196,
-                  110.340696,
-                  109.816362,
-                  110.283738,
-                  110.343613,
-                  110.456404,
-                  110.27503,
-                  112.369696
+                  79.67116,
+                  81.672267,
+                  81.379421,
+                  80.842647,
+                  81.760792,
+                  81.434813,
+                  80.89746,
+                  80.30852,
+                  81.362368,
+                  79.768932,
+                  81.951789,
+                  83.278736,
+                  80.097276,
+                  79.696677,
+                  81.067667
                 ],
                 "sample_count": 15,
-                "median": 110.27503,
-                "p95": 112.408029,
-                "min": 109.697321,
-                "max": 112.408029,
-                "stdev": 0.8129278995466925
+                "median": 81.067667,
+                "p95": 83.278736,
+                "min": 79.67116,
+                "max": 83.278736,
+                "stdev": 0.9627773757066698
               }
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  42.827279,
-                  43.166613,
-                  42.711196,
-                  42.779654,
-                  42.875238,
-                  42.769029,
-                  43.128154,
-                  42.775696,
-                  42.790154,
-                  42.961238,
-                  42.740988,
-                  43.24878,
-                  42.878655,
-                  42.754862,
-                  43.05378
+                  43.14897,
+                  41.006139,
+                  44.479505,
+                  43.757086,
+                  43.340569,
+                  42.789088,
+                  44.178804,
+                  43.129734,
+                  43.085893,
+                  41.364859,
+                  43.459981,
+                  39.506118,
+                  43.440425,
+                  43.585545,
+                  43.817508
                 ],
                 "sample_count": 15,
-                "median": 42.827279,
-                "p95": 43.24878,
-                "min": 42.711196,
-                "max": 43.24878,
-                "stdev": 0.16725050100073013
+                "median": 43.340569,
+                "p95": 44.479505,
+                "min": 39.506118,
+                "max": 44.479505,
+                "stdev": 1.2800131123105194
               }
             }
           }
@@ -4689,82 +4691,82 @@
             "perry": {
               "wall_ms": {
                 "samples": [
-                  398.746598,
-                  399.543098,
-                  399.529723,
-                  399.305973,
-                  399.349431,
-                  399.160098,
-                  399.921015,
-                  399.516848,
-                  399.513932,
-                  398.71189,
-                  400.272473,
-                  401.133723,
-                  399.188056,
-                  400.050181,
-                  399.423431
+                  86.503624,
+                  84.108061,
+                  84.313845,
+                  84.154517,
+                  84.858221,
+                  84.126516,
+                  84.672154,
+                  85.696828,
+                  85.588776,
+                  84.029403,
+                  84.543213,
+                  83.939987,
+                  84.172221,
+                  85.265141,
+                  84.184734
                 ],
                 "sample_count": 15,
-                "median": 399.513932,
-                "p95": 401.133723,
-                "min": 398.71189,
-                "max": 401.133723,
-                "stdev": 0.5868923993074753
+                "median": 84.313845,
+                "p95": 86.503624,
+                "min": 83.939987,
+                "max": 86.503624,
+                "stdev": 0.7346611376502589
               }
             },
             "node": {
               "wall_ms": {
                 "samples": [
-                  117.026056,
-                  115.894973,
-                  119.963557,
-                  118.373598,
-                  120.791764,
-                  116.606306,
-                  116.375473,
-                  118.27864,
-                  119.515181,
-                  119.377557,
-                  117.697932,
-                  120.612931,
-                  118.828014,
-                  119.037973,
-                  121.391223
+                  117.388727,
+                  114.800053,
+                  116.210066,
+                  112.588855,
+                  115.739368,
+                  115.753173,
+                  117.431067,
+                  115.078493,
+                  112.228221,
+                  114.221123,
+                  116.075054,
+                  119.933839,
+                  117.338884,
+                  114.74426,
+                  117.265067
                 ],
                 "sample_count": 15,
-                "median": 118.828014,
-                "p95": 121.391223,
-                "min": 115.894973,
-                "max": 121.391223,
-                "stdev": 1.629689378806398
+                "median": 115.753173,
+                "p95": 119.933839,
+                "min": 112.228221,
+                "max": 119.933839,
+                "stdev": 1.9188801724928934
               }
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  64.910015,
-                  65.526348,
-                  65.14664,
-                  65.319181,
-                  65.006556,
-                  65.206182,
-                  64.955015,
-                  64.961973,
-                  64.997306,
-                  67.91539,
-                  65.209389,
-                  64.877848,
-                  65.131598,
-                  65.006764,
-                  64.852432
+                  71.150033,
+                  72.225963,
+                  71.860991,
+                  72.517998,
+                  71.142249,
+                  72.680391,
+                  72.79726,
+                  72.741755,
+                  72.821865,
+                  73.362255,
+                  71.811418,
+                  72.855599,
+                  74.017808,
+                  72.371565,
+                  73.603424
                 ],
                 "sample_count": 15,
-                "median": 65.006764,
-                "p95": 67.91539,
-                "min": 64.852432,
-                "max": 67.91539,
-                "stdev": 0.7290715647271038
+                "median": 72.680391,
+                "p95": 74.017808,
+                "min": 71.142249,
+                "max": 74.017808,
+                "stdev": 0.7874142143211518
               }
             }
           }
@@ -4779,82 +4781,82 @@
             "perry": {
               "wall_ms": {
                 "samples": [
-                  93.82535,
-                  93.630392,
-                  93.547058,
-                  94.223183,
-                  93.328391,
-                  93.516849,
-                  94.06485,
-                  93.424724,
-                  93.687725,
-                  93.784933,
-                  93.547642,
-                  94.094391,
-                  93.755183,
-                  93.363308,
-                  93.571933
+                  75.563826,
+                  76.139361,
+                  75.366267,
+                  75.665456,
+                  80.052558,
+                  75.778868,
+                  76.17613,
+                  75.133814,
+                  75.97218,
+                  75.020953,
+                  74.931876,
+                  74.89121,
+                  75.397576,
+                  75.733583,
+                  76.598238
                 ],
                 "sample_count": 15,
-                "median": 93.630392,
-                "p95": 94.223183,
-                "min": 93.328391,
-                "max": 94.223183,
-                "stdev": 0.2602473482319484
+                "median": 75.665456,
+                "p95": 80.052558,
+                "min": 74.89121,
+                "max": 80.052558,
+                "stdev": 1.2091869763930623
               }
             },
             "node": {
               "wall_ms": {
                 "samples": [
-                  89.463517,
-                  90.1871,
-                  90.121891,
-                  90.572808,
-                  89.132392,
-                  89.645266,
-                  89.0261,
-                  90.462599,
-                  88.807975,
-                  88.475766,
-                  88.255141,
-                  89.473641,
-                  88.615641,
-                  90.446558,
-                  88.78035
+                  81.404884,
+                  82.142872,
+                  81.853472,
+                  81.507436,
+                  80.959853,
+                  80.981763,
+                  81.842582,
+                  82.616917,
+                  81.673446,
+                  85.535237,
+                  81.983915,
+                  79.52328,
+                  80.322262,
+                  80.512688,
+                  80.756093
                 ],
                 "sample_count": 15,
-                "median": 89.463517,
-                "p95": 90.572808,
-                "min": 88.255141,
-                "max": 90.572808,
-                "stdev": 0.753729658394014
+                "median": 81.507436,
+                "p95": 85.535237,
+                "min": 79.52328,
+                "max": 85.535237,
+                "stdev": 1.3104567970187926
               }
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  35.488599,
-                  35.661433,
-                  35.631766,
-                  35.579808,
-                  35.632558,
-                  35.683974,
-                  35.812849,
-                  35.901724,
-                  35.636224,
-                  35.462892,
-                  35.764225,
-                  35.719392,
-                  35.629849,
-                  35.658016,
-                  35.672891
+                  31.251911,
+                  35.312524,
+                  36.09779,
+                  33.103208,
+                  34.87135,
+                  34.301856,
+                  32.513797,
+                  32.099613,
+                  34.829381,
+                  31.559065,
+                  35.521003,
+                  31.720125,
+                  33.825116,
+                  33.973423,
+                  31.79764
                 ],
                 "sample_count": 15,
-                "median": 35.658016,
-                "p95": 35.901724,
-                "min": 35.462892,
-                "max": 35.901724,
-                "stdev": 0.10786669344684535
+                "median": 33.825116,
+                "p95": 36.09779,
+                "min": 31.251911,
+                "max": 36.09779,
+                "stdev": 1.5644373472274256
               }
             }
           }
@@ -4869,82 +4871,82 @@
             "perry": {
               "wall_ms": {
                 "samples": [
-                  299.661354,
-                  301.060938,
-                  301.066813,
-                  301.032355,
-                  302.98898,
-                  299.459396,
-                  301.37898,
-                  300.066688,
-                  300.874563,
-                  300.701355,
-                  300.151021,
-                  300.095021,
-                  300.199355,
-                  299.852355,
-                  299.95248
+                  170.590371,
+                  152.343238,
+                  172.323698,
+                  157.884475,
+                  165.615451,
+                  160.427814,
+                  167.977272,
+                  172.397115,
+                  169.779949,
+                  171.534635,
+                  156.138795,
+                  180.519593,
+                  159.554885,
+                  166.212276,
+                  162.742256
                 ],
                 "sample_count": 15,
-                "median": 300.199355,
-                "p95": 302.98898,
-                "min": 299.459396,
-                "max": 302.98898,
-                "stdev": 0.8588678458577798
+                "median": 166.212276,
+                "p95": 180.519593,
+                "min": 152.343238,
+                "max": 180.519593,
+                "stdev": 7.27367173220972
               }
             },
             "node": {
               "wall_ms": {
                 "samples": [
-                  259.811688,
-                  258.798354,
-                  260.603896,
-                  260.827521,
-                  259.345355,
-                  258.336438,
-                  260.380313,
-                  259.299938,
-                  260.188813,
-                  258.440771,
-                  259.855604,
-                  259.450146,
-                  257.796105,
-                  259.36098,
-                  271.380646
+                  228.915875,
+                  228.965668,
+                  278.214223,
+                  241.003527,
+                  254.944199,
+                  270.599584,
+                  229.80193,
+                  224.149675,
+                  282.302116,
+                  241.013535,
+                  245.987834,
+                  267.880756,
+                  225.565479,
+                  216.361162,
+                  290.516885
                 ],
                 "sample_count": 15,
-                "median": 259.450146,
-                "p95": 271.380646,
-                "min": 257.796105,
-                "max": 271.380646,
-                "stdev": 3.086879821469937
+                "median": 241.013535,
+                "p95": 290.516885,
+                "min": 216.361162,
+                "max": 290.516885,
+                "stdev": 23.211344296020417
               }
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  223.466063,
-                  225.246979,
-                  223.613355,
-                  222.392063,
-                  222.242063,
-                  224.114688,
-                  222.131354,
-                  222.562522,
-                  222.343771,
-                  235.018521,
-                  223.262604,
-                  223.536813,
-                  224.37898,
-                  221.720229,
-                  223.38723
+                  278.820615,
+                  255.66729,
+                  255.454062,
+                  290.183453,
+                  269.279548,
+                  247.777597,
+                  281.571832,
+                  253.371994,
+                  262.618981,
+                  281.0778,
+                  269.729889,
+                  271.279333,
+                  251.917808,
+                  251.016685,
+                  286.833237
                 ],
                 "sample_count": 15,
-                "median": 223.38723,
-                "p95": 235.018521,
-                "min": 221.720229,
-                "max": 235.018521,
-                "stdev": 3.0966616445661814
+                "median": 269.279548,
+                "p95": 290.183453,
+                "min": 247.777597,
+                "max": 290.183453,
+                "stdev": 13.737939242994571
               }
             }
           }
@@ -4959,82 +4961,82 @@
             "perry": {
               "wall_ms": {
                 "samples": [
-                  38.635995,
-                  38.726662,
-                  39.076287,
-                  38.612495,
-                  38.743787,
-                  38.695162,
-                  38.859329,
-                  38.47812,
-                  38.937328,
-                  38.760871,
-                  38.784995,
-                  38.858078,
-                  38.783995,
-                  38.408412,
-                  38.821078
+                  16.579118,
+                  17.441649,
+                  17.52251,
+                  17.513403,
+                  16.669918,
+                  17.034068,
+                  17.405292,
+                  17.102055,
+                  17.004122,
+                  16.637909,
+                  16.820249,
+                  16.923372,
+                  17.395323,
+                  17.034799,
+                  17.362331
                 ],
                 "sample_count": 15,
-                "median": 38.760871,
-                "p95": 39.076287,
-                "min": 38.408412,
-                "max": 39.076287,
-                "stdev": 0.16299952300849144
+                "median": 17.034799,
+                "p95": 17.52251,
+                "min": 16.579118,
+                "max": 17.52251,
+                "stdev": 0.31751676320930783
               }
             },
             "node": {
               "wall_ms": {
                 "samples": [
-                  53.086246,
-                  52.256996,
-                  53.133079,
-                  52.335162,
-                  52.391287,
-                  52.572245,
-                  52.62887,
-                  52.289079,
-                  54.53937,
-                  53.399704,
-                  53.371412,
-                  53.549079,
-                  51.948203,
-                  53.306995,
-                  53.344912
+                  40.183366,
+                  42.454547,
+                  40.704218,
+                  43.81623,
+                  41.64261,
+                  43.527941,
+                  44.281799,
+                  43.120771,
+                  41.868843,
+                  43.889787,
+                  41.148718,
+                  43.847087,
+                  43.712065,
+                  43.78936,
+                  41.73331
                 ],
                 "sample_count": 15,
-                "median": 53.086246,
-                "p95": 54.53937,
-                "min": 51.948203,
-                "max": 54.53937,
-                "stdev": 0.6560661508182911
+                "median": 43.120771,
+                "p95": 44.281799,
+                "min": 40.183366,
+                "max": 44.281799,
+                "stdev": 1.2920057506246567
               }
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  15.618787,
-                  15.836078,
-                  15.789454,
-                  15.822328,
-                  16.114412,
-                  15.690996,
-                  15.728162,
-                  15.781287,
-                  15.690662,
-                  15.662495,
-                  15.750787,
-                  15.665578,
-                  15.748662,
-                  15.848245,
-                  16.035704
+                  15.624045,
+                  15.737798,
+                  18.501158,
+                  15.898177,
+                  16.747593,
+                  17.135006,
+                  18.295033,
+                  15.874122,
+                  17.489689,
+                  16.331547,
+                  15.882628,
+                  15.314577,
+                  15.96382,
+                  18.044415,
+                  16.566615
                 ],
                 "sample_count": 15,
-                "median": 15.750787,
-                "p95": 16.114412,
-                "min": 15.618787,
-                "max": 16.114412,
-                "stdev": 0.13159267531500402
+                "median": 16.331547,
+                "p95": 18.501158,
+                "min": 15.314577,
+                "max": 18.501158,
+                "stdev": 1.0007533854437776
               }
             }
           }
@@ -5049,82 +5051,82 @@
             "perry": {
               "wall_ms": {
                 "samples": [
-                  236.739779,
-                  237.542904,
-                  237.316779,
-                  237.365404,
-                  239.317946,
-                  237.522404,
-                  237.672779,
-                  237.544654,
-                  238.270029,
-                  238.256362,
-                  237.306071,
-                  237.809446,
-                  237.107821,
-                  238.431237,
-                  237.713904
+                  81.303687,
+                  80.199514,
+                  81.398174,
+                  80.892568,
+                  83.179048,
+                  83.419998,
+                  82.137715,
+                  82.308974,
+                  82.883968,
+                  81.902765,
+                  83.812842,
+                  79.861974,
+                  81.675672,
+                  81.314086,
+                  82.291531
                 ],
                 "sample_count": 15,
-                "median": 237.544654,
-                "p95": 239.317946,
-                "min": 236.739779,
-                "max": 239.317946,
-                "stdev": 0.6085646985990133
+                "median": 81.902765,
+                "p95": 83.812842,
+                "min": 79.861974,
+                "max": 83.812842,
+                "stdev": 1.0957886745197716
               }
             },
             "node": {
               "wall_ms": {
                 "samples": [
-                  59.154321,
-                  59.356446,
-                  59.278446,
-                  59.442321,
-                  59.270279,
-                  59.604237,
-                  58.028238,
-                  61.097863,
-                  59.241654,
-                  58.972237,
-                  58.606362,
-                  59.135779,
-                  58.547071,
-                  59.815529,
-                  58.885446
+                  48.427175,
+                  50.998136,
+                  49.685604,
+                  50.380071,
+                  50.215845,
+                  47.651707,
+                  51.144409,
+                  48.33899,
+                  49.120339,
+                  48.248021,
+                  48.966091,
+                  48.814949,
+                  46.66825,
+                  45.71496,
+                  46.963281
                 ],
                 "sample_count": 15,
-                "median": 59.241654,
-                "p95": 61.097863,
-                "min": 58.028238,
-                "max": 61.097863,
-                "stdev": 0.660115319329833
+                "median": 48.814949,
+                "p95": 51.144409,
+                "min": 45.71496,
+                "max": 51.144409,
+                "stdev": 1.5302492063937914
               }
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  20.718154,
-                  20.501571,
-                  20.537529,
-                  20.516904,
-                  20.672112,
-                  20.582529,
-                  20.412113,
-                  20.525363,
-                  20.642654,
-                  20.60032,
-                  20.576196,
-                  20.407321,
-                  20.742737,
-                  20.567404,
-                  20.479571
+                  23.529643,
+                  22.108648,
+                  22.481235,
+                  24.42793,
+                  22.346834,
+                  23.692737,
+                  23.883674,
+                  22.464524,
+                  22.197715,
+                  22.964527,
+                  22.18948,
+                  22.588395,
+                  23.10532,
+                  22.551366,
+                  21.741844
                 ],
                 "sample_count": 15,
-                "median": 20.567404,
-                "p95": 20.742737,
-                "min": 20.407321,
-                "max": 20.742737,
-                "stdev": 0.096065710047423
+                "median": 22.551366,
+                "p95": 24.42793,
+                "min": 21.741844,
+                "max": 24.42793,
+                "stdev": 0.7361343429761414
               }
             }
           }
@@ -5139,82 +5141,82 @@
             "perry": {
               "wall_ms": {
                 "samples": [
-                  56.093651,
-                  56.065692,
-                  56.011901,
-                  56.125027,
-                  55.977193,
-                  56.01261,
-                  56.00011,
-                  56.012234,
-                  56.022609,
-                  55.865152,
-                  55.892693,
-                  55.978817,
-                  55.977984,
-                  55.932484,
-                  56.307609
+                  53.287071,
+                  54.643794,
+                  54.393797,
+                  54.01536,
+                  53.496632,
+                  53.401343,
+                  53.872644,
+                  53.974845,
+                  53.307989,
+                  53.92361,
+                  53.734707,
+                  54.304991,
+                  55.519539,
+                  53.728084,
+                  54.564857
                 ],
                 "sample_count": 15,
-                "median": 56.011901,
-                "p95": 56.307609,
-                "min": 55.865152,
-                "max": 56.307609,
-                "stdev": 0.10163446530437698
+                "median": 53.92361,
+                "p95": 55.519539,
+                "min": 53.287071,
+                "max": 55.519539,
+                "stdev": 0.5805099718208935
               }
             },
             "node": {
               "wall_ms": {
                 "samples": [
-                  97.934026,
-                  97.255277,
-                  97.937109,
-                  98.135651,
-                  98.062026,
-                  97.712526,
-                  100.194276,
-                  98.960485,
-                  99.902901,
-                  97.606984,
-                  99.698818,
-                  97.08086,
-                  98.203942,
-                  96.796526,
-                  97.386443
+                  71.388382,
+                  72.58153,
+                  71.64482,
+                  72.978721,
+                  71.308913,
+                  72.127362,
+                  71.837941,
+                  72.094821,
+                  72.644778,
+                  72.199366,
+                  73.198452,
+                  72.12616,
+                  73.19216,
+                  74.370771,
+                  72.403127
                 ],
                 "sample_count": 15,
-                "median": 97.937109,
-                "p95": 100.194276,
-                "min": 96.796526,
-                "max": 100.194276,
-                "stdev": 1.0076233820037461
+                "median": 72.199366,
+                "p95": 74.370771,
+                "min": 71.308913,
+                "max": 74.370771,
+                "stdev": 0.7728261726051538
               }
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  49.439526,
-                  49.43261,
-                  49.3074,
-                  49.214151,
-                  49.406234,
-                  49.432026,
-                  49.144317,
-                  49.282443,
-                  49.415193,
-                  49.262735,
-                  49.369943,
-                  49.18386,
-                  49.404776,
-                  49.390733,
-                  49.302568
+                  40.475316,
+                  40.302154,
+                  40.164086,
+                  41.550074,
+                  38.007148,
+                  38.529824,
+                  40.036907,
+                  39.938714,
+                  41.153283,
+                  40.710656,
+                  40.660633,
+                  38.38356,
+                  37.444086,
+                  42.090673,
+                  41.324673
                 ],
                 "sample_count": 15,
-                "median": 49.369943,
-                "p95": 49.439526,
-                "min": 49.144317,
-                "max": 49.439526,
-                "stdev": 0.09454650301212655
+                "median": 40.302154,
+                "p95": 42.090673,
+                "min": 37.444086,
+                "max": 42.090673,
+                "stdev": 1.3263467789092902
               }
             }
           }
@@ -5229,82 +5231,82 @@
             "perry": {
               "wall_ms": {
                 "samples": [
-                  48.112197,
-                  48.532489,
-                  48.228614,
-                  48.601948,
-                  48.129448,
-                  48.397697,
-                  48.296239,
-                  48.325322,
-                  48.212864,
-                  48.428864,
-                  48.769781,
-                  48.358698,
-                  48.375031,
-                  48.409156,
-                  48.616615
+                  29.213564,
+                  28.442884,
+                  28.749247,
+                  28.550315,
+                  28.391388,
+                  28.721755,
+                  28.38668,
+                  29.292882,
+                  28.739548,
+                  28.828445,
+                  28.625956,
+                  28.707879,
+                  28.985558,
+                  28.517935,
+                  28.198067
                 ],
                 "sample_count": 15,
-                "median": 48.375031,
-                "p95": 48.769781,
-                "min": 48.112197,
-                "max": 48.769781,
-                "stdev": 0.17873824707949057
+                "median": 28.707879,
+                "p95": 29.292882,
+                "min": 28.198067,
+                "max": 29.292882,
+                "stdev": 0.2931276073456064
               }
             },
             "node": {
               "wall_ms": {
                 "samples": [
-                  82.069614,
-                  83.455114,
-                  82.047031,
-                  82.402948,
-                  83.333573,
-                  82.497156,
-                  81.987906,
-                  85.154698,
-                  82.467073,
-                  80.252823,
-                  82.193448,
-                  83.283698,
-                  83.371906,
-                  84.027989,
-                  82.606115
+                  75.598501,
+                  75.204965,
+                  75.618207,
+                  75.204384,
+                  77.250606,
+                  75.987657,
+                  75.368661,
+                  75.789617,
+                  78.762449,
+                  78.292862,
+                  76.867671,
+                  77.33336,
+                  75.38367,
+                  76.237213,
+                  76.748237
                 ],
                 "sample_count": 15,
-                "median": 82.497156,
-                "p95": 85.154698,
-                "min": 80.252823,
-                "max": 85.154698,
-                "stdev": 1.0737214611790056
+                "median": 75.987657,
+                "p95": 78.762449,
+                "min": 75.204384,
+                "max": 78.762449,
+                "stdev": 1.091402729977752
               }
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  26.68274,
-                  26.852948,
-                  26.887739,
-                  26.758489,
-                  26.513072,
-                  26.776572,
-                  26.57624,
-                  26.858198,
-                  26.71949,
-                  26.808489,
-                  27.027947,
-                  26.904114,
-                  26.675573,
-                  27.101281,
-                  26.744823
+                  30.469609,
+                  33.574467,
+                  30.317556,
+                  30.533739,
+                  30.501208,
+                  30.176732,
+                  29.62913,
+                  29.93428,
+                  30.060195,
+                  29.515177,
+                  32.916148,
+                  29.82187,
+                  29.573987,
+                  30.427641,
+                  30.315532
                 ],
                 "sample_count": 15,
-                "median": 26.776572,
-                "p95": 27.101281,
-                "min": 26.513072,
-                "max": 27.101281,
-                "stdev": 0.15058033565317316
+                "median": 30.315532,
+                "p95": 33.574467,
+                "min": 29.515177,
+                "max": 33.574467,
+                "stdev": 1.1261613484266193
               }
             }
           }
@@ -5319,82 +5321,82 @@
             "perry": {
               "wall_ms": {
                 "samples": [
-                  48.556888,
-                  47.679555,
-                  48.619638,
-                  48.658972,
-                  47.845764,
-                  48.292639,
-                  48.91918,
-                  48.560139,
-                  47.452847,
-                  47.977388,
-                  48.317347,
-                  48.546721,
-                  48.355514,
-                  47.799471,
-                  48.128972
+                  34.421847,
+                  33.774659,
+                  34.767022,
+                  34.355132,
+                  33.736036,
+                  34.012593,
+                  33.613839,
+                  33.954755,
+                  33.919258,
+                  34.097671,
+                  33.95774,
+                  33.745925,
+                  34.188741,
+                  34.460349,
+                  34.648109
                 ],
                 "sample_count": 15,
-                "median": 48.317347,
-                "p95": 48.91918,
-                "min": 47.452847,
-                "max": 48.91918,
-                "stdev": 0.4052732667454009
+                "median": 34.012593,
+                "p95": 34.767022,
+                "min": 33.613839,
+                "max": 34.767022,
+                "stdev": 0.33978982507985034
               }
             },
             "node": {
               "wall_ms": {
                 "samples": [
-                  75.85893,
-                  74.90143,
-                  74.154346,
-                  79.032639,
-                  75.276388,
-                  77.55318,
-                  74.357889,
-                  76.18168,
-                  75.305638,
-                  76.492388,
-                  75.497847,
-                  74.85918,
-                  75.42018,
-                  75.590555,
-                  75.153972
+                  70.772567,
+                  69.615145,
+                  69.676058,
+                  70.99441,
+                  71.203822,
+                  71.560006,
+                  72.739539,
+                  69.193288,
+                  69.809668,
+                  70.611596,
+                  71.958321,
+                  70.44254,
+                  70.808443,
+                  70.793966,
+                  71.168636
                 ],
                 "sample_count": 15,
-                "median": 75.42018,
-                "p95": 79.032639,
-                "min": 74.154346,
-                "max": 79.032639,
-                "stdev": 1.2034376697685791
+                "median": 70.793966,
+                "p95": 72.739539,
+                "min": 69.193288,
+                "max": 72.739539,
+                "stdev": 0.9085919586240142
               }
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  44.02443,
-                  44.222889,
-                  44.358014,
-                  43.888388,
-                  44.239222,
-                  43.936597,
-                  43.936847,
-                  43.92943,
-                  44.122221,
-                  43.815888,
-                  44.336388,
-                  43.908347,
-                  43.898597,
-                  43.685513,
-                  44.212721
+                  55.41093,
+                  56.56169,
+                  56.428771,
+                  56.865067,
+                  56.176991,
+                  55.897159,
+                  56.005,
+                  56.446785,
+                  51.41032,
+                  56.77589,
+                  56.607044,
+                  58.1467,
+                  56.6532,
+                  55.394881,
+                  57.106066
                 ],
                 "sample_count": 15,
-                "median": 43.936847,
-                "p95": 44.358014,
-                "min": 43.685513,
-                "max": 44.358014,
-                "stdev": 0.19463382455536532
+                "median": 56.446785,
+                "p95": 58.1467,
+                "min": 51.41032,
+                "max": 58.1467,
+                "stdev": 1.420309439594085
               }
             }
           }
@@ -5409,82 +5411,82 @@
             "perry": {
               "wall_ms": {
                 "samples": [
-                  101.357047,
-                  101.598047,
-                  100.356256,
-                  101.029922,
-                  100.114964,
-                  101.090131,
-                  102.017089,
-                  101.109963,
-                  100.35613,
-                  101.255631,
-                  101.79988,
-                  100.312297,
-                  101.205214,
-                  100.156755,
-                  101.108005
+                  46.442185,
+                  46.898607,
+                  47.372001,
+                  47.373043,
+                  47.362744,
+                  47.139397,
+                  47.095856,
+                  46.755361,
+                  46.838455,
+                  47.522142,
+                  47.387961,
+                  47.017931,
+                  47.490463,
+                  47.587514,
+                  47.676721
                 ],
                 "sample_count": 15,
-                "median": 101.108005,
-                "p95": 102.017089,
-                "min": 100.114964,
-                "max": 102.017089,
-                "stdev": 0.5827946727658367
+                "median": 47.362744,
+                "p95": 47.676721,
+                "min": 46.442185,
+                "max": 47.676721,
+                "stdev": 0.33941327024331547
               }
             },
             "node": {
               "wall_ms": {
                 "samples": [
-                  98.535255,
-                  100.429505,
-                  100.626547,
-                  101.246547,
-                  101.423714,
-                  102.024047,
-                  99.509922,
-                  99.72438,
-                  101.323631,
-                  102.841922,
-                  98.85288,
-                  100.43163,
-                  100.148547,
-                  98.338213,
-                  101.35813
+                  91.919517,
+                  91.697883,
+                  91.512056,
+                  93.451158,
+                  90.842676,
+                  90.449602,
+                  91.783003,
+                  93.432362,
+                  94.058952,
+                  91.463145,
+                  91.878872,
+                  92.351725,
+                  93.212622,
+                  93.25973,
+                  93.988982
                 ],
                 "sample_count": 15,
-                "median": 100.43163,
-                "p95": 102.841922,
-                "min": 98.338213,
-                "max": 102.841922,
-                "stdev": 1.253765738322045
+                "median": 91.919517,
+                "p95": 94.058952,
+                "min": 90.449602,
+                "max": 94.058952,
+                "stdev": 1.0981378484469473
               }
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  40.165672,
-                  40.274297,
-                  41.193213,
-                  40.717963,
-                  40.587506,
-                  43.005881,
-                  40.353214,
-                  40.42813,
-                  40.589672,
-                  39.842464,
-                  40.107214,
-                  43.39888,
-                  40.383589,
-                  40.347339,
-                  40.101964
+                  53.116839,
+                  53.422179,
+                  55.296329,
+                  55.248399,
+                  53.843225,
+                  53.902756,
+                  53.670062,
+                  57.384829,
+                  55.632066,
+                  55.383151,
+                  58.098381,
+                  54.361784,
+                  55.693851,
+                  56.380364,
+                  57.989949
                 ],
                 "sample_count": 15,
-                "median": 40.383589,
-                "p95": 43.39888,
-                "min": 39.842464,
-                "max": 43.39888,
-                "stdev": 1.0044229392985717
+                "median": 55.296329,
+                "p95": 58.098381,
+                "min": 53.116839,
+                "max": 58.098381,
+                "stdev": 1.5654368599708093
               }
             }
           }
@@ -5494,8 +5496,8 @@
     "honest_bench": {
       "schema_version": 1,
       "suite": "honest_bench",
-      "commit": "38ff7eccc2aa0b59629bed548daf8ac56bd9fb03",
-      "generated_at": "2026-08-08T11:37:01.892278Z",
+      "commit": "827a92bad5a589e94e1630994185693ada903fe2",
+      "generated_at": "2026-09-01T14:14:47.564994Z",
       "run_config": {
         "warmup": 5,
         "requested_samples": 20
@@ -5505,18 +5507,18 @@
           "<compiled-workload>"
         ],
         "perry_compile": [
-          "/Users/perry/projects/perry/baseline-1355/target/release/perry",
+          "/root/perry-issue-9338-public-827a92b/target/release/perry",
           "<source.ts>",
           "-o",
           "<compiled-workload>"
         ],
         "node": [
-          "/Users/perry/.cache/perry-bench-tools/bin/node",
+          "/root/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
           "--experimental-strip-types",
           "<source.ts>"
         ],
         "bun": [
-          "/Users/perry/.cache/perry-bench-tools/bin/bun",
+          "/root/.cache/perry-bench-tools/bun-1.3.14/bun",
           "run",
           "<source.ts>"
         ],
@@ -5524,7 +5526,7 @@
           "<compiled-kernel>"
         ],
         "perry_http_compile": [
-          "/Users/perry/projects/perry/baseline-1355/target/release/perry",
+          "/root/perry-issue-9338-public-827a92b/target/release/perry",
           "<kernel.ts>",
           "-o",
           "<compiled-kernel>"
@@ -5556,16 +5558,16 @@
       },
       "runtime_metadata": {
         "perry": {
-          "version": "perry 0.5.1355",
+          "version": "perry 0.5.1519",
           "resolved_executable": "target/release/perry"
         },
         "node": {
           "version": "v22.23.1",
-          "resolved_executable": "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node"
+          "resolved_executable": "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node"
         },
         "bun": {
           "version": "1.3.14",
-          "resolved_executable": "~/.cache/perry-bench-tools/bun/bun"
+          "resolved_executable": "~/.cache/perry-bench-tools/bun-1.3.14/bun"
         }
       },
       "benchmarks": {
@@ -5578,63 +5580,63 @@
             "perry": {
               "wall_ms": {
                 "samples": [
-                  0.028083,
-                  0.022917,
-                  0.045084,
-                  0.01775,
-                  -0.020917,
-                  -0.008625,
-                  0.090417,
-                  0.007792,
-                  0.047958,
-                  -0.04175,
-                  -0.009959,
-                  -0.082416,
-                  0.008,
-                  -0.018125,
-                  -0.183959,
-                  -0.002334,
-                  -0.059916,
-                  -0.064875,
-                  -0.054416,
-                  0.094791
+                  1203.29221,
+                  1203.576601,
+                  1202.635374,
+                  1205.451492,
+                  1204.519432,
+                  1203.465042,
+                  1202.606922,
+                  1203.688289,
+                  1203.786463,
+                  1202.470486,
+                  1204.333425,
+                  1203.61874,
+                  1205.85694,
+                  1204.794987,
+                  1205.210102,
+                  1205.37002,
+                  1205.074649,
+                  1941.538199,
+                  2014.706841,
+                  1966.355061
                 ],
                 "sample_count": 20,
-                "median": -0.0054795,
-                "p95": 0.090417,
-                "min": -0.183959,
-                "max": 0.094791,
-                "stdev": 0.061492250236106986
+                "median": 1204.4264285,
+                "p95": 1966.355061,
+                "min": 1202.470486,
+                "max": 2014.706841,
+                "stdev": 275.23294280866907
               },
               "rss_kb": {
                 "samples": [
-                  57488.0,
-                  57472.0,
-                  57488.0,
-                  57472.0,
-                  57472.0,
-                  57472.0,
-                  57472.0,
-                  57488.0,
-                  57472.0,
-                  57472.0,
-                  57488.0,
-                  57488.0,
-                  57488.0,
-                  57488.0,
-                  57472.0,
-                  57488.0,
-                  57488.0,
-                  57488.0,
-                  57488.0,
-                  57472.0
+                  80800.0,
+                  80764.0,
+                  80788.0,
+                  81076.0,
+                  80992.0,
+                  80684.0,
+                  81084.0,
+                  81108.0,
+                  80944.0,
+                  80764.0,
+                  80964.0,
+                  81092.0,
+                  80840.0,
+                  81080.0,
+                  80676.0,
+                  80888.0,
+                  80676.0,
+                  81072.0,
+                  81092.0,
+                  81008.0
                 ],
                 "sample_count": 20,
-                "median": 57488.0,
-                "p95": 57488.0,
-                "min": 57472.0,
-                "max": 57488.0,
-                "stdev": 7.95989949685296
+                "median": 80954.0,
+                "p95": 81092.0,
+                "min": 80676.0,
+                "max": 81108.0,
+                "stdev": 153.71610195421948
               },
               "measured_command": [
                 "benchmarks/honest_bench/workloads/3_image_convolution/perry/image_conv"
@@ -5643,66 +5645,66 @@
             "node": {
               "wall_ms": {
                 "samples": [
-                  -0.018416,
-                  -0.136083,
-                  -0.073292,
-                  0.062875,
-                  0.02525,
-                  0.0625,
-                  0.004416,
-                  -0.037958,
-                  -0.027125,
-                  -0.075917,
-                  0.040542,
-                  -0.027166,
-                  0.027459,
-                  -0.030167,
-                  0.052375,
-                  0.062916,
-                  0.006792,
-                  0.035958,
-                  0.01625,
-                  0.00975
+                  973.375217,
+                  971.447546,
+                  972.381591,
+                  975.271227,
+                  969.634,
+                  972.660041,
+                  977.805128,
+                  975.870926,
+                  986.876377,
+                  979.976894,
+                  977.929181,
+                  979.803641,
+                  1183.670039,
+                  974.71618,
+                  1093.290109,
+                  1252.292942,
+                  974.618267,
+                  966.695012,
+                  967.978879,
+                  965.920996
                 ],
                 "sample_count": 20,
-                "median": 0.008271,
-                "p95": 0.062875,
-                "min": -0.136083,
-                "max": 0.062916,
-                "stdev": 0.05153317100807498
+                "median": 974.9937035,
+                "p95": 1183.670039,
+                "min": 965.920996,
+                "max": 1252.292942,
+                "stdev": 76.6011457979885
               },
               "rss_kb": {
                 "samples": [
-                  120384.0,
-                  120480.0,
-                  120432.0,
-                  120464.0,
-                  120592.0,
-                  120448.0,
-                  120592.0,
-                  120352.0,
-                  120464.0,
-                  120608.0,
-                  120448.0,
-                  120448.0,
-                  120576.0,
-                  120432.0,
-                  120384.0,
-                  120512.0,
-                  120640.0,
-                  120432.0,
-                  120464.0,
-                  120448.0
+                  118424.0,
+                  118636.0,
+                  118372.0,
+                  118236.0,
+                  118656.0,
+                  118508.0,
+                  118720.0,
+                  118632.0,
+                  118076.0,
+                  118484.0,
+                  118592.0,
+                  118364.0,
+                  118432.0,
+                  117956.0,
+                  117988.0,
+                  118280.0,
+                  118532.0,
+                  118420.0,
+                  118116.0,
+                  118492.0
                 ],
                 "sample_count": 20,
-                "median": 120456.0,
-                "p95": 120608.0,
-                "min": 120352.0,
-                "max": 120640.0,
-                "stdev": 78.70959280799259
+                "median": 118428.0,
+                "p95": 118656.0,
+                "min": 117956.0,
+                "max": 118720.0,
+                "stdev": 218.6850703637539
               },
               "measured_command": [
-                "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+                "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
                 "--experimental-strip-types",
                 "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
                 "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
@@ -5711,66 +5713,66 @@
             "bun": {
               "wall_ms": {
                 "samples": [
-                  0.060959,
-                  0.0165,
-                  0.014875,
-                  0.024042,
-                  -0.040542,
-                  -0.203416,
-                  0.027625,
-                  0.007208,
-                  -0.048458,
-                  0.005708,
-                  0.507625,
-                  -0.275625,
-                  -0.057833,
-                  0.047042,
-                  0.064834,
-                  -0.011,
-                  0.018083,
-                  -0.048875,
-                  0.006542,
-                  -0.02425
+                  523.357448,
+                  523.303468,
+                  544.101685,
+                  538.859747,
+                  557.809563,
+                  544.497604,
+                  543.87429,
+                  543.083173,
+                  553.869625,
+                  550.315568,
+                  544.095113,
+                  522.549449,
+                  539.650903,
+                  519.266388,
+                  671.222823,
+                  566.700675,
+                  521.688942,
+                  630.710774,
+                  559.09371,
+                  541.397535
                 ],
                 "sample_count": 20,
-                "median": 0.006875,
-                "p95": 0.064834,
-                "min": -0.275625,
-                "max": 0.507625,
-                "stdev": 0.14097368824486362
+                "median": 543.9847015,
+                "p95": 630.710774,
+                "min": 519.266388,
+                "max": 671.222823,
+                "stdev": 36.042828813476895
               },
               "rss_kb": {
                 "samples": [
-                  84976.0,
-                  84912.0,
-                  85040.0,
-                  85008.0,
-                  84976.0,
-                  84864.0,
-                  84944.0,
-                  84848.0,
-                  85056.0,
-                  84944.0,
-                  85024.0,
-                  84944.0,
-                  84880.0,
-                  84944.0,
-                  85056.0,
-                  84944.0,
-                  84896.0,
-                  84944.0,
-                  85008.0,
-                  85024.0
+                  93436.0,
+                  93540.0,
+                  93848.0,
+                  93348.0,
+                  94300.0,
+                  93380.0,
+                  93796.0,
+                  93912.0,
+                  94216.0,
+                  93928.0,
+                  93572.0,
+                  93488.0,
+                  93024.0,
+                  93736.0,
+                  93384.0,
+                  94040.0,
+                  93236.0,
+                  93852.0,
+                  93788.0,
+                  93456.0
                 ],
                 "sample_count": 20,
-                "median": 84944.0,
-                "p95": 85056.0,
-                "min": 84848.0,
-                "max": 85056.0,
-                "stdev": 60.9051721941577
+                "median": 93654.0,
+                "p95": 94216.0,
+                "min": 93024.0,
+                "max": 94300.0,
+                "stdev": 323.3202746503844
               },
               "measured_command": [
-                "~/.cache/perry-bench-tools/bun/bun",
+                "~/.cache/perry-bench-tools/bun-1.3.14/bun",
                 "run",
                 "benchmarks/honest_bench/workloads/3_image_convolution/node/image_conv.ts"
               ]
@@ -5786,207 +5788,207 @@
             "perry": {
               "wall_ms": {
                 "samples": [
-                  0.040125,
-                  0.089875,
-                  -0.001917,
-                  0.138167,
-                  -0.069708,
-                  -0.030166,
-                  -0.044208,
-                  0.004417,
-                  -0.028458,
-                  0.004958,
-                  -0.003958,
-                  0.015667,
-                  0.02375,
-                  0.005333,
-                  0.157542,
-                  0.00575,
-                  -0.036417,
-                  -0.023584,
-                  -0.021458,
-                  -0.0235
+                  1835.684334,
+                  1830.917012,
+                  1820.831388,
+                  1902.209639,
+                  1896.768158,
+                  1902.603285,
+                  1831.581021,
+                  1808.209619,
+                  1828.928679,
+                  1813.872353,
+                  1829.227837,
+                  1843.676358,
+                  1839.095554,
+                  1813.338195,
+                  1831.451449,
+                  1841.129201,
+                  1815.767993,
+                  1814.921954,
+                  1843.768319,
+                  1809.612619
                 ],
                 "sample_count": 20,
-                "median": 0.0012499999999999998,
-                "p95": 0.138167,
-                "min": -0.069708,
-                "max": 0.157542,
-                "stdev": 0.05653124726158092
+                "median": 1831.1842305,
+                "p95": 1902.209639,
+                "min": 1808.209619,
+                "max": 1902.603285,
+                "stdev": 28.57335238605387
               },
               "rss_kb": {
                 "samples": [
-                  1071648.0,
-                  1080544.0,
-                  1083120.0,
-                  1080560.0,
-                  1083136.0,
-                  1080544.0,
-                  1080560.0,
-                  1080560.0,
-                  1080544.0,
-                  1080544.0,
-                  1083120.0,
-                  1083136.0,
-                  1080560.0,
-                  1080544.0,
-                  1080560.0,
-                  1080544.0,
-                  1080544.0,
-                  1080560.0,
-                  1083120.0,
-                  1080560.0
+                  794516.0,
+                  794448.0,
+                  794688.0,
+                  790400.0,
+                  794476.0,
+                  802608.0,
+                  794492.0,
+                  802804.0,
+                  794380.0,
+                  794476.0,
+                  794412.0,
+                  802628.0,
+                  802696.0,
+                  790556.0,
+                  794812.0,
+                  794464.0,
+                  794468.0,
+                  802672.0,
+                  794480.0,
+                  802876.0
                 ],
                 "sample_count": 20,
-                "median": 1080560.0,
-                "p95": 1083136.0,
-                "min": 1071648.0,
-                "max": 1083136.0,
-                "stdev": 2362.5499444456195
+                "median": 794486.0,
+                "p95": 802804.0,
+                "min": 790400.0,
+                "max": 802876.0,
+                "stdev": 4194.647236657691
               },
               "measured_command": [
                 "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
                 "benchmarks/honest_bench/assets/input.json",
-                "/private/tmp/out_perry.json"
+                "/tmp/out_perry.json"
               ]
             },
             "node": {
               "wall_ms": {
                 "samples": [
-                  0.026375,
-                  -0.035917,
-                  0.048709,
-                  -0.024084,
-                  0.033625,
-                  0.034041,
-                  -0.025208,
-                  -0.048917,
-                  0.017791,
-                  0.042292,
-                  0.315166,
-                  -0.003167,
-                  -0.03875,
-                  -0.027167,
-                  0.007,
-                  -0.046583,
-                  0.051,
-                  0.0275,
-                  0.014875,
-                  -0.041792
+                  1329.248393,
+                  1227.612324,
+                  1220.61599,
+                  1248.038698,
+                  1252.098939,
+                  1284.885363,
+                  1343.372498,
+                  1214.058725,
+                  1172.592754,
+                  1194.454026,
+                  1160.372635,
+                  1310.195014,
+                  1137.366935,
+                  1134.893957,
+                  1156.61586,
+                  1156.097962,
+                  1161.174972,
+                  1158.708467,
+                  1170.386123,
+                  1155.237786
                 ],
                 "sample_count": 20,
-                "median": 0.0109375,
-                "p95": 0.051,
-                "min": -0.048917,
-                "max": 0.315166,
-                "stdev": 0.07620528614897723
+                "median": 1183.52339,
+                "p95": 1329.248393,
+                "min": 1134.893957,
+                "max": 1343.372498,
+                "stdev": 63.90039831765598
               },
               "rss_kb": {
                 "samples": [
-                  793296.0,
-                  793376.0,
-                  793360.0,
-                  793280.0,
-                  793520.0,
-                  793424.0,
-                  792640.0,
-                  793280.0,
-                  793488.0,
-                  793216.0,
-                  793472.0,
-                  793072.0,
-                  792816.0,
-                  793312.0,
-                  793424.0,
-                  793216.0,
-                  792928.0,
-                  792992.0,
-                  793312.0,
-                  793536.0
+                  579536.0,
+                  578028.0,
+                  579748.0,
+                  581364.0,
+                  581292.0,
+                  579344.0,
+                  579840.0,
+                  581136.0,
+                  580952.0,
+                  580956.0,
+                  579660.0,
+                  579420.0,
+                  580764.0,
+                  579800.0,
+                  581292.0,
+                  580600.0,
+                  580776.0,
+                  581368.0,
+                  580820.0,
+                  581160.0
                 ],
                 "sample_count": 20,
-                "median": 793304.0,
-                "p95": 793520.0,
-                "min": 792640.0,
-                "max": 793536.0,
-                "stdev": 237.21045508155834
+                "median": 580770.0,
+                "p95": 581364.0,
+                "min": 578028.0,
+                "max": 581368.0,
+                "stdev": 888.1086420027676
               },
               "measured_command": [
-                "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+                "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
                 "--experimental-strip-types",
                 "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
                 "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
                 "benchmarks/honest_bench/assets/input.json",
-                "/private/tmp/out_node.json"
+                "/tmp/out_node.json"
               ]
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  -0.006458,
-                  0.016834,
-                  -0.021375,
-                  0.021667,
-                  -0.114917,
-                  -0.03925,
-                  -0.092291,
-                  0.08675,
-                  -0.038625,
-                  -0.017041,
-                  -0.0405,
-                  -0.055875,
-                  -0.053875,
-                  -0.026417,
-                  0.039708,
-                  -0.031042,
-                  0.101708,
-                  0.085542,
-                  -0.15075,
-                  0.025542
+                  624.340689,
+                  625.109945,
+                  624.264216,
+                  626.066722,
+                  619.589467,
+                  633.374158,
+                  619.003492,
+                  624.229,
+                  621.666075,
+                  618.004186,
+                  624.870768,
+                  627.110832,
+                  623.766186,
+                  621.193932,
+                  624.222899,
+                  622.828896,
+                  626.464414,
+                  623.176665,
+                  621.693646,
+                  635.261472
                 ],
                 "sample_count": 20,
-                "median": -0.023896,
-                "p95": 0.08675,
-                "min": -0.15075,
-                "max": 0.101708,
-                "stdev": 0.0636162856734618
+                "median": 624.2259495000001,
+                "p95": 633.374158,
+                "min": 618.004186,
+                "max": 635.261472,
+                "stdev": 4.0997716152076675
               },
               "rss_kb": {
                 "samples": [
-                  594016.0,
-                  593456.0,
-                  592688.0,
-                  593424.0,
-                  591520.0,
-                  594336.0,
-                  593312.0,
-                  593232.0,
-                  594400.0,
-                  593328.0,
-                  593536.0,
-                  594160.0,
-                  591888.0,
-                  593856.0,
-                  593792.0,
-                  591360.0,
-                  593424.0,
-                  593520.0,
-                  593488.0,
-                  593312.0
+                  603524.0,
+                  603600.0,
+                  603804.0,
+                  603488.0,
+                  603620.0,
+                  603596.0,
+                  603300.0,
+                  603464.0,
+                  603580.0,
+                  603688.0,
+                  604032.0,
+                  603720.0,
+                  603484.0,
+                  603712.0,
+                  603436.0,
+                  603716.0,
+                  603520.0,
+                  603468.0,
+                  603244.0,
+                  603968.0
                 ],
                 "sample_count": 20,
-                "median": 593440.0,
-                "p95": 594336.0,
-                "min": 591360.0,
-                "max": 594400.0,
-                "stdev": 824.2314238125115
+                "median": 603588.0,
+                "p95": 603968.0,
+                "min": 603244.0,
+                "max": 604032.0,
+                "stdev": 191.08730988739154
               },
               "measured_command": [
-                "~/.cache/perry-bench-tools/bun/bun",
+                "~/.cache/perry-bench-tools/bun-1.3.14/bun",
                 "run",
                 "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
                 "benchmarks/honest_bench/assets/input.json",
-                "/private/tmp/out_bun.json"
+                "/tmp/out_bun.json"
               ]
             }
           }
@@ -6000,207 +6002,207 @@
             "perry": {
               "wall_ms": {
                 "samples": [
-                  0.041375,
-                  0.025458,
-                  -0.03025,
-                  0.010292,
-                  0.057375,
-                  -0.047333,
-                  0.0185,
-                  0.05975,
-                  0.099333,
-                  0.079667,
-                  0.026084,
-                  0.007917,
-                  0.005333,
-                  -0.033541,
-                  -0.054084,
-                  0.022875,
-                  -0.021875,
-                  -0.05075,
-                  0.035458,
-                  -0.013583
+                  19.778593,
+                  19.461461,
+                  19.82479,
+                  19.624095,
+                  19.053189,
+                  19.859093,
+                  19.576235,
+                  19.538775,
+                  20.551216,
+                  19.78725,
+                  20.096217,
+                  19.569043,
+                  18.936972,
+                  19.509411,
+                  19.145902,
+                  19.995809,
+                  19.759357,
+                  19.237503,
+                  19.449729,
+                  19.568782
                 ],
                 "sample_count": 20,
-                "median": 0.014395999999999999,
-                "p95": 0.079667,
-                "min": -0.054084,
-                "max": 0.099333,
-                "stdev": 0.04245464645886832
+                "median": 19.572639000000002,
+                "p95": 20.096217,
+                "min": 18.936972,
+                "max": 20.551216,
+                "stdev": 0.3636973517444003
               },
               "rss_kb": {
                 "samples": [
-                  8720.0,
-                  8608.0,
-                  8720.0,
-                  8720.0,
-                  8720.0,
-                  8720.0,
-                  8720.0,
-                  8720.0,
-                  8720.0,
-                  8720.0,
-                  8736.0,
-                  8736.0,
-                  8720.0,
-                  8608.0,
-                  8720.0,
-                  8720.0,
-                  8592.0,
-                  8736.0,
-                  8720.0,
-                  8720.0
+                  35832.0,
+                  35920.0,
+                  35836.0,
+                  36124.0,
+                  35916.0,
+                  36056.0,
+                  36000.0,
+                  35884.0,
+                  35756.0,
+                  35920.0,
+                  35916.0,
+                  35568.0,
+                  36080.0,
+                  35992.0,
+                  35880.0,
+                  35928.0,
+                  36116.0,
+                  35992.0,
+                  36028.0,
+                  35884.0
                 ],
                 "sample_count": 20,
-                "median": 8720.0,
-                "p95": 8736.0,
-                "min": 8592.0,
-                "max": 8736.0,
-                "stdev": 43.37003573897536
+                "median": 35920.0,
+                "p95": 36116.0,
+                "min": 35568.0,
+                "max": 36124.0,
+                "stdev": 126.46121935202112
               },
               "measured_command": [
                 "benchmarks/honest_bench/workloads/1_json_pipeline/perry/json_pipeline",
                 "benchmarks/honest_bench/assets/input_small.json",
-                "/private/tmp/out_perry.json"
+                "/tmp/out_perry.json"
               ]
             },
             "node": {
               "wall_ms": {
                 "samples": [
-                  -0.025542,
-                  -0.1445,
-                  0.018875,
-                  -0.044625,
-                  -0.109416,
-                  0.008667,
-                  -0.011625,
-                  0.02225,
-                  0.039375,
-                  0.028542,
-                  -0.009666,
-                  -0.093292,
-                  0.017125,
-                  -0.144125,
-                  -0.0405,
-                  0.031209,
-                  0.034791,
-                  -0.001666,
-                  0.00975,
-                  0.003292
+                  54.736041,
+                  53.614096,
+                  53.743457,
+                  51.094371,
+                  53.587717,
+                  52.98934,
+                  51.670737,
+                  53.009598,
+                  54.034882,
+                  50.515881,
+                  51.521488,
+                  52.47569,
+                  54.06073,
+                  52.984821,
+                  50.570152,
+                  51.398459,
+                  50.739238,
+                  53.55204,
+                  51.235835,
+                  53.238073
                 ],
                 "sample_count": 20,
-                "median": 0.0008129999999999999,
-                "p95": 0.034791,
-                "min": -0.1445,
-                "max": 0.039375,
-                "stdev": 0.056687118817659976
+                "median": 52.9870805,
+                "p95": 54.06073,
+                "min": 50.515881,
+                "max": 54.736041,
+                "stdev": 1.2905891382162678
               },
               "rss_kb": {
                 "samples": [
-                  65536.0,
-                  65488.0,
-                  65632.0,
-                  65504.0,
-                  65264.0,
-                  65504.0,
-                  65424.0,
-                  65568.0,
-                  65584.0,
-                  65536.0,
-                  65552.0,
-                  65552.0,
-                  65600.0,
-                  65616.0,
-                  65664.0,
-                  65568.0,
-                  65504.0,
-                  65504.0,
-                  65616.0,
-                  65520.0
+                  60952.0,
+                  60724.0,
+                  60800.0,
+                  61004.0,
+                  60952.0,
+                  60796.0,
+                  60640.0,
+                  61096.0,
+                  60976.0,
+                  60880.0,
+                  61228.0,
+                  60968.0,
+                  60752.0,
+                  61016.0,
+                  60676.0,
+                  60852.0,
+                  60984.0,
+                  60932.0,
+                  60868.0,
+                  60856.0
                 ],
                 "sample_count": 20,
-                "median": 65544.0,
-                "p95": 65632.0,
-                "min": 65264.0,
-                "max": 65664.0,
-                "stdev": 83.82457873440224
+                "median": 60906.0,
+                "p95": 61096.0,
+                "min": 60640.0,
+                "max": 61228.0,
+                "stdev": 139.85363777892945
               },
               "measured_command": [
-                "~/.cache/perry-bench-tools/node-v22.23.1-darwin-arm64/bin/node",
+                "~/.cache/perry-bench-tools/node-v22.23.1-linux-x64/bin/node",
                 "--experimental-strip-types",
                 "--disable-warning=MODULE_TYPELESS_PACKAGE_JSON",
                 "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
                 "benchmarks/honest_bench/assets/input_small.json",
-                "/private/tmp/out_node.json"
+                "/tmp/out_node.json"
               ]
             },
             "bun": {
               "wall_ms": {
                 "samples": [
-                  0.0055,
-                  -0.099792,
-                  0.00575,
-                  -0.032167,
-                  0.066125,
-                  -0.094916,
-                  -0.01225,
-                  0.040917,
-                  0.007417,
-                  -0.035041,
-                  0.04775,
-                  -0.038042,
-                  0.090458,
-                  0.060041,
-                  -0.117959,
-                  -0.015625,
-                  0.027417,
-                  0.030875,
-                  0.099917,
-                  -0.02275
+                  28.31262,
+                  28.22738,
+                  28.310285,
+                  27.132165,
+                  27.774024,
+                  28.230075,
+                  28.373233,
+                  27.872147,
+                  27.858562,
+                  27.619265,
+                  27.803158,
+                  27.550486,
+                  27.177049,
+                  28.768351,
+                  27.808929,
+                  27.868961,
+                  27.561156,
+                  27.903646,
+                  27.75583,
+                  28.159423
                 ],
                 "sample_count": 20,
-                "median": 0.005625,
-                "p95": 0.090458,
-                "min": -0.117959,
-                "max": 0.099917,
-                "stdev": 0.058913122553362424
+                "median": 27.8637615,
+                "p95": 28.373233,
+                "min": 27.132165,
+                "max": 28.768351,
+                "stdev": 0.3927842738369083
               },
               "rss_kb": {
                 "samples": [
-                  30832.0,
-                  30896.0,
-                  30816.0,
-                  30816.0,
-                  30800.0,
-                  30816.0,
-                  30864.0,
-                  30816.0,
-                  30800.0,
-                  30784.0,
-                  30800.0,
-                  30816.0,
-                  30784.0,
-                  30816.0,
-                  30848.0,
-                  30832.0,
-                  30800.0,
-                  30832.0,
-                  30800.0,
-                  30864.0
+                  40356.0,
+                  40516.0,
+                  40448.0,
+                  40516.0,
+                  40156.0,
+                  40516.0,
+                  40524.0,
+                  40516.0,
+                  40624.0,
+                  40580.0,
+                  40456.0,
+                  40388.0,
+                  40336.0,
+                  40512.0,
+                  40140.0,
+                  40484.0,
+                  40704.0,
+                  40368.0,
+                  40332.0,
+                  40536.0
                 ],
                 "sample_count": 20,
-                "median": 30816.0,
-                "p95": 30864.0,
-                "min": 30784.0,
-                "max": 30896.0,
-                "stdev": 27.839540226088506
+                "median": 40498.0,
+                "p95": 40624.0,
+                "min": 40140.0,
+                "max": 40704.0,
+                "stdev": 137.09208584013885
               },
               "measured_command": [
-                "~/.cache/perry-bench-tools/bun/bun",
+                "~/.cache/perry-bench-tools/bun-1.3.14/bun",
                 "run",
                 "benchmarks/honest_bench/workloads/1_json_pipeline/node/json_pipeline.ts",
                 "benchmarks/honest_bench/assets/input_small.json",
-                "/private/tmp/out_bun.json"
+                "/tmp/out_bun.json"
               ]
             }
           }

--- a/benchmarks/suite/02_loop_overhead.ts
+++ b/benchmarks/suite/02_loop_overhead.ts
@@ -1,13 +1,17 @@
 // Benchmark: Loop overhead
-// Measures raw loop iteration speed without array access
+// Measures a minimal loop-carried integer dependency without array access.
+// A plain `sum = sum + 1` induction variable is equivalent to ITERATIONS and
+// can be removed completely, leaving a misleading 0 ms benchmark. Every
+// iteration therefore feeds an inexpensive FNV-style recurrence whose final
+// value escapes below.
 const ITERATIONS = 100000000;
-let sum = 0;
+let checksum = 0x811c9dc5 | 0;
 
 const start = Date.now();
 for (let i = 0; i < ITERATIONS; i++) {
-    sum = sum + 1;
+    checksum = Math.imul(checksum ^ i, 0x01000193);
 }
 const elapsed = Date.now() - start;
 
 console.log("loop_overhead:" + elapsed);
-console.log("sum:" + sum);
+console.log("checksum:" + (checksum >>> 0));

--- a/benchmarks/suite/08_string_concat.ts
+++ b/benchmarks/suite/08_string_concat.ts
@@ -1,6 +1,6 @@
 // Benchmark: String concatenation
 // Measures string allocation and concatenation
-const ITERATIONS = 100000;
+const ITERATIONS = 1000000;
 
 let result = "";
 const start = Date.now();
@@ -9,5 +9,14 @@ for (let i = 0; i < ITERATIONS; i++) {
 }
 const elapsed = Date.now() - start;
 
+// Observe materialized bytes, not only the length metadata that the optimizer
+// can derive from ITERATIONS. Keep the scan outside the timed concatenation
+// region and stride it so verification stays cheap.
+let checksum = 0;
+for (let i = 0; i < result.length; i += 997) {
+    checksum = checksum + result.charCodeAt(i);
+}
+
 console.log("string_concat:" + elapsed);
 console.log("length:" + result.length);
+console.log("checksum:" + checksum);

--- a/benchmarks/suite/results/RESULTS.md
+++ b/benchmarks/suite/results/RESULTS.md
@@ -1,40 +1,40 @@
 # suite/ Node and Bun Results (generated)
 
-Evidence: [`public-node-bun-v1.json`](../../results/public-node-bun-v1.json) · commit `38ff7eccc2aa0b59629bed548daf8ac56bd9fb03`
-Perry: `perry 0.5.1355` · Node: `v22.23.1` · Bun: `1.3.14`
+Evidence: [`public-node-bun-v1.json`](../../results/public-node-bun-v1.json) · commit `827a92bad5a589e94e1630994185693ada903fe2`
+Perry: `perry 0.5.1519` · Node: `v22.23.1` · Bun: `1.3.14`
 Policy: 5 measured samples per runtime and benchmark; incomplete or incorrect rows are rejected.
 
 | Benchmark | Perry median | Node median | Bun median | Result |
 |---|---:|---:|---:|---|
-| 02_loop_overhead | 94 ms | 64 ms | 39 ms | loss vs both |
-| 03_array_write | 1 ms | 7 ms | 5 ms | win vs both |
-| 04_array_read | 23 ms | 11 ms | 13 ms | loss vs both |
-| 05_fibonacci | 390 ms | 913 ms | 505 ms | win vs both |
-| 06_math_intensive | 49 ms | 49 ms | 48 ms | mixed |
-| 07_object_create | 3 ms | 5 ms | 5 ms | win vs both |
-| 08_string_concat | 2 ms | 4 ms | 1 ms | mixed |
-| 09_method_calls | 9 ms | 10 ms | 8 ms | mixed |
-| 10_nested_loops | 39 ms | 17 ms | 19 ms | loss vs both |
-| 11_prime_sieve | 28 ms | 6 ms | 5 ms | loss vs both |
-| 12_binary_trees | 4 ms | 6 ms | 6 ms | win vs both |
-| 13_factorial | 94 ms | 95 ms | 95 ms | win vs both |
-| 14_closure | 47 ms | 49 ms | 49 ms | win vs both |
-| 15_mandelbrot | 22 ms | 24 ms | 28 ms | win vs both |
-| 16_matrix_multiply | 85 ms | 33 ms | 33 ms | loss vs both |
-| bench_gc_pressure | 21 ms | 15 ms | 20 ms | loss vs both |
-| bench_json_roundtrip | 184 ms | 384 ms | 219 ms | win vs both |
-| bench_object_property | 129 ms | 15 ms | 7 ms | loss vs both |
-| bench_int_arithmetic | 367 ms | 94 ms | 39 ms | loss vs both |
-| bench_buffer_readwrite | 94 ms | 96 ms | 193 ms | win vs both |
-| bench_array_grow | 8 ms | 13 ms | 9 ms | win vs both |
-| bench_string_heavy | 50 ms | 42 ms | 29 ms | loss vs both |
-| bench_numeric_array_numeric | 68 ms | 5 ms | 4 ms | loss vs both |
-| bench_numeric_array_downgrade | 17 ms | 6 ms | 5 ms | loss vs both |
+| 02_loop_overhead | 74 ms | 75 ms | 74 ms | mixed |
+| 03_array_write | 4 ms | 5 ms | 5 ms | win vs both |
+| 04_array_read | 5 ms | 7 ms | 9 ms | win vs both |
+| 05_fibonacci | 315 ms | 698 ms | 426 ms | win vs both |
+| 06_math_intensive | 44 ms | 43 ms | 47 ms | mixed |
+| 07_object_create | 4 ms | 4 ms | 7 ms | mixed |
+| 08_string_concat | 5 ms | 37 ms | 12 ms | win vs both |
+| 09_method_calls | 6 ms | 9 ms | 4 ms | mixed |
+| 10_nested_loops | 25 ms | 12 ms | 12 ms | loss vs both |
+| 11_prime_sieve | 4 ms | 4 ms | 5 ms | mixed |
+| 12_binary_trees | 6 ms | 5 ms | 9 ms | mixed |
+| 13_factorial | 59 ms | 95 ms | 61 ms | win vs both |
+| 14_closure | 29 ms | 30 ms | 29 ms | mixed |
+| 15_mandelbrot | 15 ms | 17 ms | 16 ms | win vs both |
+| 16_matrix_multiply | 22 ms | 24 ms | 22 ms | mixed |
+| bench_gc_pressure | 12 ms | 15 ms | 28 ms | win vs both |
+| bench_json_roundtrip | 184 ms | 380 ms | 185 ms | win vs both |
+| bench_object_property | 26 ms | 13 ms | 17 ms | loss vs both |
+| bench_int_arithmetic | 37 ms | 77 ms | 36 ms | mixed |
+| bench_buffer_readwrite | 79 ms | 60 ms | 76 ms | loss vs both |
+| bench_array_grow | 8 ms | 28 ms | 19 ms | win vs both |
+| bench_string_heavy | 32 ms | 37 ms | 31 ms | mixed |
+| bench_numeric_array_numeric | 4 ms | 5 ms | 3 ms | mixed |
+| bench_numeric_array_downgrade | 4 ms | 6 ms | 5 ms | win vs both |
 
 ## Summary
 
 - Wins versus both peers: **10**
-- Losses versus both peers: **11**
-- Mixed or tied rows: **3**
+- Losses versus both peers: **3**
+- Mixed or tied rows: **11**
 
 > Historical note: the former v0.5.908 single-run commentary is archived in Git history and is not current evidence.

--- a/changelog.d/9338-benchmark-measures-nothing.md
+++ b/changelog.d/9338-benchmark-measures-nothing.md
@@ -3,4 +3,5 @@
 - Benchmark rows whose Perry median is `0 ms` are now rejected as
   `MEASURES-NOTHING` instead of being reported as impossible `0.00×` wins.
   The loop-overhead and string-concatenation fixtures also retain observable
-  work and run above the internal timer's resolution floor.
+  work and run above the internal timer's resolution floor, with the native
+  loop counterparts included in the public-baseline fingerprint.

--- a/changelog.d/9338-benchmark-measures-nothing.md
+++ b/changelog.d/9338-benchmark-measures-nothing.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Benchmark rows whose Perry median is `0 ms` are now rejected as
+  `MEASURES-NOTHING` instead of being reported as impossible `0.00×` wins.
+  The loop-overhead and string-concatenation fixtures also retain observable
+  work and run above the internal timer's resolution floor.

--- a/tests/test_benchmark_gate.py
+++ b/tests/test_benchmark_gate.py
@@ -108,6 +108,16 @@ class BenchmarkArtifactTests(unittest.TestCase):
                 generated_at="2026-07-12T00:00:00Z",
             )
 
+    def test_rejects_zero_perry_median_as_measuring_nothing(self):
+        with self.assertRaisesRegex(ArtifactError, "fast.*0 ms.*measures-nothing"):
+            build_artifact(
+                records=[record("fast", [0, 0, 1], [18, 20, 22])],
+                requested_samples=3,
+                runtimes={"perry": runtime(), "node": runtime(), "bun": runtime(False)},
+                commit="abc123",
+                generated_at="2026-07-12T00:00:00Z",
+            )
+
     def test_rejects_explicit_empty_rss_samples(self):
         with self.assertRaisesRegex(ArtifactError, "perry.*0/3.*RSS"):
             build_artifact(

--- a/tests/test_benchmark_peer_fallback.sh
+++ b/tests/test_benchmark_peer_fallback.sh
@@ -41,8 +41,27 @@ while [[ $# -gt 0 ]]; do
 done
 source_file="$(cd "$(dirname "$source_file")" && pwd)/$(basename "$source_file")"
 source_name="$(basename "$source_file")"
-printf '#!/usr/bin/env bash\n%q %q\nstatus=$?\nif [[ "${PERRY_FAKE_FAIL_SOURCE:-}" == %q ]]; then exit 7; fi\nexit "$status"\n' \
-  "$PERRY_FAKE_NODE" "$source_file" "$source_name" >"$output_file"
+{
+  printf '#!/usr/bin/env bash\nset -euo pipefail\nsource_file=%q\nsource_name=%q\n' \
+    "$source_file" "$source_name"
+  cat <<'RUNNER'
+if [[ "${PERRY_FAKE_ZERO_SOURCE:-}" == "$source_name" ]]; then
+  "$PERRY_FAKE_NODE" "$source_file" | awk '
+    !replaced && /^[a-z_]+:[0-9]+/ {
+      sub(/:[0-9]+(\.[0-9]+)?$/, ":0")
+      replaced = 1
+    }
+    { print }
+  '
+  status=${PIPESTATUS[0]}
+else
+  "$PERRY_FAKE_NODE" "$source_file"
+  status=$?
+fi
+if [[ "${PERRY_FAKE_FAIL_SOURCE:-}" == "$source_name" ]]; then exit 7; fi
+exit "$status"
+RUNNER
+} >"$output_file"
 chmod +x "$output_file"
 SH
 chmod +x "$FAKE_PERRY"
@@ -103,6 +122,43 @@ if [[ -e "$TMP/failed.json" ]]; then
 fi
 if [[ -e "$ROOT/benchmarks/suite/02_loop_overhead" ]]; then
   echo "compare.sh did not clean compiled benchmark artifacts after failure" >&2
+  exit 1
+fi
+
+# A zero Perry median is not a speedup. It means the internal timer cannot
+# establish that the fixture executed useful timed work, so the table must name
+# it and artifact construction must fail even under --warn-only.
+echo 'stale artifact' >"$TMP/zero.json"
+set +e
+PATH="$TMP/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+PERRY_BIN="$FAKE_PERRY" \
+PERRY_FAKE_NODE="$NODE_REAL" \
+PERRY_FAKE_ZERO_SOURCE="02_loop_overhead.ts" \
+  "$ROOT/benchmarks/compare.sh" \
+    --quick \
+    --runs 2 \
+    --warn-only \
+    --json-out "$TMP/zero.json" \
+    >"$TMP/zero-output.txt" 2>"$TMP/zero-error.txt"
+zero_status=$?
+set -e
+if [[ "$zero_status" -ne 2 ]]; then
+  cat "$TMP/zero-error.txt" >&2
+  echo "expected a zero Perry median to exit 2, got $zero_status" >&2
+  exit 1
+fi
+if ! grep -q "MEASURES-NOTHING" "$TMP/zero-output.txt"; then
+  cat "$TMP/zero-output.txt" >&2
+  echo "compare.sh did not label the zero Perry row as MEASURES-NOTHING" >&2
+  exit 1
+fi
+if ! grep -q "measures-nothing" "$TMP/zero-error.txt"; then
+  cat "$TMP/zero-error.txt" >&2
+  echo "artifact rejection did not explain the measures-nothing verdict" >&2
+  exit 1
+fi
+if [[ -e "$TMP/zero.json" ]]; then
+  echo "compare.sh left a stale JSON artifact after a measures-nothing row" >&2
   exit 1
 fi
 

--- a/tests/test_public_baseline.py
+++ b/tests/test_public_baseline.py
@@ -193,6 +193,7 @@ class PublicBaselineTests(unittest.TestCase):
             "benchmarks/honest_bench/workloads/1_json_pipeline/perry/*.ts",
             SOURCE_PATHS,
         )
+        self.assertIn("benchmarks/polyglot/bench.*", SOURCE_PATHS)
 
     def test_measurement_config_rejects_an_invalid_run_count(self):
         config = load_measurement_config()


### PR DESCRIPTION
## Summary

Make the two genuinely timing-free fixtures execute observable work, and prevent any future Perry median of 0 ms from being published as a false benchmark win. This also refreshes the public evidence from the required Linux benchmark host without a version bump.

## Changes

- Replace `02_loop_overhead`'s foldable induction with an observable 32-bit FNV-style carry. Align the Rust, C++, Go, Swift, Java, Python, and Zig counterparts and include native polyglot sources in the public-baseline fingerprint.
- Increase `08_string_concat` to one million appends and consume strided characters after the timed region, so the result cannot be represented by length metadata alone.
- Label a zero Perry median `MEASURES-NOTHING`; reject it during both artifact construction and validation, even under `--warn-only`, instead of computing `0.00x` ratios or retaining stale JSON.
- Add unit and shell-integration coverage for the rejection path.
- Refresh the complete public Node/Bun evidence. On the published run, `02_loop_overhead` measured 74 ms for Perry and `08_string_concat` measured 5 ms; all 24 suite rows passed correctness.
- Make honest-bench host metadata/reporting and Zig builds portable to the Linux evidence host used for this refresh.

`bench_typed_array_untyped_access` was audited but intentionally not changed here: it already emits element-derived checksums and measured about 877 ms under Perry on `perrymaster`. Its first numeric line is a Perry-to-Perry typed/untyped ratio, not elapsed time; explicit metric classification for that positional-parser bug belongs to #9374.

## Related issue

Fixes #9338

Refs #9374

## Test plan

Run on `root@perrymaster.skelpo.net` from a clean worktree at the pushed tip:

- `PYTHONPATH=. python3 -m unittest tests.test_public_baseline tests.test_benchmark_gate -v` — 42 passed
- `./tests/test_benchmark_peer_fallback.sh` — passed, including injected zero-median rejection
- `python3 benchmarks/ci_public_baseline_check.py` — passed
- `./scripts/pre-tag-check.sh --quick` — passed
- Shell syntax, Python byte-compilation, file-size policy, `git diff --check`, and native Linux Zig builds — passed
- Public baseline protocol under the configured quiet-host policy: suite 5 samples, compute/JSON polyglot 11 samples, app patterns 15 samples, and honest bench 20 samples per cell; assembly, rendering, correctness, and freshness checks passed

- [ ] `cargo build --release` clean — no Rust or Cargo inputs changed; the public protocol rebuilt the required release Perry/static packages at the measured commit
- [ ] Full Cargo test matrix — not run; no Rust crate changed
- [x] Added or updated regression coverage under `tests/`
- [x] Docs update not applicable (no CLI, stdlib, or runtime API change)
- [x] Platform UI build not applicable

## Screenshots / output

Before, Perry self-reported 0 ms for loop overhead and 0–1 ms for string concatenation. The refreshed five-sample medians are:

```text
loop_overhead   Perry 74 ms   Node 75 ms   Bun 74 ms   correctness pass
string_concat   Perry  5 ms   Node 37 ms   Bun 12 ms   correctness pass
```

An injected zero Perry row now prints `MEASURES-NOTHING`, exits 2, and refuses to publish an artifact.

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md
- [x] My commits follow the repository's commit-prefix convention
- [x] I've read CONTRIBUTING.md and agree to the Code of Conduct


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Benchmark reports now identify zero-millisecond Perry measurements as **MEASURES-NOTHING** instead of calculating misleading speedups.
  - Benchmark collection and reporting now support macOS and Linux environments more consistently.
  - Loop-overhead and string-concatenation benchmarks now perform observable work for more reliable measurements.

- **Documentation**
  - Refreshed benchmark tables, methodology notes, changelog entries, and recorded results with updated runtime comparisons and environment details.

- **Bug Fixes**
  - Prevented invalid benchmark artifacts and ratios when measurements contain zero-duration results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->