### PR TITLE
ci: tolerate the two known compile-smoke tokio-coherence failures (#9470)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3041,6 +3041,49 @@ jobs:
           SKIP=${#skip_files[@]}
           echo "Compile smoke: $PASS passed, $FAIL failed, $SKIP skipped"
 
+          # Known-failing cases (#9470). These two are NOT a compiler bug in
+          # the code under test: auto-optimize rebuilds the stdlib static into
+          # `target/perry-auto-<hash>/` WITHOUT the ext wrappers in the same
+          # cargo invocation, so tokio's features resolve differently for them
+          # and the linker correctly refuses the pair ("bundle a DIFFERENT
+          # tokio compilation"). The refusal is the right behaviour — the
+          # alternative is a binary with two `tokio::runtime::context::CONTEXT`
+          # thread-locals and "there is no reactor running" at runtime
+          # (#507, #7629) — so this list tolerates the CI red, it does NOT
+          # weaken the check that protects users.
+          #
+          # Pre-existing: the 2026-08-31 full tier (run 33372993990) failed the
+          # same way on test_issue_414_mysql_query_params. Adding ext crates to
+          # this job's `cargo build` line does NOT help — mysql2 is already
+          # there; auto-optimize's LATER rebuild is what breaks coherence.
+          #
+          # Delete an entry the moment #9470 lands — an entry that stops
+          # matching is a stale exemption, and the check below fails on one.
+          KNOWN_FAIL=(
+            test_issue_340_axios_response_props
+            test_issue_414_mysql_query_params
+          )
+          UNEXPECTED=()
+          STALE=()
+          for marker in "$LOGS_DIR"/*.fail; do
+            [[ -e "$marker" ]] || continue
+            name=$(basename "$marker" .fail)
+            known=0
+            for k in "${KNOWN_FAIL[@]}"; do [[ "$name" == "$k" ]] && known=1 && break; done
+            [[ $known -eq 1 ]] || UNEXPECTED+=("$name")
+          done
+          for k in "${KNOWN_FAIL[@]}"; do
+            [[ -e "$LOGS_DIR/$k.fail" ]] || STALE+=("$k")
+          done
+          if [[ ${#STALE[@]} -gt 0 ]]; then
+            echo "::error::known-failure entries that now PASS — delete them from KNOWN_FAIL (#9470):"
+            printf '  - %s\n' "${STALE[@]}"
+            exit 1
+          fi
+          if [[ ${#UNEXPECTED[@]} -gt 0 ]]; then
+            echo "::error::compile-smoke has ${#UNEXPECTED[@]} failure(s) beyond the known list:"
+            printf '  - %s\n' "${UNEXPECTED[@]}"
+          fi
           if [[ $FAIL -gt 0 ]]; then
             echo "Compile failures:"
             for marker in "$LOGS_DIR"/*.fail; do
@@ -3057,7 +3100,13 @@ jobs:
                 echo "    --- end ---"
               fi
             done
-            exit 1
+            # Fail ONLY on failures outside the known list. A known one is
+            # still printed above with its stderr, so it stays visible rather
+            # than silently tolerated.
+            if [[ ${#UNEXPECTED[@]} -gt 0 ]]; then
+              exit 1
+            fi
+            echo "All ${FAIL} failure(s) are known (#9470); not failing the job."
           fi
 
       - name: Upload compile-smoke error logs

--- a/changelog.d/PENDINGCS-compile-smoke-known.md
+++ b/changelog.d/PENDINGCS-compile-smoke-known.md
@@ -1,0 +1,40 @@
+**ci: tolerate two known compile-smoke failures (#9470)**
+
+`compile-smoke` is in `full-suite-gate`'s `needs` and exits on `FAIL -gt 0` with
+no allowlist, so two long-standing failures were blocking **every** release cut:
+
+```
+Compile smoke: 1359 passed, 2 failed, 67 skipped
+- test_issue_340_axios_response_props
+- test_issue_414_mysql_query_params
+```
+
+Both are the tokio-coherence refusal. Auto-optimize rebuilds the stdlib static
+into `target/perry-auto-<hash>/` **without** the ext wrappers in the same cargo
+invocation (`optimized_libs/driver.rs:846-857` passes only
+`-p perry-runtime-static -p perry-stdlib-static --no-default-features`), so
+tokio's features resolve differently for them and the linker refuses the pair.
+
+Root cause and fix options are #9470. Adding ext crates to this job's
+`cargo build` line does **not** help — `perry-ext-mysql2` is already there;
+auto-optimize's *later* rebuild is what breaks coherence.
+
+Pre-existing: the 2026-08-31 full tier (run 33372993990) failed the same way
+(1347 passed, 1 failed, `test_issue_414_mysql_query_params`).
+
+**This does not weaken the check that protects users.** The linker still refuses
+to produce a two-tokio binary — the alternative is two independent
+`tokio::runtime::context::CONTEXT` thread-locals and "there is no reactor
+running" at runtime (#507, #7629). Only CI's tolerance changes, and each known
+failure is still printed with its stderr.
+
+The list is self-policing, verified in all four directions:
+
+| case | result |
+|---|---|
+| exactly the 2 known | passes |
+| known + a NEW failure | **fails**, naming the new one |
+| a known one now passes | **fails** as a stale entry |
+| all pass | **fails** as stale entries |
+
+So it cannot silently absorb a new break, and it cannot rot once #9470 lands.


### PR DESCRIPTION
## What

Gives `compile-smoke` a two-entry known-failure list so it stops blocking every
release cut. **Not a fix** — #9470 is the fix. This is a tracked, self-policing
tolerance.

## Why this blocks releases

`compile-smoke` is in `full-suite-gate`'s `needs`, and the job exits on
`FAIL -gt 0` with no allowlist. Two long-standing failures therefore block every
release regardless of what the release contains:

```
Compile smoke: 1359 passed, 2 failed, 67 skipped
- test_issue_340_axios_response_props
- test_issue_414_mysql_query_params
```

Pre-existing: the 2026-08-31 full tier (run 33372993990) failed the same way
(1347 passed, 1 failed, `test_issue_414_mysql_query_params`). It is 2 now
because `axios` joined.

## Root cause (fix tracked in #9470)

Both are the tokio-coherence refusal:

```
target/perry-auto-<hash>/release/libperry_stdlib.a bundles tokio-e69c74b77ea3bbaf
libperry_ext_mysql2.a                              bundles tokio-aa3a849219b7b42b
```

`optimized_libs/driver.rs:846-857` rebuilds only
`-p perry-runtime-static -p perry-stdlib-static --no-default-features`. The ext
wrappers are not in that invocation, so cargo resolves tokio's features
differently for them.

**Adding ext crates to this job's `cargo build` line does not help** —
`perry-ext-mysql2` is already on that line and still fails. The main build does
unify tokio; auto-optimize's *subsequent* rebuild breaks it.

## This does not weaken user protection

The linker's refusal is unchanged and still correct — a two-tokio binary means
two independent `tokio::runtime::context::CONTEXT` thread-locals and "there is
no reactor running" at runtime (#507, #7629). Only whether **CI goes red**
changes. Each known failure is still printed with its stderr, so it stays
visible.

## Self-policing — verified in all four directions

| case | expected | got |
|---|---|---|
| exactly the 2 known | pass | **exit 0**, "all 2 known" |
| known + a NEW failure | fail | **exit 1**, names `test_brand_new_break` |
| a known one now passes | fail | **exit 1**, names the stale entry |
| all pass | fail | **exit 1**, both stale |

It cannot silently absorb a new break, and a stale entry fails the job — so the
list must be deleted when #9470 lands rather than lingering.

YAML parses (28 jobs) and the edited `run` block passes `bash -n`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compile checks to distinguish known failures from unexpected failures.
  * CI now continues when only approved failures occur while keeping their details visible in logs.
  * The workflow fails for new failures or outdated exemptions.
* **Documentation**
  * Added release documentation describing compile-check handling and safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->