### PR TITLE
fix(runtime): `in` and destructuring on a Uint8Array with own properties (#9347)

### DIFF
--- a/crates/perry-runtime/src/array/iterator.rs
+++ b/crates/perry-runtime/src/array/iterator.rs
@@ -1300,12 +1300,32 @@ fn throw_iterator_result_not_object() -> ! {
 #[no_mangle]
 pub extern "C" fn js_iterator_next_result(iter_f64: f64) -> f64 {
     let next = named_field(iter_f64, b"next");
-    if !is_callable_value(next) {
+    let result = if is_callable_value(next) {
+        let prev_this = crate::object::js_implicit_this_set(iter_f64);
+        let result = unsafe { crate::closure::js_native_call_value(next, std::ptr::null(), 0) };
+        crate::object::js_implicit_this_set(prev_this);
+        result
+    } else if next.to_bits() == crate::value::TAG_UNDEFINED
+        && is_builtin_iterator_class_id(crate::value::js_nanbox_get_pointer(iter_f64) as usize)
+    {
+        // Buffer iterators expose `next` through the native class-id tower,
+        // rather than as a stored closure.  The general iterator drain uses
+        // this same fallback; without it IteratorNext (and therefore
+        // Uint8Array destructuring) treats an ordinary buffer iterator as if
+        // it had no callable `next` at all.  Native dispatch still checks an
+        // own `next` override before advancing the builtin iterator.
+        unsafe {
+            crate::object::js_native_call_method(
+                iter_f64,
+                b"next".as_ptr() as *const i8,
+                4,
+                std::ptr::null(),
+                0,
+            )
+        }
+    } else {
         crate::closure::throw_not_callable();
-    }
-    let prev_this = crate::object::js_implicit_this_set(iter_f64);
-    let result = unsafe { crate::closure::js_native_call_value(next, std::ptr::null(), 0) };
-    crate::object::js_implicit_this_set(prev_this);
+    };
     if !is_object_like_value(result) {
         iter_bt_dump("js_iterator_next_result", result);
         throw_iterator_result_not_object();

--- a/crates/perry-runtime/src/object/field_get_set/has_property.rs
+++ b/crates/perry-runtime/src/object/field_get_set/has_property.rs
@@ -730,6 +730,24 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
                     } {
                         return nanbox_true;
                     }
+                    // A Uint8Array is represented by a registered buffer, but
+                    // ordinary properties written through the typed-array
+                    // [[Set]] path live in TYPED_ARRAY_OWN_PROPS.  The
+                    // lookup_typed_array_kind arm above can never see this
+                    // receiver, and the legacy buffer table below is a
+                    // different store.  Ask the buffer-aware typed-array own
+                    // property helper as well, matching Object.keys,
+                    // hasOwnProperty, and getOwnPropertyDescriptor.
+                    let key_str = crate::value::js_get_string_pointer_unified(key)
+                        as *const crate::StringHeader;
+                    if unsafe {
+                        crate::typedarray_props::typed_array_has_own_property(
+                            obj_addr as *const crate::typedarray::TypedArrayHeader,
+                            key_str,
+                        )
+                    } {
+                        return nanbox_true;
+                    }
                     // #6406: the Buffer-specific surface the %TypedArray% chain
                     // above does NOT cover — a user own-property (`buf.foo = v`)
                     // and the `Buffer.prototype` methods (`readUInt8`,

--- a/test-files/test_gap_9347_uint8array_destructuring.ts
+++ b/test-files/test_gap_9347_uint8array_destructuring.ts
@@ -1,0 +1,29 @@
+// Uint8Array uses Perry's buffer representation while Int32Array uses the
+// typed-array representation.  Both must drive the iterator protocol during
+// binding and assignment destructuring.
+function makeValues<T extends Uint8Array | Int32Array>(value: T): T {
+  value[0] = 6;
+  value[1] = 7;
+  value[2] = 8;
+  return value;
+}
+
+function binding(label: string, value: Uint8Array | Int32Array): void {
+  const [first, ...rest] = value;
+  console.log(label, first, rest.join(","));
+}
+
+function assignment(label: string, value: Uint8Array | Int32Array): void {
+  let first = 0;
+  let rest: number[] = [];
+  [first, ...rest] = value;
+  console.log(label, first, rest.join(","));
+}
+
+const i32 = makeValues(new Int32Array(3));
+const u8 = makeValues(new Uint8Array(3));
+
+binding("binding-i32", i32);
+binding("binding-u8", u8);
+assignment("assignment-i32", i32);
+assignment("assignment-u8", u8);

--- a/test-files/test_gap_9347_uint8array_in_expando.ts
+++ b/test-files/test_gap_9347_uint8array_in_expando.ts
@@ -1,0 +1,15 @@
+// Uint8Array uses Perry's buffer representation while Int32Array uses the
+// typed-array representation.  Ordinary own properties must be visible to the
+// `in` operator on both, including when the write is type-erased.
+function inspect(label: string, value: Uint8Array | Int32Array): void {
+  (value as any).extra = 9;
+  console.log(
+    label,
+    "extra" in value,
+    value.hasOwnProperty("extra"),
+    Object.keys(value).join(","),
+  );
+}
+
+inspect("i32", new Int32Array(1));
+inspect("u8", new Uint8Array(1));


### PR DESCRIPTION
Two more instances of the #9342 split-brain class, both **wrong answers on ordinary JavaScript**.

A `Uint8Array` is represented by a registered **buffer**, so `lookup_typed_array_kind` can never recognise it. A site that reads that "no" as *"this value has no such property"* or *"is not iterable"* computes the wrong result rather than taking a slow path.

## Confirmed against node, before and after

```js
function inspect(label, value) {
  value.extra = 9;
  console.log(label, "extra" in value, value.hasOwnProperty("extra"), Object.keys(value).join(","));
}
inspect("i32", new Int32Array(1));
inspect("u8",  new Uint8Array(1));
```

| | node | before | after |
|---|---|---|---|
| `"extra" in u8` | `true` | **`false`** | `true` |
| destructuring a `Uint8Array` | works | **`TypeError: value is not a function`** | works |

The first is the nastier shape: `in` answered `false` while `hasOwnProperty` on the *same object* answered `true` — the object disagreed with itself and nothing threw. The second is a spurious `TypeError` on valid code.

## The fix

`has_property.rs` now also asks the buffer-aware own-property helper, matching what `Object.keys`, `hasOwnProperty` and `getOwnPropertyDescriptor` already do. `array/iterator.rs` gets the matching treatment for the iteration path destructuring uses. This is the same repair as the two fixes that came before it: **give this site the buffer arm its older siblings already have.**

## Method note

Found by **differential testing**, not by reading dispatch code — write the JavaScript, run it under node and under perry, diff. That is how both earlier instances in this class were found, and it is why the audit was re-framed that way after a first attempt spent its budget enumerating call sites without producing a reproduction.

## Tests

Two differential fixtures under `test-files/`. `perry-runtime` suite: **2926 passed, 0 failed**.

## Provenance

Authored by a Codex agent working #9347. The bugs, the fixes and the suite were **re-verified independently** by the session that filed the issue: a pre-fix binary reproduces both divergences, the agent's tree eliminates both, and neither result is taken from the agent's report. (A sibling agent's report on #9374 cited a commit hash that was never created, which is why nothing here is relayed unchecked.)

Remaining audit scope from #9347 is unchanged — these were found by covering property/iteration surfaces; the wider miss-consumer sweep is still open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed destructuring of `Uint8Array` and other typed arrays so iterator values and rest elements are handled correctly.
  * Ensured custom properties on typed arrays are recognized by the `in` operator, `hasOwnProperty`, and `Object.keys`.

* **Tests**
  * Added regression coverage for typed-array binding and assignment destructuring.
  * Added coverage for custom typed-array properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->