### PR TITLE
chore(lint): record string payload-access ratchet progress (360 -> 359)

### DIFF
--- a/scripts/string_payload_access_baseline.txt
+++ b/scripts/string_payload_access_baseline.txt
@@ -12,7 +12,7 @@ inline-offset | perry-ext-nodemailer | 1
 inline-offset | perry-ext-pg | 2
 inline-offset | perry-ext-zlib | 3
 inline-offset | perry-ffi | 3
-inline-offset | perry-runtime | 360
+inline-offset | perry-runtime | 359
 inline-offset | perry-stdlib | 48
 inline-offset | perry-updater | 5
 reader-helper | perry-ext-ethers | 1


### PR DESCRIPTION
`lint` fails on `main`:

```
String payload-access baseline is stale; record the progress:
  inline-offset | perry-runtime: baseline 360, found 359
Run: python3 scripts/string_payload_access_inventory.py --write-baseline
```

An inline-offset site was removed (359 < 360 — progress) without recording it, and the ratchet requires the baseline to move with it. This is the output of the command the gate itself names; the only change is one number in `scripts/string_payload_access_baseline.txt`.

Verified both directions locally: the gate now passes, and `--self-test` still passes (the checker can still fail), so this records progress rather than disarming the ratchet.

Blocking: `lint` is in `full-suite-gate`'s needs, so this stops any release cut.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `inline-offset` baseline to reflect one fewer open-coded string payload access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->