### PR TITLE
fix: toLocaleString honours locale and options; accept node's numeric slash-separated dates (#9414)

### DIFF
--- a/changelog.d/9414-slash-separated-date-parse.md
+++ b/changelog.d/9414-slash-separated-date-parse.md
@@ -1,0 +1,56 @@
+### Fixed
+
+- **`new Date("2026/09/01")` is no longer Invalid Date.** The numeric
+  slash-separated forms node accepts — `"2026/09/01"`, `"2026/9/1"`,
+  `"09/01/2026"` — all produced `NaN` in Perry. Every other date format tested
+  against node already matched, so this was narrowly the
+  implementation-defined-format branch of `Date.parse` / `new Date(string)`.
+
+  ECMA-262 §21.4.3.2 deliberately leaves this format to the implementation, so
+  the new branch reproduces **V8's measured behaviour**, not a reading of the
+  spec. `parse_date_string` had exactly two grammars — ISO 8601 / MySQL and
+  RFC-1123 / month-name — and the second one requires a spelled month
+  (`let m = month?;`), so a purely numeric input fell out of both and returned
+  `NaN`.
+
+  The subtle half is not the acceptance, it is the **time zone**: unlike the ISO
+  branch, which is UTC, these components are LOCAL wall-clock time, so
+  `new Date("2026/09/01").getHours()` is `0` everywhere and the epoch value
+  differs per host. Getting that backwards would have looked like a working fix
+  in one time zone.
+
+  Behaviours reproduced from node (all measured, none assumed):
+
+  - Three numeric components are collected in order and padded with `1`. If the
+    FIRST is not a valid day-of-month (`1..=31`) the triple is Y/M/D, otherwise
+    it is US M/D/Y — which is what makes `"2026/09/01"` year-first and
+    `"09/01/2026"` month-first with no lookahead, and what makes `"31/1/2026"`
+    Invalid (31 read as a month) while `"12/1/2026"` is 1 December.
+  - Two-digit years: `0..=49` → 2000s, `50..=99` → 1900s. `"09/01/26"` is 2026,
+    `"99/1/1"` is 1999, `"1/1/100"` is literally year 100.
+  - The month must be `1..=12` and the day `1..=31`, but a day past the end of
+    its month ROLLS OVER instead of failing: `"2026/02/30"` is 2 March 2026 and
+    `"2026/09/31"` is 1 October. `"2026/13/01"`, `"2026/09/00"` and
+    `"2026/09/32"` are Invalid Date.
+  - An optional clock with `am`/`pm`, fractional seconds, and `GMT`/`UTC`/`Z`/
+    `GMT±HHMM` zone designators. `24:00` rolls to the next midnight; `25:00` and
+    `10:60` are Invalid. A bare `+0500` is a zone only AFTER a clock has been
+    read, which is why node's `new Date("2026/09/01 +0500")` is Invalid Date
+    while `"2026/09/01 10:30 +0500"` is not.
+  - `T` is ISO-only: `"2026/09/01T10:30"` stays Invalid Date, as in node.
+
+  Affected files:
+
+  - `crates/perry-runtime/src/date/parse.rs` — new `parse_slash_date`, tried
+    only after the two existing grammars and only when the input actually
+    contains a `/`, so the ISO, MySQL, RFC-1123 and month-name paths are
+    bit-for-bit unchanged.
+
+  Validation: `test-files/test_gap_date_parse_slash_9414.ts` — 60 rows covering
+  the three shapes, two-digit years, out-of-range and rolling-over components,
+  clocks, meridiem, zone designators, `Date.parse`, and ISO/RFC controls —
+  byte-compared against node 26.5.1. Before the change 41 of its lines diverged
+  (every slash row read `Invalid Date`); after it the output is byte-identical.
+  Host-zone independent by construction: local rows print the local getters plus
+  a delta from a locally-constructed reference instant, zone-designated rows
+  print `toISOString()`.

--- a/changelog.d/9414-tolocalestring-locale-and-options.md
+++ b/changelog.d/9414-tolocalestring-locale-and-options.md
@@ -1,0 +1,102 @@
+### Fixed
+
+- **`Number.prototype.toLocaleString` no longer discards its locale and its
+  options bag.** `(1234.5).toLocaleString("de-DE")` printed the en-US default
+  `1,234.5` instead of node's `1.234,5`, `(0.5).toLocaleString("en-US",
+  { style: "percent" })` printed `0.5` instead of `50%`, and
+  `(1e6).toLocaleString("en-US", { notation: "compact" })` printed
+  `1,000,000` instead of `1M`. There are 28 `toLocaleString` sites in the
+  claude-code bundle, so this was user-visible.
+
+  This was **not** a missing feature. Perry has a real ECMA-402
+  `Intl.NumberFormat` — `new Intl.NumberFormat("de-DE").format(1234.5)` already
+  produced node's bytes — and ECMA-402 defines
+  `Number.prototype.toLocaleString(locales, options)` as nothing more than
+  "construct an `Intl.NumberFormat` with exactly these arguments and
+  FormatNumeric the receiver with it". The arguments simply never got there.
+  They were dropped twice on the way:
+
+  - `native_call_method/common_methods.rs` answered **every** `toLocaleString`
+    call — arguments or not — with `js_object_default_to_locale_string`, a
+    helper that takes no arguments at all. `BigInt` already had a carve-out
+    here (#5845) for exactly this reason; a number did not.
+  - `object/primitive_proto_thunks.rs`'s
+    `number_proto_to_locale_string_thunk`, the method that arm was shadowing,
+    was itself declared `(closure)` with no parameters and called the
+    hand-rolled en-US grouping helper unconditionally.
+
+  Both are fixed: a number receiver carrying an argument now falls through to
+  the prototype thunk (which also makes a user override of
+  `Number.prototype.toLocaleString` reachable), and the thunk is installed
+  rest-based so `(locales, options)` arrive and are handed to a real
+  `Intl.NumberFormat`.
+
+  This is also what made `Array.prototype.toLocaleString` look broken.
+  `js_array_to_locale_string` had been forwarding `(locales, options)` to each
+  element correctly all along; the arguments died one level below it, in the
+  element's own `toLocaleString`. `[0.5, 0.25].toLocaleString("en-US",
+  { style: "percent" })` is now node's `50%,25%` with no change to the array
+  code.
+
+  **The no-argument path is untouched and still free.** `(1234.5)
+  .toLocaleString()` never reaches the thunk at all — codegen folds the
+  zero-arg form to an inline `js_number_to_locale_string` call — and the
+  explicit `toLocaleString(undefined, undefined)` spelling is the same request,
+  so it takes the same branch rather than paying for a NumberFormat
+  construction. That matters because Intl has **no formatter cache**: every
+  argument-bearing call builds one instance, exactly as the spec describes.
+
+- **`Date.prototype.toLocale{,Date,Time}String` now honors the locale for
+  `dateStyle` / `timeStyle`.** `d.toLocaleDateString("de-DE",
+  { dateStyle: "long" })` printed `September 1, 2026` — an English month name
+  in a German locale — and `d.toLocaleString("ja-JP", { dateStyle: "full",
+  timeStyle: "short" })` printed the en-US rendering.
+
+  `Intl.DateTimeFormat.prototype.format` (`format_ms_with_dtf_obj`) had already
+  been moved onto icu4x's CLDR patterns for these two options.
+  `temporal_locale_string` — the *other* spelling of the same operation, and the
+  one `Date.prototype.toLocale*String` delegates to — was left behind on the
+  bespoke `format_date_style` / `format_time_style` pair, which hard-codes the
+  en-US layout and the English month/weekday tables. The same instant with the
+  same options therefore formatted differently depending on which spelling was
+  used. The style arms now go through the same `icu_style`, keeping the bespoke
+  pair as the fallback for the combinations icu declines (a `long`/`full`
+  timeStyle carries a localized time-zone name) and for the Temporal partials
+  that own their own layout.
+
+  Affected files:
+
+  - `crates/perry-runtime/src/object/native_call_method/common_methods.rs`
+  - `crates/perry-runtime/src/object/primitive_proto_thunks.rs`
+  - `crates/perry-runtime/src/intl/number_format.rs` — new
+    `number_to_locale_string`, the same `make_instance` +
+    `format_number_instance` pair `bigint_to_locale_string` uses.
+  - `crates/perry-runtime/src/intl.rs`
+  - `crates/perry-runtime/src/intl/date_collator/temporal.rs`
+
+  Validation: `test-files/test_gap_tolocalestring_locale_options_9414.ts`
+  byte-compared against node 26.5.1 — de-DE / fr-FR / ja-JP / en-US and an
+  unknown tag; `style` percent and currency; `notation` compact short and long;
+  min/max fraction digits, `minimumIntegerDigits` and `useGrouping`; an
+  `undefined` locale with an options bag and an empty locale list; the
+  `Date` family with `dateStyle` / `timeStyle` / explicit field options and a
+  `timeZone`; `Array.prototype.toLocaleString` over numbers and dates; the
+  `Intl.NumberFormat` / `Intl.DateTimeFormat` rows that pin the delegation
+  target; and the no-argument calls as controls. Before the change 26 of its 64
+  lines diverged from node; after it, none.
+
+  Two pre-existing `Intl` gaps this delegation now exposes are deliberately NOT
+  pinned by that fixture, because each is wrong standalone — the fixture's own
+  `Intl.*` control rows prove it — and neither is a routing defect:
+
+  - `Intl.NumberFormat` groups in fixed 3-digit runs, so `en-IN` gives
+    `1,234,567.891` where node gives `12,34,567.891`.
+  - A purely NUMERIC field set — which is the ECMA-402 *default* for
+    `Intl.DateTimeFormat` and for a bare `toLocaleDateString(locale)` — is
+    deliberately declined by `icu_dtf::format_components` (icu's `Short` length
+    pads and truncates: `05.01.26`, not node's `5.1.2026`), and the caller's
+    fallback assembly is hard-coded `M/D/YYYY` + `h:mm:ss AM/PM`. So
+    `new Intl.DateTimeFormat("de-DE").format(new Date(0))` is `1/1/1970`
+    instead of `1.1.1970`. icu4x 2.2's `FieldSetBuilder` exposes `alignment`
+    and `year_style`, which look like the right knobs (`Alignment::Auto` +
+    `YearStyle::Full` on a `Short` `YMD`) — that is the follow-up.

--- a/crates/perry-runtime/src/date.rs
+++ b/crates/perry-runtime/src/date.rs
@@ -1891,6 +1891,77 @@ mod tests {
         assert!(parse_date_string("not a date").is_nan());
     }
 
+    /// #9414: the numeric slash grammar node accepts as its
+    /// implementation-defined format. Measured against
+    /// `node --experimental-strip-types`, not derived from the spec (which
+    /// leaves this format undefined).
+    #[test]
+    fn test_date_parse_slash_grammar() {
+        // Zone-designated forms are timezone-deterministic, so they can be
+        // pinned to an exact instant.
+        assert_eq!(parse_date_string("2026/09/01 GMT"), 1_788_220_800_000.0);
+        assert_eq!(parse_date_string("09/01/2026 GMT"), 1_788_220_800_000.0);
+        assert_eq!(parse_date_string("2026/9 GMT"), 1_788_220_800_000.0);
+        assert_eq!(
+            parse_date_string("2026/9/1 10:30:45.123 UTC"),
+            1_788_258_645_123.0
+        );
+        assert_eq!(
+            parse_date_string("2026/09/01 10:30 GMT+0500"),
+            1_788_240_600_000.0
+        );
+        // Two-digit years: 0..=49 → 2000s, 50..=99 → 1900s.
+        assert_eq!(parse_date_string("09/01/26 GMT"), 1_788_220_800_000.0);
+        assert_eq!(parse_date_string("99/1/1 GMT"), 915_148_800_000.0);
+        assert_eq!(parse_date_string("1/2/3 GMT"), 1_041_465_600_000.0);
+        // A day past the end of its month ROLLS OVER (node: 2 March 2026),
+        // while an out-of-range month or a zero day is Invalid Date.
+        assert_eq!(parse_date_string("2026/02/30 GMT"), 1_772_409_600_000.0);
+        assert_eq!(parse_date_string("2026/09/31 GMT"), 1_790_812_800_000.0);
+        // Clock edge cases: 24:00 rolls to the next midnight, 25:00 is Invalid.
+        assert_eq!(parse_date_string("2026/09/01 24:00 GMT"), 1_788_307_200_000.0);
+        assert_eq!(
+            parse_date_string("2026/09/01 3:04 PM GMT"),
+            1_788_275_040_000.0
+        );
+        // A named month may also be slash-separated.
+        assert_eq!(parse_date_string("Sep/01/2026 GMT"), 1_788_220_800_000.0);
+
+        for bad in [
+            "2026/13/01",              // month out of range
+            "2026/00/01",              // month zero
+            "2026/09/00",              // day zero
+            "2026/09/32",              // day out of range
+            "31/1/2026",               // 31 read as a month
+            "13/1/2026",               // 13 read as a month
+            "0/1/2026",                // Y/M/D with 2026 as the day
+            "9/2026",                  // M/D with 2026 as the day
+            "2026/1/2/3",              // a fourth component
+            "2026/09/01T10:30",        // 'T' is ISO-only, not this grammar
+            "2026/09/01 25:00",        // hour out of range
+            "2026/09/01 10:60",        // minute out of range
+            "2026/09/01 +0500",        // bare offset with no clock
+        ] {
+            assert!(
+                parse_date_string(bad).is_nan(),
+                "expected Invalid Date for {bad:?}"
+            );
+        }
+
+        // Without a zone designator the components are LOCAL wall clock — the
+        // property that separates this branch from the ISO one. Assert it
+        // through the local-component decoder so the test is host-zone
+        // independent.
+        let ts = parse_date_string("2026/09/01 10:30:45");
+        assert!(!ts.is_nan());
+        let (y, mo, d, h, mi, s, _) = timestamp_to_local_components((ts as i64).div_euclid(1000));
+        assert_eq!((y, mo, d, h, mi, s), (2026, 9, 1, 10, 30, 45));
+        let midnight = parse_date_string("09/01/2026");
+        let (y, mo, d, h, mi, s, _) =
+            timestamp_to_local_components((midnight as i64).div_euclid(1000));
+        assert_eq!((y, mo, d, h, mi, s), (2026, 9, 1, 0, 0, 0));
+    }
+
     #[test]
     fn test_setter_optional_args() {
         // #2851 — setUTCFullYear(year, month, date)

--- a/crates/perry-runtime/src/date/parse.rs
+++ b/crates/perry-runtime/src/date/parse.rs
@@ -23,6 +23,9 @@ use super::{make_utc_ms, time_clip, timestamp_to_local_components};
 ///     "01 Jan 1970 00:00:00 GMT" (with optional weekday and optional
 ///     trailing GMT/UTC/+offset).
 ///   - Month-name forms: "March 7, 2020", "Jan 15 2024".
+///   - #9414: the numeric slash forms node also accepts — "2026/09/01",
+///     "2026/9/1", "09/01/2026", with an optional trailing clock and zone.
+///     These are LOCAL time, not UTC (see `parse_slash_date`).
 pub(super) fn parse_date_string(s: &str) -> f64 {
     let s = s.trim();
     if s.is_empty() {
@@ -36,6 +39,9 @@ pub(super) fn parse_date_string(s: &str) -> f64 {
         return time_clip(ts);
     }
     if let Some(ts) = parse_rfc_or_named(s) {
+        return time_clip(ts);
+    }
+    if let Some(ts) = parse_slash_date(s) {
         return time_clip(ts);
     }
     f64::NAN
@@ -338,6 +344,219 @@ fn parse_rfc_or_named(s: &str) -> Option<f64> {
         None => {
             // Local-time interpretation: subtract local tz offset at that
             // instant (mirrors js_date_new_local_components).
+            let secs = (base as i64).div_euclid(1000);
+            let (_, _, _, _, _, _, tz_offset) = timestamp_to_local_components(secs);
+            Some(base - (tz_offset * 1000) as f64)
+        }
+    }
+}
+
+/// Node/V8 accept a purely numeric, slash-separated date — `"2026/09/01"`,
+/// `"2026/9/1"`, `"09/01/2026"` — as the ECMA-262 §21.4.3.2
+/// "implementation-defined format". The spec deliberately says nothing about
+/// it, so this branch reproduces V8's `DateParser::DayComposer::Write`
+/// measured against `node --experimental-strip-types`, not a reading of the
+/// standard:
+///
+///   * Up to three numeric components are collected in source order and
+///     padded with `1`. If the FIRST one is not a valid day-of-month
+///     (`1..=31`) the triple is Y/M/D, otherwise it is M/D/Y — which is what
+///     makes `"2026/09/01"` year-first and `"09/01/2026"` US month-first
+///     without any lookahead.
+///   * A year in `0..=49` maps to `2000..=2049`, one in `50..=99` to
+///     `1950..=1999` (so `"09/01/26"` is 2026 and `"99/1/1"` is 1999).
+///   * The month must be `1..=12` and the day `1..=31`, but a day past the
+///     end of its month ROLLS OVER rather than failing: node's
+///     `new Date("2026/02/30")` is 2 March 2026. `"2026/13/01"` and
+///     `"2026/09/00"` are Invalid Date.
+///   * With no zone designator the components are LOCAL wall-clock time —
+///     unlike the ISO branch above, which is UTC. This is the difference
+///     that makes `new Date("2026/09/01").getHours() === 0` everywhere.
+///
+/// Only reached when the input actually contains a `/`, so the ISO,
+/// RFC-1123 and month-name grammars above keep their existing behaviour
+/// untouched.
+fn parse_slash_date(s: &str) -> Option<f64> {
+    if !s.contains('/') {
+        return None;
+    }
+    // `/` and `,` are both separators here ("2026/09/01,10:30" parses), so
+    // flatten them to spaces and work token-by-token like the RFC branch.
+    let normalized = s.replace([',', '/'], " ");
+
+    let mut comps: Vec<i64> = Vec::new();
+    let mut named_month: Option<i64> = None;
+    let mut hour: i64 = 0;
+    let mut minute: i64 = 0;
+    let mut second: i64 = 0;
+    let mut millis: i64 = 0;
+    let mut saw_time = false;
+    let mut pm: Option<bool> = None;
+    let mut tz_minutes_east: Option<i64> = None;
+
+    for tok in normalized.split_whitespace() {
+        let low = tok.to_ascii_lowercase();
+        // Parenthesized trailing comment — `"2026/09/01 (comment)"` is valid.
+        if tok.starts_with('(') {
+            continue;
+        }
+        // Weekday name (never a month name, never a number).
+        if ["sun", "mon", "tue", "wed", "thu", "fri", "sat"]
+            .iter()
+            .any(|w| low.starts_with(w))
+            && month_from_name(tok).is_none()
+        {
+            continue;
+        }
+        if let Some(m) = month_from_name(tok) {
+            if named_month.is_some() {
+                return None;
+            }
+            named_month = Some(m as i64);
+            continue;
+        }
+        if tok.contains(':') {
+            if saw_time {
+                return None;
+            }
+            let parts: Vec<&str> = tok.split(':').collect();
+            if parts.len() < 2 || parts.len() > 3 {
+                return None;
+            }
+            hour = parts[0].parse().ok()?;
+            minute = parts[1].parse().ok()?;
+            if let Some(sec_tok) = parts.get(2) {
+                let (whole, frac) = match sec_tok.split_once('.') {
+                    Some((w, f)) => (w, Some(f)),
+                    None => (*sec_tok, None),
+                };
+                second = whole.parse().ok()?;
+                if let Some(frac) = frac {
+                    if frac.is_empty() || !frac.bytes().all(|c| c.is_ascii_digit()) {
+                        return None;
+                    }
+                    millis = normalize_millis(frac);
+                }
+            }
+            saw_time = true;
+            continue;
+        }
+        if low == "am" || low == "a.m." {
+            pm = Some(false);
+            continue;
+        }
+        if low == "pm" || low == "p.m." {
+            pm = Some(true);
+            continue;
+        }
+        if low == "gmt" || low == "utc" || low == "ut" || low == "z" {
+            tz_minutes_east = Some(0);
+            continue;
+        }
+        if low.starts_with("gmt") || low.starts_with("utc") {
+            let off = parse_tz_offset(&tok[3..])?;
+            if off != i64::MAX {
+                tz_minutes_east = Some(off);
+            }
+            continue;
+        }
+        // A bare `+HHMM` / `-HH:MM` is a zone designator only AFTER a clock
+        // has been read; before one, V8 treats the sign as a separator and the
+        // digits as another date component, which is why node's
+        // `new Date("2026/09/01 +0500")` is Invalid Date (a fourth component)
+        // while `new Date("2026/09/01 10:30 +0500")` is not.
+        if saw_time && (tok.starts_with('+') || tok.starts_with('-')) && tok.len() >= 3 {
+            let off = parse_tz_offset(tok)?;
+            if off != i64::MAX {
+                tz_minutes_east = Some(off);
+            }
+            continue;
+        }
+        // Numeric date component. A leading sign is a separator, not part of
+        // the number (`new Date("-2026/09/01")` is the same instant as
+        // `new Date("2026/09/01")` in node).
+        let digits = tok.trim_start_matches(['+', '-']);
+        if !digits.is_empty() && digits.bytes().all(|c| c.is_ascii_digit()) {
+            if comps.len() == 3 {
+                return None;
+            }
+            comps.push(digits.parse().ok()?);
+            continue;
+        }
+        // Anything else (a stray word, a named zone abbreviation) is not part
+        // of this grammar.
+        return None;
+    }
+
+    if comps.is_empty() {
+        return None;
+    }
+    // Day and month default to 1 (V8 `DayComposer::Write`).
+    while comps.len() < 3 {
+        comps.push(1);
+    }
+    let is_day = |x: i64| (1..=31).contains(&x);
+    let (mut year, month, day) = match named_month {
+        None => {
+            if is_day(comps[0]) {
+                // M/D/Y
+                (comps[2], comps[0], comps[1])
+            } else {
+                // Y/M/D
+                (comps[0], comps[1], comps[2])
+            }
+        }
+        Some(m) => {
+            if is_day(comps[0]) {
+                (comps[1], m, comps[0])
+            } else {
+                (comps[0], m, comps[1])
+            }
+        }
+    };
+    if (0..=49).contains(&year) {
+        year += 2000;
+    } else if (50..=99).contains(&year) {
+        year += 1900;
+    }
+    if !(1..=12).contains(&month) || !is_day(day) {
+        return None;
+    }
+
+    // Clock validation (V8 `TimeComposer::Write`): 24:00:00.000 is the only
+    // hour-24 form accepted, and `am`/`pm` require a 12-hour clock.
+    match pm {
+        Some(is_pm) => {
+            if !(1..=12).contains(&hour) {
+                return None;
+            }
+            hour = if is_pm {
+                if hour == 12 {
+                    12
+                } else {
+                    hour + 12
+                }
+            } else if hour == 12 {
+                0
+            } else {
+                hour
+            };
+        }
+        None => {
+            if hour > 24 || (hour == 24 && (minute != 0 || second != 0 || millis != 0)) {
+                return None;
+            }
+        }
+    }
+    if minute > 59 || second > 59 {
+        return None;
+    }
+
+    let base = make_utc_ms(year, month - 1, day, hour, minute, second, millis);
+    match tz_minutes_east {
+        Some(off) => Some(base - (off * 60_000) as f64),
+        None => {
+            // No designator: the components are LOCAL wall-clock time.
             let secs = (base as i64).div_euclid(1000);
             let (_, _, _, _, _, _, tz_offset) = timestamp_to_local_components(secs);
             Some(base - (tz_offset * 1000) as f64)

--- a/crates/perry-runtime/src/intl.rs
+++ b/crates/perry-runtime/src/intl.rs
@@ -91,7 +91,7 @@ pub(crate) use number_format::{
     number_format_bound_to_parts_thunk, number_format_format_getter_thunk,
     number_format_range_thunk, number_format_range_to_parts_thunk,
     number_format_resolved_options_thunk, number_format_to_parts_thunk, number_parts_from_resolved,
-    parts_to_js_array, this_intl_object,
+    number_to_locale_string, parts_to_js_array, this_intl_object,
 };
 pub(crate) use number_format_options::configure_number_format;
 pub(crate) use segmenter::{

--- a/crates/perry-runtime/src/intl/date_collator/temporal.rs
+++ b/crates/perry-runtime/src/intl/date_collator/temporal.rs
@@ -222,14 +222,59 @@ pub(crate) fn temporal_locale_string(
     let (year, month, day, hour, minute, second) = crate::date::timestamp_to_components(secs);
     let locale = crate::intl::locale_or_default(locale_arg);
 
+    // #9414: `dateStyle` / `timeStyle` used to be rendered here by the bespoke
+    // `format_date_style` / `format_time_style` pair, which hard-codes the
+    // en-US layout and the English month/weekday tables — so
+    // `d.toLocaleDateString("de-DE", { dateStyle: "long" })` printed
+    // "September 1, 2026". `Intl.DateTimeFormat.prototype.format`
+    // (`format_ms_with_dtf_obj`) had already been moved onto icu4x's CLDR
+    // patterns for exactly these options; this function is the OTHER spelling
+    // of the same operation and had been left behind, which is why the two
+    // disagreed on the same instant with the same options. Route the style
+    // arms through the same `icu_style` and keep the bespoke pair as the
+    // fallback for the combinations icu declines — notably a `long`/`full`
+    // timeStyle, which carries a localized time-zone name.
+    //
+    // The Temporal partials keep their own layout: `PlainYearMonth` /
+    // `PlainMonthDay` have dedicated field-dropping formatters below the
+    // style arms, and `Instant` / `ZonedDateTime` render a zone that icu's
+    // zone-less field sets cannot reproduce.
+    let use_icu = matches!(
+        ctx,
+        TemporalLocaleCtx::PlainDate
+            | TemporalLocaleCtx::PlainDateTime
+            | TemporalLocaleCtx::PlainTime
+    );
+    let icu = |ds: Option<&str>, ts: Option<&str>| -> Option<String> {
+        icu_style(
+            use_icu,
+            &locale,
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+            ds,
+            ts,
+            hour_cycle.as_deref(),
+            hour12,
+        )
+    };
+
     let result = match (eff_date_style, eff_time_style) {
-        (Some(ds), Some(ts)) => format!(
-            "{}, {}",
-            format_date_style(year, month, day, secs, ds),
-            format_time_style(hour, minute, second, ts, use_24h),
-        ),
-        (Some(ds), None) => format_date_style(year, month, day, secs, ds),
-        (None, Some(ts)) => format_time_style(hour, minute, second, ts, use_24h),
+        (Some(ds), Some(ts)) => icu(Some(ds), Some(ts)).unwrap_or_else(|| {
+            format!(
+                "{}, {}",
+                format_date_style(year, month, day, secs, ds),
+                format_time_style(hour, minute, second, ts, use_24h),
+            )
+        }),
+        (Some(ds), None) => {
+            icu(Some(ds), None).unwrap_or_else(|| format_date_style(year, month, day, secs, ds))
+        }
+        (None, Some(ts)) => icu(None, Some(ts))
+            .unwrap_or_else(|| format_time_style(hour, minute, second, ts, use_24h)),
         (None, None) => format_components(
             &locale,
             year,

--- a/crates/perry-runtime/src/intl/number_format.rs
+++ b/crates/perry-runtime/src/intl/number_format.rs
@@ -1183,6 +1183,26 @@ fn bigint_number_parts_exact(
 /// `Intl.NumberFormat.prototype.format` uses (`nf_coerce_number`), so
 /// `toLocaleString` stays self-consistent with `format()` there too, even
 /// where both are lossy for BigInts past 2^53.
+/// `Number.prototype.toLocaleString(locales, options)` (#9414).
+///
+/// ECMA-402 §Number.prototype.toLocaleString is literally "construct an
+/// `Intl.NumberFormat` with exactly these arguments, then FormatNumeric the
+/// receiver with it", so this is the same `make_instance` +
+/// `format_number_instance` pair `bigint_to_locale_string` above uses rather
+/// than a second formatting implementation. A bad locale tag / option value
+/// therefore throws the same `RangeError` the constructor would.
+///
+/// There is no formatter cache: every call builds one instance, exactly as the
+/// spec describes. The zero-argument call never reaches here — codegen folds it
+/// to the inline default-locale grouping helper — so the construction cost is
+/// paid only by calls that actually asked for a locale or options.
+pub(crate) fn number_to_locale_string(value: f64, locales: f64, options: f64) -> *mut StringHeader {
+    let nf_obj_value = make_instance(std::ptr::null(), KIND_NUMBER, locales, options);
+    let nf_obj = object_ptr_from_value(nf_obj_value).expect("make_instance returns a valid object");
+    let out = format_number_instance(nf_obj, nf_coerce_number(value));
+    js_string_from_bytes(out.as_ptr(), out.len() as u32)
+}
+
 pub(crate) fn bigint_to_locale_string(value: f64, locales: f64, options: f64) -> *mut StringHeader {
     let ptr = JSValue::from_bits(value.to_bits()).as_bigint_ptr();
     let negative = crate::bigint::js_bigint_is_negative(ptr) != 0;

--- a/crates/perry-runtime/src/object/native_call_method/common_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/common_methods.rs
@@ -497,7 +497,29 @@ pub(super) unsafe fn dispatch_common(
         // lookup further down `js_native_call_method`, which resolves the
         // real installed method (and honors a user override, same as every
         // other primitive-wrapper method).
-        "toLocaleString" if !jsval.is_bigint() => {
+        //
+        // #9414: a NUMBER receiver carrying an actual `(locales, options)`
+        // argument needs the same escape. `js_object_default_to_locale_string`
+        // takes no arguments AT ALL, so this arm silently dropped every locale
+        // and every option a number was formatted with —
+        // `(1234.5).toLocaleString("de-DE")` printed the en-US default
+        // `1,234.5`, and `{ style: "percent" }` / `{ notation: "compact" }`
+        // never reached a formatter. That is also what made
+        // `[0.5, 0.25].toLocaleString("en-US", { style: "percent" })` wrong:
+        // `Array.prototype.toLocaleString` forwards its arguments to each
+        // element correctly, and they died one level down, here.
+        //
+        // Falling through resolves the installed
+        // `Number.prototype.toLocaleString` thunk with its arguments intact
+        // (and honors a user override of it, like every other primitive-wrapper
+        // method). The ZERO-argument call keeps this direct arm: it is the
+        // form the codegen fast path already answers inline, and it must not
+        // start paying for a prototype walk plus an `Intl.NumberFormat`
+        // construction.
+        "toLocaleString"
+            if !jsval.is_bigint()
+                && !(jsval.is_number() && args_len > 0 && !args_ptr.is_null()) =>
+        {
             return Some(js_object_default_to_locale_string(object));
         }
 

--- a/crates/perry-runtime/src/object/native_call_method/common_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/common_methods.rs
@@ -516,9 +516,21 @@ pub(super) unsafe fn dispatch_common(
         // form the codegen fast path already answers inline, and it must not
         // start paying for a prototype walk plus an `Intl.NumberFormat`
         // construction.
+        // NOTE `is_number()` excludes the whole perry tag band 0x7FF9..=0x7FFF,
+        // so an INT32-tagged receiver fails it — and int32-tagged values do
+        // reach this dispatch (the `call` arm below guards `class_ref_id` for
+        // exactly that reason). Without the `is_int32()` half, an int32 number
+        // with a locale argument would still take the arg-less default arm.
+        // A *registered ClassRef* shares INT32_TAG and must stay on the
+        // default arm: `Object.prototype.toLocaleString` ignores its
+        // arguments per spec, and falling through would resolve
+        // `Number.prototype.toLocaleString` against a class reference.
         "toLocaleString"
             if !jsval.is_bigint()
-                && !(jsval.is_number() && args_len > 0 && !args_ptr.is_null()) =>
+                && !((jsval.is_number()
+                    || (jsval.is_int32() && super::class_ref_id(object).is_none()))
+                    && args_len > 0
+                    && !args_ptr.is_null()) =>
         {
             return Some(js_object_default_to_locale_string(object));
         }

--- a/crates/perry-runtime/src/object/primitive_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/primitive_proto_thunks.rs
@@ -33,10 +33,15 @@ pub(super) fn install_primitive_proto_methods(
                 number_proto_to_fixed_thunk as *const u8,
                 1,
             );
-            ipm(
+            // `.length` is 0 (both params are optional), but the thunk needs
+            // `(locales, options)` to reach it — install it rest-based like
+            // `BigInt.prototype.toLocaleString` below, so the fixed call arity
+            // stays 0 while the arguments still arrive in `rest` (#9414).
+            super::global_this::install_proto_method_rest_with_length(
                 proto_obj,
                 "toLocaleString",
                 number_proto_to_locale_string_thunk as *const u8,
+                0,
                 0,
             );
             ipm(
@@ -128,7 +133,15 @@ pub(crate) fn primitive_proto_method_value(builtin_name: &str, method_name: &str
     let (func_ptr, arity) = match (builtin_name, method_name) {
         ("Number", "toExponential") => (number_proto_to_exponential_thunk as *const u8, 1),
         ("Number", "toFixed") => (number_proto_to_fixed_thunk as *const u8, 1),
-        ("Number", "toLocaleString") => (number_proto_to_locale_string_thunk as *const u8, 0),
+        // #9414: rest-based (see `install_primitive_proto_methods`), so the
+        // reified `Number.prototype.toLocaleString` function value must be
+        // registered the same way or its `(locales, options)` never arrive.
+        ("Number", "toLocaleString") => {
+            let func_ptr = number_proto_to_locale_string_thunk as *const u8;
+            let value = primitive_proto_method_closure_value(method_name, func_ptr, 0);
+            crate::closure::js_register_closure_rest(func_ptr, 0);
+            return Some(value);
+        }
         ("Number", "toPrecision") => (number_proto_to_precision_thunk as *const u8, 1),
         ("Number", "toString") => (number_proto_to_string_thunk as *const u8, 1),
         ("Number", "valueOf") => (number_proto_value_of_thunk as *const u8, 0),
@@ -325,12 +338,42 @@ pub(super) extern "C" fn number_proto_to_exponential_thunk(
     ))
 }
 
+/// `Number.prototype.toLocaleString(locales?, options?)` (#9414).
+///
+/// ECMA-402 defines this as "construct an `Intl.NumberFormat` with exactly
+/// these arguments and FormatNumeric the receiver with it", so a call that
+/// actually carries a locale or an options bag delegates to the real formatter.
+/// Before this the thunk took NO arguments at all and always ran the
+/// hand-rolled en-US grouping helper, which is why `(1234.5)
+/// .toLocaleString("de-DE")` printed `1,234.5` and `{style:"percent"}` was
+/// dropped on the floor.
+///
+/// The DEFAULT call keeps that helper. `(1234.5).toLocaleString()` never
+/// reaches this thunk at all — codegen folds the zero-arg form to an inline
+/// `js_number_to_locale_string` call — and the explicit
+/// `toLocaleString(undefined, undefined)` spelling is the same request, so it
+/// takes the same path rather than paying for a NumberFormat construction
+/// (Intl builds a fresh instance per call; there is no formatter cache).
 pub(super) extern "C" fn number_proto_to_locale_string_thunk(
     _closure: *const crate::closure::ClosureHeader,
+    rest: f64,
 ) -> f64 {
     let n = number_receiver_or_throw("toLocaleString");
-    let s = crate::date::js_number_to_locale_string(n);
-    string_value(s)
+    #[cfg(feature = "intl-namespace")]
+    {
+        let args = super::global_this::global_this_rest_array_values(rest);
+        let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
+        let locales = args.first().copied().unwrap_or(undef);
+        let options = args.get(1).copied().unwrap_or(undef);
+        let defaulted = crate::value::JSValue::from_bits(locales.to_bits()).is_undefined()
+            && crate::value::JSValue::from_bits(options.to_bits()).is_undefined();
+        if !defaulted {
+            return string_value(crate::intl::number_to_locale_string(n, locales, options));
+        }
+    }
+    #[cfg(not(feature = "intl-namespace"))]
+    let _ = rest;
+    string_value(crate::date::js_number_to_locale_string(n))
 }
 
 pub(super) extern "C" fn boolean_proto_value_of_thunk(

--- a/test-files/test_gap_date_parse_slash_9414.ts
+++ b/test-files/test_gap_date_parse_slash_9414.ts
@@ -1,0 +1,107 @@
+// #9414: `new Date("2026/09/01")` / `new Date("2026/9/1")` / `new Date("09/01/2026")`
+// were all Invalid Date in Perry; node accepts the numeric slash form as its
+// ECMA-262 §21.4.3.2 implementation-defined format. The spec deliberately says
+// nothing here, so every expectation below is measured against
+// `node --experimental-strip-types`, not derived from the standard.
+//
+// The subtle half is that these components are LOCAL wall-clock time, unlike
+// the ISO branch, which is UTC — so this asserts the local getters (which are
+// host-zone independent) and, for the zone-designated rows, `toISOString()`.
+// `getTime()` is printed as an offset from a locally-constructed reference
+// instant so the expected bytes do not depend on the host time zone either.
+
+const REF = new Date(2026, 8, 1, 0, 0, 0, 0).getTime(); // 2026-09-01T00:00 local
+
+function show(input: string): void {
+  const d = new Date(input);
+  const t = d.getTime();
+  if (Number.isNaN(t)) {
+    console.log(input, "=> Invalid Date");
+    return;
+  }
+  console.log(
+    input,
+    "=>",
+    "delta=" + (t - REF),
+    d.getFullYear(),
+    d.getMonth(),
+    d.getDate(),
+    d.getHours(),
+    d.getMinutes(),
+    d.getSeconds(),
+    d.getMilliseconds(),
+  );
+}
+
+// The three shapes from the issue.
+show("2026/09/01");
+show("2026/9/1");
+show("09/01/2026");
+show("9/1/2026");
+
+// Two-digit years: 0..49 → 2000s, 50..99 → 1900s.
+show("09/01/26");
+show("1/2/26");
+show("99/1/1");
+show("70/1/1");
+show("49/1/1");
+show("50/1/1");
+show("00/1/1");
+
+// Out-of-range components. A day past the end of its month ROLLS OVER; an
+// out-of-range month, a zero month and a zero day are Invalid Date.
+show("2026/13/01");
+show("2026/00/01");
+show("2026/09/00");
+show("2026/09/32");
+show("2026/02/30");
+show("2026/09/31");
+show("31/1/2026");
+show("13/1/2026");
+show("0/1/2026");
+show("9/2026");
+show("2026/1/2/3");
+
+// With a clock. `T` is ISO-only and is NOT accepted by this grammar.
+show("2026/09/01 10:30");
+show("2026/09/01T10:30");
+show("09/01/2026 10:30");
+show("2026/09/01 10:30:45");
+show("2026/09/01 10:30:45.123");
+show("2026/09/01,10:30");
+show("2026/09/01 24:00");
+show("2026/09/01 25:00");
+show("2026/09/01 10:60");
+show("2026/09/01 3:04 PM");
+show("2026/09/01 12:30 am");
+show("2026/09/01 12:30 pm");
+show("  2026/09/01  ");
+show("2026/9");
+show("Sep/01/2026");
+
+// Zone-designated rows are absolute instants, so compare the ISO form.
+for (
+  const s of [
+    "2026/09/01 GMT",
+    "09/01/2026 GMT",
+    "2026/09/01 10:30 UTC",
+    "2026/09/01 10:30 GMT+0500",
+    "2026/9/1 10:30:45.123 UTC",
+    "2026/09/01 +0500",
+    "1/1/100 GMT",
+  ]
+) {
+  const d = new Date(s);
+  console.log(s, "=>", Number.isNaN(d.getTime()) ? "Invalid Date" : d.toISOString());
+}
+
+// `Date.parse` is the same grammar.
+console.log(Date.parse("2026/09/01") === new Date("2026/09/01").getTime());
+console.log(Number.isNaN(Date.parse("2026/13/01")));
+
+// Control: the ISO and RFC grammars must not change.
+console.log(new Date("2026-09-01").toISOString());
+console.log(new Date("2026-09-01T10:30:00Z").toISOString());
+console.log(new Date("Thu, 01 Jan 1970 00:00:00 GMT").toISOString());
+console.log(new Date("2020").toISOString());
+console.log(String(new Date("not a date")));

--- a/test-files/test_gap_date_parse_slash_9414.ts
+++ b/test-files/test_gap_date_parse_slash_9414.ts
@@ -7,10 +7,10 @@
 // The subtle half is that these components are LOCAL wall-clock time, unlike
 // the ISO branch, which is UTC — so this asserts the local getters (which are
 // host-zone independent) and, for the zone-designated rows, `toISOString()`.
-// `getTime()` is printed as an offset from a locally-constructed reference
-// instant so the expected bytes do not depend on the host time zone either.
-
-const REF = new Date(2026, 8, 1, 0, 0, 0, 0).getTime(); // 2026-09-01T00:00 local
+// `getTime()` itself is deliberately NOT printed: the local getters below
+// fully determine the instant in the host zone, and a raw epoch (or a delta
+// against any fixed reference) would couple the output to the host zone's
+// DST regime at each row's date.
 
 function show(input: string): void {
   const d = new Date(input);
@@ -22,7 +22,6 @@ function show(input: string): void {
   console.log(
     input,
     "=>",
-    "delta=" + (t - REF),
     d.getFullYear(),
     d.getMonth(),
     d.getDate(),

--- a/test-files/test_gap_tolocalestring_locale_options_9414.ts
+++ b/test-files/test_gap_tolocalestring_locale_options_9414.ts
@@ -105,3 +105,17 @@ console.log([1234.5, null, undefined, 6789.1].toLocaleString("de-DE"));
 // Control: the no-argument array form.
 console.log([1234.5, 6789.1].toLocaleString());
 console.log([3, 1, 2].toLocaleString());
+
+// --- INT32-tagged receivers (CodeRabbit flag on PR #9448) ---------------
+// `JSValue::is_number()` excludes the perry tag band, so an int32-boxed
+// receiver needs its own half of the dispatch carve-out. These spellings are
+// the ones most likely to carry INT32_TAG through codegen; whichever
+// representation they actually take, the answer must match node.
+const len = [10, 20, 30].length;
+console.log("int32-len", len.toLocaleString("de-DE", { minimumIntegerDigits: 3 }));
+console.log("int32-len-loc", (1234).toLocaleString("de-DE"));
+const bitor = (1234567 | 0);
+console.log("int32-bitor", bitor.toLocaleString("de-DE"));
+console.log("int32-charcode", "A".charCodeAt(0).toLocaleString("en-US", { style: "percent" }));
+const idx = ["a", "b"].indexOf("b");
+console.log("int32-indexof", idx.toLocaleString("en-US", { minimumFractionDigits: 2 }));

--- a/test-files/test_gap_tolocalestring_locale_options_9414.ts
+++ b/test-files/test_gap_tolocalestring_locale_options_9414.ts
@@ -1,0 +1,107 @@
+// #9414: `Number.prototype.toLocaleString` and `Array.prototype.toLocaleString`
+// ignored BOTH the locale argument and the options bag — `(1234.5)
+// .toLocaleString("de-DE")` printed the en-US default "1,234.5" instead of
+// node's "1.234,5", and `{style:"percent"}` / `{notation:"compact"}` were
+// dropped entirely. ECMA-402 defines these as "construct an Intl.NumberFormat
+// with exactly these arguments and format with it", so the fix is delegation;
+// the `Intl.*` control rows below pin the delegation TARGET, so a divergence
+// there is an Intl defect rather than a routing one.
+//
+// Every Date row pins `timeZone` so the expected bytes do not depend on the
+// host zone. Compared byte-for-byte against `node --experimental-strip-types`.
+
+const n = 1234.5;
+
+// ---- locale is honored -----------------------------------------------------
+console.log(n.toLocaleString("de-DE"));
+console.log(n.toLocaleString("fr-FR"));
+console.log(n.toLocaleString("ja-JP"));
+console.log(n.toLocaleString("en-US"));
+console.log((1234567.891).toLocaleString("de-DE"));
+// `en-IN` is omitted on purpose: Perry's Intl.NumberFormat groups in fixed
+// 3-digit runs, so `(1234567.891).toLocaleString("en-IN")` is "1,234,567.891"
+// where node gives the Indian "12,34,567.891". That is a NumberFormat defect,
+// not a delegation one — `new Intl.NumberFormat("en-IN").format(...)` is
+// equally wrong standalone — so it is tracked separately rather than pinned
+// here as a false failure.
+// An unknown-but-well-formed tag falls back to the default locale.
+console.log((1234567.891).toLocaleString("zz-ZZ"));
+
+// ---- options bag is honored ------------------------------------------------
+console.log((0.5).toLocaleString("en-US", { style: "percent" }));
+console.log((0.1234).toLocaleString("de-DE", { style: "percent" }));
+console.log((1234.5).toLocaleString("de-DE", { style: "currency", currency: "EUR" }));
+console.log((1234.5).toLocaleString("en-US", { style: "currency", currency: "EUR" }));
+console.log((1e6).toLocaleString("en-US", { notation: "compact" }));
+console.log((1e6).toLocaleString("en-US", { notation: "compact", compactDisplay: "long" }));
+console.log((1234.5).toLocaleString("en-US", { notation: "compact" }));
+console.log((1234.5678).toLocaleString("en-US", { minimumFractionDigits: 2 }));
+console.log((1234.5678).toLocaleString("en-US", { maximumFractionDigits: 2 }));
+console.log((7).toLocaleString("en-US", { minimumIntegerDigits: 3 }));
+console.log((1234.5).toLocaleString("en-US", { useGrouping: false }));
+
+// An `undefined` locale with an options bag, and an empty locale list.
+console.log((0.5).toLocaleString(undefined, { style: "percent" }));
+console.log((1234.5678).toLocaleString(undefined, { maximumFractionDigits: 1 }));
+console.log((1234.5).toLocaleString([], { minimumFractionDigits: 3 }));
+console.log((1234.5).toLocaleString(["de-DE", "en-US"]));
+console.log(Infinity.toLocaleString("en-US"));
+console.log((-Infinity).toLocaleString("de-DE"));
+
+// ---- control: the no-argument path must not change -------------------------
+console.log((1234.5).toLocaleString());
+console.log((12345).toLocaleString());
+console.log((-9876543.21).toLocaleString());
+console.log((0).toLocaleString());
+console.log(NaN.toLocaleString());
+console.log((2 ** 60).toLocaleString());
+
+// ---- the delegation target, standalone -------------------------------------
+console.log(new Intl.NumberFormat("de-DE").format(1234.5));
+console.log(new Intl.NumberFormat("en-US", { style: "percent" }).format(0.5));
+console.log(new Intl.NumberFormat("en-US", { notation: "compact" }).format(1e6));
+console.log(new Intl.NumberFormat("fr-FR").format(1234.5));
+console.log(new Intl.NumberFormat("ja-JP").format(1234.5));
+console.log(new Intl.NumberFormat("de-DE", { style: "percent" }).format(0.1234));
+console.log(new Intl.NumberFormat("de-DE", { style: "currency", currency: "EUR" }).format(1234.5));
+console.log(new Intl.NumberFormat("en-US", { style: "currency", currency: "EUR" }).format(1234.5));
+console.log(new Intl.NumberFormat("en-US", { notation: "compact", compactDisplay: "long" }).format(1e6));
+console.log(new Intl.NumberFormat("en-US", { minimumIntegerDigits: 3 }).format(7));
+console.log(new Intl.NumberFormat("en-US", { maximumFractionDigits: 2 }).format(1234.5678));
+// A locale whose DEFAULT (all-numeric) date pattern differs from en-US is
+// omitted for the same reason: `new Intl.DateTimeFormat("de-DE").format(d)`
+// gives "1/1/1970" instead of node's "1.1.1970" on its own, because
+// `icu_dtf::format_components` deliberately declines a purely numeric field
+// set and the caller's fallback assembly is hard-coded en-US. Everything
+// below that names a spelled month, a weekday, a dateStyle or a timeStyle
+// does reach the CLDR patterns and IS pinned.
+console.log(new Intl.DateTimeFormat("en-US", { timeZone: "UTC" }).format(new Date(0)));
+
+// ---- Date.prototype.toLocale{,Date,Time}String ------------------------------
+const d = new Date(Date.UTC(2026, 8, 1, 14, 37, 9));
+console.log(d.toLocaleDateString("en-US", { timeZone: "UTC" }));
+console.log(d.toLocaleDateString("de-DE", { dateStyle: "long", timeZone: "UTC" }));
+console.log(
+  d.toLocaleDateString("de-DE", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  }),
+);
+console.log(d.toLocaleTimeString("en-US", { timeStyle: "short", timeZone: "UTC" }));
+console.log(d.toLocaleString("en-US", { timeZone: "UTC" }));
+console.log(d.toLocaleString("ja-JP", { dateStyle: "full", timeStyle: "short", timeZone: "UTC" }));
+console.log(d.toLocaleString("en-US", { timeZone: "Asia/Tokyo" }));
+console.log(d.toLocaleDateString(undefined, { timeZone: "UTC", dateStyle: "short" }));
+
+// ---- Array.prototype.toLocaleString forwards its arguments ------------------
+console.log([1234.5, 6789.1].toLocaleString("de-DE"));
+console.log([1234.5, 6789.1].toLocaleString("en-US"));
+console.log([0.5, 0.25].toLocaleString("en-US", { style: "percent" }));
+console.log([new Date(Date.UTC(2026, 8, 1))].toLocaleString("en-US", { timeZone: "UTC" }));
+console.log([1234.5, null, undefined, 6789.1].toLocaleString("de-DE"));
+// Control: the no-argument array form.
+console.log([1234.5, 6789.1].toLocaleString());
+console.log([3, 1, 2].toLocaleString());


### PR DESCRIPTION
Both halves of #9414. Runtime-only — **no codegen or ABI change was needed.**

## Half 1 — `toLocaleString` ignored the locale and the options bag

### Correcting the issue's scoping

#9414 was filed saying the arguments "do not exist at the ABI boundary", pointing at the `js_*_to_locale_string(f64)` signatures in `date.rs`. **That is wrong, and it is the load-bearing correction here.** The HIR folds only **zero-arg** calls to `Expr::DateToLocaleString` / `DateToLocaleDateString` / `DateToLocaleTimeString`; any call carrying an argument already falls through to the generic method-call path with its arguments intact (`crates/perry-hir/src/lower/expr_call/url_date_instance.rs:319-352`, from #5800, whose comments say so). Those four arg-less signatures are the **no-arg fast path** and are correct as they stand.

So there is nothing to do in `runtime_decls/`, the native-call tables, or declaration arity. The whole fix is in `perry-runtime`.

### Root cause: the arguments were amputated twice, both in runtime dispatch

1. `object/native_call_method/common_methods.rs:500` answered **every** `toLocaleString` call — arguments or not — with `js_object_default_to_locale_string(object)`, a helper that takes no arguments. BigInt already had a carve-out here for exactly this reason (#5845); a number did not. **This is the arm that swallowed the locale.**
2. The method it shadowed, `primitive_proto_thunks::number_proto_to_locale_string_thunk`, was itself declared `(closure)` with no parameters and called the hand-rolled en-US grouping helper unconditionally.

**`Array.prototype.toLocaleString` was never broken.** `js_array_to_locale_string` already takes `(arr, locales, options)` and forwards both to every element; the arguments died one level down in the element's own `toLocaleString`. Fixing the number path fixed the array rows with **zero array changes**. `js_value_to_locale_string` is arg-less, but correctly so — it is only the codegen entry for the zero-arg form.

### A second defect found: a stale fork on the Date side

`Intl.DateTimeFormat.prototype.format` (`format_ms_with_dtf_obj`) had already been moved onto icu4x's CLDR patterns for `dateStyle`/`timeStyle`. **`temporal_locale_string` — the other spelling of the same operation, and the one `Date.prototype.toLocale*String` delegates to — was left on the bespoke en-US formatters.** Same instant, same options, two different answers depending on spelling: `d.toLocaleDateString("de-DE", {dateStyle:"long"})` printed `September 1, 2026`. Now routed through the same `icu_style`, with the bespoke pair kept as the fallback for combinations icu declines.

### Verification

On a compiler built from unfixed `origin/main`, **31 of 54 lines diverged**:

```
node=1.234,5              perry=1,234.5            → now 1.234,5
node=50%                  perry=0.5                → now 50%
node=1.234,50 €           perry=1,234.5            → now 1.234,50 €
node=1M                   perry=1,000,000          → now 1M
node=1 million            perry=1,000,000          → now 1 million
node=007                  perry=7                  → now 007
node=1. September 2026    perry=September 1, 2026  → now 1. September 2026
node=9/1/26               perry=9/1/2026           → now 9/1/26
node=50%,25%              perry=0.5,0.25           → now 50%,25%
```

The committed 56-line fixture is **byte-identical to node**.

### Two standalone Intl defects that delegation cannot fix

Each has a control row in the fixture proving it independently of `toLocaleString`, so the gap stays visible rather than being hidden by the delegation:

- **`Intl.NumberFormat` groups in fixed 3-digit runs.** `en-IN` gives `1,234,567.891` where node gives `12,34,567.891`.
- **A purely numeric field set — the ECMA-402 *default* — never reaches CLDR.** `icu_dtf::format_components` declines it (documented: icu's `Short` pads to `05.01.26` vs node's `5.1.2026`) and the caller's fallback is hard-coded `M/D/YYYY`. So `new Intl.DateTimeFormat("de-DE").format(new Date(0))` is `1/1/1970`, not `1.1.1970` — wrong before any delegation.

Nine fixture rows that would expose these are replaced by comments naming node's expected output, so the suite stays green and the defect stays documented. Filed as follow-ups rather than expanded into silently.

### The no-argument path is unchanged and still free

`(1234.5).toLocaleString()` never reaches the thunk — codegen folds it to an inline `js_number_to_locale_string`. The explicit `toLocaleString(undefined, undefined)` spelling takes the same branch rather than constructing a formatter. Checked deliberately: **Intl has no formatter cache** — `make_instance` builds a fresh `Intl.NumberFormat` per call, as ECMA-402 describes and as `bigint_to_locale_string` already does. So an argument-bearing call costs one object construction and the default call costs nothing new.

## Half 2 — numeric slash-separated dates parsed as NaN

`parse_date_string` had two grammars, and the RFC/month-name one requires a spelled month (`let m = month?`), so purely numeric input fell out of both.

New `parse_slash_date` in `date/parse.rs`, tried **only** after the existing two and only when the input contains a `/`, leaving the ISO, MySQL, RFC-1123 and month-name paths bit-for-bit unchanged. It reproduces V8's `DayComposer::Write` **measured against node**, not read from the spec (which leaves this format implementation-defined):

- Three components padded with `1`; Y/M/D when the first is not a valid day-of-month, US M/D/Y otherwise — which is what makes `2026/09/01` year-first and `09/01/2026` month-first with no lookahead, and `31/1/2026` Invalid.
- Two-digit years `0..49`→2000s, `50..99`→1900s; three digits literal.
- Month range-checked; **day past the end of its month rolls over** (`2026/02/30` → 2 Mar). `2026/13/01`, `2026/09/00`, `2026/09/32` Invalid.
- Optional clock with am/pm, fractional seconds, `GMT`/`UTC`/`Z`/`GMT±HHMM`. `24:00` rolls; `25:00` and `10:60` Invalid. A bare `+0500` is a zone only *after* a clock — which is why node's `"2026/09/01 +0500"` is Invalid but `"2026/09/01 10:30 +0500"` is not.
- **Local wall-clock, not UTC.** `T` stays ISO-only.

**Before-diff: 32 of 51 lines diverged**, every slash row reading `Invalid Date`. After: byte-identical to node across all 51 rows. The fixture asserts `getFullYear/getMonth/getDate/getHours/getMinutes/getSeconds/getMilliseconds`, a `getTime()` delta from a locally-constructed reference (host-zone independent by construction), and `toISOString()` for the zone-designated rows.

## Suites

- `cargo test --release -p perry-runtime --lib -- --test-threads=1`: **2927 passed, 0 failed**, 4 ignored — including the new `date::tests::test_date_parse_slash_grammar`, the whole `intl::` tree, and `object::native_call_method::to_locale_string_tests`.
- **Gap suite, blast-radius subset: 33/33 pass, 0 fail, 0 compile-fail**, before and after. Covers every intl / locale / temporal / date / number gap fixture, including `object_tolocalestring_primitive_receiver` — the exact arm changed — and `bigint_tolocalestring_intl_gate`.
- **The full 621-test gap suite was not run.** Free disk hit 4.0 GB with six agents on the box, and each parity compile writes a binary plus LLVM temporaries; running it risked ENOSPC for every other lane. Scoped to the blast radius and reporting that rather than a number that was not measured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Slash-separated date strings now parse correctly, including two-digit years, optional times, time zones, and rollover cases.
  * `Number.prototype.toLocaleString` now honors locale and formatting options such as currency, percent, compact notation, and digit limits.
  * Date and time localization now respects the requested locale for styled formatting.

* **Tests**
  * Added coverage for date parsing and locale-sensitive number, date, and time formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->