### PR TITLE
fix(build-cache): key PERRY_U8_INLINE_READ — it changes emitted code (#9342)

### DIFF
--- a/crates/perry/src/commands/compile/build_cache.rs
+++ b/crates/perry/src/commands/compile/build_cache.rs
@@ -37,6 +37,10 @@ const BUILD_CACHE_ENV_VARS: &[&str] = &[
     // a different backend means different object bytes.
     "PERRY_LLVM_INPROCESS",
     "PERRY_WRITE_BARRIERS",
+    // #9342 kill switch: `PERRY_U8_INLINE_READ=0` removes the inline u8-read
+    // lane from the emitted code, so an object built with the lane must not be
+    // served from cache to a build that turned it off (and vice versa).
+    "PERRY_U8_INLINE_READ",
     "PERRY_SHADOW_STACK",
     "PERRY_RS4GC",
     // `-Os` vs `-O3` for every native module.


### PR DESCRIPTION
`cargo-test` fails on `main`:

```
commands::compile::build_cache::tests::codegen_env_vars_are_build_cache_inputs ... FAILED
these codegen env vars key neither the build cache nor an exclusion (#6394's rule):
  ["PERRY_U8_INLINE_READ"]
Add each to BUILD_CACHE_ENV_VARS, or to BUILD_CACHE_ENV_VARS_EXCLUDED
```

#9342 added the var but did not register it, and the #6394 guard correctly refuses to let a codegen-affecting env var go unaccounted for.

**It belongs in `BUILD_CACHE_ENV_VARS`, not the exclusion list.** It is a codegen kill switch — `perry-codegen/src/expr/u8_buffer_read.rs` gates the inline u8-read lane on it, and `issue_9342_u8_inline_read.rs` asserts that `PERRY_U8_INLINE_READ=0` *removes the lane*. Since it changes emitted code, an object built with the lane must not be served from cache to a build that turned it off, or vice versa. Excluding it would let exactly that happen — silently, and only under a cache hit.

Verified: `codegen_env_vars_are_build_cache_inputs` passes with the entry added.

Blocking: `cargo-test` is in `full-suite-gate`'s needs, so this stops any release cut.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Build caching now correctly accounts for the inline byte-read configuration, preventing incompatible cached build artifacts from being reused when this setting changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->