### PR TITLE
fix(runtime): thread the array pointer from across_mut re-reads in the codepoint fill (follow-up to #9461)

### DIFF
--- a/crates/perry-runtime/src/array/alloc.rs
+++ b/crates/perry-runtime/src/array/alloc.rs
@@ -435,6 +435,12 @@ pub(crate) unsafe fn js_array_from_string_codepoints(
         js_array_alloc_pointer_elements(count as u32)
     });
     let arr_handle = scope.root_raw_mut_ptr(arr);
+    // The CURRENT array pointer, refreshed from every `across_mut` re-read
+    // below. Nothing between one refresh and the next allocates
+    // (`with_const_ptr` only copies into a stack buffer and
+    // `store_codepoint_string` is a direct slot write + barrier), so this is
+    // always valid — including at the final return, which needs no re-read.
+    let mut arr_latest = arr;
 
     let mut offset = 0usize;
     for index in 0..count {
@@ -443,21 +449,26 @@ pub(crate) unsafe fn js_array_from_string_codepoints(
         // it a pointer into the GC heap is the #5062 dangling-source class. A
         // WTF-8 sequence is at most 4 bytes.
         let mut buf = [0u8; 4];
-        let seq_len;
-        {
-            let s_now = s_handle.get_raw_const_ptr::<crate::string::StringHeader>();
+        // The copy into `buf` is the whole validity window for the string
+        // pointer, so scope it with `with_const_ptr` — nothing in the closure
+        // allocates, and the pointer never escapes it.
+        let seq_len = s_handle.with_const_ptr::<crate::string::StringHeader, _>(|s_now| {
             let bytes = std::slice::from_raw_parts(
                 crate::string::string_data(s_now),
                 (*s_now).byte_len as usize,
             );
             if offset >= bytes.len() {
-                break;
+                return 0;
             }
             let (advance, _, _) = crate::string::wtf8_step(bytes, offset);
             let end = (offset + advance).min(bytes.len());
-            seq_len = end - offset;
-            buf[..seq_len].copy_from_slice(&bytes[offset..end]);
+            let len = end - offset;
+            buf[..len].copy_from_slice(&bytes[offset..end]);
             offset = end;
+            len
+        });
+        if seq_len == 0 {
+            break;
         }
         // `js_string_from_bytes` hardcodes flags = 0, so a lone surrogate
         // carved out of a WTF-8 source would lose its marker and
@@ -470,9 +481,10 @@ pub(crate) unsafe fn js_array_from_string_codepoints(
                 crate::string::js_string_from_bytes(seq.as_ptr(), seq_len as u32)
             }
         });
+        arr_latest = arr_now;
         store_codepoint_string(arr_now, index, sh);
     }
-    arr_handle.get_raw_mut_ptr::<ArrayHeader>()
+    arr_latest
 }
 
 /// Exact-sized array allocation for array literals `[a, b, c, ...]`.

--- a/crates/perry-runtime/src/array/strict_store_tests.rs
+++ b/crates/perry-runtime/src/array/strict_store_tests.rs
@@ -265,12 +265,11 @@ fn set_length_rejection_throws_only_in_strict_mode() {
         // flag is a state no program can reach, and the predicate rightly
         // ignores it. Set the flag so this test exercises the shape the
         // end-to-end fixture produces, rather than a half-built one.
-        *super::header::array_gc_header(locked).expect("live array header") =
-            crate::gc::GcHeader {
-                _reserved: (*super::header::array_gc_header(locked).unwrap())._reserved
-                    | crate::gc::OBJ_FLAG_ARRAY_DESCRIPTORS,
-                ..*super::header::array_gc_header(locked).unwrap()
-            };
+        *super::header::array_gc_header(locked).expect("live array header") = crate::gc::GcHeader {
+            _reserved: (*super::header::array_gc_header(locked).unwrap())._reserved
+                | crate::gc::OBJ_FLAG_ARRAY_DESCRIPTORS,
+            ..*super::header::array_gc_header(locked).unwrap()
+        };
 
         assert!(
             catch_runtime_throw(|| {


### PR DESCRIPTION
#9461's `Array.from(str)` lone-surrogate fix landed with two raw-handle sites in `array/alloc.rs`, a module the ratchet locks at zero — the bare `raw_handle_debt.py` is red on `main` right now.

Both conversions are real scoping, not scanner-appeasement:

- The per-iteration string read becomes `with_const_ptr`: copying the WTF-8 sequence into the stack buffer is the pointer's whole validity window, nothing in the closure allocates, and the pointer never escapes it.
- The final `get_raw_mut_ptr` return is **removed entirely** by threading the pointer each `across_mut` already re-read. That is sound because nothing between one refresh and the next allocates — `with_const_ptr` only fills a stack buffer, and `store_codepoint_string` is a direct slot write plus barrier — so the last re-read is still current at the return, including on the zero-codepoint early paths, where the pointer from the rooted allocation has spanned no allocation at all.

Net effect: the module carries **zero** raw-handle debt, no ceiling added, one fewer real re-read.

**Verified behaviourally** with the rest of the batch: lone surrogate preserved through `Array.from` (`parts[1].isWellFormed() === false`, length 1), byte-identical to node, plus `perry-runtime`/`perry-codegen`/`perry-hir` green (80 suites) and a clean release build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when creating arrays from strings, including safer handling during memory management and array growth.
  * Preserved correct behavior when processing string code points.

* **Tests**
  * Updated strict-mode array length assignment test formatting without changing its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->