### PR TITLE
style: rustfmt after the five-fix batch

### DIFF
--- a/crates/perry-runtime/src/date.rs
+++ b/crates/perry-runtime/src/date.rs
@@ -1919,7 +1919,10 @@ mod tests {
         assert_eq!(parse_date_string("2026/02/30 GMT"), 1_772_409_600_000.0);
         assert_eq!(parse_date_string("2026/09/31 GMT"), 1_790_812_800_000.0);
         // Clock edge cases: 24:00 rolls to the next midnight, 25:00 is Invalid.
-        assert_eq!(parse_date_string("2026/09/01 24:00 GMT"), 1_788_307_200_000.0);
+        assert_eq!(
+            parse_date_string("2026/09/01 24:00 GMT"),
+            1_788_307_200_000.0
+        );
         assert_eq!(
             parse_date_string("2026/09/01 3:04 PM GMT"),
             1_788_275_040_000.0
@@ -1928,19 +1931,19 @@ mod tests {
         assert_eq!(parse_date_string("Sep/01/2026 GMT"), 1_788_220_800_000.0);
 
         for bad in [
-            "2026/13/01",              // month out of range
-            "2026/00/01",              // month zero
-            "2026/09/00",              // day zero
-            "2026/09/32",              // day out of range
-            "31/1/2026",               // 31 read as a month
-            "13/1/2026",               // 13 read as a month
-            "0/1/2026",                // Y/M/D with 2026 as the day
-            "9/2026",                  // M/D with 2026 as the day
-            "2026/1/2/3",              // a fourth component
-            "2026/09/01T10:30",        // 'T' is ISO-only, not this grammar
-            "2026/09/01 25:00",        // hour out of range
-            "2026/09/01 10:60",        // minute out of range
-            "2026/09/01 +0500",        // bare offset with no clock
+            "2026/13/01",       // month out of range
+            "2026/00/01",       // month zero
+            "2026/09/00",       // day zero
+            "2026/09/32",       // day out of range
+            "31/1/2026",        // 31 read as a month
+            "13/1/2026",        // 13 read as a month
+            "0/1/2026",         // Y/M/D with 2026 as the day
+            "9/2026",           // M/D with 2026 as the day
+            "2026/1/2/3",       // a fourth component
+            "2026/09/01T10:30", // 'T' is ISO-only, not this grammar
+            "2026/09/01 25:00", // hour out of range
+            "2026/09/01 10:60", // minute out of range
+            "2026/09/01 +0500", // bare offset with no clock
         ] {
             assert!(
                 parse_date_string(bad).is_nan(),

--- a/crates/perry-runtime/src/object/field_get_set/accessors.rs
+++ b/crates/perry-runtime/src/object/field_get_set/accessors.rs
@@ -502,16 +502,13 @@ pub(crate) unsafe fn invoke_accessor_getter(get_bits: u64, receiver: f64) -> JSV
         recv_h.get_nanbox_f64(),
     );
     let recv_h = scope.root_nanbox_f64(coerced);
-    let call_bits = crate::closure::clone_closure_rebind_this(
-        get_h.get_nanbox_u64(),
-        recv_h.get_nanbox_f64(),
-    );
+    let call_bits =
+        crate::closure::clone_closure_rebind_this(get_h.get_nanbox_u64(), recv_h.get_nanbox_f64());
     let call_h = scope.root_nanbox_u64(call_bits);
     if (call_h.get_nanbox_u64() & crate::value::POINTER_MASK) == 0 {
         return JSValue::undefined();
     }
-    let prev_h =
-        scope.root_nanbox_f64(super::super::js_implicit_this_set(recv_h.get_nanbox_f64()));
+    let prev_h = scope.root_nanbox_f64(super::super::js_implicit_this_set(recv_h.get_nanbox_f64()));
     let closure = (call_h.get_nanbox_u64() & crate::value::POINTER_MASK)
         as *const crate::closure::ClosureHeader;
     let result_f64 = crate::closure::js_closure_call0(closure);
@@ -539,16 +536,13 @@ pub(crate) unsafe fn invoke_accessor_setter(set_bits: u64, receiver: f64, value:
         recv_h.get_nanbox_f64(),
     );
     let recv_h = scope.root_nanbox_f64(coerced);
-    let call_bits = crate::closure::clone_closure_rebind_this(
-        set_h.get_nanbox_u64(),
-        recv_h.get_nanbox_f64(),
-    );
+    let call_bits =
+        crate::closure::clone_closure_rebind_this(set_h.get_nanbox_u64(), recv_h.get_nanbox_f64());
     let call_h = scope.root_nanbox_u64(call_bits);
     if (call_h.get_nanbox_u64() & crate::value::POINTER_MASK) == 0 {
         return;
     }
-    let prev_h =
-        scope.root_nanbox_f64(super::super::js_implicit_this_set(recv_h.get_nanbox_f64()));
+    let prev_h = scope.root_nanbox_f64(super::super::js_implicit_this_set(recv_h.get_nanbox_f64()));
     let closure = (call_h.get_nanbox_u64() & crate::value::POINTER_MASK)
         as *const crate::closure::ClosureHeader;
     let _ = crate::closure::js_closure_call1(closure, value_h.get_nanbox_f64());

--- a/crates/perry-runtime/src/os.rs
+++ b/crates/perry-runtime/src/os.rs
@@ -839,14 +839,14 @@ pub use signal::{js_process_kill, js_util_convert_process_signal_to_exit_code};
 
 #[path = "os_process_streams.rs"]
 mod process_streams;
+#[cfg(test)]
+pub(crate) use process_streams::test_set_stdin_data_listener;
 pub use process_streams::{
     js_process_stderr, js_process_stdin, js_process_stdout, mark_process_stdin_destroyed,
     pump_process_stdin, scan_process_stream_singleton_roots_mut, set_process_stdin_raw_state,
     stdin_chunk_jsvalue, stdin_has_encoding, stdin_is_detached, stdin_listeners_keep_loop_alive,
     stdin_push_bytes,
 };
-#[cfg(test)]
-pub(crate) use process_streams::test_set_stdin_data_listener;
 
 /// Get the operating system name
 /// Returns: "Darwin", "Linux", "Windows_NT", etc.


### PR DESCRIPTION
One or more of #9435/#9437/#9439/#9444/#9448 landed with formatting `rustfmt` reformats — my validation train carried a rustfmt commit that doesn't travel when the PRs merge from their own heads. `cargo fmt --all -- --check` is a required `lint` step and is currently red on `main`. Formatting only.