### PR TITLE
fix(bench): score benchmarks by an explicit time label, never by output position (#9374)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -202,10 +202,11 @@ jobs:
 
       - name: Validate benchmark artifact and fallback gates
         run: |
-          python3 -m unittest discover -s tests -p 'test_benchmark_gate.py' -v
+          python3 -m unittest discover -s tests -p 'test_benchmark_*.py' -v
           ./tests/test_benchmark_peer_fallback.sh
           ./tests/test_benchmark_output_verifier.sh
-          bash -n benchmarks/compare.sh benchmarks/honest_bench/run.sh \
+          bash -n benchmarks/compare.sh benchmarks/quick.sh \
+            benchmarks/suite/run_benchmarks.sh benchmarks/honest_bench/run.sh \
             benchmarks/honest_bench/harness/run_http_bench.sh \
             tests/test_benchmark_peer_fallback.sh
 

--- a/benchmarks/benchmark_gate.py
+++ b/benchmarks/benchmark_gate.py
@@ -66,6 +66,12 @@ def _number(value: Any, context: str) -> float:
     return value
 
 
+def _integer_ms(value: Any, context: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ArtifactError(f"{context}: expected an integer millisecond value, got {value!r}")
+    return value
+
+
 def distribution(values: Iterable[Any]) -> dict[str, Any]:
     """Return raw samples and deterministic summary statistics."""
     samples = [_number(value, "sample") for value in values]
@@ -155,18 +161,20 @@ def build_artifact(
                 raise ArtifactError(
                     f"{name}: {runtime_name} has {len(rss_samples)}/{requested_samples} RSS samples"
                 )
+            integer_wall_samples = [
+                _integer_ms(value, f"{name}: {runtime_name} wall sample")
+                for value in wall_samples
+            ]
             if any(_number(value, f"{name}: {runtime_name} RSS sample") <= 0 for value in rss_samples):
                 raise ArtifactError(f"{name}: {runtime_name} has an invalid zero RSS sample")
-            if any(_number(value, f"{name}: {runtime_name} wall sample") < 0 for value in wall_samples):
+            if any(value < 0 for value in integer_wall_samples):
                 raise ArtifactError(f"{name}: {runtime_name} has an invalid negative wall sample")
-            if runtime_name == "perry" and statistics.median(
-                _number(value, f"{name}: Perry wall sample") for value in wall_samples
-            ) == 0:
+            if runtime_name == "perry" and statistics.median(integer_wall_samples) == 0:
                 raise ArtifactError(
                     f"{name}: Perry median is 0 ms (measures-nothing); refusing to compute ratios"
                 )
             runtime_results[runtime_name] = {
-                "wall_ms": distribution(wall_samples),
+                "wall_ms": distribution(integer_wall_samples),
                 "rss_kb": distribution(rss_samples),
             }
 
@@ -323,6 +331,9 @@ def validate_artifact(payload: Mapping[str, Any]) -> None:
                     raise ArtifactError(
                         f"{name}: {runtime_name} has {len(samples)}/{requested} {metric_name} samples"
                     )
+                if metric_name == "wall_ms":
+                    for value in samples:
+                        _integer_ms(value, f"{name}: {runtime_name} wall sample")
                 recalculated = distribution(samples)
                 for field, value in recalculated.items():
                     if metric.get(field) != value:

--- a/benchmarks/benchmark_time.py
+++ b/benchmarks/benchmark_time.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Extract declared integer-millisecond fields from suite benchmark output.
+
+The suite contains both elapsed times and other numeric metrics.  A numeric
+line is not a time merely because it appears first, so every fixture has one
+explicit cross-runtime timing contract here.  ``01_startup`` is the sole
+external-timing fixture.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+
+@dataclass(frozen=True)
+class TimingContract:
+    """The output labels that have measurement rather than semantic meaning."""
+
+    time_label: str | None
+    auxiliary_time_labels: tuple[str, ...] = ()
+    metric_labels: tuple[str, ...] = ()
+
+    @property
+    def measurement_labels(self) -> frozenset[str]:
+        labels = self.auxiliary_time_labels + self.metric_labels
+        if self.time_label is not None:
+            labels = (self.time_label,) + labels
+        return frozenset(labels)
+
+
+# This is intentionally exhaustive rather than inferred from output position or
+# filename.  Some established fixtures use a historical timing label that does
+# not match their filename (for example 12_binary_trees -> object_alloc).
+TIMING_CONTRACTS: dict[str, TimingContract] = {
+    "01_startup": TimingContract(None),
+    "02_loop_overhead": TimingContract("loop_overhead"),
+    "03_array_write": TimingContract("array_write"),
+    "04_array_read": TimingContract("array_read"),
+    "05_fibonacci": TimingContract("fibonacci"),
+    "06_math_intensive": TimingContract("math_intensive"),
+    "07_object_create": TimingContract("object_create"),
+    "08_string_concat": TimingContract("string_concat"),
+    "09_method_calls": TimingContract("method_calls"),
+    "10_nested_loops": TimingContract("nested_loops"),
+    "11_prime_sieve": TimingContract("prime_sieve"),
+    "12_binary_trees": TimingContract("object_alloc"),
+    "13_factorial": TimingContract("accumulate"),
+    "14_closure": TimingContract("function_calls"),
+    "15_mandelbrot": TimingContract("mandelbrot"),
+    "16_matrix_multiply": TimingContract("matrix_multiply"),
+    "17_loop_data_dependent": TimingContract("loop_data_dependent"),
+    "bench_array_grow": TimingContract("array_grow"),
+    "bench_buffer_readwrite": TimingContract("buffer_readwrite"),
+    "bench_gc_pressure": TimingContract("gc_pressure"),
+    "bench_int_arithmetic": TimingContract("int_arithmetic"),
+    "bench_json_readonly": TimingContract("json_readonly"),
+    "bench_json_readonly_indexed": TimingContract("json_readonly_indexed"),
+    "bench_json_roundtrip": TimingContract("json_roundtrip"),
+    "bench_json_typed_roundtrip": TimingContract("json_typed_roundtrip"),
+    "bench_numeric_array_downgrade": TimingContract("numeric_array_downgrade"),
+    "bench_numeric_array_numeric": TimingContract("numeric_array_numeric"),
+    "bench_object_property": TimingContract("object_property"),
+    "bench_string_heavy": TimingContract("string_heavy"),
+    # Keep ta_untyped_typed_ratio first in the fixture: it is the intentional
+    # machine-normalized #5525 Perry-to-Perry regression metric.  Cross-runtime
+    # tables compare the declared absolute untyped-access time instead.
+    "bench_typed_array_untyped_access": TimingContract(
+        "ta_untyped_access",
+        auxiliary_time_labels=("ta_typed_access",),
+        metric_labels=("ta_untyped_typed_ratio",),
+    ),
+}
+
+
+class UnscoreableError(ValueError):
+    """Raised when stdout cannot establish an integer elapsed time."""
+
+
+def benchmark_name(value: str | Path) -> str:
+    return Path(value).stem
+
+
+def timing_contract(value: str | Path) -> TimingContract:
+    name = benchmark_name(value)
+    try:
+        return TIMING_CONTRACTS[name]
+    except KeyError as exc:
+        raise UnscoreableError(
+            f"{name}: no declared cross-runtime millisecond label"
+        ) from exc
+
+
+def extract_time_ms(value: str | Path, output: str) -> int:
+    """Return the one declared integer-millisecond value in ``output``."""
+
+    name = benchmark_name(value)
+    contract = timing_contract(name)
+    label = contract.time_label
+    if label is None:
+        raise UnscoreableError(
+            f"{name}: no internal time-labelled line; measure process startup externally"
+        )
+
+    values: list[str] = []
+    for raw_line in output.splitlines():
+        key, separator, raw_value = raw_line.strip().partition(":")
+        if separator and key == label:
+            values.append(raw_value.strip())
+
+    if not values:
+        raise UnscoreableError(
+            f"{name}: missing required time-labelled line {label}:<integer-ms>"
+        )
+    if len(values) != 1:
+        raise UnscoreableError(
+            f"{name}: expected one {label}:<integer-ms> line, found {len(values)}"
+        )
+
+    raw_value = values[0]
+    if not re.fullmatch(r"[0-9]+", raw_value):
+        raise UnscoreableError(
+            f"{name}: non-integer millisecond value {raw_value!r} for {label}"
+        )
+    return int(raw_value)
+
+
+_CONSOLE_LITERAL_RE = re.compile(
+    r"console\.log\(\s*(?:\"([^\"]*)\"|'([^']*)')"
+)
+
+
+@dataclass(frozen=True)
+class FixtureAudit:
+    name: str
+    first_output: str
+    is_time: bool
+    reason: str
+
+
+def _console_literal_prefixes(source: str) -> list[str]:
+    return [
+        match.group(1) if match.group(1) is not None else match.group(2)
+        for match in _CONSOLE_LITERAL_RE.finditer(source)
+    ]
+
+
+def audit_fixture_first_lines(suite_dir: str | Path) -> list[FixtureAudit]:
+    """Statically audit the first console output of every suite fixture."""
+
+    suite_dir = Path(suite_dir)
+    fixtures = sorted(suite_dir.glob("*.ts"))
+    fixture_names = {path.stem for path in fixtures}
+    contract_names = set(TIMING_CONTRACTS)
+    if fixture_names != contract_names:
+        missing = sorted(fixture_names - contract_names)
+        stale = sorted(contract_names - fixture_names)
+        raise UnscoreableError(
+            f"timing contract coverage mismatch: missing={missing or 'none'}, "
+            f"stale={stale or 'none'}"
+        )
+
+    audits: list[FixtureAudit] = []
+    for fixture in fixtures:
+        source = fixture.read_text(encoding="utf-8")
+        prefixes = _console_literal_prefixes(source)
+        if not prefixes:
+            raise UnscoreableError(f"{fixture.stem}: fixture has no static console.log output")
+
+        contract = TIMING_CONTRACTS[fixture.stem]
+        emitted_labels = {prefix[:-1] for prefix in prefixes if prefix.endswith(":")}
+        declared_labels = contract.measurement_labels
+        missing_labels = sorted(declared_labels - emitted_labels)
+        if missing_labels:
+            raise UnscoreableError(
+                f"{fixture.stem}: declared output label(s) not emitted: "
+                + ", ".join(missing_labels)
+            )
+
+        first = prefixes[0]
+        first_label = first[:-1] if first.endswith(":") else None
+        display = f"{first}<value>" if first_label is not None else first
+        if contract.time_label is not None and first_label == contract.time_label:
+            audits.append(FixtureAudit(fixture.stem, display, True, "declared time"))
+        elif contract.time_label is None:
+            audits.append(
+                FixtureAudit(
+                    fixture.stem,
+                    display,
+                    False,
+                    "external timing required",
+                )
+            )
+        elif first_label in contract.metric_labels:
+            audits.append(
+                FixtureAudit(
+                    fixture.stem,
+                    display,
+                    False,
+                    f"non-time metric; cross-runtime time is {contract.time_label}",
+                )
+            )
+        else:
+            audits.append(
+                FixtureAudit(
+                    fixture.stem,
+                    display,
+                    False,
+                    f"not the declared time label {contract.time_label}",
+                )
+            )
+    return audits
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    extract = subparsers.add_parser("extract", help="extract a fixture's declared time")
+    extract.add_argument("benchmark", help="fixture filename or stem")
+    audit = subparsers.add_parser("audit", help="audit suite fixtures' first output lines")
+    audit.add_argument(
+        "--suite-dir",
+        default=str(Path(__file__).resolve().parent / "suite"),
+        help="directory containing suite .ts fixtures",
+    )
+    audit.add_argument("--all", action="store_true", help="show time-first rows too")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        if args.command == "extract":
+            print(extract_time_ms(args.benchmark, sys.stdin.read()))
+            return 0
+
+        audits = audit_fixture_first_lines(args.suite_dir)
+        shown = audits if args.all else [audit for audit in audits if not audit.is_time]
+        non_time_count = len(audits) - sum(audit.is_time for audit in audits)
+        print(
+            f"Audited {len(audits)} suite fixtures; "
+            f"{non_time_count} have a non-time first line:"
+        )
+        for audit in shown:
+            print(f"  {audit.name}: {audit.first_output} ({audit.reason})")
+        return 0
+    except UnscoreableError as exc:
+        print(f"UNSCOREABLE: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/compare.sh
+++ b/benchmarks/compare.sh
@@ -18,6 +18,7 @@ COMPILETS="${PERRY_BIN:-$ROOT/target/release/perry}"
 BASELINE="$SCRIPT_DIR/baseline.json"
 VERIFY_OUTPUT="$SCRIPT_DIR/verify_benchmark_output.py"
 BENCHMARK_GATE="$SCRIPT_DIR/benchmark_gate.py"
+TIME_EXTRACTOR="$SCRIPT_DIR/benchmark_time.py"
 
 # Thresholds
 SPEED_THRESHOLD=15    # >15% slower = regression
@@ -79,6 +80,11 @@ fi
 
 if [[ ! -f "$BENCHMARK_GATE" ]]; then
   echo -e "${RED}Benchmark artifact builder not found at $BENCHMARK_GATE${NC}"
+  exit 1
+fi
+
+if [[ ! -f "$TIME_EXTRACTOR" ]]; then
+  echo -e "${RED}Benchmark time extractor not found at $TIME_EXTRACTOR${NC}"
   exit 1
 fi
 
@@ -217,7 +223,9 @@ cleanup() {
 trap cleanup EXIT
 
 extract_time() {
-  awk -F: '/^[a-z_]+:[0-9]+/ {print $2; exit}' <<<"$1"
+  local benchmark="$1"
+  local output="$2"
+  python3 "$TIME_EXTRACTOR" extract "$benchmark" <<<"$output"
 }
 
 measure_rss() {
@@ -288,6 +296,14 @@ median() {
   python3 -c "import sys; xs=sorted(int(x) for x in sys.argv[1:]); print(xs[len(xs)//2] if xs else 0)" "$@"
 }
 
+format_ms() {
+  if [[ "$1" =~ ^[0-9]+$ ]]; then
+    printf '%sms' "$1"
+  else
+    printf '%s' "$1"
+  fi
+}
+
 join_samples() {
   local IFS=,
   printf '%s' "$*"
@@ -325,6 +341,8 @@ for bench in $BENCHMARKS; do
   p_out_samples=()
   p_ms_samples=()
   p_rss_samples=()
+  p_unscoreable=0
+  p_failed=0
   if [[ -f "$SUITE_DIR/$name" ]]; then
     for (( run=0; run<RUNS; run++ )); do
       p_out="$RUN_OUTPUT_DIR/$name.perry.$run.out"
@@ -333,13 +351,23 @@ for bench in $BENCHMARKS; do
       r_rss="${measurement%%|*}"
       r_status="${measurement##*|}"
       r_out=$(cat "$p_out")
-      r_ms=$(extract_time "$r_out")
-      if [[ "$r_status" -eq 0 && -n "$r_ms" ]]; then
+      if [[ "$r_status" -ne 0 ]]; then
+        p_failed=1
+      elif r_ms=$(extract_time "$name" "$r_out"); then
         p_ms_samples+=("$r_ms")
         p_rss_samples+=("${r_rss:-0}")
+      else
+        p_unscoreable=1
       fi
     done
-    if [[ ${#p_ms_samples[@]} -gt 0 ]]; then
+    if [[ $p_unscoreable -eq 1 ]]; then
+      p_ms_samples=()
+      p_rss_samples=()
+      perry_ms="UNSCOREABLE"
+    elif [[ $p_failed -eq 1 ]]; then
+      p_ms_samples=()
+      p_rss_samples=()
+    elif [[ ${#p_ms_samples[@]} -gt 0 ]]; then
       perry_ms=$(median "${p_ms_samples[@]}")
     fi
     if [[ ${#p_rss_samples[@]} -gt 0 ]]; then
@@ -353,6 +381,8 @@ for bench in $BENCHMARKS; do
   n_out_samples=()
   n_ms_samples=()
   n_rss_samples=()
+  n_unscoreable=0
+  n_failed=0
   if [[ $HAS_NODE -eq 1 ]]; then
     for (( run=0; run<RUNS; run++ )); do
       n_out="$RUN_OUTPUT_DIR/$name.node.$run.out"
@@ -361,13 +391,24 @@ for bench in $BENCHMARKS; do
       r_rss="${measurement%%|*}"
       r_status="${measurement##*|}"
       r_out=$(cat "$n_out")
-      r_ms=$(extract_time "$r_out")
-      if [[ "$r_status" -eq 0 && -n "$r_ms" ]]; then
+      if [[ "$r_status" -ne 0 ]]; then
+        n_failed=1
+      elif r_ms=$(extract_time "$name" "$r_out"); then
         n_ms_samples+=("$r_ms")
         n_rss_samples+=("${r_rss:-0}")
+      else
+        n_unscoreable=1
       fi
     done
-    if [[ ${#n_ms_samples[@]} -gt 0 ]]; then
+    if [[ $n_unscoreable -eq 1 ]]; then
+      n_ms_samples=()
+      n_rss_samples=()
+      node_ms="UNSCOREABLE"
+    elif [[ $n_failed -eq 1 ]]; then
+      n_ms_samples=()
+      n_rss_samples=()
+      node_ms="ERR"
+    elif [[ ${#n_ms_samples[@]} -gt 0 ]]; then
       node_ms=$(median "${n_ms_samples[@]}")
     fi
     if [[ ${#n_rss_samples[@]} -gt 0 ]]; then
@@ -382,6 +423,8 @@ for bench in $BENCHMARKS; do
   b_out_samples=()
   b_ms_samples=()
   b_rss_samples=()
+  b_unscoreable=0
+  b_failed=0
   if [[ $HAS_BUN -eq 1 ]]; then
     for (( run=0; run<RUNS; run++ )); do
       b_out="$RUN_OUTPUT_DIR/$name.bun.$run.out"
@@ -390,13 +433,24 @@ for bench in $BENCHMARKS; do
       r_rss="${measurement%%|*}"
       r_status="${measurement##*|}"
       r_out=$(cat "$b_out")
-      r_ms=$(extract_time "$r_out")
-      if [[ "$r_status" -eq 0 && -n "$r_ms" ]]; then
+      if [[ "$r_status" -ne 0 ]]; then
+        b_failed=1
+      elif r_ms=$(extract_time "$name" "$r_out"); then
         b_ms_samples+=("$r_ms")
         b_rss_samples+=("${r_rss:-0}")
+      else
+        b_unscoreable=1
       fi
     done
-    if [[ ${#b_ms_samples[@]} -gt 0 ]]; then
+    if [[ $b_unscoreable -eq 1 ]]; then
+      b_ms_samples=()
+      b_rss_samples=()
+      bun_ms="UNSCOREABLE"
+    elif [[ $b_failed -eq 1 ]]; then
+      b_ms_samples=()
+      b_rss_samples=()
+      bun_ms="ERR"
+    elif [[ ${#b_ms_samples[@]} -gt 0 ]]; then
       bun_ms=$(median "${b_ms_samples[@]}")
     fi
     if [[ ${#b_rss_samples[@]} -gt 0 ]]; then
@@ -408,20 +462,16 @@ for bench in $BENCHMARKS; do
   speed_ratio="-"
   bun_speed_ratio="-"
   mem_ratio="-"
-  perry_display="${perry_ms}ms"
+  perry_display=$(format_ms "$perry_ms")
   if [[ "$perry_ms" == "0" ]]; then
     perry_display="MEASURES-NOTHING"
     speed_ratio="MEASURES-NOTHING"
     bun_speed_ratio="MEASURES-NOTHING"
-  elif [[ "$perry_ms" != "ERR" && "$node_ms" != "-" ]]; then
-    if [[ "$node_ms" -gt 0 ]] 2>/dev/null; then
-      speed_ratio=$(python3 -c "print(f'{int(\"$perry_ms\")/int(\"$node_ms\"):.2f}')" 2>/dev/null || echo "-")
-    fi
+  elif [[ "$perry_ms" =~ ^[0-9]+$ && "$node_ms" =~ ^[0-9]+$ && "$node_ms" -gt 0 ]]; then
+    speed_ratio=$(python3 -c "print(f'{int(\"$perry_ms\")/int(\"$node_ms\"):.2f}')")
   fi
-  if [[ "$perry_ms" != "0" && "$perry_ms" != "ERR" && "$bun_ms" != "-" ]]; then
-    if [[ "$bun_ms" -gt 0 ]] 2>/dev/null; then
-      bun_speed_ratio=$(python3 -c "print(f'{int(\"$perry_ms\")/int(\"$bun_ms\"):.2f}')" 2>/dev/null || echo "-")
-    fi
+  if [[ "$perry_ms" =~ ^[1-9][0-9]*$ && "$bun_ms" =~ ^[0-9]+$ && "$bun_ms" -gt 0 ]]; then
+    bun_speed_ratio=$(python3 -c "print(f'{int(\"$perry_ms\")/int(\"$bun_ms\"):.2f}')")
   fi
   if [[ "$perry_rss" -gt 0 && "$node_rss" -gt 0 ]] 2>/dev/null; then
     mem_ratio=$(python3 -c "print(f'{int(\"$perry_rss\")/int(\"$node_rss\"):.2f}')" 2>/dev/null || echo "-")
@@ -444,12 +494,12 @@ for bench in $BENCHMARKS; do
       : > "$missing_out"
       p_out_samples=("$missing_out")
     fi
-    python3 - "$VERIFY_OUTPUT" "${reference_outputs[0]}" "$correctness_json" "$reference" "${p_out_samples[@]}" <<'PY'
+    python3 - "$VERIFY_OUTPUT" "$name" "${reference_outputs[0]}" "$correctness_json" "$reference" "${p_out_samples[@]}" <<'PY'
 import importlib.util
 import json
 import sys
 
-verifier_path, expected_path, output_path, reference, *actual_paths = sys.argv[1:]
+verifier_path, benchmark, expected_path, output_path, reference, *actual_paths = sys.argv[1:]
 spec = importlib.util.spec_from_file_location("benchmark_output_verifier", verifier_path)
 module = importlib.util.module_from_spec(spec)
 assert spec.loader is not None
@@ -461,6 +511,7 @@ for index, actual_path in enumerate(actual_paths, start=1):
         expected_path=expected_path,
         actual_path=actual_path,
         reference=reference,
+        benchmark=benchmark,
     )
     report["sample"] = index
     reports.append(report)
@@ -515,9 +566,11 @@ sys.exit(1 if merged["status"] == "fail" else 0)
 PY
   fi
   correctness_status=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['status'])" "$correctness_json")
+  node_display=$(format_ms "$node_ms")
+  bun_display=$(format_ms "$bun_ms")
 
   printf "%-20s %10s %10s %10s %10s %10s %10s %10s\n" \
-    "$display" "$perry_display" "${node_ms}ms" "${bun_ms}ms" "$speed_ratio" "$bun_speed_ratio" "${perry_rss}KB" "$correctness_status"
+    "$display" "$perry_display" "$node_display" "$bun_display" "$speed_ratio" "$bun_speed_ratio" "${perry_rss}KB" "$correctness_status"
 
   # Save raw samples as JSONL. The artifact builder rejects any available
   # runtime that did not produce exactly RUNS timing and RSS samples.

--- a/benchmarks/quick.sh
+++ b/benchmarks/quick.sh
@@ -10,6 +10,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SUITE_DIR="$SCRIPT_DIR/suite"
 COMPILETS="$ROOT/target/release/perry"
+TIME_EXTRACTOR="$SCRIPT_DIR/benchmark_time.py"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -20,6 +21,11 @@ NC='\033[0m'
 if [[ ! -f "$COMPILETS" ]]; then
   echo "Building Perry..."
   (cd "$ROOT" && cargo build --release --quiet)
+fi
+
+if [[ ! -f "$TIME_EXTRACTOR" ]]; then
+  echo "Benchmark time extractor not found at $TIME_EXTRACTOR" >&2
+  exit 1
 fi
 
 BENCHMARKS="05_fibonacci.ts 06_math_intensive.ts 10_nested_loops.ts 13_factorial.ts 16_matrix_multiply.ts"
@@ -56,7 +62,17 @@ else
 fi
 
 extract_time() {
-  awk -F: '/^[a-z_]+:[0-9]+/ {print $2; exit}' <<<"$1"
+  local benchmark="$1"
+  local output="$2"
+  python3 "$TIME_EXTRACTOR" extract "$benchmark" <<<"$output"
+}
+
+format_ms() {
+  if [[ "$1" =~ ^[0-9]+$ ]]; then
+    printf '%sms' "$1"
+  else
+    printf '%s' "$1"
+  fi
 }
 
 measure() {
@@ -110,7 +126,9 @@ for bench in $BENCHMARKS; do
   result=$(measure "./$name")
   p_rss=$(sed -n '1p' <<<"$result")
   p_out=$(sed '1d' <<<"$result")
-  p_ms=$(extract_time "$p_out")
+  if ! p_ms=$(extract_time "$name" "$p_out"); then
+    p_ms="UNSCOREABLE"
+  fi
 
   # Node
   n_ms="-"; n_rss="-"
@@ -119,7 +137,9 @@ for bench in $BENCHMARKS; do
     result=$(measure "${NODE_CMD[@]}" "$bench")
     n_rss=$(sed -n '1p' <<<"$result")
     n_out=$(sed '1d' <<<"$result")
-    n_ms=$(extract_time "$n_out")
+    if ! n_ms=$(extract_time "$name" "$n_out"); then
+      n_ms="UNSCOREABLE"
+    fi
 
     if [[ "$p_ms" =~ ^[0-9]+$ && "$n_ms" =~ ^[0-9]+$ && "$n_ms" -gt 0 ]]; then
       ratio=$(python3 -c "print(f'{$p_ms/$n_ms:.2f}x')")
@@ -134,8 +154,10 @@ for bench in $BENCHMARKS; do
     fi
   fi
 
-  printf "%-18s %7sms %7sms %8b %6sMB %6sMB %8s\n" \
-    "$display" "$p_ms" "$n_ms" "$ratio" "$p_rss" "$n_rss" "$mratio"
+  p_display=$(format_ms "$p_ms")
+  n_display=$(format_ms "$n_ms")
+  printf "%-18s %9s %9s %8b %6sMB %6sMB %8s\n" \
+    "$display" "$p_display" "$n_display" "$ratio" "$p_rss" "$n_rss" "$mratio"
 
   rm -f "$SUITE_DIR/$name"
 done

--- a/benchmarks/suite/run_benchmarks.sh
+++ b/benchmarks/suite/run_benchmarks.sh
@@ -6,6 +6,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 COMPILETS="${SCRIPT_DIR}/../../target/release/perry"
 RESULTS_DIR="${SCRIPT_DIR}/results"
+TIME_EXTRACTOR="${SCRIPT_DIR}/../benchmark_time.py"
 mkdir -p "$RESULTS_DIR"
 
 # Colors for output
@@ -57,6 +58,10 @@ if [ -f "$COMPILETS" ]; then
 else
     echo -e "${RED}✗${NC} perry not found at $COMPILETS"
     echo "   Run: cd ${SCRIPT_DIR}/../.. && cargo build --release"
+    exit 1
+fi
+if [ ! -f "$TIME_EXTRACTOR" ]; then
+    echo -e "${RED}✗${NC} benchmark time extractor not found at $TIME_EXTRACTOR"
     exit 1
 fi
 
@@ -128,7 +133,21 @@ fi
 
 # Function to extract timing from output
 extract_time() {
-    echo "$1" | grep -E "^[a-z_]+:[0-9]+" | head -1 | cut -d: -f2
+    local benchmark="$1"
+    local output="$2"
+    python3 "$TIME_EXTRACTOR" extract "$benchmark" <<<"$output"
+}
+
+is_integer_ms() {
+    [[ "$1" =~ ^[0-9]+$ ]]
+}
+
+format_ms() {
+    if is_integer_ms "$1"; then
+        printf '%sms' "$1"
+    else
+        printf '%s' "$1"
+    fi
 }
 
 # Run benchmarks
@@ -159,7 +178,9 @@ for bench in $BENCHMARKS; do
     # Run Perry
     if [ -f "./$name" ]; then
         output=$("./$name" 2>&1)
-        perry_time=$(extract_time "$output")
+        if ! perry_time=$(extract_time "$name" "$output"); then
+            perry_time="UNSCOREABLE"
+        fi
     else
         perry_time="ERR"
     fi
@@ -167,7 +188,9 @@ for bench in $BENCHMARKS; do
     # Run Node.js
     if [ $HAS_NODE -eq 1 ]; then
         output=$(node "$bench" 2>&1)
-        node_time=$(extract_time "$output")
+        if ! node_time=$(extract_time "$name" "$output"); then
+            node_time="UNSCOREABLE"
+        fi
     else
         node_time="-"
     fi
@@ -175,7 +198,9 @@ for bench in $BENCHMARKS; do
     # Run Bun
     if [ $HAS_BUN -eq 1 ]; then
         output=$(bun run "$bench" 2>&1)
-        bun_time=$(extract_time "$output")
+        if ! bun_time=$(extract_time "$name" "$output"); then
+            bun_time="UNSCOREABLE"
+        fi
     else
         bun_time="-"
     fi
@@ -183,13 +208,15 @@ for bench in $BENCHMARKS; do
     # Run Static Hermes
     if [ $HAS_SHERMES -eq 1 ] && [ -f "./${name}_shermes" ]; then
         output=$("./${name}_shermes" 2>&1)
-        shermes_time=$(extract_time "$output")
+        if ! shermes_time=$(extract_time "$name" "$output"); then
+            shermes_time="UNSCOREABLE"
+        fi
     else
         shermes_time="-"
     fi
 
     # Track wins/losses vs Node
-    if [ -n "$perry_time" ] && [ "$perry_time" != "ERR" ] && [ -n "$node_time" ] && [ "$node_time" != "-" ]; then
+    if is_integer_ms "$perry_time" && is_integer_ms "$node_time"; then
         if [ "$perry_time" -lt "$node_time" ]; then
             WINS_NODE=$((WINS_NODE + 1))
         elif [ "$perry_time" -gt "$node_time" ]; then
@@ -200,7 +227,7 @@ for bench in $BENCHMARKS; do
     fi
 
     # Track wins/losses vs Bun
-    if [ -n "$perry_time" ] && [ "$perry_time" != "ERR" ] && [ -n "$bun_time" ] && [ "$bun_time" != "-" ]; then
+    if is_integer_ms "$perry_time" && is_integer_ms "$bun_time"; then
         if [ "$perry_time" -lt "$bun_time" ]; then
             WINS_BUN=$((WINS_BUN + 1))
         elif [ "$perry_time" -gt "$bun_time" ]; then
@@ -211,7 +238,7 @@ for bench in $BENCHMARKS; do
     fi
 
     # Track wins/losses vs Static Hermes
-    if [ -n "$perry_time" ] && [ "$perry_time" != "ERR" ] && [ -n "$shermes_time" ] && [ "$shermes_time" != "-" ]; then
+    if is_integer_ms "$perry_time" && is_integer_ms "$shermes_time"; then
         if [ "$perry_time" -lt "$shermes_time" ]; then
             WINS_SHERMES=$((WINS_SHERMES + 1))
         elif [ "$perry_time" -gt "$shermes_time" ]; then
@@ -222,24 +249,28 @@ for bench in $BENCHMARKS; do
     fi
 
     # Print results with colors based on comparison to Node
-    if [ -n "$perry_time" ] && [ "$perry_time" != "ERR" ]; then
-        if [ -n "$node_time" ] && [ "$node_time" != "-" ] && [ "$perry_time" -lt "$node_time" ]; then
+    if is_integer_ms "$perry_time"; then
+        if is_integer_ms "$node_time" && [ "$perry_time" -lt "$node_time" ]; then
             perry_display="${GREEN}${perry_time}ms${NC}"
-        elif [ -n "$node_time" ] && [ "$node_time" != "-" ] && [ "$perry_time" -gt "$node_time" ]; then
+        elif is_integer_ms "$node_time" && [ "$perry_time" -gt "$node_time" ]; then
             perry_display="${RED}${perry_time}ms${NC}"
         else
             perry_display="${perry_time}ms"
         fi
     else
-        perry_display="ERR"
+        perry_display="$perry_time"
     fi
+
+    node_display=$(format_ms "$node_time")
+    bun_display=$(format_ms "$bun_time")
+    shermes_display=$(format_ms "$shermes_time")
 
     if [ $HAS_SHERMES -eq 1 ]; then
         printf "%-20s " "$display_name"
-        echo -e "${perry_display}\t\t${node_time:-"-"}ms\t\t${bun_time:-"-"}ms\t\t${shermes_time:-"-"}ms"
+        echo -e "${perry_display}\t\t${node_display}\t\t${bun_display}\t\t${shermes_display}"
     else
         printf "%-20s " "$display_name"
-        echo -e "${perry_display}\t\t${node_time:-"-"}ms\t\t${bun_time:-"-"}ms"
+        echo -e "${perry_display}\t\t${node_display}\t\t${bun_display}"
     fi
 done
 

--- a/benchmarks/verify_benchmark_output.py
+++ b/benchmarks/verify_benchmark_output.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 """Compare semantic benchmark stdout against a reference stdout file.
 
-Benchmark programs print a volatile timing line first, for example
-``json_roundtrip:97``. This verifier ignores that first timing-shaped line
+The verifier ignores a suite fixture's explicitly declared measurement labels
 and compares the remaining stable ``key:value`` or ``key=value`` lines.
 """
 
@@ -16,22 +15,15 @@ from pathlib import Path
 from typing import Any
 
 
+BENCHMARKS_DIR = Path(__file__).resolve().parent
+if str(BENCHMARKS_DIR) not in sys.path:
+    sys.path.insert(0, str(BENCHMARKS_DIR))
+
+from benchmark_time import timing_contract
+
+
 ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 KV_RE = re.compile(r"^([A-Za-z0-9_(). -]+?)\s*([:=])\s*(.*?)\s*$")
-NUMERIC_RE = re.compile(r"^-?\d+(?:\.\d+)?$")
-
-# These are semantic even if they appear as the first output line. The suite
-# normally prints timing first, but keeping common evidence keys explicit makes
-# direct verifier use less surprising.
-FIRST_LINE_SEMANTIC_KEYS = {
-    "checksum",
-    "length",
-    "sum",
-    "result",
-    "value",
-    "primes",
-    "total_iter",
-}
 
 
 def _strip_ansi(value: str) -> str:
@@ -46,9 +38,9 @@ def _parse_kv(line: str) -> tuple[str, str, str] | None:
     return key.strip(), sep, value.strip()
 
 
-def semantic_lines_from_text(text: str) -> list[str]:
+def semantic_lines_from_text(text: str, benchmark: str) -> list[str]:
     lines: list[str] = []
-    first_content_seen = False
+    ignored_labels = timing_contract(benchmark).measurement_labels
 
     for raw_line in text.splitlines():
         line = _strip_ansi(raw_line).strip()
@@ -56,19 +48,11 @@ def semantic_lines_from_text(text: str) -> list[str]:
             continue
 
         kv = _parse_kv(line)
-        is_first_content = not first_content_seen
-        first_content_seen = True
-
         if not kv:
             continue
 
-        key, sep, value = kv
-        if (
-            is_first_content
-            and sep == ":"
-            and key not in FIRST_LINE_SEMANTIC_KEYS
-            and NUMERIC_RE.match(value)
-        ):
+        key, _, value = kv
+        if key in ignored_labels:
             continue
 
         lines.append(f"{key}:{value}")
@@ -126,10 +110,11 @@ def compare_stdout_files(
     *,
     expected_path: str | Path,
     actual_path: str | Path,
+    benchmark: str,
     reference: str = "node",
 ) -> dict[str, Any]:
-    expected_lines = semantic_lines_from_text(_read_text(expected_path))
-    actual_lines = semantic_lines_from_text(_read_text(actual_path))
+    expected_lines = semantic_lines_from_text(_read_text(expected_path), benchmark)
+    actual_lines = semantic_lines_from_text(_read_text(actual_path), benchmark)
 
     if not expected_lines:
         return {
@@ -178,6 +163,11 @@ def main(argv: list[str] | None = None) -> int:
         default="node",
         help="Reference source recorded in the JSON report",
     )
+    parser.add_argument(
+        "--benchmark",
+        required=True,
+        help="Suite fixture filename/stem whose declared measurement labels are ignored",
+    )
     parser.add_argument("--json-out", help="Write the JSON report to this path")
     args = parser.parse_args(argv)
 
@@ -185,7 +175,7 @@ def main(argv: list[str] | None = None) -> int:
         report = {
             "status": "unchecked",
             "reference": "none",
-            "actual_lines": semantic_lines_from_text(_read_text(args.actual)),
+            "actual_lines": semantic_lines_from_text(_read_text(args.actual), args.benchmark),
             "expected_lines": [],
             "reason": "reference unavailable",
         }
@@ -194,6 +184,7 @@ def main(argv: list[str] | None = None) -> int:
             expected_path=args.expected,
             actual_path=args.actual,
             reference=args.reference,
+            benchmark=args.benchmark,
         )
 
     _write_json(report, args.json_out)

--- a/changelog.d/9374-explicit-benchmark-times.md
+++ b/changelog.d/9374-explicit-benchmark-times.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- Cross-runtime benchmark runners now select an explicit per-fixture integer
+  millisecond label and report `UNSCOREABLE` when it is absent or malformed,
+  instead of treating the first numeric output line as elapsed time. The
+  typed-array fixture keeps its intentional ratio-first #5525 regression
+  metric while cross-runtime comparisons use `ta_untyped_access`.

--- a/scripts/pre-tag-check.sh
+++ b/scripts/pre-tag-check.sh
@@ -93,13 +93,14 @@ run_check "cargo fmt --all --check" cargo fmt --all -- --check
 
 # 2. Benchmark harness, fallback, verifier, and shell-syntax tests.
 run_check "benchmark harness tests" \
-    python3 -m unittest discover -s tests -p 'test_benchmark_gate.py' -v
+    python3 -m unittest discover -s tests -p 'test_benchmark_*.py' -v
 run_check "benchmark peer fallback tests" \
     ./tests/test_benchmark_peer_fallback.sh
 run_check "benchmark output verifier tests" \
     ./tests/test_benchmark_output_verifier.sh
 run_check "benchmark shell syntax" \
-    bash -n benchmarks/compare.sh benchmarks/honest_bench/run.sh \
+    bash -n benchmarks/compare.sh benchmarks/quick.sh \
+        benchmarks/suite/run_benchmarks.sh benchmarks/honest_bench/run.sh \
         benchmarks/honest_bench/harness/run_http_bench.sh \
         tests/test_benchmark_peer_fallback.sh
 

--- a/tests/test_benchmark_gate.py
+++ b/tests/test_benchmark_gate.py
@@ -118,6 +118,16 @@ class BenchmarkArtifactTests(unittest.TestCase):
                 generated_at="2026-07-12T00:00:00Z",
             )
 
+    def test_rejects_fractional_millisecond_samples(self):
+        with self.assertRaisesRegex(ArtifactError, "integer millisecond.*0.939655"):
+            build_artifact(
+                records=[record("fast", [0.939655, 1, 1], [18, 20, 22])],
+                requested_samples=3,
+                runtimes={"perry": runtime(), "node": runtime(), "bun": runtime(False)},
+                commit="abc123",
+                generated_at="2026-07-12T00:00:00Z",
+            )
+
     def test_rejects_explicit_empty_rss_samples(self):
         with self.assertRaisesRegex(ArtifactError, "perry.*0/3.*RSS"):
             build_artifact(

--- a/tests/test_benchmark_output_verifier.sh
+++ b/tests/test_benchmark_output_verifier.sh
@@ -31,6 +31,7 @@ checksum:11842140
 EOF
 
 if python3 "$VERIFIER" \
+  --benchmark bench_json_roundtrip \
   --expected "$TMP_DIR/json-node.out" \
   --actual "$TMP_DIR/json-perry.out" \
   --json-out "$TMP_DIR/json-report.json"; then
@@ -54,6 +55,7 @@ checksum:2998500000
 EOF
 
 python3 "$VERIFIER" \
+  --benchmark bench_array_grow \
   --expected "$TMP_DIR/array-node.out" \
   --actual "$TMP_DIR/array-perry.out" \
   --json-out "$TMP_DIR/array-report.json"
@@ -69,8 +71,34 @@ fibonacci:456
 EOF
 
 python3 "$VERIFIER" \
+  --benchmark 05_fibonacci \
   --expected "$TMP_DIR/fibonacci-node.out" \
   --actual "$TMP_DIR/fibonacci-perry.out" \
   --json-out "$TMP_DIR/fibonacci-report.json"
 assert_json "$TMP_DIR/fibonacci-report.json" "data['status'] == 'unchecked'"
 assert_json "$TMP_DIR/fibonacci-report.json" "data['expected_lines'] == []"
+
+# The #5525 ratio and both absolute elapsed-time lines are measurements, not
+# correctness evidence. Their values may differ across runtimes; the checksum
+# is the semantic line that must match.
+cat >"$TMP_DIR/typed-array-node.out" <<'EOF'
+ta_untyped_typed_ratio:0.94
+ta_untyped_access:290
+ta_typed_access:309
+checksum:123
+EOF
+
+cat >"$TMP_DIR/typed-array-perry.out" <<'EOF'
+ta_untyped_typed_ratio:1.17
+ta_untyped_access:257
+ta_typed_access:220
+checksum:123
+EOF
+
+python3 "$VERIFIER" \
+  --benchmark bench_typed_array_untyped_access \
+  --expected "$TMP_DIR/typed-array-node.out" \
+  --actual "$TMP_DIR/typed-array-perry.out" \
+  --json-out "$TMP_DIR/typed-array-report.json"
+assert_json "$TMP_DIR/typed-array-report.json" "data['status'] == 'pass'"
+assert_json "$TMP_DIR/typed-array-report.json" "data['expected_lines'] == ['checksum:123']"

--- a/tests/test_benchmark_peer_fallback.sh
+++ b/tests/test_benchmark_peer_fallback.sh
@@ -54,6 +54,21 @@ if [[ "${PERRY_FAKE_ZERO_SOURCE:-}" == "$source_name" ]]; then
     { print }
   '
   status=${PIPESTATUS[0]}
+elif [[ "${PERRY_FAKE_MISSING_TIME_SOURCE:-}" == "$source_name" ]]; then
+  "$PERRY_FAKE_NODE" "$source_file" | awk '
+    !removed && /^[a-z_]+:[0-9]+/ { removed = 1; next }
+    { print }
+  '
+  status=${PIPESTATUS[0]}
+elif [[ "${PERRY_FAKE_FRACTIONAL_TIME_SOURCE:-}" == "$source_name" ]]; then
+  "$PERRY_FAKE_NODE" "$source_file" | awk '
+    !replaced && /^[a-z_]+:[0-9]+/ {
+      sub(/:[0-9]+$/, ":0.9396551724137931")
+      replaced = 1
+    }
+    { print }
+  '
+  status=${PIPESTATUS[0]}
 else
   "$PERRY_FAKE_NODE" "$source_file"
   status=$?
@@ -122,6 +137,48 @@ if [[ -e "$TMP/failed.json" ]]; then
 fi
 if [[ -e "$ROOT/benchmarks/suite/02_loop_overhead" ]]; then
   echo "compare.sh did not clean compiled benchmark artifacts after failure" >&2
+  exit 1
+fi
+
+# A missing declared time and a fractional value in that millisecond field are
+# both UNSCOREABLE. Other numeric output must never become a positional fallback.
+echo 'stale artifact' >"$TMP/unscoreable.json"
+set +e
+PATH="$TMP/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+PERRY_BIN="$FAKE_PERRY" \
+PERRY_FAKE_NODE="$NODE_REAL" \
+PERRY_FAKE_MISSING_TIME_SOURCE="05_fibonacci.ts" \
+PERRY_FAKE_FRACTIONAL_TIME_SOURCE="06_math_intensive.ts" \
+  "$ROOT/benchmarks/compare.sh" \
+    --quick \
+    --runs 2 \
+    --warn-only \
+    --json-out "$TMP/unscoreable.json" \
+    >"$TMP/unscoreable-output.txt" 2>"$TMP/unscoreable-error.txt"
+unscoreable_status=$?
+set -e
+if [[ "$unscoreable_status" -ne 2 ]]; then
+  cat "$TMP/unscoreable-error.txt" >&2
+  echo "expected unscoreable timing samples to exit 2, got $unscoreable_status" >&2
+  exit 1
+fi
+if [[ $(grep -c "UNSCOREABLE" "$TMP/unscoreable-output.txt") -lt 2 ]]; then
+  cat "$TMP/unscoreable-output.txt" >&2
+  echo "compare.sh did not label both invalid rows UNSCOREABLE" >&2
+  exit 1
+fi
+if ! grep -q "missing required time-labelled line fibonacci" "$TMP/unscoreable-error.txt"; then
+  cat "$TMP/unscoreable-error.txt" >&2
+  echo "missing timing label was not explained" >&2
+  exit 1
+fi
+if ! grep -q "non-integer millisecond value.*0.9396551724137931" "$TMP/unscoreable-error.txt"; then
+  cat "$TMP/unscoreable-error.txt" >&2
+  echo "fractional millisecond value was not rejected explicitly" >&2
+  exit 1
+fi
+if [[ -e "$TMP/unscoreable.json" ]]; then
+  echo "compare.sh left a stale JSON artifact after unscoreable rows" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Fixes #9374.

Every suite runner identified "the time" **positionally** — the first `label:number` line. For `bench_typed_array_untyped_access` that line is `ta_untyped_typed_ratio`, a **perry-to-perry ratio**, so two independent sessions scored a **7.7× loss as parity** for weeks. That is worse than an obviously-broken number because it is *plausible*: nothing prompts a second look.

**The fixture is not the bug and is unchanged.** It emits the ratio first deliberately and says so — that is the #5525 regression metric, and it is sound for perry-vs-perry tracking. What was invalid is feeding a ratio into a *cross-runtime* comparison, which neither the fixture nor the runner owned.

## The fix

`benchmarks/benchmark_time.py` holds **one explicit timing contract per fixture**, exhaustive rather than inferred. Inference from position was the original bug — and inference from *filename* would have been a second one, because several established fixtures report under a historical label that doesn't match their name (`12_binary_trees` → `object_alloc`). `01_startup` is declared external-timing: it prints `started`, and measured with a wall clock around the process it is ~7.6 ms median vs node's ~90.

Two further guards:
- A value that is not an integer millisecond count is **rejected** rather than scored. `0.9396551724137931` is not a plausible elapsed time — that single check would have caught this on day one, across every fixture at once.
- A row with no time-labelled line reports **`UNSCOREABLE`**, never a number.

## Verified behaviour

```
$ printf 'ta_untyped_typed_ratio:0.9396551724137931\nta_untyped_access:257\n...' \
    | python3 benchmarks/benchmark_time.py extract bench_typed_array_untyped_access
257

$ python3 benchmarks/benchmark_time.py audit
Audited 30 suite fixtures; 2 have a non-time first line:
  01_startup: started (external timing required)
  bench_typed_array_untyped_access: ta_untyped_typed_ratio:<value> (non-time metric; cross-runtime time is ta_untyped_access)

$ printf 'ratio:0.94\nchecksum:12\n' | ... extract bench_typed_array_untyped_access
UNSCOREABLE: missing required time-labelled line ta_untyped_access:<integer-ms>
```

| | scored as |
|---|---|
| before | ratio 0.9397 vs node 0.94 → false **1.000× "parity"** |
| after | 257 ms vs 290 ms → **0.886×, a win** |

Applied to all three runners plus the CI workflow and the pre-tag check, with harness tests covering extraction, the integer rule and the UNSCOREABLE path.

## Follow-up worth its own issue

The mirror image of this bug, arriving from the winning side: `02_loop_overhead` and `08_string_concat` now print **perry=0 ms** against node's 51 and 4. Genuine wins, but they have hit their own resolution floor — a future regression of up to 1 ms is invisible and further improvement is unmeasurable. They need a larger N to remain useful as guards.

## Provenance

Authored by a Codex agent; **reviewed, verified and published by the session that filed #9374**. The agent's own report cited a commit hash that was never created, and it could not reach GitHub — so the work was re-verified from the working tree before publication rather than relayed on its say-so. The three checks above are that verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit, fixture-specific benchmark timing extraction and validation.
  * Benchmark reports now distinguish failed runs from unscoreable results.
  * Timing displays consistently show integer millisecond values.

* **Bug Fixes**
  * Prevented fractional or malformed timing values from being scored.
  * Improved benchmark output verification to compare only declared measurements.
  * Added clearer handling for missing timing data and invalid results.

* **Tests**
  * Expanded benchmark coverage for invalid timings, fallback behavior, and typed-array comparisons.
  * Broadened lint and shell-syntax checks across benchmark tests and scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->