### PR TITLE
fix(runtime): inspect decodes classes, holes and promise state (#9415); Array.from(str) keeps lone surrogates (#9431)

### DIFF
--- a/changelog.d/9415-inspect-class-hole-promise.md
+++ b/changelog.d/9415-inspect-class-hole-promise.md
@@ -1,0 +1,63 @@
+**`console.log` / `util.inspect` no longer decode a class as an integer, a
+sparse-array hole as `NaN`, or a settled promise as pending.**
+
+```js
+console.log(class Klass {})   // was "1"                  now "[class Klass]"
+console.log(new Array(3))     // was "[ NaN, NaN, NaN ]"  now "[ <3 empty items> ]"
+console.log(Promise.resolve(1)) // was "Promise { <pending> }" now "Promise { 1 }"
+```
+
+Three separate defects with one shape: a ladder classifies a NaN-boxed value
+by tag, has no arm for the case in hand, and lets the bits fall through to
+"must be a regular number".
+
+A class value is an INT32-tagged NaN box carrying the class id, so every
+`else if v.is_int32()` arm printed `as_int32()` — the raw id. `INT32_TAG | 2`
+and a ClassRef with `class_id == 2` are bit-identical; `class_ref_id`'s
+registry probe is the only thing separating them, exactly as
+`symbol/iterator.rs` documents for `for…of`. Class ids are small and
+sequential, so a program with N classes leaves the integers `1..=N`
+genuinely undecidable at the display ladder; perry now answers "class" for
+those, because a class id leaking into output is never right. The probe stays
+inside the `is_int32()` arm, where a value is already being turned into a
+heap `String`, so ordinary numbers — plain f64 doubles — never pay for it.
+
+`TAG_HOLE`'s bit pattern *is* a NaN, which is why a hole printed as `NaN`
+rather than crashing. Runs of holes now collapse to Node's `<N empty items>`,
+and the single-line/multi-line decision counts the entries Node prints
+instead of the array's `length` — `new Array(7)` is seven slots but one
+entry, so it stays on one line. The same sentinel is why a tombstoned
+`Map`/`Set` inspected wrongly: `js_set_delete` writes `TAG_HOLE` over the
+slot and decrements `size` without touching `used`, so walking `0..size` both
+rendered the tombstone and stopped short of the live tail
+(`new Set([1,2,3])` after `delete(1)` printed `Set(2) { NaN, 2 }`). Both
+walks are now bounded by `used` and skip holes, like the collection iterator
+objects already did.
+
+The promise arm was a hard-coded `"Promise { <pending> }"` string; it now
+reads the state byte, and `format_jsvalue_for_json` gained the promise arm it
+never had, so a promise-valued field says `Promise { 1 }` instead of
+`[object Object]`.
+
+All three renderings live in one `builtins/formatting/value_repr.rs` shared
+by the ladders in `console.rs` and `formatting.rs`, because a fix applied to
+`console.log` and not `console.error`, or to `format_jsvalue` and not to
+`format_jsvalue_for_json` (which renders the same array once it is an object
+field), is a half-fix that reads as a working one.
+
+One consequence had to be paid for: `util.isDeepStrictEqual` compares the
+formatted rendering of two non-pointer operands, and two DISTINCT classes that
+share a name now render identically where their class ids used to differ. A
+class reference is therefore compared by identity in that tail — after
+`js_jsvalue_equals` has already settled the equal case, so an ordinary integer
+is unaffected.
+
+The bit-identity collision turns out not to be observable through the display
+ladders at all: a JS number is a plain f64 double and never reaches the INT32
+arm. Measured with class ids 1 and 2 live, `console.log(1)`, `console.log(2)`,
+`[9].length`, `"A".charCodeAt(0)` and `3 | 0` all still print integers. The
+registry probe is the second line of defence, not the only one.
+
+`test-files/test_gap_9415_inspect_class_hole_promise.ts` is byte-compared
+against node. Built from unfixed `origin/main` the same fixture diverges on
+34 of its stdout lines and on all 4 of its stderr lines.

--- a/changelog.d/9431-array-from-lone-surrogate.md
+++ b/changelog.d/9431-array-from-lone-surrogate.md
@@ -1,0 +1,40 @@
+**`Array.from(str)` no longer returns `[]` for a string containing a lone
+surrogate.**
+
+```js
+Array.from("a\ud83db")   // was []   now 3 elements, node-identical
+```
+
+`js_array_from_string_codepoints` validated the payload with
+`std::str::from_utf8` and returned an EMPTY array on `Err`. Perry string
+payloads are WTF-8, not UTF-8 — a lone surrogate is a legal payload, produced
+by slicing a pair, by `charAt`, or by a chunked decoder — so any string
+holding one made the whole conversion silently yield nothing. Whole-array
+data loss with no error: the result was empty, not wrong-length.
+
+The spread, `for…of` and `[Symbol.iterator]` forms over the same string were
+already correct, which is what made this a wrong answer rather than a
+consistent limitation. The walk now steps the raw bytes with the bounded
+`wtf8_step` decoder the other iterators use, which yields one code point per
+step and reports a lone surrogate as its own single-unit step. A part carved
+out of a WTF-8 source is built through `js_string_from_wtf8_bytes` so it
+keeps `STRING_FLAG_HAS_LONE_SURROGATES` — `isWellFormed()` on the element
+still reports `false`, and `JSON.stringify` still escapes it as a broken
+half.
+
+The mapped form `Array.from(str, fn)` took the same walk and was empty too;
+it is fixed by the same change and asserted alongside.
+
+The rewrite also closes a pre-existing GC hazard the old loop carried: it
+held a raw `elements` pointer and a borrow of the source payload across every
+per-element allocation, so an evacuating collection could move both out from
+under it. The walk now uses the `RuntimeHandleScope` discipline
+`string/split.rs` established — root the source and the result, re-read the
+source after every allocation, publish each element only after its write and
+barrier — which is why this was left out of the earlier surrogate batch
+rather than done as a one-line swap.
+
+`test-files/test_gap_9431_array_from_lone_surrogate.ts` is byte-compared
+against node and asserts `.length` plus every element's char codes across all
+five iteration forms. Built from unfixed `origin/main` the same fixture
+diverges on 18 lines.

--- a/crates/perry-runtime/src/array/alloc.rs
+++ b/crates/perry-runtime/src/array/alloc.rs
@@ -351,11 +351,50 @@ pub extern "C" fn js_array_from_arraylike_holey_value(boxed: f64) -> *mut ArrayH
     crate::array::js_array_from_value(boxed)
 }
 
-/// `Array.from(string)` — split the source string into Unicode codepoints
-/// and emit each as a 1-codepoint string element (matches `[..."hello"]` /
+/// Store a freshly built part string into slot `index` of an all-pointer
+/// result array and publish the slot.
+///
+/// Mirrors `string/split.rs`'s `store_split_string`: the array is allocated
+/// with `length == 0` and each element is published only after its write and
+/// barrier, so a collection triggered by the NEXT part's allocation never scans
+/// an uninitialized slot.
+///
+/// # Safety
+///
+/// `arr` must be a live all-pointer `GC_TYPE_ARRAY` with capacity > `index`,
+/// and `string` a live `StringHeader`.
+unsafe fn store_codepoint_string(
+    arr: *mut ArrayHeader,
+    index: usize,
+    string: *mut crate::string::StringHeader,
+) {
+    let elements = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
+    let value = crate::value::js_nanbox_string(string as i64);
+    // GC_STORE_AUDIT(BARRIERED): codepoint array slot is followed by a runtime write barrier.
+    ptr::write(elements.add(index), value);
+    crate::gc::runtime_write_barrier_slot(
+        arr as usize,
+        elements.add(index) as usize,
+        value.to_bits(),
+    );
+    (*arr).length = (index + 1) as u32;
+}
+
+/// `Array.from(string)` — split the source string into Unicode code points and
+/// emit each as a 1-code-point string element (matches `[..."hello"]` /
 /// `for (const c of "hello")` semantics). Surrogate pairs in UTF-16 source
-/// space materialize as a single codepoint per ECMA-262 §22.1.5 String
+/// space materialize as a single code point per ECMA-262 §22.1.5 String
 /// Iterator Records, so `[..."🎉"]` yields a 1-element array (not 2).
+///
+/// #9431: this used to run `std::str::from_utf8(bytes)` and return an EMPTY
+/// array on `Err`. Perry string payloads are WTF-8, not UTF-8 — a lone
+/// surrogate (`"a\ud83db"`, the half of a pair a slicing bug or a chunked
+/// decoder leaves behind) is a legal payload that `from_utf8` rejects — so
+/// `Array.from` silently answered `[]` for the whole string while `[...s]` and
+/// `for…of` over the same string were correct. Step the raw bytes with the
+/// bounded `wtf8_step` decoder instead, which yields one code point per step
+/// and reports a lone surrogate as its own single-unit step, exactly as the
+/// string iterator does.
 pub(crate) unsafe fn js_array_from_string_codepoints(
     s: *const crate::string::StringHeader,
 ) -> *mut ArrayHeader {
@@ -366,28 +405,74 @@ pub(crate) unsafe fn js_array_from_string_codepoints(
     if byte_len == 0 {
         return js_array_alloc(0);
     }
-    let data_ptr = (s as *const u8).add(std::mem::size_of::<crate::string::StringHeader>());
-    let bytes = std::slice::from_raw_parts(data_ptr, byte_len);
-    let src = match std::str::from_utf8(bytes) {
-        Ok(s) => s,
-        Err(_) => return js_array_alloc(0),
-    };
-    // Pre-count to size the result exactly.
-    let cp_count = src.chars().count() as u32;
-    let arr = js_array_alloc(cp_count);
-    (*arr).length = cp_count;
-    clear_array_numeric_layout(arr);
-    let elements = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
-    for (i, ch) in src.chars().enumerate() {
-        let mut buf = [0u8; 4];
-        let s_ref = ch.encode_utf8(&mut buf);
-        let s_ptr = crate::string::js_string_from_bytes(s_ref.as_ptr(), s_ref.len() as u32);
-        let value = crate::value::js_nanbox_string(s_ptr as i64);
-        // GC_STORE_AUDIT(BARRIERED): string codepoint array slot is immediately recorded via note_array_slot.
-        *elements.add(i) = value;
-        note_array_slot(arr, i, value.to_bits());
+
+    // GC safety: `js_string_from_bytes` allocates, and a collection can both
+    // reclaim and (under evacuation) MOVE the source string and the result
+    // array. The pre-#9431 loop held a raw `elements` pointer and a borrow of
+    // the source payload across every per-element allocation — pre-existing,
+    // and exactly the `string/split.rs` hazard. Root both, re-read the source
+    // after each allocation, and store each part into the rooted array
+    // immediately.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let s_handle = scope.root_string_ptr(s);
+    let src_has_lone_surrogates = (*s).flags & crate::string::STRING_FLAG_HAS_LONE_SURROGATES != 0;
+
+    // Pass 1: count the code points. No allocation here, so the payload cannot
+    // move under us.
+    let mut count = 0usize;
+    {
+        let bytes = std::slice::from_raw_parts(crate::string::string_data(s), byte_len);
+        let mut i = 0usize;
+        while i < bytes.len() {
+            let (advance, _, _) = crate::string::wtf8_step(bytes, i);
+            i = (i + advance).min(bytes.len());
+            count += 1;
+        }
     }
-    arr
+
+    // Pass 2: allocate the result, then fill it slot by slot.
+    let (arr, _) = s_handle.across_const::<crate::string::StringHeader, _>(|| {
+        js_array_alloc_pointer_elements(count as u32)
+    });
+    let arr_handle = scope.root_raw_mut_ptr(arr);
+
+    let mut offset = 0usize;
+    for index in 0..count {
+        // Copy the sequence into a stack buffer BEFORE allocating:
+        // `js_string_from_bytes` allocates first and copies second, so handing
+        // it a pointer into the GC heap is the #5062 dangling-source class. A
+        // WTF-8 sequence is at most 4 bytes.
+        let mut buf = [0u8; 4];
+        let seq_len;
+        {
+            let s_now = s_handle.get_raw_const_ptr::<crate::string::StringHeader>();
+            let bytes = std::slice::from_raw_parts(
+                crate::string::string_data(s_now),
+                (*s_now).byte_len as usize,
+            );
+            if offset >= bytes.len() {
+                break;
+            }
+            let (advance, _, _) = crate::string::wtf8_step(bytes, offset);
+            let end = (offset + advance).min(bytes.len());
+            seq_len = end - offset;
+            buf[..seq_len].copy_from_slice(&bytes[offset..end]);
+            offset = end;
+        }
+        // `js_string_from_bytes` hardcodes flags = 0, so a lone surrogate
+        // carved out of a WTF-8 source would lose its marker and
+        // `isWellFormed()` on the element would wrongly report true.
+        let seq = &buf[..seq_len];
+        let (sh, arr_now) = arr_handle.across_mut::<ArrayHeader, _>(|| {
+            if src_has_lone_surrogates && crate::string::bytes_have_lone_surrogate(seq) {
+                crate::string::js_string_from_wtf8_bytes(seq.as_ptr(), seq_len as u32)
+            } else {
+                crate::string::js_string_from_bytes(seq.as_ptr(), seq_len as u32)
+            }
+        });
+        store_codepoint_string(arr_now, index, sh);
+    }
+    arr_handle.get_raw_mut_ptr::<ArrayHeader>()
 }
 
 /// Exact-sized array allocation for array literals `[a, b, c, ...]`.

--- a/crates/perry-runtime/src/array/tests.rs
+++ b/crates/perry-runtime/src/array/tests.rs
@@ -1909,3 +1909,6 @@ fn push_built_array_gets_and_keeps_dense_raw_f64_flag() {
 
 #[path = "tests_proto_discriminator.rs"]
 mod proto_discriminator;
+
+#[path = "tests_from_string_codepoints.rs"]
+mod from_string_codepoints;

--- a/crates/perry-runtime/src/array/tests_from_string_codepoints.rs
+++ b/crates/perry-runtime/src/array/tests_from_string_codepoints.rs
@@ -1,0 +1,88 @@
+//! #9431: `Array.from(str)` on a WTF-8 payload holding a lone surrogate.
+//!
+//! The walk used to validate the payload with `std::str::from_utf8` and return
+//! an EMPTY array on `Err`, so any lone surrogate lost the whole string. These
+//! pin the three properties the fixture asserts at the JS level: the element
+//! COUNT is the code-point count, each element carries the source bytes
+//! verbatim, and a part carved out of a WTF-8 source keeps
+//! `STRING_FLAG_HAS_LONE_SURROGATES` so `isWellFormed()` still reports false.
+
+use super::*;
+use crate::string::{
+    js_string_from_bytes, js_string_from_wtf8_bytes, string_data, StringHeader,
+    STRING_FLAG_HAS_LONE_SURROGATES,
+};
+
+/// The `index`-th element of the result, as (bytes, flags).
+unsafe fn element(arr: *mut ArrayHeader, index: usize) -> (Vec<u8>, u32) {
+    let elements = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
+    let value = *elements.add(index);
+    let part = crate::value::js_nanbox_get_pointer(value) as *const StringHeader;
+    assert!(!part.is_null(), "element {index} is not a string");
+    let bytes = std::slice::from_raw_parts(string_data(part), (*part).byte_len as usize).to_vec();
+    (bytes, (*part).flags)
+}
+
+#[test]
+fn lone_surrogate_keeps_every_code_point() {
+    // "a" + U+D83D encoded as WTF-8 (ED A0 BD) + "b".
+    let src = [b'a', 0xED, 0xA0, 0xBD, b'b'];
+    let s = js_string_from_wtf8_bytes(src.as_ptr(), src.len() as u32);
+    let arr = unsafe { js_array_from_string_codepoints(s) };
+    assert_eq!(
+        unsafe { (*arr).length },
+        3,
+        "lone surrogate lost the string"
+    );
+    unsafe {
+        assert_eq!(element(arr, 0).0, b"a");
+        assert_eq!(element(arr, 1).0, [0xED, 0xA0, 0xBD]);
+        assert_eq!(element(arr, 2).0, b"b");
+        // The carved-out half must stay marked as a broken half.
+        assert_eq!(
+            element(arr, 1).1 & STRING_FLAG_HAS_LONE_SURROGATES,
+            STRING_FLAG_HAS_LONE_SURROGATES
+        );
+        // ASCII neighbours are ordinary well-formed strings.
+        assert_eq!(element(arr, 0).1 & STRING_FLAG_HAS_LONE_SURROGATES, 0);
+    }
+}
+
+#[test]
+fn an_astral_pair_is_still_one_element() {
+    // U+1F600 — two UTF-16 code units, ONE code point.
+    let src = [b'a', 0xF0, 0x9F, 0x98, 0x80, b'b'];
+    let s = js_string_from_bytes(src.as_ptr(), src.len() as u32);
+    let arr = unsafe { js_array_from_string_codepoints(s) };
+    assert_eq!(unsafe { (*arr).length }, 3);
+    unsafe {
+        assert_eq!(element(arr, 1).0, [0xF0, 0x9F, 0x98, 0x80]);
+    }
+}
+
+#[test]
+fn ascii_and_empty_are_unchanged() {
+    let s = js_string_from_bytes(b"abc".as_ptr(), 3);
+    let arr = unsafe { js_array_from_string_codepoints(s) };
+    assert_eq!(unsafe { (*arr).length }, 3);
+    unsafe {
+        assert_eq!(element(arr, 2).0, b"c");
+    }
+    let empty = js_string_from_bytes(b"".as_ptr(), 0);
+    let arr = unsafe { js_array_from_string_codepoints(empty) };
+    assert_eq!(unsafe { (*arr).length }, 0);
+}
+
+#[test]
+fn a_truncated_multibyte_tail_still_yields_a_part() {
+    // #6085: an exact-sized payload ending in a truncated 4-byte lead. The
+    // bounded decoder must not read past the allocation, and the byte must
+    // not vanish from the result.
+    let src = [b'a', 0xF0];
+    let s = js_string_from_bytes(src.as_ptr(), src.len() as u32);
+    let arr = unsafe { js_array_from_string_codepoints(s) };
+    assert_eq!(unsafe { (*arr).length }, 2);
+    unsafe {
+        assert_eq!(element(arr, 1).0, [0xF0]);
+    }
+}

--- a/crates/perry-runtime/src/builtins/console.rs
+++ b/crates/perry-runtime/src/builtins/console.rs
@@ -31,7 +31,11 @@ pub extern "C" fn js_console_log(value: JSValue) {
             println!("{}", format_finite_number_js(n));
         }
     } else if value.is_int32() {
-        println!("{}", value.as_int32());
+        // #9415: a class reference shares the INT32 tag, so this arm printed
+        // the raw class id (`console.log(class K {})` -> `49`).
+        println!("{}", int32_or_class_repr(f64::from_bits(value.bits())));
+    } else if is_array_hole(f64::from_bits(value.bits())) {
+        println!("undefined");
     } else {
         println!("{:?}", value);
     }
@@ -70,7 +74,9 @@ pub extern "C" fn js_console_log_dynamic(value: f64) {
         // bigint (refs GH #33).
         println!("{}{}", p, format_jsvalue(value, 0));
     } else if jsval.is_int32() {
-        println!("{}{}", p, jsval.as_int32());
+        println!("{}{}", p, int32_or_class_repr(value));
+    } else if is_array_hole(value) {
+        println!("{}undefined", p);
     } else {
         // Must be a regular number — but first check for a raw (non-NaN-boxed)
         // heap pointer. The codegen returns Buffer pointers as
@@ -267,7 +273,9 @@ pub extern "C" fn js_console_error_dynamic(value: f64) {
         // Object/array pointer - format as JSON
         eprintln!("{}", format_jsvalue(value, 0));
     } else if jsval.is_int32() {
-        eprintln!("{}", jsval.as_int32());
+        eprintln!("{}", int32_or_class_repr(value));
+    } else if is_array_hole(value) {
+        eprintln!("undefined");
     } else {
         let n = value;
         if n.is_nan() {
@@ -326,7 +334,9 @@ pub extern "C" fn js_console_warn_dynamic(value: f64) {
         // Object/array pointer - format as JSON
         eprintln!("{}", format_jsvalue(value, 0));
     } else if jsval.is_int32() {
-        eprintln!("{}", jsval.as_int32());
+        eprintln!("{}", int32_or_class_repr(value));
+    } else if is_array_hole(value) {
+        eprintln!("undefined");
     } else {
         let n = value;
         if n.is_nan() {
@@ -868,7 +878,7 @@ fn color_mode_received(value: f64) -> String {
         return jsval.as_bool().to_string();
     }
     if jsval.is_int32() {
-        return jsval.as_int32().to_string();
+        return int32_or_class_repr(value);
     }
     if jsval.is_number() {
         let n = jsval.as_number();

--- a/crates/perry-runtime/src/builtins/formatting.rs
+++ b/crates/perry-runtime/src/builtins/formatting.rs
@@ -30,6 +30,8 @@ mod prototype_equality;
 mod strip_vt;
 mod typed_array_equality;
 mod util_format;
+mod value_repr;
+pub(crate) use value_repr::{int32_or_class_repr, is_array_hole};
 
 pub use strip_vt::js_util_strip_vt_control_characters;
 pub use util_format::{js_util_format, js_util_format_with_options, js_util_inspect};
@@ -974,81 +976,23 @@ pub(crate) fn format_jsvalue(value: f64, depth: usize) -> String {
                     let data_ptr = (maybe_arr as *const u8)
                         .add(std::mem::size_of::<crate::array::ArrayHeader>())
                         as *const f64;
-                    let mut parts: Vec<String> = Vec::with_capacity(length);
-                    let mut all_numeric = true;
-                    for i in 0..length {
-                        let elem_value = *data_ptr.add(i);
-                        let elem_jsval = JSValue::from_bits(elem_value.to_bits());
+                    // #9415: a hole slot is `TAG_HOLE`, whose bits read back as
+                    // a NaN, so element-by-element recursion printed
+                    // `new Array(3)` as `[ NaN, NaN, NaN ]`. Runs of holes are
+                    // ONE entry (`<N empty items>`), which is also why the
+                    // layout below counts entries rather than slots.
+                    let parts = value_repr::array_entries_with_holes(data_ptr, length, |elem| {
+                        let elem_jsval = JSValue::from_bits(elem.to_bits());
                         // Quote string elements like Node's util.inspect: 'hello'
                         if elem_jsval.is_any_string() {
-                            all_numeric = false;
-                            let s = format_jsvalue(elem_value, depth + 1);
-                            parts.push(format!("'{}'", s));
-                        } else {
-                            if !elem_jsval.is_number() && !elem_jsval.is_int32() {
-                                all_numeric = false;
-                            }
-                            parts.push(format_jsvalue(elem_value, depth + 1));
+                            let s = format_jsvalue(elem, depth + 1);
+                            return value_repr::ArrayEntry::new(format!("'{}'", s), false);
                         }
-                    }
-                    let inner = parts.join(", ");
-                    // Node uses multi-line when length > 6 or single-line exceeds breakLength (76)
-                    let use_multiline =
-                        !inspect_compact_enabled() || length > 6 || inner.len() + 4 > 76;
-                    let body_str = if !use_multiline {
-                        format!("[ {} ]", inner)
-                    } else if all_numeric {
-                        // Node.js groupArrayElements for numeric arrays:
-                        // right-align each number to max width, compute per-line
-                        // column count via Node's sqrt heuristic.
-                        let max_len = parts.iter().map(|s| s.len()).max().unwrap_or(1);
-                        // biasedMax = max(maxLength - 2, 1)
-                        let biased_max = max_len.saturating_sub(2).max(1);
-                        // cols_by_sqrt = round(sqrt(2.5 * biasedMax * N) / biasedMax)
-                        let cols_by_sqrt = ((2.5_f64 * biased_max as f64 * length as f64).sqrt()
-                            / biased_max as f64)
-                            .round() as usize;
-                        // cols_by_width = ceil(breakLength / (maxLen + 2)); breakLength=76
-                        let actual_max = max_len + 2;
-                        let cols_by_width = 76_usize.div_ceil(actual_max);
-                        let columns = cols_by_sqrt
-                            .min(cols_by_width.max(1))
-                            .min(12) // compact(3) * 4
-                            .min(15) // absolute max per Node
-                            .max(1);
-                        let indent = "  ";
-                        let mut lines: Vec<String> = parts
-                            .chunks(columns)
-                            .map(|chunk| {
-                                let elems: Vec<String> = chunk
-                                    .iter()
-                                    .map(|s| format!("{:>width$}", s, width = max_len))
-                                    .collect();
-                                format!("{}{}", indent, elems.join(", "))
-                            })
-                            .collect();
-                        // Trailing comma on every line but the last (Node format)
-                        let n_lines = lines.len();
-                        for line in lines.iter_mut().take(n_lines - 1) {
-                            line.push(',');
-                        }
-                        format!("[\n{}\n]", lines.join("\n"))
-                    } else {
-                        // Non-numeric multi-line: short arrays of wide string
-                        // entries print one item per row in Node's compact
-                        // inspect layout.
-                        let indent = "  ";
-                        let chunk_size = if length <= 6 { 1 } else { 4 };
-                        let mut row_strs: Vec<String> = parts
-                            .chunks(chunk_size)
-                            .map(|chunk| format!("{}{}", indent, chunk.join(", ")))
-                            .collect();
-                        let n = row_strs.len();
-                        for line in row_strs.iter_mut().take(n - 1) {
-                            line.push(',');
-                        }
-                        format!("[\n{}\n]", row_strs.join("\n"))
-                    };
+                        let rendered = format_jsvalue(elem, depth + 1);
+                        let numeric = value_repr::entry_is_numeric(elem, &rendered);
+                        value_repr::ArrayEntry::new(rendered, numeric)
+                    });
+                    let body_str = value_repr::render_array_body(&parts, inspect_compact_enabled());
                     inspect_finish_circular(ptr as usize, body_str)
                 } else if gc_type == crate::gc::GC_TYPE_OBJECT {
                     // Object — check for keys_array. Cycle check FIRST so the
@@ -1084,7 +1028,9 @@ pub(crate) fn format_jsvalue(value: f64, depth: usize) -> String {
                 } else if gc_type == crate::gc::GC_TYPE_CLOSURE {
                     format_function_for_console(ptr as *const crate::closure::ClosureHeader)
                 } else if gc_type == crate::gc::GC_TYPE_PROMISE {
-                    "Promise { <pending> }".to_string()
+                    value_repr::promise_inspect(ptr as *const crate::promise::Promise, |v| {
+                        format_jsvalue_for_json(v, depth + 1)
+                    })
                 } else {
                     // Safe fallback for unknown GC types — avoid heuristic
                     // pointer interpretation which can crash on closures,
@@ -1093,7 +1039,14 @@ pub(crate) fn format_jsvalue(value: f64, depth: usize) -> String {
                 }
             }
         } else if jsval.is_int32() {
-            jsval.as_int32().to_string()
+            // Shares its tag with a class reference; `int32_or_class_repr` is
+            // the only place that decides which one these bits are (#9415).
+            value_repr::int32_or_class_repr(value)
+        } else if value_repr::is_array_hole(value) {
+            // A hole that escaped its array. `js_array_get_f64` normalizes one
+            // to `undefined`, so that is what it must display as — not the
+            // `NaN` the raw-double tail below would produce (#9415).
+            "undefined".to_string()
         } else {
             // Regular number — but first check for raw (non-NaN-boxed) heap
             // pointers. The codegen sometimes returns a raw
@@ -1721,18 +1674,26 @@ fn format_jsvalue_for_json(value: f64, depth: usize) -> String {
                         let data_ptr = (maybe_arr as *const u8)
                             .add(std::mem::size_of::<crate::array::ArrayHeader>())
                             as *const f64;
-                        let mut parts: Vec<String> = Vec::with_capacity(length);
-                        for i in 0..length {
-                            let elem_value = *data_ptr.add(i);
-                            parts.push(format_jsvalue_for_json(elem_value, depth + 1));
-                        }
+                        // #9415: the same hole grouping the `format_jsvalue`
+                        // array arm does. This is the twin that renders an
+                        // array reached as an object FIELD, so without it
+                        // `{ h: new Array(3) }` still said
+                        // `{ h: [ NaN, NaN, NaN ] }`.
+                        let parts =
+                            value_repr::array_entries_with_holes(data_ptr, length, |elem| {
+                                value_repr::ArrayEntry::new(
+                                    format_jsvalue_for_json(elem, depth + 1),
+                                    false,
+                                )
+                            });
                         // Node formats empty arrays as `[]` and non-empty
                         // arrays with a space inside the brackets:
                         // `[ 1, 2, 3 ]`. Match byte-for-byte.
-                        let body_str = if length == 0 {
+                        let body_str = if parts.is_empty() {
                             "[]".to_string()
                         } else {
-                            format!("[ {} ]", parts.join(", "))
+                            let texts: Vec<&str> = parts.iter().map(|p| p.text.as_str()).collect();
+                            format!("[ {} ]", texts.join(", "))
                         };
                         inspect_finish_circular(ptr as usize, body_str)
                     } else if gc_type == crate::gc::GC_TYPE_OBJECT {
@@ -1769,13 +1730,22 @@ fn format_jsvalue_for_json(value: f64, depth: usize) -> String {
                         // path as `format_jsvalue` so the registered function
                         // name flows out instead of `[object Object]`.
                         format_function_for_console(ptr as *const crate::closure::ClosureHeader)
+                    } else if gc_type == crate::gc::GC_TYPE_PROMISE {
+                        // Promise-valued field. Without this arm it fell to
+                        // `[object Object]` below, so the state defect was
+                        // invisible here rather than merely wrong (#9415).
+                        value_repr::promise_inspect(ptr as *const crate::promise::Promise, |v| {
+                            format_jsvalue_for_json(v, depth + 1)
+                        })
                     } else {
                         "[object Object]".to_string()
                     }
                 }
             }
         } else if jsval.is_int32() {
-            jsval.as_int32().to_string()
+            value_repr::int32_or_class_repr(value)
+        } else if value_repr::is_array_hole(value) {
+            "undefined".to_string()
         } else {
             // A TypedArray field is a RAW (non-NaN-boxed) heap pointer, so it
             // lands here, not in the pointer branch; redirect it (#800).
@@ -1949,8 +1919,19 @@ fn js_util_deep_strict_equal_bool(
         }
         formatted_deep_equal(left, right, skip_prototype)
     } else {
+        // A class REFERENCE is compared by identity, never by its rendering.
+        // Since #9415 a class ref renders as `[class Name]`, so two DISTINCT
+        // classes that happen to share a name format identically — the
+        // formatted comparison would call them deep-equal, where node (and the
+        // pre-#9415 class-id rendering, by accident) says they are not. The
+        // probe runs only after `js_jsvalue_equals` has already answered "not
+        // equal", so an ordinary integer that collides with a live class id is
+        // unaffected: equal integers were settled one line above, and unequal
+        // ones are unequal either way.
         crate::value::js_jsvalue_equals(left, right) != 0
-            || formatted_deep_equal(left, right, skip_prototype)
+            || (crate::object::class_ref_id(left).is_none()
+                && crate::object::class_ref_id(right).is_none()
+                && formatted_deep_equal(left, right, skip_prototype))
     }
 }
 

--- a/crates/perry-runtime/src/builtins/formatting/collections.rs
+++ b/crates/perry-runtime/src/builtins/formatting/collections.rs
@@ -63,9 +63,20 @@ pub(super) unsafe fn format_map(map: *const crate::map::MapHeader, depth: usize)
     if size == 0 || entries.is_null() {
         return "Map(0) {}".to_string();
     }
+    // #9415: `size` is the LIVE count, but the raw entry indices run `0..used`
+    // — a tombstoned `delete` writes `MAP_HOLE_KEY_BITS` (`TAG_HOLE`) over the
+    // slot, decrements `size`, and leaves `used` alone. Walking `0..size` both
+    // rendered the tombstone (whose key bits read back as a NaN, so
+    // `new Map([["a",1],["b",2]])` after `delete "a"` printed
+    // `Map(1) { NaN => undefined }`) and stopped short of the live tail. Bound
+    // by `used` and skip the holes, exactly as the Map iterator object does.
+    let used = crate::map::map_used_entries(map) as usize;
     let mut parts: Vec<String> = Vec::with_capacity(size);
-    for i in 0..size {
+    for i in 0..used {
         let key = *entries.add(i * 2);
+        if key.to_bits() == crate::map::MAP_HOLE_KEY_BITS {
+            continue;
+        }
         let val = *entries.add(i * 2 + 1);
         parts.push(format!(
             "{} => {}",
@@ -92,9 +103,17 @@ pub(super) unsafe fn format_set(set: *const crate::set::SetHeader, depth: usize)
     if size == 0 || elements.is_null() {
         return "Set(0) {}".to_string();
     }
+    // #9415: same tombstone bound as `format_map` above — `new Set([1,2,3])`
+    // after `delete 1` printed `Set(2) { NaN, 2 }`, both rendering the hole and
+    // never reaching the live `3`.
+    let used = crate::set::set_used_entries(set) as usize;
     let mut parts: Vec<String> = Vec::with_capacity(size);
-    for i in 0..size {
-        parts.push(format_member(*elements.add(i), depth));
+    for i in 0..used {
+        let value = *elements.add(i);
+        if value.to_bits() == crate::set::SET_HOLE_VALUE_BITS {
+            continue;
+        }
+        parts.push(format_member(value, depth));
     }
     wrap("Set", size, &parts)
 }

--- a/crates/perry-runtime/src/builtins/formatting/value_repr.rs
+++ b/crates/perry-runtime/src/builtins/formatting/value_repr.rs
@@ -1,0 +1,383 @@
+//! Value-kind renderings the display ladders used to get wrong, plus the array
+//! body layout that depends on them. (#9415.)
+//!
+//! Three defects, one mistake in three places: a ladder classifies a NaN-boxed
+//! value by tag, has no arm for the case at hand, and lets the bits fall
+//! through to "must be a regular number" (or to a hard-coded string). A class
+//! reference printed as its raw class id (`49`); a sparse-array hole printed as
+//! `NaN`, because `TAG_HOLE`'s bit pattern *is* a NaN; every promise printed as
+//! `<pending>`. None of the three is a formatting preference — each is a value
+//! decoded as the wrong kind.
+//!
+//! The renderings live here rather than in `formatting.rs` so the display
+//! ladders across `console.rs` and `formatting.rs` share one implementation: a
+//! fix applied to `console.log` and not to `console.error`, or to
+//! `format_jsvalue` and not to `format_jsvalue_for_json` (which renders the
+//! same array once it is a field of an object), is a half-fix that reads as a
+//! working one.
+
+use crate::value::JSValue;
+
+/// Node's `util.inspect` label for a CLASS value: `[class Name]`,
+/// `[class Name extends Parent]`, `[class (anonymous)]`. `None` for anything
+/// that is not a registered class reference.
+///
+/// ## The ambiguity this resolves, and the one it cannot
+///
+/// A class value is an INT32-tagged NaN box carrying the class id
+/// (`class_constructor_ref_value`), which is how compiled code names a class
+/// without materializing an object. `INT32_TAG | 2` — the number 2 — and a
+/// ClassRef with `class_id == 2` are **bit-identical**; `class_ref_id`'s
+/// registry probe is the only thing separating them, exactly as
+/// `symbol/iterator.rs` documents for `for…of`. Class ids are small and
+/// sequential (codegen's `next_class_id = max(existing) + 1`), so in a program
+/// with N classes the integers `1..=N` are genuinely undecidable at this
+/// point. Perry answers "class" for those: a class id leaking into output is
+/// never right, while the integer reading is only *sometimes* right. The
+/// registry probe is what keeps every other integer printing as itself.
+///
+/// ## Cost
+///
+/// `class_ref_id` is an RwLock read plus a hash lookup. Following
+/// `symbol/iterator.rs`'s discipline — probe only where the code was already
+/// about to do something unusual — it is paid only inside the `is_int32()` arm
+/// of a display ladder: a value already being turned into a heap `String` for
+/// output, and already in the INT32 representation, which ordinary JS numbers
+/// (plain f64 doubles) never reach. Nothing on a hot path probes the registry.
+pub(crate) fn class_ref_inspect_label(value: f64) -> Option<String> {
+    let class_id = crate::object::class_ref_id(value)?;
+    Some(class_label_for_id(class_id))
+}
+
+/// `[class …]` for a resolved class id.
+fn class_label_for_id(class_id: u32) -> String {
+    // The name comes from whatever `class_name_for_id` reports — deliberately
+    // NOT re-derived here. #9413 covers class `.name` leaking compiler-internal
+    // spellings; when that lands, the corrected name flows straight through.
+    let own = crate::object::class_name_for_id(class_id).unwrap_or_default();
+    let mut out = String::with_capacity(16 + own.len());
+    out.push_str("[class ");
+    if own.is_empty() {
+        out.push_str("(anonymous)");
+    } else {
+        out.push_str(&own);
+    }
+    if let Some(parent) = parent_class_name(class_id) {
+        out.push_str(" extends ");
+        out.push_str(&parent);
+    }
+    out.push(']');
+    out
+}
+
+/// The `extends` half of the label. Node renders the heritage from the parent's
+/// `.name`, so an unnamed base contributes nothing rather than a dangling
+/// `extends`.
+fn parent_class_name(class_id: u32) -> Option<String> {
+    let parent = crate::object::get_parent_class_id(class_id)?;
+    if parent == 0 || parent == class_id {
+        return None;
+    }
+    crate::object::class_name_for_id(parent).filter(|n| !n.is_empty())
+}
+
+/// Node's rendering of an INT32-tagged NaN box. The tag is shared between small
+/// integers and class references, so this is the ONE place that decides which
+/// one a display ladder is looking at; every `else if v.is_int32()` arm in a
+/// console/inspect ladder calls it.
+pub(crate) fn int32_or_class_repr(value: f64) -> String {
+    match class_ref_inspect_label(value) {
+        Some(label) => label,
+        None => JSValue::from_bits(value.to_bits()).as_int32().to_string(),
+    }
+}
+
+/// True for the sparse-array hole sentinel (`TAG_HOLE`, #323).
+///
+/// A hole is not a value: `js_array_get_f64` translates it to `undefined` per
+/// OrdinaryGet, and `Object.keys` / `in` inspect slots directly to tell a hole
+/// from an explicit `undefined` write. Only code that reads element slots
+/// *raw* — which every array formatter does — can observe one, and every such
+/// reader must classify it before its ladder reaches "must be a regular
+/// number", where the sentinel's bits read back as `NaN`.
+#[inline]
+pub(crate) fn is_array_hole(value: f64) -> bool {
+    value.to_bits() == crate::value::TAG_HOLE
+}
+
+/// Node's label for a run of `count` consecutive array holes.
+fn empty_items_label(count: usize) -> String {
+    if count == 1 {
+        "<1 empty item>".to_string()
+    } else {
+        format!("<{} empty items>", count)
+    }
+}
+
+/// One entry of a rendered array — what Node prints between the commas. A run
+/// of holes is ONE entry (`<N empty items>`), which is why the entry count and
+/// the array's `length` are different numbers and why the layout decisions
+/// below count entries.
+pub(crate) struct ArrayEntry {
+    pub(crate) text: String,
+    /// Eligible for Node's right-aligned numeric column layout. False for a
+    /// hole run, and false for a class reference, which shares the INT32 tag
+    /// with the integers that layout is meant for.
+    pub(crate) numeric: bool,
+}
+
+impl ArrayEntry {
+    pub(crate) fn new(text: String, numeric: bool) -> Self {
+        ArrayEntry { text, numeric }
+    }
+}
+
+/// Split an array's raw element slots into the entries Node prints: each
+/// non-hole slot rendered by `render`, each *run* of holes collapsed to one
+/// `<N empty items>` entry.
+///
+/// # Safety
+///
+/// `data_ptr` must point at `len` readable f64 element slots.
+pub(crate) unsafe fn array_entries_with_holes<F>(
+    data_ptr: *const f64,
+    len: usize,
+    mut render: F,
+) -> Vec<ArrayEntry>
+where
+    F: FnMut(f64) -> ArrayEntry,
+{
+    let mut parts: Vec<ArrayEntry> = Vec::with_capacity(len);
+    let mut i = 0usize;
+    while i < len {
+        let elem = *data_ptr.add(i);
+        if is_array_hole(elem) {
+            let start = i;
+            while i < len && is_array_hole(*data_ptr.add(i)) {
+                i += 1;
+            }
+            parts.push(ArrayEntry::new(empty_items_label(i - start), false));
+            continue;
+        }
+        parts.push(render(elem));
+        i += 1;
+    }
+    parts
+}
+
+/// Classify a rendered element for the numeric column layout. A number or an
+/// int32 qualifies — unless the int32 was a class reference, whose label is not
+/// a numeral and must not be right-aligned into a column of them.
+pub(crate) fn entry_is_numeric(elem: f64, rendered: &str) -> bool {
+    let jv = JSValue::from_bits(elem.to_bits());
+    if jv.is_int32() {
+        // Both renderings come from `int32_or_class_repr`, so this is a test on
+        // our own output, not a guess about arbitrary text: an integer never
+        // starts with `[`.
+        return !rendered.starts_with('[');
+    }
+    jv.is_number()
+}
+
+/// Lay out rendered entries as Node's `util.inspect` array body.
+///
+/// The single-line / multi-line decision counts ENTRIES, not array slots:
+/// `new Array(7)` is seven slots but one entry, and Node prints it as
+/// `[ <7 empty items> ]` rather than breaking it over lines. For a hole-free
+/// array the two counts are identical, so nothing else moves.
+pub(crate) fn render_array_body(parts: &[ArrayEntry], compact: bool) -> String {
+    if parts.is_empty() {
+        return "[]".to_string();
+    }
+    let texts: Vec<&str> = parts.iter().map(|p| p.text.as_str()).collect();
+    let inner = texts.join(", ");
+    let entries = parts.len();
+    // Node uses multi-line when the entry count exceeds 6 or the single-line
+    // form exceeds breakLength (76).
+    if compact && entries <= 6 && inner.len() + 4 <= 76 {
+        return format!("[ {} ]", inner);
+    }
+    if parts.iter().all(|p| p.numeric) {
+        return numeric_column_body(&texts);
+    }
+    // Non-numeric multi-line: short arrays of wide entries print one item per
+    // row in Node's compact inspect layout.
+    let chunk_size = if entries <= 6 { 1 } else { 4 };
+    join_rows(texts.chunks(chunk_size).map(|chunk| chunk.join(", ")))
+}
+
+/// Node's `groupArrayElements` for numeric arrays: right-align each numeral to
+/// the widest, with a per-line column count from Node's sqrt heuristic.
+fn numeric_column_body(texts: &[&str]) -> String {
+    let entries = texts.len();
+    let max_len = texts.iter().map(|s| s.len()).max().unwrap_or(1);
+    // biasedMax = max(maxLength - 2, 1)
+    let biased_max = max_len.saturating_sub(2).max(1);
+    // cols_by_sqrt = round(sqrt(2.5 * biasedMax * N) / biasedMax)
+    let cols_by_sqrt = ((2.5_f64 * biased_max as f64 * entries as f64).sqrt() / biased_max as f64)
+        .round() as usize;
+    // cols_by_width = ceil(breakLength / (maxLen + 2)); breakLength = 76
+    let cols_by_width = 76_usize.div_ceil(max_len + 2);
+    let columns = cols_by_sqrt
+        .min(cols_by_width.max(1))
+        .min(12) // compact(3) * 4
+        .min(15) // absolute max per Node
+        .max(1);
+    join_rows(texts.chunks(columns).map(|chunk| {
+        chunk
+            .iter()
+            .map(|s| format!("{:>width$}", s, width = max_len))
+            .collect::<Vec<String>>()
+            .join(", ")
+    }))
+}
+
+/// Indent each row, comma-terminate every row but the last, wrap in brackets.
+fn join_rows<I: Iterator<Item = String>>(rows: I) -> String {
+    let mut lines: Vec<String> = rows.map(|row| format!("  {}", row)).collect();
+    let last = lines.len().saturating_sub(1);
+    for line in lines.iter_mut().take(last) {
+        line.push(',');
+    }
+    format!("[\n{}\n]", lines.join("\n"))
+}
+
+/// Node's `util.inspect` rendering of a Promise: `Promise { <pending> }`,
+/// `Promise { <value> }` once fulfilled, `Promise { <rejected> <reason> }` once
+/// rejected.
+///
+/// Perry hard-coded the pending form, so every settled promise misreported its
+/// state — `console.log(Promise.resolve(1))` said `<pending>` for a promise
+/// that had already resolved. The state is a plain byte in the `Promise` cell;
+/// nothing about the tag encoding was involved.
+///
+/// # Safety
+///
+/// `ptr` must be a live `GC_TYPE_PROMISE` cell.
+pub(crate) unsafe fn promise_inspect<F>(ptr: *const crate::promise::Promise, mut fmt: F) -> String
+where
+    F: FnMut(f64) -> String,
+{
+    if ptr.is_null() {
+        return "Promise { <pending> }".to_string();
+    }
+    match (*ptr).state {
+        crate::promise::PromiseState::Pending => "Promise { <pending> }".to_string(),
+        crate::promise::PromiseState::Fulfilled => format!("Promise {{ {} }}", fmt((*ptr).value)),
+        crate::promise::PromiseState::Rejected => {
+            format!("Promise {{ <rejected> {} }}", fmt((*ptr).reason))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(text: &str, numeric: bool) -> ArrayEntry {
+        ArrayEntry::new(text.to_string(), numeric)
+    }
+
+    #[test]
+    fn empty_items_label_singular_and_plural() {
+        assert_eq!(empty_items_label(1), "<1 empty item>");
+        assert_eq!(empty_items_label(2), "<2 empty items>");
+        assert_eq!(empty_items_label(7), "<7 empty items>");
+    }
+
+    #[test]
+    fn hole_sentinel_is_the_only_hole() {
+        assert!(is_array_hole(f64::from_bits(crate::value::TAG_HOLE)));
+        assert!(!is_array_hole(f64::from_bits(crate::value::TAG_UNDEFINED)));
+        assert!(!is_array_hole(f64::NAN));
+        assert!(!is_array_hole(0.0));
+        // TDZ shares the 0x7FFC singleton namespace and must not be mistaken
+        // for a hole — reading one is a ReferenceError, not an empty slot.
+        assert!(!is_array_hole(f64::from_bits(crate::value::TAG_TDZ)));
+    }
+
+    #[test]
+    fn hole_runs_collapse_and_non_holes_render() {
+        let hole = f64::from_bits(crate::value::TAG_HOLE);
+        let slots = [1.0, hole, hole, 2.0, hole];
+        let parts = unsafe {
+            array_entries_with_holes(slots.as_ptr(), slots.len(), |v| {
+                ArrayEntry::new(v.to_string(), true)
+            })
+        };
+        let rendered: Vec<&str> = parts.iter().map(|p| p.text.as_str()).collect();
+        assert_eq!(rendered, ["1", "<2 empty items>", "2", "<1 empty item>"]);
+        assert_eq!(
+            parts.iter().map(|p| p.numeric).collect::<Vec<_>>(),
+            [true, false, true, false]
+        );
+    }
+
+    #[test]
+    fn a_whole_array_of_holes_is_one_entry() {
+        let hole = f64::from_bits(crate::value::TAG_HOLE);
+        let slots = [hole; 7];
+        let parts = unsafe {
+            array_entries_with_holes(slots.as_ptr(), slots.len(), |_| {
+                ArrayEntry::new("?".to_string(), true)
+            })
+        };
+        assert_eq!(parts.len(), 1);
+        // Seven SLOTS but one ENTRY, so Node keeps it on one line.
+        assert_eq!(render_array_body(&parts, true), "[ <7 empty items> ]");
+    }
+
+    #[test]
+    fn single_line_layout_matches_node() {
+        let parts = vec![
+            entry("1", true),
+            entry("<1 empty item>", false),
+            entry("3", true),
+        ];
+        assert_eq!(render_array_body(&parts, true), "[ 1, <1 empty item>, 3 ]");
+        assert_eq!(render_array_body(&[], true), "[]");
+    }
+
+    #[test]
+    fn seven_numeric_entries_still_column_wrap() {
+        let parts: Vec<ArrayEntry> = (0..7).map(|i| entry(&i.to_string(), true)).collect();
+        let body = render_array_body(&parts, true);
+        assert!(
+            body.starts_with("[\n"),
+            "expected multi-line body, got {body}"
+        );
+    }
+
+    #[test]
+    fn an_unregistered_int32_is_not_a_class() {
+        // 0 is never a class id, and the registry probe rejects the rest.
+        let n = f64::from_bits(crate::value::INT32_TAG);
+        assert_eq!(class_ref_inspect_label(n), None);
+        assert_eq!(int32_or_class_repr(n), "0");
+        let big = f64::from_bits(crate::value::INT32_TAG | 0xFFFF_FFF0);
+        assert_eq!(class_ref_inspect_label(big), None);
+    }
+
+    #[test]
+    fn a_plain_double_is_never_a_class() {
+        assert_eq!(class_ref_inspect_label(49.0), None);
+        assert_eq!(class_ref_inspect_label(f64::NAN), None);
+    }
+
+    #[test]
+    fn entry_numeric_classification() {
+        assert!(entry_is_numeric(49.0, "49"));
+        assert!(entry_is_numeric(
+            f64::from_bits(crate::value::INT32_TAG | 49),
+            "49"
+        ));
+        assert!(!entry_is_numeric(
+            f64::from_bits(crate::value::INT32_TAG | 49),
+            "[class Klass]"
+        ));
+        assert!(!entry_is_numeric(
+            f64::from_bits(crate::value::TAG_UNDEFINED),
+            "undefined"
+        ));
+    }
+}

--- a/crates/perry-runtime/src/builtins/mod.rs
+++ b/crates/perry-runtime/src/builtins/mod.rs
@@ -154,10 +154,10 @@ pub use formatting::{
 
 pub(crate) use formatting::{
     boxed_primitive_json_value, boxed_primitive_payload, boxed_primitive_to_string_tag,
-    format_finite_number_js, format_jsvalue, is_negative_zero, jsvalue_string_content,
-    prune_dead_boxed_primitive_payload_owners, InspectCompactGuard, InspectCustomInspectGuard,
-    InspectDepthLimitGuard, InspectGettersGuard, InspectShowHiddenGuard, InspectSortedGuard,
-    INT_EXACT_FASTPATH_LIMIT,
+    format_finite_number_js, format_jsvalue, int32_or_class_repr, is_array_hole, is_negative_zero,
+    jsvalue_string_content, prune_dead_boxed_primitive_payload_owners, InspectCompactGuard,
+    InspectCustomInspectGuard, InspectDepthLimitGuard, InspectGettersGuard, InspectShowHiddenGuard,
+    InspectSortedGuard, INT_EXACT_FASTPATH_LIMIT,
 };
 #[cfg(test)]
 pub(crate) use formatting::{

--- a/test-files/test_gap_9415_inspect_class_hole_promise.ts
+++ b/test-files/test_gap_9415_inspect_class_hole_promise.ts
@@ -1,0 +1,144 @@
+// #9415 — three `console.log` / `util.inspect` value-representation defects,
+// byte-compared against `node --experimental-strip-types`.
+//
+//   1. a class value printed as a bare integer (its class id): a class ref is
+//      an INT32-tagged NaN box, and every display ladder's `is_int32()` arm
+//      printed `as_int32()`. `console.log(class Klass {})` said `1`.
+//   2. an array hole printed as `NaN`: `TAG_HOLE`'s bit pattern IS a NaN, so a
+//      ladder that falls through to "must be a regular number" turns holes into
+//      NaN. `console.log(new Array(3))` said `[ NaN, NaN, NaN ]`.
+//   3. every promise reported `<pending>`: the state byte was never read.
+//
+// Also covers the same hole sentinel in the Map/Set inspect walks, where a
+// tombstoned `delete` left `TAG_HOLE` in the raw slot AND the `0..size` bound
+// stopped short of the live tail (`new Set([1,2,3])` after `delete(1)` printed
+// `Set(2) { NaN, 2 }`).
+//
+// Deliberately NOT covered, because each is a separate pre-existing divergence
+// this fix does not touch (each is called out in the report):
+//   - `String(SomeClass)` / `util.format("%s", SomeClass)`: perry answers
+//     `function Klass() { [native code] }`, node the class source text.
+//   - `util.format("%s", someObject)`: node inspects an object with no user
+//     `toString`, perry uses `String(value)`.
+//   - `util.format("%o", …)`: node's `%o` is `showHidden: true`, which perry
+//     does not implement for arrays or classes.
+
+import util from "node:util";
+
+class Klass {}
+class Base {}
+class Sub extends Base {}
+class Holder {
+  a: number;
+  constructor() {
+    this.a = 1;
+  }
+}
+
+// --- 1. class values ---
+console.log("class-named", Klass);
+console.log("class-extends", Sub);
+console.log("class-anonymous", class {});
+console.log("class-anonymous-extends", class extends Base {});
+console.log("inspect-named", util.inspect(Klass));
+console.log("inspect-extends", util.inspect(Sub));
+console.log("format-O", util.format("%O", Klass));
+console.log("class-in-array", [Klass, Sub]);
+console.log("class-in-object", { k: Klass });
+console.error("class-error", Klass);
+console.warn("class-warn", Klass);
+
+// An INSTANCE is an ordinary object and must not be labelled `[class …]`.
+console.log("instance", new Holder());
+console.log("instance-inspect", util.inspect(new Holder()));
+console.log("instance-not-class", util.inspect(new Holder()).startsWith("[class"));
+
+// A plain integer must stay an integer. Class ids are small and sequential —
+// `Klass` above is id 1, `Base` id 2 — and a ClassRef is bit-identical to the
+// int32 with the same payload, so these are the lines an over-eager fix (one
+// that labels every INT32-tagged value without the class-registry probe) gets
+// wrong. They print integers because a JS number is a plain f64 double and
+// never reaches the INT32 display arm at all; the registry probe is the second
+// line of defence, not the only one.
+console.log("plain-int", 49);
+console.log("plain-ints", 1, 2, 3, 4, 5);
+console.log("collides-with-class-id", 1);
+console.log("collides-with-class-id-2", 2);
+const asAny: any = 1;
+console.log("collides-via-any", asAny);
+console.log("length-is-a-number", [9].length);
+console.log("indexof-is-a-number", ["a", "b"].indexOf("b"));
+console.log("bitwise-is-a-number", 3 | 0);
+console.log("charcode-is-a-number", "A".charCodeAt(0));
+console.log("plain-int-array", [10, 20, 30]);
+console.log("int-expression", 6 * 8 + 1);
+
+// Two DISTINCT classes that share a name render identically, so deep-equality
+// must not be decided by the rendering.
+class Twin {}
+function makeTwin() {
+  class Twin {}
+  return Twin;
+}
+console.log("same-name-classes-differ", util.isDeepStrictEqual(Twin, makeTwin()));
+console.log("same-class-equals-itself", util.isDeepStrictEqual(Twin, Twin));
+console.log("equal-numbers-still-equal", util.isDeepStrictEqual(1, 1));
+console.log("unequal-numbers-differ", util.isDeepStrictEqual(1, 2));
+
+// --- 2. array holes ---
+console.log("new-array", new Array(3));
+console.log("elision", [1, , 3]);
+const deleted = [1, 2, 3];
+delete deleted[0];
+console.log("delete", deleted);
+const trailing: number[] = [1];
+trailing[3] = 4;
+console.log("grown", trailing);
+console.log("nested-in-object", { h: new Array(3) });
+console.log("nested-in-array", [new Array(2)]);
+console.log("inspect-holes", util.inspect(new Array(3)));
+console.log("format-O-holes", util.format("%O", new Array(3)));
+console.log("empty", new Array(0));
+console.log("one-hole", new Array(1));
+console.log("mixed-runs", [1, , 2, , , 3]);
+console.error("holes-error", new Array(3));
+console.warn("holes-warn", new Array(3));
+// Seven SLOTS but ONE entry: the single-line/multi-line decision counts the
+// entries Node prints, not the array's length.
+console.log("seven-holes", new Array(7));
+console.log("map-over-holes", new Array(3).map((x) => x));
+// A hole is still not a value anywhere else.
+console.log("holes-json", JSON.stringify(new Array(3)));
+console.log("holes-string", String([1, , 3]));
+console.log("holes-length", new Array(3).length);
+console.log("holes-keys", Object.keys(new Array(3)).length);
+
+// --- 3. promise state ---
+const settled = Promise.resolve(1);
+console.log("resolved", settled);
+console.log("pending", new Promise(() => {}));
+console.log("resolved-inspect", util.inspect(Promise.resolve("x")));
+console.log("resolved-undefined", Promise.resolve(undefined));
+console.log("resolved-object", Promise.resolve({ a: 1 }));
+console.log("promise-in-array", [Promise.resolve(1)]);
+console.log("promise-in-object", { p: Promise.resolve(1) });
+const rejected = Promise.reject(42);
+rejected.catch(() => {});
+console.log("rejected", rejected);
+
+// --- Map / Set tombstones ---
+const numbers = new Set([1, 2, 3]);
+numbers.delete(1);
+console.log("set-delete", numbers);
+const strings = new Set(["a", "b", "c"]);
+strings.delete("b");
+console.log("set-delete-middle", strings);
+const pairs = new Map<string, number>([
+  ["a", 1],
+  ["b", 2],
+]);
+pairs.delete("a");
+console.log("map-delete", pairs);
+console.log("set-intact", new Set([1, 2]));
+console.log("map-intact", new Map([["k", 1]]));
+console.log("set-spread", [...numbers], numbers.size);

--- a/test-files/test_gap_9431_array_from_lone_surrogate.ts
+++ b/test-files/test_gap_9431_array_from_lone_surrogate.ts
@@ -1,0 +1,82 @@
+// #9431 — `Array.from(str)` returned `[]` for any string containing a lone
+// surrogate, byte-compared against `node --experimental-strip-types`.
+//
+// `js_array_from_string_codepoints` ran `std::str::from_utf8` over the payload
+// and returned an EMPTY array on `Err`. Perry string payloads are WTF-8, so a
+// lone surrogate — a legal payload, produced by slicing a pair or by a chunked
+// decoder — made the whole conversion silently yield nothing. Whole-array data
+// loss, not a wrong element: the length was 0, not 3.
+//
+// The spread / `for…of` / `[Symbol.iterator]` forms over the SAME string were
+// already correct, which is what made this a wrong answer rather than a
+// consistent limitation — so every case asserts all five forms together. Each
+// element is reported by CHAR CODE, never printed raw: a lone surrogate has no
+// UTF-8 encoding and would reach the terminal as replacement bytes.
+
+function codes(parts: string[]): string {
+  return parts
+    .map((c) => {
+      let out = "";
+      for (let i = 0; i < c.length; i++) out += (i ? "+" : "") + c.charCodeAt(i).toString(16);
+      return out;
+    })
+    .join(",");
+}
+
+const cases: [string, string][] = [
+  ["ascii", "abc"],
+  ["lone-high-mid", "a\ud83db"],
+  ["lone-low-mid", "a\udc00b"],
+  ["lone-high-only", "\ud83d"],
+  ["lone-low-only", "\udc00"],
+  ["lone-high-start", "\ud83dab"],
+  ["lone-high-end", "ab\ud83d"],
+  ["pair", "a😀b"],
+  ["pair-plus-lones", "x😀y\ud83dz\udc00w"],
+  ["two-lone-highs", "\ud83d\ud83d"],
+  ["reversed-pair", "\ude00\ud83d"],
+  ["empty", ""],
+];
+
+for (const [name, s] of cases) {
+  const from = Array.from(s);
+  console.log("from", name, "src.length", s.length, "len", from.length, codes(from));
+
+  const spread = [...s];
+  console.log("spread", name, "len", spread.length, codes(spread));
+
+  const forOf: string[] = [];
+  for (const c of s) forOf.push(c);
+  console.log("forof", name, "len", forOf.length, codes(forOf));
+
+  // The mapped form takes the same walk, so it was empty too.
+  const mapped = Array.from(s, (c: string, i: number) => i + ":" + codes([c]));
+  console.log("mapped", name, "len", mapped.length, mapped.join("|"));
+
+  const manual: string[] = [];
+  const iter = s[Symbol.iterator]();
+  for (let r = iter.next(); !r.done; r = iter.next()) manual.push(r.value as string);
+  console.log("iter", name, "len", manual.length, codes(manual));
+
+  // Every form must agree with every other form, element for element.
+  console.log(
+    "agree",
+    name,
+    codes(from) === codes(spread) && codes(from) === codes(forOf) && codes(from) === codes(manual),
+  );
+}
+
+// A lone surrogate carved out of a WTF-8 source keeps its marker: the element
+// is a broken half, not a repaired or replaced character.
+const half = Array.from("a\ud83db")[1];
+console.log("element-length", half.length);
+console.log("element-code", half.charCodeAt(0));
+console.log("element-well-formed", half.isWellFormed());
+console.log("element-json", JSON.stringify(half));
+// A whole pair survives as one two-unit element.
+const emoji = Array.from("a😀b")[1];
+console.log("pair-length", emoji.length);
+console.log("pair-codepoint", emoji.codePointAt(0));
+console.log("pair-well-formed", emoji.isWellFormed());
+// Join round-trips the source.
+console.log("rejoin", Array.from("x😀y\ud83dz").join("") === "x😀y\ud83dz");


### PR DESCRIPTION
Two value-representation fixes: values decoded as the wrong kind, wrong values reaching the user.

## #9415 — `console.log` / `util.inspect` printed classes as integers, holes as `NaN`, settled promises as pending

### The tag ambiguity

A class ref is NaN-boxed `0x7FFE` — **the same tag as INT32** — so display ladders reached `is_int32()` and printed the class id: `console.log(class Klass {})` → `1`. The disambiguator already existed: `class_ref_id()` (tag test + registry check), with ~15 callers; `symbol/iterator.rs` documents the collision explicitly. The display ladders never asked it.

The known seven `is_int32()` sites in `console.rs` were **not the whole story** — only four are display ladders; the two that matter most are in `builtins/formatting.rs`: `format_jsvalue` and `format_jsvalue_for_json`, which `util.inspect`, `%O`, array elements, object fields and Map/Set members all route through. `{ k: Klass }` printed `{ k: 1 }` through the *json* twin, which `console.rs` never touches.

### The fix

New `formatting/value_repr.rs` holds one implementation of each rendering; every ladder calls into it:

- `int32_or_class_repr` → `[class Name]` / `[class Name extends Parent]` / `[class (anonymous)]`, else the integer. The name comes from `class_name_for_id` **unmodified**, so #9413's name fix flows straight through.
- `array_entries_with_holes` → runs of `TAG_HOLE` collapse to `<N empty items>` in both array walks; the single-/multi-line decision counts *entries*, not `length` (`new Array(7)` is one entry, so it stays on one line as in node).
- A stray hole reaching a scalar tail prints `undefined`, not `NaN`.
- `promise_inspect` reads `(*p).state`; the json twin also gains the promise arm it never had (`{ p: Promise.resolve(1) }` was `{ p: [object Object] }`).

### The residual ambiguity is not observable

`INT32_TAG | 1` is bit-identical for the number 1 and a ClassRef with `class_id == 1`; the registry probe cannot separate them. **Instrumented rather than assumed:** with class ids 1 and 2 live, `console.log(1)`, `console.log(x)` where `x: any = 1`, `[9].length`, `"A".charCodeAt(0)`, `3 | 0` all still print integers — a JS number in perry is a plain f64 double and never reaches the INT32 display arm. The registry probe is the second line of defence, not the only one. These controls are pinned in the fixture.

### A consequence paid for deliberately

`util.isDeepStrictEqual` compares the *formatted* rendering of two non-pointer operands, so two distinct classes sharing a name would now compare equal. A class ref now compares by identity in that tail — after `js_jsvalue_equals` has settled the equal case, so `isDeepStrictEqual(1, 1.0)` is untouched. Pinned in the fixture.

### Same defect in Map/Set formatting, fixed here

`formatting/collections.rs` had two superimposed bugs: no `TAG_HOLE` arm, **and** the loop bounded by `size` (live count) while raw indices run `0..used`. `new Set([1,2,3]); s.delete(1)` printed `Set(2) { NaN, 2 }` — rendering the tombstone *and* never reaching the live `3`. Map was worse: `Map(1) { NaN => undefined }`. Now bounded by `used` with holes skipped, matching the collection iterators.

### Verification

Fixture on a binary from unfixed `origin/main`: **34 stdout lines and all 4 stderr lines diverge** (`[class Klass]` vs `1`, `[ <3 empty items> ]` vs `[ NaN, NaN, NaN ]`, `Promise { 1 }` vs `Promise { <pending> }`, `Set(2) { 2, 3 }` vs `Set(2) { NaN, 2 }` …). After: stdout and stderr **byte-identical to node**.

## #9431 — `Array.from(str)` returned `[]` for any string with a lone surrogate

`js_array_from_string_codepoints` did `std::str::from_utf8(bytes)` with `Err(_) => return js_array_alloc(0)`. Perry payloads are **WTF-8**, so a lone surrogate emptied the whole array — the mapped form `Array.from(str, fn)` takes the same walk and was also empty. Fixed with the bounded `wtf8_step` walk; parts carved from a WTF-8 source go through `js_string_from_wtf8_bytes` so `isWellFormed()` still reports `false`.

Also closed the pre-existing GC hazard on that loop: it held a raw `elements` pointer and a source borrow across per-element allocations. Now roots both, re-reads after each allocation, publishes each slot only after its write and barrier — the `string/split.rs` pattern.

Fixture on unfixed main: **27 lines diverge, then it throws** (`TypeError … reading 'length'`, exit 1). After: byte-identical to node, exit 0.

## Suites

| | result |
|---|---|
| `cargo test -p perry-runtime --lib -- --test-threads=1` | **2939 passed, 0 failed**, 4 ignored — incl. 13 new unit tests |
| Gap suite (622) | **617 pass / 5 parity_fail — exactly the 5 committed snapshot entries**, both directions |
| Full `test-files/` (1441) | **1288 pass**; 111 of 114 counted failures are in the committed `known_failures.json`, all 4 crashes listed |

The 3 unlisted failures are environmental, each verified individually: `test_parity_dns`/`test_parity_dns_promises` fail **under node itself** here (no resolver records), and `test_sock_write_map` passes standalone — its echo port was held by a concurrent agent's parity run.

No other fixture moved: grepped `test-files/` first — nothing else prints a class, promise, hole array or tombstoned collection at top level — and the suite confirms it.

## Same-shape defects found, reproduced, and deliberately NOT fixed here

The `if tag == A || tag == B { … } else { treat as C }` fall-through audit, run exhaustively. Each of these is real and reproduced; each needs work outside this PR's scope:

- `builtins/table.rs:444,456` — `console.table([[1,,3]])` renders the hole cell as `NaN`; the sibling primitives-only branch at `:467` already skips `TAG_HOLE`. A cell-only fix still would not match node (node omits the hole's *column*), so the header derivation needs the same treatment.
- `builtins/table.rs:546` — `delete o.a; console.table(o)` prints `b | NaN`: `object_key_names` compacts tombstoned keys without preserving slot indices, then indexes fields by compacted position. Three sibling sites do this correctly; `table.rs` is the outlier.
- `array/indexing.rs:549` — the Set/Map arm of `js_array_get_f64` returns a raw slot with **no hole translation** (the array arm at `:440` has it). This is the hole-*leak source* that makes the next two reachable.
- `builtins/arithmetic.rs:778` — `classify_value_typeof` has no hole arm: `typeof hole === "number"`.
- `value/to_string.rs:1357` — `js_jsvalue_to_string` renders a hole as `"NaN"`.
- `param_type_guard.rs:658,684` — `OP_MAP`/`OP_SET` arms have the `size`-vs-`used` bound and no hole arm; silently deopts a `Map<string,number>` param after any `.delete()`.

Verified clean, no change needed: `value/truthy.rs`, `json/stringify.rs` (hole → `null`, correct per spec), `v8_serde`, structured clone, `napi_typeof`, array sort/join/iter.

Also noted: both array formatters read `*data_ptr.add(i)` across recursive calls that can allocate — the inspect path is not GC-safepoint-audited. Pre-existing; not widened here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved console and inspection output for classes, sparse-array holes, promises, and collections after deletions.
  * Promises now display their actual pending, fulfilled, or rejected state.
  * `Array.from()` now correctly preserves lone surrogate characters and truncated sequences.
  * Class values are displayed by name instead of internal numeric identifiers.

* **Tests**
  * Added regression coverage for value inspection and string iteration edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->