### PR TITLE
fix(runtime): resolve dynamic-heritage super() per class evaluation

### DIFF
--- a/changelog.d/9406-dynamic-heritage-super-per-evaluation.md
+++ b/changelog.d/9406-dynamic-heritage-super-per-evaluation.md
@@ -1,0 +1,102 @@
+### Fixed
+
+- **A factory that returns `class D extends <its parameter>` no longer
+  SIGSEGVs when it is chained through its own previous result.** The five-line
+  repro is zod v4's `$constructor` shape, the single most-used class factory in
+  the `claude-code` bundle:
+
+  ```js
+  function mk(P) { class D extends (P ?? Object) {} return D; }
+  const A = mk(null);
+  const B = mk(A);
+  console.log("ok " + typeof new B());   // node: ok object -- perry: SIGSEGV
+  ```
+
+  One level was fine; the second level died, and only when the derived class
+  was actually instantiated. Not a regression — it reproduced identically on
+  `83754818e` (#9242) and `a03be729c` (#9336).
+
+  The recursion is a `super()` chain that never descends.
+  `CLASS_DYNAMIC_PARENT_VALUE` — the stash a compiled constructor's `super()`
+  leg reads back through `js_get_dynamic_parent_value` — is keyed by the
+  **template** class id and is last-wins, so one class evaluated N times leaves
+  exactly one heritage recorded. When that heritage is an *earlier evaluation
+  of the same template*, the parent's constructor re-reads the same entry,
+  resolves the same parent, and re-enters itself until the stack guard page.
+  Two lowerings reach it, and each needed its own half of the fix.
+
+  **A non-capturing function-body class DECLARATION** (no captures, no private
+  elements, no computed keys) keeps the shared-template lowering: it has no
+  per-evaluation class object at all, so `mk(null) === mk(A)` and the second
+  evaluation stashed `ClassRef(D)` against D itself.
+  `js_register_class_parent_dynamic` already rejects `parent_cid == class_id`
+  for the registry edge it writes ("so a recursive helper that returns its
+  receiver can't create a cycle"); the VALUE stash beside it did not. It does
+  now — a class is never its own superclass, and rejecting the write keeps
+  whichever heritage the earlier evaluation recorded, the only heritage a
+  single class id can describe.
+
+  **A capture-carrying declaration or a class EXPRESSION** does materialize a
+  distinct class object per evaluation, and each already pins its own heritage
+  (`js_class_object_pin_parent`) — the per-evaluation prototype chain and the
+  per-evaluation capture snapshot both read it from there. The `super()` leg
+  could not: a compiled constructor knows only its template class id, so it
+  asked the template stash and got the LAST evaluation's parent at every level.
+  `new B(x)` replayed B's constructor, resolved A, replayed A's constructor,
+  resolved A again, and looped. The constructor replay now names the evaluation
+  it belongs to for the duration of the call, and `js_get_dynamic_parent_value`
+  answers from that evaluation's pinned heritage when one is active.
+
+  Affected files:
+
+  - `crates/perry-runtime/src/object/class_registry/evaluation_heritage.rs`
+    (new) — the self-heritage predicate and the active-replay frame, with the
+    NaN-boxed class objects the frames hold.
+  - `crates/perry-runtime/src/object/class_registry/parent_static.rs` — reject a
+    self-heritage stash write; split `js_get_dynamic_parent_value` into the
+    per-evaluation override plus `template_dynamic_parent_value`, which
+    `js_class_object_pin_parent` keeps using so a pin still records what the
+    class DEFINITION evaluated.
+  - `crates/perry-runtime/src/object/class_constructors.rs` — push the frame
+    around the class-object constructor replay, keyed on the same
+    `capture_owner` object that supplies the constructor's capture params. The
+    guard pops on unwind.
+  - `crates/perry-runtime/src/object/class_registry/gc_roots.rs` — the frames
+    hold live heap pointers across a user constructor body, so the class
+    side-table root scanner visits and forwards them.
+
+  Validation: `test-files/test_gap_9364_factory_decl_dynamic_parent_chain.ts`
+  plus byte-comparison against node 26.5.1 over 20 probes — both lowerings, one
+  / two / three chain levels, an explicit `super()`, a rest-parameter
+  constructor, a declared-class parent instead of `Object`, static state on the
+  derived class, and the full zod `$constructor` shape (`Object.defineProperty`
+  on `name`, an initializer closure, `instanceof`). All previously-SIGSEGVing
+  probes now match node. `perry-runtime` 2895 passed / 0 failed. Five focused
+  unit tests cover the stash guard (including a ClassRef to a *different* class,
+  which must still be recorded) and the override (including that it answers only
+  for the replaying class's own template id, and that the frame pops); each half
+  was sabotage-checked — disabling the guard fails exactly two, disabling the
+  override fails exactly one. A 20,000-iteration construction loop over a
+  three-level chain runs clean under `PERRY_GC_SCHEDULE_SEED=999
+  PERRY_GC_SCHEDULE_RATE=1 PERRY_GC_PROTECT_FROMSPACE=1` (20,005 copying minors,
+  20,000 loop polls, from-space `mprotect`ed), which is what exercises the new
+  root.
+
+  `scripts/run_lint_gates.sh` passes all 60 gates (including
+  `gc_runtime_root_holders.py`, which is what the new root has to satisfy). The
+  full gap suite reports 597/611 with 14 output mismatches; five are the
+  committed snapshot entries and the other nine reproduce on the pristine merge
+  base under the identical procedure — `test_gap_6336_class_expr_builtin_parent`
+  is reproduced there by adding two `eprintln!`s to `perry-runtime` and nothing
+  else, i.e. that host's ext-wrapper archives go incoherent on any runtime edit.
+
+  Two adjacent gaps are deliberately NOT addressed here and remain open. A
+  shared-template class declaration still collapses its evaluations, so
+  `mk(null) === mk(A)` reads `true` where node says `false` (and therefore
+  `Object.getPrototypeOf(B) === A` reads `false`); giving that shape a
+  per-evaluation class object is a lowering change with a far wider blast
+  radius than a crash fix should carry. Separately, a single evaluation of
+  `class D extends (P ?? Object) { constructor(d) { super(d); this.d = d; } }`
+  loses `this.d` — that reproduces unchanged on the merge base and is not
+  introduced or worsened here; the chained form used to SIGSEGV and now reaches
+  the same pre-existing wrong value.

--- a/crates/perry-runtime/src/object/class_constructors.rs
+++ b/crates/perry-runtime/src/object/class_constructors.rs
@@ -1308,6 +1308,14 @@ pub(crate) unsafe fn replay_class_object_constructor(
         };
         final_args.push(v);
     }
+    // #9364: name the evaluation this constructor belongs to for the duration
+    // of the replay, so a `super()` in its body resolves THIS class object's
+    // pinned heritage rather than the template's last-wins stash. `capture_owner`
+    // is the class object that owns `ctor_ptr` — the same object whose captured
+    // environment fills the trailing cap params — so it is also the object whose
+    // heritage that constructor's `super()` means. The guard pops on unwind.
+    let _active_evaluation =
+        super::class_registry::push_active_class_evaluation(capture_owner_handle.get_nanbox_f64());
     inst_handle.with_mut_ptr::<ObjectHeader, _>(|inst| {
         let _ = call_vtable_method(
             ctor_ptr,

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -48,6 +48,10 @@ mod construct;
 pub(crate) use construct::scan_current_new_target_root_mut;
 pub mod decl_prototype_table;
 mod dispatch;
+pub(crate) mod evaluation_heritage;
+pub(crate) use evaluation_heritage::{
+    active_class_evaluation_parent, is_self_heritage_value, push_active_class_evaluation,
+};
 mod function_prototype;
 mod gc_roots;
 pub(crate) mod parent_static;

--- a/crates/perry-runtime/src/object/class_registry/evaluation_heritage.rs
+++ b/crates/perry-runtime/src/object/class_registry/evaluation_heritage.rs
@@ -1,0 +1,157 @@
+//! Which heritage a `super()` sees when one class TEMPLATE is evaluated more
+//! than once (#9364).
+//!
+//! `CLASS_DYNAMIC_PARENT_VALUE` is keyed by TEMPLATE class id and is last-wins,
+//! so a factory that evaluates its class twice leaves exactly one parent
+//! recorded — the last one. That is the value the compiled constructor's
+//! `super()` leg reads back (`js_get_dynamic_parent_value`). When the recorded
+//! parent is an EARLIER evaluation of the same template, replaying that
+//! parent's constructor re-reads the same entry, resolves the same parent, and
+//! re-enters the same constructor: unbounded recursion into the stack guard
+//! page.
+//!
+//! ```text
+//! function mk(P) { class D extends (P ?? Object) { constructor(d) { super(d); … } } return D; }
+//! const A = mk(null);   // stash[D] = Object
+//! const B = mk(A);      // stash[D] = A   <- last-wins
+//! new B({});            // B.super -> A, A.super -> stash[D] -> A -> …
+//! ```
+//!
+//! Every evaluation already carries its OWN heritage as an own property on its
+//! class object (`js_class_object_pin_parent`), and the two consumers that were
+//! already per-evaluation — the prototype chain
+//! (`class_evaluation_prototype_value`) and the capture snapshot
+//! (`pinned_class_object_for_ancestor`) — read it from there. The `super()` leg
+//! could not, because a compiled constructor knows only its template class id.
+//! This module supplies the missing context: the class OBJECT whose constructor
+//! is currently being replayed, so a `super()` inside that replay resolves THAT
+//! evaluation's parent instead of the template's.
+
+use super::*;
+
+crate::perry_thread_local! {
+    /// NaN-boxed class OBJECTS whose constructors are being replayed on this
+    /// thread, innermost last. Pushed by
+    /// `class_constructors::replay_class_object_constructor` around the
+    /// constructor call and popped by [`ActiveClassEvaluation`]'s `Drop`, so an
+    /// unwinding constructor cannot leave a stale frame behind.
+    ///
+    /// These are live heap pointers held across a user constructor body, so the
+    /// class side-table root scanner visits and forwards them
+    /// (`gc_roots::scan_class_side_table_roots_mut`).
+    pub(crate) static ACTIVE_CLASS_EVALUATIONS: RwLock<Vec<u64>> = RwLock::new(Vec::new());
+}
+
+/// Pops the frame [`push_active_class_evaluation`] pushed.
+pub(crate) struct ActiveClassEvaluation {
+    pushed: bool,
+}
+
+impl Drop for ActiveClassEvaluation {
+    fn drop(&mut self) {
+        if !self.pushed {
+            return;
+        }
+        ACTIVE_CLASS_EVALUATIONS.with(|stack| {
+            if let Ok(mut guard) = stack.write() {
+                guard.pop();
+            }
+        });
+    }
+}
+
+/// Record `class_value` as the evaluation whose constructor is about to run.
+///
+/// A value that is not a per-evaluation class object records nothing (a class
+/// DECLARATION replayed by class id has no evaluation to distinguish), and the
+/// returned guard is then inert.
+pub(crate) fn push_active_class_evaluation(class_value: f64) -> ActiveClassEvaluation {
+    if !is_class_object_value(class_value) {
+        return ActiveClassEvaluation { pushed: false };
+    }
+    let bits = class_value.to_bits();
+    let pushed = ACTIVE_CLASS_EVALUATIONS
+        .with(|stack| {
+            stack.write().ok().map(|mut guard| {
+                guard.push(bits);
+            })
+        })
+        .is_some();
+    ActiveClassEvaluation { pushed }
+}
+
+/// This evaluation's pinned heritage, when `class_id` is the template of the
+/// class object whose constructor is currently being replayed.
+///
+/// Only the innermost frame is consulted: a `super()` leg belongs to the
+/// constructor that is running, and each nested replay pushes its own frame, so
+/// a chain of same-template evaluations walks one step per level instead of
+/// resolving to the same parent forever. `None` means "no per-evaluation answer
+/// here" — the caller falls back to the template stash, which is the whole of
+/// the pre-#9364 behaviour.
+pub(crate) fn active_class_evaluation_parent(class_id: u32) -> Option<f64> {
+    if class_id == 0 {
+        return None;
+    }
+    let bits = ACTIVE_CLASS_EVALUATIONS
+        .with(|stack| stack.read().ok().and_then(|guard| guard.last().copied()))?;
+    let class_value = f64::from_bits(bits);
+    if !is_class_object_value(class_value) {
+        return None;
+    }
+    let obj = crate::value::JSValue::from_bits(bits).as_pointer::<ObjectHeader>();
+    if obj.is_null() || js_object_get_class_id(obj) != class_id {
+        return None;
+    }
+    class_object_pinned_parent(obj)
+}
+
+/// Visit + forward the class objects held by the active replay frames.
+pub(crate) fn scan_active_class_evaluations_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    ACTIVE_CLASS_EVALUATIONS.with(|stack| {
+        if let Ok(mut guard) = stack.write() {
+            for value_bits in guard.iter_mut() {
+                visitor.visit_nanbox_u64_slot(value_bits);
+            }
+        }
+    });
+}
+
+/// Does `parent_bits` denote the very class being defined?
+///
+/// A class is never its own superclass, so such a heritage value is not a
+/// usable parent edge — the same rejection `js_register_class_parent_dynamic`
+/// already applies to its `register_class` calls (`parent_cid != class_id`).
+/// The VALUE stash needs it too, and for the same reason.
+///
+/// It is the shared-template hazard above in its other half. A function-body
+/// class DECLARATION with no captures, no private elements and no computed keys
+/// keeps the shared-template lowering and has no per-evaluation class object at
+/// all, so both evaluations answer to one class id and `mk(null) === mk(A)`:
+///
+/// ```text
+/// function mk(P) { class D extends (P ?? Object) {} return D; }
+/// const A = mk(null);   // stash[D] = Object
+/// const B = mk(A);      // A *is* `ClassRef(D)` — a self-edge
+/// new B();
+/// ```
+///
+/// Without this guard the second evaluation records `ClassRef(D)` against D, and
+/// every `super()` in D's constructor resolves its parent to D and re-enters D's
+/// constructor. There is no class object to distinguish the evaluations, so the
+/// active-replay override above cannot help here; rejecting the write keeps
+/// whichever heritage the earlier evaluation recorded, which is the only
+/// heritage this single class id can describe.
+///
+/// Deliberately limited to the ClassRef (INT32) form: a POINTER-tagged
+/// per-evaluation class OBJECT that shares the template id is a *different*
+/// class value with its own pinned heritage, and rejecting those would break the
+/// factory chains that lowering already models correctly.
+pub(crate) fn is_self_heritage_value(class_id: u32, parent_bits: u64) -> bool {
+    const INT32_TAG: u64 = 0x7FFE_0000_0000_0000;
+    parent_bits & 0xFFFF_0000_0000_0000 == INT32_TAG && parent_bits as u32 == class_id
+}
+
+#[cfg(test)]
+#[path = "evaluation_heritage/tests.rs"]
+mod tests;

--- a/crates/perry-runtime/src/object/class_registry/evaluation_heritage/tests.rs
+++ b/crates/perry-runtime/src/object/class_registry/evaluation_heritage/tests.rs
@@ -1,0 +1,178 @@
+//! #9364: heritage resolution when one class template is evaluated more than
+//! once — the self-edge the VALUE stash must reject, and the per-evaluation
+//! override that keeps a `super()` chain walking instead of looping.
+
+use super::super::{js_get_dynamic_parent_value, js_register_class_parent_dynamic};
+use super::{active_class_evaluation_parent, push_active_class_evaluation};
+
+const INT32_TAG: u64 = 0x7FFE_0000_0000_0000;
+const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
+
+/// The NaN-boxed ClassRef a shared-template `class X {}` evaluates to.
+fn class_ref(class_id: u32) -> f64 {
+    f64::from_bits(INT32_TAG | class_id as u64)
+}
+
+fn register(class_id: u32) {
+    unsafe { crate::object::class_registry::js_register_class_id(class_id) };
+}
+
+#[test]
+fn a_self_heritage_class_ref_does_not_displace_an_earlier_evaluations_parent() {
+    let _lock = crate::gc::global_side_table_test_lock();
+    const PARENT: u32 = 0x0936_4001;
+    const CHILD: u32 = 0x0936_4002;
+    register(PARENT);
+    register(CHILD);
+
+    // First evaluation of the shared template records a real heritage.
+    js_register_class_parent_dynamic(CHILD, class_ref(PARENT));
+    assert_eq!(
+        js_get_dynamic_parent_value(CHILD).to_bits(),
+        class_ref(PARENT).to_bits(),
+        "fixture must start with a stashed heritage, or the verdict below is vacuous",
+    );
+
+    // A later evaluation extends the earlier one — which, sharing the template
+    // id, IS `ClassRef(CHILD)`.
+    js_register_class_parent_dynamic(CHILD, class_ref(CHILD));
+    assert_eq!(
+        js_get_dynamic_parent_value(CHILD).to_bits(),
+        class_ref(PARENT).to_bits(),
+        "a self-heritage ClassRef must not displace the recorded parent",
+    );
+}
+
+#[test]
+fn a_self_heritage_class_ref_is_not_recorded_at_all() {
+    let _lock = crate::gc::global_side_table_test_lock();
+    const SOLO: u32 = 0x0936_4003;
+    register(SOLO);
+
+    js_register_class_parent_dynamic(SOLO, class_ref(SOLO));
+    assert_eq!(
+        js_get_dynamic_parent_value(SOLO).to_bits(),
+        TAG_UNDEFINED,
+        "a class is never its own superclass, so nothing may be stashed",
+    );
+}
+
+/// The guard reads the ClassRef PAYLOAD, not merely the INT32 tag.
+#[test]
+fn a_class_ref_to_a_different_class_is_still_recorded() {
+    let _lock = crate::gc::global_side_table_test_lock();
+    const PARENT: u32 = 0x0936_4004;
+    const CHILD: u32 = 0x0936_4005;
+    register(PARENT);
+    register(CHILD);
+
+    js_register_class_parent_dynamic(CHILD, class_ref(PARENT));
+    assert_eq!(
+        js_get_dynamic_parent_value(CHILD).to_bits(),
+        class_ref(PARENT).to_bits(),
+    );
+    assert_eq!(
+        crate::object::class_registry::get_parent_class_id(CHILD),
+        Some(PARENT),
+        "the registry edge is unaffected by the stash guard",
+    );
+}
+
+/// A per-evaluation class object under replay answers with ITS OWN pinned
+/// heritage, not the template's last-wins stash. This is what stops a chained
+/// factory's `super()` from resolving to the same parent at every level.
+#[test]
+fn an_active_replay_resolves_this_evaluations_pinned_heritage() {
+    let _lock = crate::gc::global_side_table_test_lock();
+    const TEMPLATE: u32 = 0x0936_4006;
+    const FIRST_PARENT: u32 = 0x0936_4007;
+    const LAST_PARENT: u32 = 0x0936_4008;
+    register(TEMPLATE);
+    register(FIRST_PARENT);
+    register(LAST_PARENT);
+
+    {
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let class_handle = scope.root_raw_mut_ptr(crate::object::js_object_alloc(TEMPLATE, 0));
+        class_handle.with_mut_ptr::<crate::ObjectHeader, _>(|class| {
+            crate::object::class_registry::js_object_mark_class(class as i64)
+        });
+        let class_value = class_handle.with_mut_ptr::<crate::ObjectHeader, _>(|class| {
+            crate::value::js_nanbox_pointer(class as i64)
+        });
+        assert!(
+            crate::object::class_registry::is_class_object_value(class_value),
+            "fixture must be a per-evaluation class object, or the override cannot apply",
+        );
+
+        // This evaluation's heritage, pinned onto its own class object exactly
+        // as codegen does right after `RegisterClassParentDynamic`.
+        js_register_class_parent_dynamic(TEMPLATE, class_ref(FIRST_PARENT));
+        class_handle.with_mut_ptr::<crate::ObjectHeader, _>(|class| {
+            super::super::parent_static::js_class_object_pin_parent(class as i64, TEMPLATE)
+        });
+
+        // A LATER evaluation of the same template overwrites the shared stash.
+        js_register_class_parent_dynamic(TEMPLATE, class_ref(LAST_PARENT));
+        assert_eq!(
+            js_get_dynamic_parent_value(TEMPLATE).to_bits(),
+            class_ref(LAST_PARENT).to_bits(),
+            "without an active replay the template stash is still last-wins",
+        );
+
+        {
+            let _active =
+                push_active_class_evaluation(class_handle.with_mut_ptr::<crate::ObjectHeader, _>(
+                    |class| crate::value::js_nanbox_pointer(class as i64),
+                ));
+            assert_eq!(
+                js_get_dynamic_parent_value(TEMPLATE).to_bits(),
+                class_ref(FIRST_PARENT).to_bits(),
+                "a replay must resolve the replaying evaluation's own heritage",
+            );
+        }
+
+        assert_eq!(
+            js_get_dynamic_parent_value(TEMPLATE).to_bits(),
+            class_ref(LAST_PARENT).to_bits(),
+            "the frame must pop, restoring the template stash for other callers",
+        );
+        assert!(
+            active_class_evaluation_parent(TEMPLATE).is_none(),
+            "no frame is active once the guard has dropped",
+        );
+    }
+}
+
+/// The override is scoped to the replaying class's OWN template id: an
+/// unrelated class asking for its heritage during someone else's replay still
+/// reads the stash.
+#[test]
+fn an_active_replay_does_not_answer_for_another_class_id() {
+    let _lock = crate::gc::global_side_table_test_lock();
+    const TEMPLATE: u32 = 0x0936_4009;
+    const OTHER: u32 = 0x0936_400A;
+    const OTHER_PARENT: u32 = 0x0936_400B;
+    register(TEMPLATE);
+    register(OTHER);
+    register(OTHER_PARENT);
+
+    {
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let class_handle = scope.root_raw_mut_ptr(crate::object::js_object_alloc(TEMPLATE, 0));
+        class_handle.with_mut_ptr::<crate::ObjectHeader, _>(|class| {
+            crate::object::class_registry::js_object_mark_class(class as i64)
+        });
+        js_register_class_parent_dynamic(OTHER, class_ref(OTHER_PARENT));
+
+        let _active =
+            push_active_class_evaluation(class_handle.with_mut_ptr::<crate::ObjectHeader, _>(
+                |class| crate::value::js_nanbox_pointer(class as i64),
+            ));
+        assert!(active_class_evaluation_parent(OTHER).is_none());
+        assert_eq!(
+            js_get_dynamic_parent_value(OTHER).to_bits(),
+            class_ref(OTHER_PARENT).to_bits(),
+        );
+    }
+}

--- a/crates/perry-runtime/src/object/class_registry/gc_roots.rs
+++ b/crates/perry-runtime/src/object/class_registry/gc_roots.rs
@@ -181,6 +181,12 @@ pub fn scan_class_side_table_roots_mut(visitor: &mut crate::gc::RuntimeRootVisit
         }
     });
 
+    // #9364: the class objects whose constructors are being replayed on this
+    // thread. Each is a live heap pointer held across a user constructor body,
+    // so an evacuating minor must visit and forward it — the `super()` leg reads
+    // its pinned heritage back after any allocation the body performs.
+    super::evaluation_heritage::scan_active_class_evaluations_mut(visitor);
+
     scan_class_symbol_member_keys_mut(visitor);
     scan_function_class_id_keys_mut(visitor);
 }

--- a/crates/perry-runtime/src/object/class_registry/parent_static.rs
+++ b/crates/perry-runtime/src/object/class_registry/parent_static.rs
@@ -59,7 +59,8 @@ pub extern "C" fn js_register_class_parent(class_id: u32, parent_class_id: u32) 
 /// Anything else (closures, primitives, null/undefined) is a no-op:
 /// the class stays parentless, identical to the pre-#711 behavior.
 /// Self-registration (`parent_cid == class_id`) is rejected so a
-/// recursive helper that returns its receiver can't create a cycle.
+/// recursive helper that returns its receiver can't create a cycle — and the
+/// VALUE stash below applies the same rejection (`is_self_heritage_value`).
 #[no_mangle]
 pub extern "C" fn js_register_class_parent_dynamic(class_id: u32, mut parent_value: f64) {
     // Stash the parent VALUE keyed by child class id so `super()` can read it
@@ -72,7 +73,8 @@ pub extern "C" fn js_register_class_parent_dynamic(class_id: u32, mut parent_val
     {
         const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
         let bits = parent_value.to_bits();
-        if bits != TAG_UNDEFINED && class_id != 0 {
+        if bits != TAG_UNDEFINED && class_id != 0 && !super::is_self_heritage_value(class_id, bits)
+        {
             CLASS_DYNAMIC_PARENT_VALUE.with(|table| {
                 let mut guard = table.write().unwrap();
                 if guard.is_none() {
@@ -316,7 +318,12 @@ pub extern "C" fn js_class_object_pin_parent(obj: i64, template_class_id: u32) {
     if obj == 0 || template_class_id == 0 {
         return;
     }
-    let parent = js_get_dynamic_parent_value(template_class_id);
+    // The template stash, deliberately: this records the heritage the
+    // `RegisterClassParentDynamic` call immediately preceding us evaluated for
+    // THIS evaluation. `js_get_dynamic_parent_value`'s active-replay override
+    // would answer with an enclosing constructor replay's parent when a factory
+    // is re-entered from inside a constructor body.
+    let parent = template_dynamic_parent_value(template_class_id);
     if parent.to_bits() == TAG_UNDEFINED {
         return;
     }
@@ -411,6 +418,25 @@ pub(crate) fn class_object_own_field_bytes(
 /// falls back to re-evaluating its extends expression.
 #[no_mangle]
 pub extern "C" fn js_get_dynamic_parent_value(class_id: u32) -> f64 {
+    // #9364: while a per-evaluation class OBJECT's constructor is being
+    // replayed, THAT evaluation's pinned heritage is the answer. The stash
+    // below is keyed by the shared TEMPLATE id and is last-wins, so for a
+    // factory whose class is evaluated more than once it names one evaluation's
+    // parent for all of them — and when that parent is an earlier evaluation of
+    // the same template, `super()` resolves to it at every level and re-enters
+    // the same constructor forever.
+    if let Some(parent) = super::active_class_evaluation_parent(class_id) {
+        return parent;
+    }
+    template_dynamic_parent_value(class_id)
+}
+
+/// The TEMPLATE-keyed heritage: the `js_register_class_parent_dynamic` stash,
+/// then the static parent-id edge as a ClassRef. This is
+/// [`js_get_dynamic_parent_value`] without its per-evaluation override, for the
+/// callers that must see what the class DEFINITION recorded rather than what
+/// the constructor currently running inherits.
+pub(crate) fn template_dynamic_parent_value(class_id: u32) -> f64 {
     const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
     const INT32_TAG: u64 = 0x7FFE_0000_0000_0000;
     if class_id == 0 {

--- a/test-files/test_gap_9364_factory_decl_dynamic_parent_chain.ts
+++ b/test-files/test_gap_9364_factory_decl_dynamic_parent_chain.ts
@@ -1,0 +1,11 @@
+// Issue #9364: each evaluation of a class declaration inside a factory owns
+// its dynamic parent. Chaining the factory through its previous result must
+// construct normally instead of recursing through the shared template id.
+function mk(P: any): any {
+  class D extends (P ?? Object) {}
+  return D;
+}
+
+const A = mk(null);
+const B = mk(A);
+console.log("ok " + typeof new B());


### PR DESCRIPTION
Fixes #9364

```js
function mk(P) { class D extends (P ?? Object) {} return D; }
const A = mk(null);
const B = mk(A);
console.log("ok " + typeof new B());   // node: ok object — perry: SIGSEGV
```

## Root cause

The recursion is a `super()` chain that never descends.

`CLASS_DYNAMIC_PARENT_VALUE` — the stash a compiled constructor's `super()` leg reads back through `js_get_dynamic_parent_value` — is keyed by the **template** class id and is last-wins, so one class evaluated N times leaves exactly one heritage recorded. When that heritage is an *earlier evaluation of the same template*, the parent's constructor re-reads the same entry, resolves the same parent, and re-enters itself until the stack guard page. GDB shows the frames; the repro needs two chained levels and an actual `new`, exactly as the issue reports.

Two lowerings reach it, and each needed its own half of the fix.

**A non-capturing function-body class DECLARATION** (no captures, no private elements, no computed keys) keeps the shared-template lowering: it has no per-evaluation class object at all, so `mk(null) === mk(A)` and the second evaluation stashed `ClassRef(D)` against D itself. `js_register_class_parent_dynamic` already rejects `parent_cid == class_id` for the registry edge it writes ("so a recursive helper that returns its receiver can't create a cycle"); the VALUE stash beside it did not. It does now — a class is never its own superclass, and rejecting the write keeps whichever heritage the earlier evaluation recorded, the only heritage a single class id can describe.

**A capture-carrying declaration or a class EXPRESSION** does materialize a distinct class object per evaluation, and each already pins its own heritage (`js_class_object_pin_parent`) — the per-evaluation prototype chain and the per-evaluation capture snapshot both read it from there. The `super()` leg could not: a compiled constructor knows only its template class id, so it asked the template stash and got the LAST evaluation's parent at every level. `new B(x)` replayed B's constructor, resolved A, replayed A's constructor, resolved A again, and looped. The constructor replay now names the evaluation it belongs to for the duration of the call, and `js_get_dynamic_parent_value` answers from that evaluation's pinned heritage when one is active.

The issue's headline case — zod v4's `$constructor` — is the *second* shape (its `Definition` captures the initializer), so it needs both halves; the reduced repro in the issue is the first.

## What changed

- `crates/perry-runtime/src/object/class_registry/evaluation_heritage.rs` (new) — the self-heritage predicate and the active-replay frame, plus the NaN-boxed class objects those frames hold.
- `crates/perry-runtime/src/object/class_registry/parent_static.rs` — reject a self-heritage stash write; split `js_get_dynamic_parent_value` into the per-evaluation override plus `template_dynamic_parent_value`, which `js_class_object_pin_parent` keeps using so a pin still records what the class DEFINITION evaluated rather than what an enclosing replay inherits.
- `crates/perry-runtime/src/object/class_constructors.rs` — push the frame around the class-object constructor replay, keyed on the same `capture_owner` object that supplies that constructor's capture params. The guard pops on unwind.
- `crates/perry-runtime/src/object/class_registry/gc_roots.rs` — the frames hold live heap pointers across a user constructor body, so the class side-table root scanner visits and forwards them.
- `test-files/test_gap_9364_factory_decl_dynamic_parent_chain.ts` — the issue's repro as a gap fixture.

## Validation

Everything below on `perrymaster`, Node oracle 26.5.1 (the `.node-version` pin), `npm ci` clean.

- **Parity fixture**: `test_gap_9364_factory_decl_dynamic_parent_chain` CRASH → PASS. Verified on the merge base (CRASH) and on this branch (PASS) with the same harness invocation.
- **Byte-compared against node over 20 probes**: both lowerings; one / two / three chain levels; an explicit `super()`; a rest-parameter constructor; a declared class as the parent instead of `Object`; static state on the derived class; and the full zod `$constructor` shape (`Object.defineProperty` on `name`, an initializer closure, `instanceof`). Every previously-SIGSEGVing probe now matches node.
- **`perry-runtime`**: 2895 passed / 0 failed (`RUST_TEST_THREADS=1 cargo test --release -p perry-runtime`), doc-tests ok.
- **Five focused unit tests** in `evaluation_heritage::tests` cover the stash guard (including a ClassRef to a *different* class, which must still be recorded) and the override (including that it answers only for the replaying class's own template id, and that the frame pops). Each half is sabotage-checked: neutering the guard fails exactly two of them, neutering the override fails exactly one.
- **GC**: a 20,000-iteration construction loop over a three-level chain runs clean under `PERRY_GC_SCHEDULE_SEED=999 PERRY_GC_SCHEDULE_RATE=1 PERRY_GC_SCHEDULE_ALLOC_KB=0 PERRY_GC_PROTECT_FROMSPACE=1` — 20,005 copying minors, 20,000 loop polls, 15,632 objects moved, from-space `mprotect`ed — which is what exercises the new root.
- **Lint**: `scripts/run_lint_gates.sh` — all 60 gates pass (2 CI-only skipped), including `gc_runtime_root_holders.py`, `check_file_size.sh` and the `-D warnings` / clippy compile tier.
- **Class-expression / mixin / dynamic-parent corpus**: 26 existing fixtures re-run, all PASS (`6356_dynamic_parent_mixin_chain`, `5952_mixin_factory_binding`, `9051_dynamic_parent_ctor_field_init_once`, `class_expr_dynamic_parent_ctor`, `class_expr_identity`, `class_extends_runtime_value_super`, `9089_class_expr_self_private_identity`, `9104_named_class_expr_static_self_capture`, `5592_extends_proxy_superclass`, `6232_class_extends_array`, `6924_extends_buffer_statics`, the `class_expr_*` set, …).
- **Full gap suite** (fast mode, 611 tests): 597 pass / 14 output mismatches. Five are the committed snapshot entries. The other nine reproduce **on the pristine merge base** under the identical procedure, so none is attributable to this change; `test_gap_6336_class_expr_builtin_parent` is reproduced on the merge base by adding two `eprintln!`s to `perry-runtime` and nothing else, i.e. this host's ext-wrapper/auto-optimize archives go incoherent on any runtime edit. CI's gap shard is the authority for the snapshot diff.

## Deliberately not addressed

- A shared-template class declaration still collapses its evaluations, so `mk(null) === mk(A)` reads `true` where node says `false` (and therefore `Object.getPrototypeOf(B) === A` reads `false`). Giving that shape a per-evaluation class object is a lowering change — broadening `fresh_binding` in `lower_decl/body_stmt.rs` to any dynamic heritage — with a far wider blast radius than a crash fix should carry.
- A **single** evaluation of `class D extends (P ?? Object) { constructor(d) { super(d); this.d = d; } }` loses `this.d`. That reproduces unchanged on the merge base and is neither introduced nor worsened here; the chained form used to SIGSEGV and now reaches the same pre-existing wrong value.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash when dynamically generated classes are chained through earlier results.
  * Corrected `super()` resolution for repeatedly evaluated class factories.
  * Prevented recursive class inheritance from causing stack overflows.
  * Improved reliability during garbage collection while class constructors are running.
* **Tests**
  * Added regression coverage for dynamic parent chains and repeated class evaluation.
  * Validated behavior against Node.js across multiple probes and stress iterations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->