### PR TITLE
fix(stdlib): ghash 0.6 API follow-up

### DIFF
--- a/crates/perry-stdlib/src/crypto/cipher.rs
+++ b/crates/perry-stdlib/src/crypto/cipher.rs
@@ -113,17 +113,20 @@ pub(super) fn gcm_ghash<C>(key: &[u8], aad: &[u8], ciphertext: &[u8]) -> Option<
 where
     C: aes::cipher::BlockEncrypt + aes::cipher::KeyInit,
 {
-    use ghash::universal_hash::{KeyInit as GHashKeyInit, UniversalHash};
+    use ghash::universal_hash::UniversalHash;
 
     let h = aes_encrypt_block::<C>(key, [0u8; 16])?;
-    let mut ghash = ghash::GHash::new(ghash::Key::from_slice(&h));
+    // ghash 0.6 deprecates Array::from_slice in favour of TryFrom; the block
+    // is a fixed [u8; 16], so the conversion cannot fail.
+    let ghash_key = ghash::Key::try_from(&h[..]).ok()?;
+    let mut ghash = ghash::GHash::new(&ghash_key);
     ghash.update_padded(aad);
     ghash.update_padded(ciphertext);
 
     let mut lengths = [0u8; 16];
     lengths[..8].copy_from_slice(&((aad.len() as u64).wrapping_mul(8)).to_be_bytes());
     lengths[8..].copy_from_slice(&((ciphertext.len() as u64).wrapping_mul(8)).to_be_bytes());
-    let length_block = ghash::Block::clone_from_slice(&lengths);
+    let length_block = ghash::Block::try_from(&lengths[..]).ok()?;
     ghash.update(std::slice::from_ref(&length_block));
 
     let tag = ghash.finalize();


### PR DESCRIPTION
#9457's ghash 0.5→0.6 bump leaves three warnings in `crypto/cipher.rs` that `-D warnings` rejects: two deprecated `Array::from_slice`/`clone_from_slice` calls (now `TryFrom`, infallible here since both blocks are fixed `[u8; 16]`), and a `KeyInit` import the new `GHash::new` no longer needs in scope.

**Verified behaviourally, since this is tag-verification crypto:** an AES-256-GCM round trip with AAD is byte-identical to node — same ciphertext, same auth tag, plaintext recovered, and a forged tag rejected. `perry-stdlib` + `perry-runtime` suites green (the one `async_hooks` failure in the first run is the documented cross-test-contamination flake — it passes filtered and passes on a full re-run, 2974/0).