### PR TITLE
deps(ui-android): jni 0.22 with the code migration (from #9454)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -220,7 +220,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1028,12 +1028,6 @@ dependencies = [
  "libc",
  "shlex 2.0.1",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cexpr"
@@ -1937,7 +1931,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2242,7 +2236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2803,7 +2797,7 @@ dependencies = [
  "gobject-sys 0.22.6",
  "libc",
  "system-deps",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3318,7 +3312,7 @@ dependencies = [
  "hickory-proto",
  "idna",
  "ipnet",
- "jni 0.22.4",
+ "jni",
  "rand 0.10.2",
  "thiserror 2.0.18",
  "tinyvec",
@@ -3336,7 +3330,7 @@ dependencies = [
  "data-encoding",
  "idna",
  "ipnet",
- "jni 0.22.4",
+ "jni",
  "once_cell",
  "prefix-trie",
  "rand 0.10.2",
@@ -3359,7 +3353,7 @@ dependencies = [
  "hickory-proto",
  "ipconfig",
  "ipnet",
- "jni 0.22.4",
+ "jni",
  "moka",
  "ndk-context",
  "once_cell",
@@ -4068,7 +4062,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4147,22 +4141,6 @@ checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
-dependencies = [
- "cesu8",
- "cfg-if",
- "combine",
- "jni-sys 0.3.1",
- "log",
- "thiserror 1.0.69",
- "walkdir",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
@@ -4170,7 +4148,7 @@ dependencies = [
  "cfg-if",
  "combine",
  "jni-macros",
- "jni-sys 0.4.1",
+ "jni-sys",
  "log",
  "simd_cesu8",
  "thiserror 2.0.18",
@@ -4189,15 +4167,6 @@ dependencies = [
  "rustc_version",
  "simd_cesu8",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
-dependencies = [
- "jni-sys 0.4.1",
 ]
 
 [[package]]
@@ -5037,7 +5006,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6530,7 +6499,7 @@ version = "0.5.1519"
 dependencies = [
  "base64 0.22.1",
  "itoa",
- "jni 0.21.1",
+ "jni",
  "libc",
  "perry-audio-miniaudio",
  "perry-ext-sharp",
@@ -7863,7 +7832,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8504,7 +8473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8781,7 +8750,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9331,7 +9300,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9928,7 +9897,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10540,7 +10509,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -10769,15 +10738,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -10819,21 +10779,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -10909,12 +10854,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -10939,12 +10878,6 @@ checksum = "db3bc5134e8ce0da5d64dcec3529793f1d33aee5a51fc2b4662e0f881dd463e6"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -10966,12 +10899,6 @@ name = "windows_i686_gnu"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0343a6f35bf43a07b009b8591b78b10ea03de86b06f48e28c96206cd0f453b50"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -11011,12 +10938,6 @@ checksum = "1acdcbf4ca63d8e7a501be86fee744347186275ec2754d129ddeab7a1e3a02e4"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -11041,12 +10962,6 @@ checksum = "893c0924c5a990ec73cd2264d1c0cba1773a929e1a3f5dbccffd769f8c4edebb"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
@@ -11062,12 +10977,6 @@ name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -11092,12 +11001,6 @@ name = "windows_x86_64_msvc"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a29bd61f32889c822c99a8fdf2e93378bd2fae4d7efd2693fab09fcaaf7eff4b"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/crates/perry-ui-android/Cargo.toml
+++ b/crates/perry-ui-android/Cargo.toml
@@ -26,7 +26,7 @@ perry-runtime = { path = "../perry-runtime", default-features = false }
 perry-ext-sharp = { path = "../perry-ext-sharp" }
 base64.workspace = true
 libc.workspace = true
-jni = "0.21"
+jni = "0.22"
 serde_json.workspace = true
 itoa.workspace = true
 ryu.workspace = true

--- a/crates/perry-ui-android/src/app.rs
+++ b/crates/perry-ui-android/src/app.rs
@@ -1,4 +1,4 @@
-use jni::objects::JValue;
+use jni::JValue;
 use std::cell::RefCell;
 
 use crate::jni_bridge;
@@ -125,25 +125,25 @@ fn attach_root_to_activity() {
     }
     if root_handle > 0 {
         if let Some(root_ref) = widgets::get_widget(root_handle) {
-            let mut env = jni_bridge::get_env();
-            let root_obj = root_ref.as_obj();
-            let bridge_class = jni_bridge::with_cache(|c| {
-                env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap()
-            });
-            let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-            let _ = env.call_static_method(
-                bridge_cls,
-                "setContentView",
-                "(Landroid/view/View;)V",
-                &[JValue::Object(root_obj)],
-            );
-            unsafe {
-                __android_log_print(
-                    3,
-                    b"PerryApp\0".as_ptr(),
-                    b"attach_root_to_activity: setContentView called\0".as_ptr(),
+            jni_bridge::with_env(|env| {
+                let root_obj = root_ref.as_obj();
+                let bridge_class =
+                    jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+                let bridge_cls: &jni::objects::JClass = &bridge_class;
+                let _ = env.call_static_method(
+                    bridge_cls,
+                    jni::jni_str!("setContentView"),
+                    jni::jni_sig!("(Landroid/view/View;)V"),
+                    &[JValue::Object(root_obj)],
                 );
-            }
+                unsafe {
+                    __android_log_print(
+                        3,
+                        b"PerryApp\0".as_ptr(),
+                        b"attach_root_to_activity: setContentView called\0".as_ptr(),
+                    );
+                }
+            })
         }
     }
 }
@@ -172,24 +172,25 @@ fn start_timer_pump() {
         );
     }
 
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(16);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 16);
 
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
 
-    // Register the pump timer — fires every 8ms, calls nativePumpTick on UI thread
-    let _ = env.call_static_method(
-        bridge_cls,
-        "startPumpTimer",
-        "(J)V",
-        &[jni::objects::JValue::Long(8)], // 8ms interval
-    );
+        // Register the pump timer — fires every 8ms, calls nativePumpTick on UI thread
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("startPumpTimer"),
+            jni::jni_sig!("(J)V"),
+            &[jni::JValue::Long(8)], // 8ms interval
+        );
 
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }
 
 /// Counter for throttled pump tick logging
@@ -200,7 +201,7 @@ static PUMP_TICK_COUNT: std::sync::atomic::AtomicU64 = std::sync::atomic::Atomic
 /// even though timers were registered on the perry-native thread.
 #[no_mangle]
 pub extern "C" fn Java_com_perry_app_PerryBridge_nativePumpTick(
-    _env: jni::JNIEnv,
+    _env: jni::EnvUnowned,
     _class: jni::objects::JClass,
 ) {
     let count = PUMP_TICK_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -360,24 +361,25 @@ thread_local! {
 
 /// Set a repeating timer via PerryBridge.setTimer.
 pub fn set_timer(interval_ms: f64, callback: f64) {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(16);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 16);
 
-    let cb_key = crate::callback::register(callback);
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
+        let cb_key = crate::callback::register(callback);
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
 
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let _ = env.call_static_method(
-        bridge_cls,
-        "setTimer",
-        "(JJ)V",
-        &[JValue::Long(cb_key), JValue::Long(interval_ms as i64)],
-    );
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("setTimer"),
+            jni::jni_sig!("(JJ)V"),
+            &[JValue::Long(cb_key), JValue::Long(interval_ms as i64)],
+        );
 
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }
 
 /// Register callback for app activation (resume).

--- a/crates/perry-ui-android/src/audio.rs
+++ b/crates/perry-ui-android/src/audio.rs
@@ -4,7 +4,7 @@
 //! reads PCM data via JNI calls, and process (A-weight + RMS + dB) in Rust.
 //! Results are stored in atomics, read lock-free by the main/UI thread.
 
-use jni::objects::{JObject, JValue};
+use jni::JValue;
 use std::fs::File;
 use std::io::Write;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -115,191 +115,194 @@ pub fn start() -> i64 {
     // Check RECORD_AUDIO permission. PerryActivity requests all dangerous
     // permissions declared in the manifest at startup (before native code runs),
     // so this should already be granted by the time we get here.
-    {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let activity = crate::widgets::get_activity(&mut env);
+    let granted = jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
+        let activity = crate::widgets::get_activity(env);
         let perm_str = env.new_string("android.permission.RECORD_AUDIO").unwrap();
         let result = env.call_static_method(
-            "androidx/core/content/ContextCompat",
-            "checkSelfPermission",
-            "(Landroid/content/Context;Ljava/lang/String;)I",
+            jni::jni_str!("androidx/core/content/ContextCompat"),
+            jni::jni_str!("checkSelfPermission"),
+            jni::jni_sig!("(Landroid/content/Context;Ljava/lang/String;)I"),
             &[JValue::Object(&activity), JValue::Object(&perm_str.into())],
         );
         unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
         }
 
-        let granted = result.map(|v| v.i().unwrap_or(-1)).unwrap_or(-1) == 0;
-        if !granted {
-            return 0;
-        }
+        result.map(|v| v.i().unwrap_or(-1)).unwrap_or(-1) == 0
+    });
+    if !granted {
+        return 0;
     }
 
     // Spawn a background thread that creates AudioRecord via JNI and reads data.
     // JNI calls must happen on a thread attached to the JVM.
-    let vm = jni_bridge::get_vm().clone();
-
     RUNNING.store(true, Ordering::Relaxed);
 
     std::thread::spawn(move || {
-        // Attach this thread to the JVM
-        let mut env = vm
-            .attach_current_thread_permanently()
-            .expect("Failed to attach audio thread to JVM");
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 32);
 
-        let _ = env.push_local_frame(32);
+            // Constants for AudioRecord
+            // MediaRecorder.AudioSource.MIC = 1
+            // AudioFormat.CHANNEL_IN_MONO = 16
+            // AudioFormat.ENCODING_PCM_FLOAT = 4
+            let audio_source: i32 = 1;
+            let sample_rate: i32 = 48000;
+            let channel_config: i32 = 16; // CHANNEL_IN_MONO
+            let audio_format: i32 = 4; // ENCODING_PCM_FLOAT
+            let buffer_size_frames: i32 = 1024;
 
-        // Constants for AudioRecord
-        // MediaRecorder.AudioSource.MIC = 1
-        // AudioFormat.CHANNEL_IN_MONO = 16
-        // AudioFormat.ENCODING_PCM_FLOAT = 4
-        let audio_source: i32 = 1;
-        let sample_rate: i32 = 48000;
-        let channel_config: i32 = 16; // CHANNEL_IN_MONO
-        let audio_format: i32 = 4; // ENCODING_PCM_FLOAT
-        let buffer_size_frames: i32 = 1024;
+            // Get minimum buffer size
+            let audio_record_cls = match env.find_class(jni::jni_str!("android/media/AudioRecord"))
+            {
+                Ok(cls) => cls,
+                Err(_) => {
+                    RUNNING.store(false, Ordering::Relaxed);
+                    return;
+                }
+            };
 
-        // Get minimum buffer size
-        let audio_record_cls = match env.find_class("android/media/AudioRecord") {
-            Ok(cls) => cls,
-            Err(_) => {
-                RUNNING.store(false, Ordering::Relaxed);
-                return;
-            }
-        };
-
-        let min_buf = env.call_static_method(
-            &audio_record_cls,
-            "getMinBufferSize",
-            "(III)I",
-            &[
-                JValue::Int(sample_rate),
-                JValue::Int(channel_config),
-                JValue::Int(audio_format),
-            ],
-        );
-        let min_buffer_size = match min_buf {
-            Ok(v) => v.i().unwrap_or(4096).max(buffer_size_frames * 4), // float = 4 bytes
-            Err(_) => {
-                RUNNING.store(false, Ordering::Relaxed);
-                return;
-            }
-        };
-
-        // Create AudioRecord
-        let record = env.new_object(
-            "android/media/AudioRecord",
-            "(IIIII)V",
-            &[
-                JValue::Int(audio_source),
-                JValue::Int(sample_rate),
-                JValue::Int(channel_config),
-                JValue::Int(audio_format),
-                JValue::Int(min_buffer_size),
-            ],
-        );
-        let record = match record {
-            Ok(r) => r,
-            Err(_) => {
-                RUNNING.store(false, Ordering::Relaxed);
-                return;
-            }
-        };
-
-        // Check state (1 = STATE_INITIALIZED)
-        let state = env.call_method(&record, "getState", "()I", &[]);
-        if state.map(|v| v.i().unwrap_or(0)).unwrap_or(0) != 1 {
-            RUNNING.store(false, Ordering::Relaxed);
-            return;
-        }
-
-        // Start recording
-        let _ = env.call_method(&record, "startRecording", "()V", &[]);
-
-        // Create a float array for reading samples
-        let float_array = env
-            .new_float_array(buffer_size_frames)
-            .expect("Failed to create float array");
-
-        let mut filter_state = AWeightState::new();
-        let mut ema_db: f64 = 0.0;
-
-        // Read loop
-        while RUNNING.load(Ordering::Relaxed) {
-            // AudioRecord.read(float[], int, int, int) — READ_BLOCKING = 0
-            let float_array_obj = unsafe { JObject::from_raw(float_array.as_raw()) };
-            let read_result = env.call_method(
-                &record,
-                "read",
-                "([FIII)I",
+            let min_buf = env.call_static_method(
+                &audio_record_cls,
+                jni::jni_str!("getMinBufferSize"),
+                jni::jni_sig!("(III)I"),
                 &[
-                    JValue::Object(&float_array_obj),
-                    JValue::Int(0),
-                    JValue::Int(buffer_size_frames),
-                    JValue::Int(0), // READ_BLOCKING
+                    JValue::Int(sample_rate),
+                    JValue::Int(channel_config),
+                    JValue::Int(audio_format),
                 ],
             );
-            std::mem::forget(float_array_obj); // Don't drop — we still own float_array
-
-            let frames_read = match read_result {
-                Ok(v) => v.i().unwrap_or(0),
-                Err(_) => break,
-            };
-
-            if frames_read <= 0 {
-                continue;
-            }
-
-            // Copy float data from Java array to Rust
-            let n = frames_read as usize;
-            let mut samples = vec![0.0f32; n];
-            let _ = env.get_float_array_region(&float_array, 0, &mut samples);
-
-            if RECORDING.load(Ordering::Relaxed) {
-                RECORDED_SAMPLES.lock().unwrap().extend_from_slice(&samples);
-            }
-
-            // Process: A-weight + RMS + dB
-            let mut sum_sq = 0.0f64;
-            let mut peak = 0.0f32;
-
-            for i in 0..n {
-                let s = samples[i];
-                let abs_s = s.abs();
-                if abs_s > peak {
-                    peak = abs_s;
+            let min_buffer_size = match min_buf {
+                Ok(v) => v.i().unwrap_or(4096).max(buffer_size_frames * 4), // float = 4 bytes
+                Err(_) => {
+                    RUNNING.store(false, Ordering::Relaxed);
+                    return;
                 }
-                let weighted = a_weight_filter(s as f64, &mut filter_state);
-                sum_sq += weighted * weighted;
-            }
-
-            let rms = (sum_sq / n as f64).sqrt();
-            let db_raw = if rms > 1.0e-10 {
-                20.0 * rms.log10() + 110.0
-            } else {
-                0.0
             };
-            let db_clamped = db_raw.max(0.0).min(140.0);
 
-            let dt = n as f64 / sample_rate as f64;
-            let tau = 0.125;
-            let alpha = 1.0 - (-dt / tau).exp();
-            ema_db += alpha * (db_clamped - ema_db);
+            // Create AudioRecord
+            let record = env.new_object(
+                jni::jni_str!("android/media/AudioRecord"),
+                jni::jni_sig!("(IIIII)V"),
+                &[
+                    JValue::Int(audio_source),
+                    JValue::Int(sample_rate),
+                    JValue::Int(channel_config),
+                    JValue::Int(audio_format),
+                    JValue::Int(min_buffer_size),
+                ],
+            );
+            let record = match record {
+                Ok(r) => r,
+                Err(_) => {
+                    RUNNING.store(false, Ordering::Relaxed);
+                    return;
+                }
+            };
 
-            CURRENT_DB.store(ema_db.to_bits(), Ordering::Relaxed);
-            CURRENT_PEAK.store((peak as f64).to_bits(), Ordering::Relaxed);
-
-            let idx = WAVEFORM_WRITE_INDEX.load(Ordering::Relaxed) as usize % WAVEFORM_SIZE;
-            unsafe {
-                WAVEFORM_BUFFER[idx] = ema_db;
+            // Check state (1 = STATE_INITIALIZED)
+            let state = env.call_method(
+                &record,
+                jni::jni_str!("getState"),
+                jni::jni_sig!("()I"),
+                &[],
+            );
+            if state.map(|v| v.i().unwrap_or(0)).unwrap_or(0) != 1 {
+                RUNNING.store(false, Ordering::Relaxed);
+                return;
             }
-            WAVEFORM_WRITE_INDEX.store((idx + 1) as u64, Ordering::Relaxed);
-        }
 
-        // Stop and release
-        let _ = env.call_method(&record, "stop", "()V", &[]);
-        let _ = env.call_method(&record, "release", "()V", &[]);
+            // Start recording
+            let _ = env.call_method(
+                &record,
+                jni::jni_str!("startRecording"),
+                jni::jni_sig!("()V"),
+                &[],
+            );
+
+            // Create a float array for reading samples
+            let float_array = env
+                .new_float_array(buffer_size_frames as usize)
+                .expect("Failed to create float array");
+
+            let mut filter_state = AWeightState::new();
+            let mut ema_db: f64 = 0.0;
+
+            // Read loop
+            while RUNNING.load(Ordering::Relaxed) {
+                // AudioRecord.read(float[], int, int, int) — READ_BLOCKING = 0
+                let read_result = env.call_method(
+                    &record,
+                    jni::jni_str!("read"),
+                    jni::jni_sig!("([FIII)I"),
+                    &[
+                        JValue::Object(float_array.as_ref()),
+                        JValue::Int(0),
+                        JValue::Int(buffer_size_frames),
+                        JValue::Int(0), // READ_BLOCKING
+                    ],
+                );
+
+                let frames_read = match read_result {
+                    Ok(v) => v.i().unwrap_or(0),
+                    Err(_) => break,
+                };
+
+                if frames_read <= 0 {
+                    continue;
+                }
+
+                // Copy float data from Java array to Rust
+                let n = frames_read as usize;
+                let mut samples = vec![0.0f32; n];
+                let _ = float_array.get_region(env, 0, &mut samples);
+
+                if RECORDING.load(Ordering::Relaxed) {
+                    RECORDED_SAMPLES.lock().unwrap().extend_from_slice(&samples);
+                }
+
+                // Process: A-weight + RMS + dB
+                let mut sum_sq = 0.0f64;
+                let mut peak = 0.0f32;
+
+                for i in 0..n {
+                    let s = samples[i];
+                    let abs_s = s.abs();
+                    if abs_s > peak {
+                        peak = abs_s;
+                    }
+                    let weighted = a_weight_filter(s as f64, &mut filter_state);
+                    sum_sq += weighted * weighted;
+                }
+
+                let rms = (sum_sq / n as f64).sqrt();
+                let db_raw = if rms > 1.0e-10 {
+                    20.0 * rms.log10() + 110.0
+                } else {
+                    0.0
+                };
+                let db_clamped = db_raw.max(0.0).min(140.0);
+
+                let dt = n as f64 / sample_rate as f64;
+                let tau = 0.125;
+                let alpha = 1.0 - (-dt / tau).exp();
+                ema_db += alpha * (db_clamped - ema_db);
+
+                CURRENT_DB.store(ema_db.to_bits(), Ordering::Relaxed);
+                CURRENT_PEAK.store((peak as f64).to_bits(), Ordering::Relaxed);
+
+                let idx = WAVEFORM_WRITE_INDEX.load(Ordering::Relaxed) as usize % WAVEFORM_SIZE;
+                unsafe {
+                    WAVEFORM_BUFFER[idx] = ema_db;
+                }
+                WAVEFORM_WRITE_INDEX.store((idx + 1) as u64, Ordering::Relaxed);
+            }
+
+            // Stop and release
+            let _ = env.call_method(&record, jni::jni_str!("stop"), jni::jni_sig!("()V"), &[]);
+            let _ = env.call_method(&record, jni::jni_str!("release"), jni::jni_sig!("()V"), &[]);
+        })
     });
 
     1
@@ -324,32 +327,38 @@ pub fn get_waveform(_count: f64) -> f64 {
 }
 
 pub fn get_device_model() -> i64 {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
 
-    // android.os.Build.MODEL
-    let build_cls = env.find_class("android/os/Build").ok();
-    let model = build_cls
-        .and_then(|cls| {
-            env.get_static_field(&cls, "MODEL", "Ljava/lang/String;")
+        // android.os.Build.MODEL
+        let build_cls = env.find_class(jni::jni_str!("android/os/Build")).ok();
+        let model = build_cls
+            .and_then(|cls| {
+                env.get_static_field(
+                    &cls,
+                    jni::jni_str!("MODEL"),
+                    jni::jni_sig!("Ljava/lang/String;"),
+                )
                 .ok()
                 .and_then(|v| v.l().ok())
                 .and_then(|obj| {
                     if obj.is_null() {
                         return None;
                     }
-                    let jstr: jni::objects::JString = obj.into();
-                    env.get_string(&jstr).ok().map(|s| String::from(s))
+                    let jstr: jni::objects::JString =
+                        unsafe { jni::objects::JString::from_raw(env, obj.into_raw()) };
+                    jstr.try_to_string(env).ok().map(|s| String::from(s))
                 })
-        })
-        .unwrap_or_else(|| "Unknown".to_string());
+            })
+            .unwrap_or_else(|| "Unknown".to_string());
 
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
 
-    let bytes = model.as_bytes();
-    unsafe { js_string_from_bytes(bytes.as_ptr(), bytes.len() as i32) }
+        let bytes = model.as_bytes();
+        unsafe { js_string_from_bytes(bytes.as_ptr(), bytes.len() as i32) }
+    })
 }
 
 /// Set the output filename a subsequent `start_recording()` will write to.

--- a/crates/perry-ui-android/src/background.rs
+++ b/crates/perry-ui-android/src/background.rs
@@ -10,7 +10,7 @@
 
 use crate::callback;
 use crate::jni_bridge;
-use jni::objects::JValue;
+use jni::JValue;
 
 use perry_ffi::copy_string_from_raw as str_from_header;
 
@@ -36,21 +36,22 @@ pub fn register_task(identifier_ptr: *const u8, handler: f64) {
     }
     let key = callback::register(handler);
 
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let id_jstr = env.new_string(&id).expect("new_string");
-    let _ = env.call_static_method(
-        bridge_cls,
-        "backgroundRegisterTask",
-        "(Ljava/lang/String;J)V",
-        &[JValue::Object(&id_jstr), JValue::Long(key)],
-    );
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let id_jstr = env.new_string(&id).expect("new_string");
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("backgroundRegisterTask"),
+            jni::jni_sig!("(Ljava/lang/String;J)V"),
+            &[JValue::Object(&id_jstr), JValue::Long(key)],
+        );
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }
 
 pub fn schedule(
@@ -73,28 +74,29 @@ pub fn schedule(
     let req_net = boolean_truthy(requires_network);
     let req_charge = boolean_truthy(requires_charging);
 
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(16);
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let id_jstr = env.new_string(&id).expect("new_string");
-    let kind_jstr = env.new_string(&kind).expect("new_string");
-    let _ = env.call_static_method(
-        bridge_cls,
-        "backgroundSchedule",
-        "(Ljava/lang/String;Ljava/lang/String;DZZ)V",
-        &[
-            JValue::Object(&id_jstr),
-            JValue::Object(&kind_jstr),
-            JValue::Double(earliest_start_ms),
-            JValue::Bool(if req_net { 1 } else { 0 }),
-            JValue::Bool(if req_charge { 1 } else { 0 }),
-        ],
-    );
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 16);
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let id_jstr = env.new_string(&id).expect("new_string");
+        let kind_jstr = env.new_string(&kind).expect("new_string");
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("backgroundSchedule"),
+            jni::jni_sig!("(Ljava/lang/String;Ljava/lang/String;DZZ)V"),
+            &[
+                JValue::Object(&id_jstr),
+                JValue::Object(&kind_jstr),
+                JValue::Double(earliest_start_ms),
+                JValue::Bool(req_net),
+                JValue::Bool(req_charge),
+            ],
+        );
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }
 
 pub fn cancel(identifier_ptr: *const u8) {
@@ -102,19 +104,20 @@ pub fn cancel(identifier_ptr: *const u8) {
     if id.is_empty() {
         return;
     }
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let id_jstr = env.new_string(&id).expect("new_string");
-    let _ = env.call_static_method(
-        bridge_cls,
-        "backgroundCancel",
-        "(Ljava/lang/String;)V",
-        &[JValue::Object(&id_jstr)],
-    );
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let id_jstr = env.new_string(&id).expect("new_string");
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("backgroundCancel"),
+            jni::jni_sig!("(Ljava/lang/String;)V"),
+            &[JValue::Object(&id_jstr)],
+        );
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }

--- a/crates/perry-ui-android/src/callback.rs
+++ b/crates/perry-ui-android/src/callback.rs
@@ -215,7 +215,7 @@ pub fn invoke_with_string_array(key: i64, paths: &[String]) {
 /// This runs on the UI thread. Pumps microtasks after to drive async/await.
 #[no_mangle]
 pub extern "C" fn Java_com_perry_app_PerryBridge_nativeInvokeCallback0(
-    _env: jni::JNIEnv,
+    _env: jni::EnvUnowned,
     _class: jni::objects::JClass,
     key: jni::sys::jlong,
 ) {
@@ -227,7 +227,7 @@ pub extern "C" fn Java_com_perry_app_PerryBridge_nativeInvokeCallback0(
 /// This runs on the UI thread. Pumps microtasks after to drive async/await.
 #[no_mangle]
 pub extern "C" fn Java_com_perry_app_PerryBridge_nativeInvokeCallback1(
-    _env: jni::JNIEnv,
+    _env: jni::EnvUnowned,
     _class: jni::objects::JClass,
     key: jni::sys::jlong,
     arg: jni::sys::jdouble,
@@ -240,7 +240,7 @@ pub extern "C" fn Java_com_perry_app_PerryBridge_nativeInvokeCallback1(
 /// This runs on the UI thread. Pumps microtasks after to drive async/await.
 #[no_mangle]
 pub extern "C" fn Java_com_perry_app_PerryBridge_nativeInvokeCallback2(
-    _env: jni::JNIEnv,
+    _env: jni::EnvUnowned,
     _class: jni::objects::JClass,
     key: jni::sys::jlong,
     arg1: jni::sys::jdouble,
@@ -254,26 +254,28 @@ pub extern "C" fn Java_com_perry_app_PerryBridge_nativeInvokeCallback2(
 /// Converts the Java String to a NaN-boxed Perry string and invokes the callback.
 #[no_mangle]
 pub extern "C" fn Java_com_perry_app_PerryBridge_nativeInvokeCallbackWithString(
-    mut env: jni::JNIEnv,
+    mut env: jni::EnvUnowned,
     _class: jni::objects::JClass,
     key: jni::sys::jlong,
     text: jni::objects::JString,
 ) {
-    let rust_str: String = env.get_string(&text).map(|s| s.into()).unwrap_or_default();
-    let bytes = rust_str.as_bytes();
-    let nanboxed = unsafe {
-        let str_ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
-        js_nanbox_string(str_ptr as i64)
-    };
-    invoke1(key as i64, nanboxed);
-    pump_microtasks();
+    crate::jni_bridge::with_unowned_env(&mut env, |env| {
+        let rust_str = text.try_to_string(env).unwrap_or_default();
+        let bytes = rust_str.as_bytes();
+        let nanboxed = unsafe {
+            let str_ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+            js_nanbox_string(str_ptr as i64)
+        };
+        invoke1(key as i64, nanboxed);
+        pump_microtasks();
+    });
 }
 
 /// JNI entry point: called from Java PerryBridge.nativeInvokeCallback4(long key, double, double, double, double).
 /// Issue #552 geolocation success callback: (lat, lng, accuracy, timestamp_ms).
 #[no_mangle]
 pub extern "C" fn Java_com_perry_app_PerryBridge_nativeInvokeCallback4(
-    _env: jni::JNIEnv,
+    _env: jni::EnvUnowned,
     _class: jni::objects::JClass,
     key: jni::sys::jlong,
     arg0: jni::sys::jdouble,
@@ -289,25 +291,28 @@ pub extern "C" fn Java_com_perry_app_PerryBridge_nativeInvokeCallback4(
 /// Issue #552 image picker callback: passes a NaN-boxed Perry array of NaN-boxed Perry strings.
 #[no_mangle]
 pub extern "C" fn Java_com_perry_app_PerryBridge_nativeInvokeCallbackWithStringArray(
-    mut env: jni::JNIEnv,
+    mut env: jni::EnvUnowned,
     _class: jni::objects::JClass,
     key: jni::sys::jlong,
     paths: jni::objects::JObjectArray,
 ) {
-    let mut rust_paths: Vec<String> = Vec::new();
-    if let Ok(len) = env.get_array_length(&paths) {
-        for i in 0..len {
-            if let Ok(item) = env.get_object_array_element(&paths, i) {
-                let jstr: jni::objects::JString = item.into();
-                let s: Option<String> = env.get_string(&jstr).map(|j| j.into()).ok();
-                if let Some(s) = s {
-                    rust_paths.push(s);
+    crate::jni_bridge::with_unowned_env(&mut env, |env| {
+        let mut rust_paths: Vec<String> = Vec::new();
+        if let Ok(len) = paths.len(env) {
+            for i in 0..len {
+                if let Ok(item) = paths.get_element(env, i) {
+                    // The Java declaration is `String[]`; retain 0.21's
+                    // zero-call wrapper conversion instead of type-checking.
+                    let jstr = unsafe { jni::objects::JString::from_raw(env, item.into_raw()) };
+                    if let Ok(s) = jstr.try_to_string(env) {
+                        rust_paths.push(s);
+                    }
                 }
             }
         }
-    }
-    invoke_with_string_array(key as i64, &rust_paths);
-    pump_microtasks();
+        invoke_with_string_array(key as i64, &rust_paths);
+        pump_microtasks();
+    });
 }
 
 /// JNI entry point for the issue #583 deep-link callback. Java signature:
@@ -317,27 +322,26 @@ pub extern "C" fn Java_com_perry_app_PerryBridge_nativeInvokeCallbackWithStringA
 /// `"foreground"`.
 #[no_mangle]
 pub extern "C" fn Java_com_perry_app_PerryBridge_nativeInvokeDeepLinkCallback(
-    mut env: jni::JNIEnv,
+    mut env: jni::EnvUnowned,
     _class: jni::objects::JClass,
     key: jni::sys::jlong,
     url: jni::objects::JString,
     source: jni::objects::JString,
 ) {
-    let url_str: String = env.get_string(&url).map(|s| s.into()).unwrap_or_default();
-    let source_str: String = env
-        .get_string(&source)
-        .map(|s| s.into())
-        .unwrap_or_default();
-    let url_jsval = unsafe {
-        let p = js_string_from_bytes(url_str.as_ptr(), url_str.len() as i64);
-        js_nanbox_string(p as i64)
-    };
-    let source_jsval = unsafe {
-        let p = js_string_from_bytes(source_str.as_ptr(), source_str.len() as i64);
-        js_nanbox_string(p as i64)
-    };
-    invoke2(key as i64, url_jsval, source_jsval);
-    pump_microtasks();
+    crate::jni_bridge::with_unowned_env(&mut env, |env| {
+        let url_str = url.try_to_string(env).unwrap_or_default();
+        let source_str = source.try_to_string(env).unwrap_or_default();
+        let url_jsval = unsafe {
+            let p = js_string_from_bytes(url_str.as_ptr(), url_str.len() as i64);
+            js_nanbox_string(p as i64)
+        };
+        let source_jsval = unsafe {
+            let p = js_string_from_bytes(source_str.as_ptr(), source_str.len() as i64);
+            js_nanbox_string(p as i64)
+        };
+        invoke2(key as i64, url_jsval, source_jsval);
+        pump_microtasks();
+    });
 }
 
 /// JNI entry point for the issue #582 network reachability callback. Java
@@ -347,21 +351,23 @@ pub extern "C" fn Java_com_perry_app_PerryBridge_nativeInvokeDeepLinkCallback(
 /// "ethernet" | "none" | "unknown"`.
 #[no_mangle]
 pub extern "C" fn Java_com_perry_app_PerryBridge_nativeInvokeNetworkCallback(
-    mut env: jni::JNIEnv,
+    mut env: jni::EnvUnowned,
     _class: jni::objects::JClass,
     key: jni::sys::jlong,
     connected: jni::sys::jboolean,
     kind: jni::objects::JString,
 ) {
-    const TAG_FALSE: u64 = 0x7FFC_0000_0000_0003;
-    const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
-    let connected_jsval = f64::from_bits(if connected != 0 { TAG_TRUE } else { TAG_FALSE });
-    let kind_str: String = env.get_string(&kind).map(|s| s.into()).unwrap_or_default();
-    let bytes = kind_str.as_bytes();
-    let kind_jsval = unsafe {
-        let str_ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
-        js_nanbox_string(str_ptr as i64)
-    };
-    invoke2(key as i64, connected_jsval, kind_jsval);
-    pump_microtasks();
+    crate::jni_bridge::with_unowned_env(&mut env, |env| {
+        const TAG_FALSE: u64 = 0x7FFC_0000_0000_0003;
+        const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
+        let connected_jsval = f64::from_bits(if connected { TAG_TRUE } else { TAG_FALSE });
+        let kind_str = kind.try_to_string(env).unwrap_or_default();
+        let bytes = kind_str.as_bytes();
+        let kind_jsval = unsafe {
+            let str_ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+            js_nanbox_string(str_ptr as i64)
+        };
+        invoke2(key as i64, connected_jsval, kind_jsval);
+        pump_microtasks();
+    });
 }

--- a/crates/perry-ui-android/src/camera.rs
+++ b/crates/perry-ui-android/src/camera.rs
@@ -12,7 +12,8 @@
 //! - sample_color(x, y) → packed RGB from latest frame
 //! - set_on_tap(handle, callback) → tap gesture on camera view
 
-use jni::objects::{JObject, JValue};
+use jni::objects::JObject;
+use jni::JValue;
 
 use crate::callback;
 use crate::jni_bridge;
@@ -36,38 +37,38 @@ fn log(msg: &str) {
 
 /// Create a TextureView widget for camera preview. Returns widget handle.
 pub fn create() -> i64 {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(16);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 16);
 
-    let activity = widgets::get_activity(&mut env);
+        let activity = widgets::get_activity(env);
 
-    // Create TextureView(context)
-    let texture_view = env.new_object(
-        "android/view/TextureView",
-        "(Landroid/content/Context;)V",
-        &[JValue::Object(&activity)],
-    );
-    let texture_view = match texture_view {
-        Ok(v) => v,
-        Err(e) => {
-            log(&format!("[camera] failed to create TextureView: {:?}", e));
-            unsafe {
-                env.pop_local_frame(&JObject::null());
+        // Create TextureView(context)
+        let texture_view = env.new_object(
+            jni::jni_str!("android/view/TextureView"),
+            jni::jni_sig!("(Landroid/content/Context;)V"),
+            &[JValue::Object(&activity)],
+        );
+        let texture_view = match texture_view {
+            Ok(v) => v,
+            Err(e) => {
+                log(&format!("[camera] failed to create TextureView: {:?}", e));
+                unsafe {
+                    let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+                }
+                return 0;
             }
-            return 0;
+        };
+
+        let global =
+            jni_bridge::new_global_ref(env, texture_view).expect("Failed to create global ref");
+        let handle = widgets::register_widget(global);
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
         }
-    };
 
-    let global = env
-        .new_global_ref(texture_view)
-        .expect("Failed to create global ref");
-    let handle = widgets::register_widget(global);
-    unsafe {
-        env.pop_local_frame(&JObject::null());
-    }
-
-    log(&format!("[camera] created TextureView, handle={}", handle));
-    handle
+        log(&format!("[camera] created TextureView, handle={}", handle));
+        handle
+    })
 }
 
 /// Start the camera capture session. Passes the TextureView to Kotlin for Camera2 setup.
@@ -80,125 +81,145 @@ pub fn start(handle: i64) {
         }
     };
 
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(16);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 16);
 
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
 
-    let _ = env.call_static_method(
-        bridge_cls,
-        "startCamera",
-        "(Landroid/view/TextureView;)V",
-        &[JValue::Object(view_ref.as_obj())],
-    );
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("startCamera"),
+            jni::jni_sig!("(Landroid/view/TextureView;)V"),
+            &[JValue::Object(view_ref.as_obj())],
+        );
 
-    if env.exception_check().unwrap_or(false) {
-        log("[camera] start: Java exception occurred");
-        let _ = env.exception_clear();
-    }
+        if env.exception_check() {
+            log("[camera] start: Java exception occurred");
+            let _ = env.exception_clear();
+        }
 
-    unsafe {
-        env.pop_local_frame(&JObject::null());
-    }
-    log("[camera] start called");
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+        }
+        log("[camera] start called");
+    })
 }
 
 /// Stop the camera capture session.
 pub fn stop(_handle: i64) {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
 
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
 
-    let _ = env.call_static_method(bridge_cls, "stopCamera", "()V", &[]);
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("stopCamera"),
+            jni::jni_sig!("()V"),
+            &[],
+        );
 
-    if env.exception_check().unwrap_or(false) {
-        let _ = env.exception_clear();
-    }
+        if env.exception_check() {
+            let _ = env.exception_clear();
+        }
 
-    unsafe {
-        env.pop_local_frame(&JObject::null());
-    }
-    log("[camera] stopped");
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+        }
+        log("[camera] stopped");
+    })
 }
 
 /// Freeze the camera (pause preview, keep last frame).
 pub fn freeze(_handle: i64) {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
 
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
 
-    let _ = env.call_static_method(bridge_cls, "freezeCamera", "()V", &[]);
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("freezeCamera"),
+            jni::jni_sig!("()V"),
+            &[],
+        );
 
-    if env.exception_check().unwrap_or(false) {
-        let _ = env.exception_clear();
-    }
+        if env.exception_check() {
+            let _ = env.exception_clear();
+        }
 
-    unsafe {
-        env.pop_local_frame(&JObject::null());
-    }
-    log("[camera] frozen");
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+        }
+        log("[camera] frozen");
+    })
 }
 
 /// Unfreeze the camera (resume live preview).
 pub fn unfreeze(_handle: i64) {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
 
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
 
-    let _ = env.call_static_method(bridge_cls, "unfreezeCamera", "()V", &[]);
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("unfreezeCamera"),
+            jni::jni_sig!("()V"),
+            &[],
+        );
 
-    if env.exception_check().unwrap_or(false) {
-        let _ = env.exception_clear();
-    }
+        if env.exception_check() {
+            let _ = env.exception_clear();
+        }
 
-    unsafe {
-        env.pop_local_frame(&JObject::null());
-    }
-    log("[camera] unfrozen");
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+        }
+        log("[camera] unfrozen");
+    })
 }
 
 /// Sample the color at normalized coordinates (0.0-1.0) from the latest frame.
 /// Returns packed RGB as f64: r * 65536 + g * 256 + b.
 /// Returns -1.0 if no frame is available.
 pub fn sample_color(x: f64, y: f64) -> f64 {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
 
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
 
-    let result = env.call_static_method(
-        bridge_cls,
-        "cameraSampleColor",
-        "(DD)D",
-        &[JValue::Double(x), JValue::Double(y)],
-    );
+        let result = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("cameraSampleColor"),
+            jni::jni_sig!("(DD)D"),
+            &[JValue::Double(x), JValue::Double(y)],
+        );
 
-    if env.exception_check().unwrap_or(false) {
-        let _ = env.exception_clear();
-        unsafe {
-            env.pop_local_frame(&JObject::null());
+        if env.exception_check() {
+            let _ = env.exception_clear();
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+            return -1.0;
         }
-        return -1.0;
-    }
 
-    let value = result.map(|v| v.d().unwrap_or(-1.0)).unwrap_or(-1.0);
-    unsafe {
-        env.pop_local_frame(&JObject::null());
-    }
-    value
+        let value = result.map(|v| v.d().unwrap_or(-1.0)).unwrap_or(-1.0);
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+        }
+        value
+    })
 }
 
 /// Set a tap handler that receives normalized (x, y) coordinates.
@@ -213,26 +234,27 @@ pub fn set_on_tap(handle: i64, callback_f64: f64) {
 
     let key = callback::register(callback_f64);
 
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(16);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 16);
 
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
 
-    let _ = env.call_static_method(
-        bridge_cls,
-        "setCameraTapCallback",
-        "(Landroid/view/View;J)V",
-        &[JValue::Object(view_ref.as_obj()), JValue::Long(key)],
-    );
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("setCameraTapCallback"),
+            jni::jni_sig!("(Landroid/view/View;J)V"),
+            &[JValue::Object(view_ref.as_obj()), JValue::Long(key)],
+        );
 
-    if env.exception_check().unwrap_or(false) {
-        let _ = env.exception_clear();
-    }
+        if env.exception_check() {
+            let _ = env.exception_clear();
+        }
 
-    unsafe {
-        env.pop_local_frame(&JObject::null());
-    }
-    log(&format!("[camera] set_on_tap: key={}", key));
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+        }
+        log(&format!("[camera] set_on_tap: key={}", key));
+    })
 }

--- a/crates/perry-ui-android/src/clipboard.rs
+++ b/crates/perry-ui-android/src/clipboard.rs
@@ -1,5 +1,5 @@
 use crate::jni_bridge;
-use jni::objects::JValue;
+use jni::JValue;
 
 extern "C" {
     fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
@@ -9,47 +9,53 @@ extern "C" {
 /// Read the current text from the system clipboard.
 /// Returns a NaN-boxed string (f64) or TAG_UNDEFINED if empty.
 pub fn read() -> f64 {
-    let mut env = jni_bridge::get_env();
+    jni_bridge::with_env(|env| {
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let result = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("clipboardRead"),
+            jni::jni_sig!("()Ljava/lang/String;"),
+            &[],
+        );
 
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let result = env.call_static_method(bridge_cls, "clipboardRead", "()Ljava/lang/String;", &[]);
-
-    if let Ok(val) = result {
-        if let Ok(obj) = val.l() {
-            if !obj.is_null() {
-                let jstr: jni::objects::JString = obj.into();
-                let s: String = env
-                    .get_string(&jstr)
-                    .map(|js| js.into())
-                    .unwrap_or_default();
-                let bytes = s.as_bytes();
-                unsafe {
-                    let str_ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
-                    return js_nanbox_string(str_ptr as i64);
+        if let Ok(val) = result {
+            if let Ok(obj) = val.l() {
+                if !obj.is_null() {
+                    let jstr: jni::objects::JString =
+                        unsafe { jni::objects::JString::from_raw(env, obj.into_raw()) };
+                    let s: String = jstr
+                        .try_to_string(env)
+                        .map(|js| js.into())
+                        .unwrap_or_default();
+                    let bytes = s.as_bytes();
+                    unsafe {
+                        let str_ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+                        return js_nanbox_string(str_ptr as i64);
+                    }
                 }
             }
         }
-    }
 
-    // Return TAG_UNDEFINED
-    f64::from_bits(0x7FFC_0000_0000_0001)
+        // Return TAG_UNDEFINED
+        f64::from_bits(0x7FFC_0000_0000_0001)
+    })
 }
 
 /// Write text to the system clipboard.
 pub fn write(text_ptr: *const u8) {
     let text = unsafe { crate::app::str_from_header(text_ptr) };
-    let mut env = jni_bridge::get_env();
-
-    let jstr = env.new_string(text).expect("Failed to create JNI string");
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let _ = env.call_static_method(
-        bridge_cls,
-        "clipboardWrite",
-        "(Ljava/lang/String;)V",
-        &[JValue::Object(&jstr)],
-    );
+    jni_bridge::with_env(|env| {
+        let jstr = env.new_string(text).expect("Failed to create JNI string");
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("clipboardWrite"),
+            jni::jni_sig!("(Ljava/lang/String;)V"),
+            &[JValue::Object(&jstr)],
+        );
+    })
 }

--- a/crates/perry-ui-android/src/deeplinks.rs
+++ b/crates/perry-ui-android/src/deeplinks.rs
@@ -21,7 +21,7 @@
 
 use crate::callback;
 use crate::jni_bridge;
-use jni::objects::JValue;
+use jni::JValue;
 
 /// Register the deep-link handler. Stores the closure-key on the Kotlin
 /// side. Setting a fresh handler replaces the previous one. If a URL
@@ -30,43 +30,57 @@ use jni::objects::JValue;
 pub fn set_handler(callback: f64) {
     let key = callback::register(callback);
 
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
 
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let _ = env.call_static_method(bridge_cls, "appOnOpenUrl", "(J)V", &[JValue::Long(key)]);
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("appOnOpenUrl"),
+            jni::jni_sig!("(J)V"),
+            &[JValue::Long(key)],
+        );
 
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }
 
 /// Read the cold-start URL (or `""` if the app was launched without one).
 /// Walks across to the Kotlin side, which owns the `intent.data` snapshot.
 pub fn launch_url() -> String {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
 
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let result_str: String =
-        match env.call_static_method(bridge_cls, "appGetLaunchUrl", "()Ljava/lang/String;", &[]) {
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let result_str: String = match env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("appGetLaunchUrl"),
+            jni::jni_sig!("()Ljava/lang/String;"),
+            &[],
+        ) {
             Ok(v) => match v.l() {
                 Ok(obj) => {
-                    let jstr: jni::objects::JString = obj.into();
-                    env.get_string(&jstr).map(|s| s.into()).unwrap_or_default()
+                    let jstr: jni::objects::JString =
+                        unsafe { jni::objects::JString::from_raw(env, obj.into_raw()) };
+                    jstr.try_to_string(env)
+                        .map(|s| s.into())
+                        .unwrap_or_default()
                 }
                 Err(_) => String::new(),
             },
             Err(_) => String::new(),
         };
 
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
 
-    result_str
+        result_str
+    })
 }

--- a/crates/perry-ui-android/src/dialog.rs
+++ b/crates/perry-ui-android/src/dialog.rs
@@ -2,7 +2,7 @@
 
 use crate::callback;
 use crate::jni_bridge;
-use jni::objects::JValue;
+use jni::JValue;
 
 use perry_ffi::copy_string_from_raw as str_from_header;
 
@@ -35,39 +35,40 @@ pub fn alert(title_ptr: *const u8, message_ptr: *const u8, _buttons_ptr: *const 
     let title = unsafe { str_from_header(title_ptr) };
     let message = unsafe { str_from_header(message_ptr) };
 
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
 
-    let activity = crate::widgets::get_activity(&mut env);
+        let activity = crate::widgets::get_activity(env);
 
-    // Use PerryBridge.showAlert(Activity, String title, String message, long callback)
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
+        // Use PerryBridge.showAlert(Activity, String title, String message, long callback)
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
 
-    let jtitle = env.new_string(title).expect("Failed to create JNI string");
-    let jmessage = env
-        .new_string(message)
-        .expect("Failed to create JNI string");
-    let cb_key = if callback != 0.0 {
-        callback::register(callback)
-    } else {
-        0
-    };
+        let jtitle = env.new_string(title).expect("Failed to create JNI string");
+        let jmessage = env
+            .new_string(message)
+            .expect("Failed to create JNI string");
+        let cb_key = if callback != 0.0 {
+            callback::register(callback)
+        } else {
+            0
+        };
 
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let _ = env.call_static_method(
-        bridge_cls,
-        "showAlert",
-        "(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;J)V",
-        &[
-            JValue::Object(&activity),
-            JValue::Object(&jtitle),
-            JValue::Object(&jmessage),
-            JValue::Long(cb_key),
-        ],
-    );
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("showAlert"),
+            jni::jni_sig!("(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;J)V"),
+            &[
+                JValue::Object(&activity),
+                JValue::Object(&jtitle),
+                JValue::Object(&jmessage),
+                JValue::Long(cb_key),
+            ],
+        );
 
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }

--- a/crates/perry-ui-android/src/drag_drop.rs
+++ b/crates/perry-ui-android/src/drag_drop.rs
@@ -58,7 +58,7 @@
 use crate::app::str_from_header;
 use crate::callback;
 use crate::jni_bridge;
-use jni::objects::JValue;
+use jni::JValue;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::ffi::c_void;
@@ -141,25 +141,26 @@ fn install_drag_source(handle: i64, keys: (i64, i64, i64)) {
         return;
     };
     let (text_key, file_key, url_key) = keys;
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let _ = env.call_static_method(
-        bridge_cls,
-        "setDragSource",
-        "(Landroid/view/View;JJJ)V",
-        &[
-            JValue::Object(view_ref.as_obj()),
-            JValue::Long(text_key),
-            JValue::Long(file_key),
-            JValue::Long(url_key),
-        ],
-    );
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("setDragSource"),
+            jni::jni_sig!("(Landroid/view/View;JJJ)V"),
+            &[
+                JValue::Object(view_ref.as_obj()),
+                JValue::Long(text_key),
+                JValue::Long(file_key),
+                JValue::Long(url_key),
+            ],
+        );
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }
 
 // --- FFI: drop destination ---------------------------------------------------
@@ -173,20 +174,21 @@ pub extern "C" fn perry_ui_widget_on_drop(widget: i64, callback: f64) {
         return;
     };
     let key = callback::register(callback);
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let _ = env.call_static_method(
-        bridge_cls,
-        "setOnDropCallback",
-        "(Landroid/view/View;J)V",
-        &[JValue::Object(view_ref.as_obj()), JValue::Long(key)],
-    );
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("setOnDropCallback"),
+            jni::jni_sig!("(Landroid/view/View;J)V"),
+            &[JValue::Object(view_ref.as_obj()), JValue::Long(key)],
+        );
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }
 
 // --- FFI: drag source --------------------------------------------------------
@@ -233,7 +235,7 @@ pub extern "C" fn perry_ui_widget_set_drag_url(widget: i64, provider: f64) {
 /// microtasks afterwards (matching every other callback in this crate).
 #[no_mangle]
 pub extern "C" fn Java_com_perry_app_PerryBridge_nativeInvokeDropCallback(
-    mut env: jni::JNIEnv,
+    mut env: jni::EnvUnowned,
     _class: jni::objects::JClass,
     key: jni::sys::jlong,
     text: jni::objects::JString,
@@ -248,37 +250,39 @@ pub extern "C" fn Java_com_perry_app_PerryBridge_nativeInvokeDropCallback(
         return;
     }
 
-    // Read the optional `text` representation.
-    let text_str: Option<String> = if text.is_null() {
-        None
-    } else {
-        env.get_string(&text).map(|s| s.into()).ok()
-    };
+    jni_bridge::with_unowned_env(&mut env, |env| {
+        // Read the optional `text` representation.
+        let text_str = if text.is_null() {
+            None
+        } else {
+            text.try_to_string(env).ok()
+        };
 
-    let files_vec = read_string_array(&mut env, &files);
-    let urls_vec = read_string_array(&mut env, &urls);
+        let files_vec = read_string_array(env, &files);
+        let urls_vec = read_string_array(env, &urls);
 
-    unsafe {
-        // Up to three fields: text, files, urls.
-        let obj = js_object_alloc(0, 3);
-        if obj.is_null() {
-            return;
+        unsafe {
+            // Up to three fields: text, files, urls.
+            let obj = js_object_alloc(0, 3);
+            if obj.is_null() {
+                return;
+            }
+            if let Some(t) = text_str {
+                js_object_set_field_by_name(obj, js_key(b"text"), nanbox_str(&t));
+            }
+            if !files_vec.is_empty() {
+                let arr = build_string_array(&files_vec);
+                js_object_set_field_by_name(obj, js_key(b"files"), js_nanbox_pointer(arr as i64));
+            }
+            if !urls_vec.is_empty() {
+                let arr = build_string_array(&urls_vec);
+                js_object_set_field_by_name(obj, js_key(b"urls"), js_nanbox_pointer(arr as i64));
+            }
+            let payload = js_nanbox_pointer(obj as i64);
+            js_closure_call1(closure_ptr, payload);
         }
-        if let Some(t) = text_str {
-            js_object_set_field_by_name(obj, js_key(b"text"), nanbox_str(&t));
-        }
-        if !files_vec.is_empty() {
-            let arr = build_string_array(&files_vec);
-            js_object_set_field_by_name(obj, js_key(b"files"), js_nanbox_pointer(arr as i64));
-        }
-        if !urls_vec.is_empty() {
-            let arr = build_string_array(&urls_vec);
-            js_object_set_field_by_name(obj, js_key(b"urls"), js_nanbox_pointer(arr as i64));
-        }
-        let payload = js_nanbox_pointer(obj as i64);
-        js_closure_call1(closure_ptr, payload);
-    }
-    pump_microtasks();
+        pump_microtasks();
+    });
 }
 
 /// Called from `PerryBridge` when a drag is starting, once per registered
@@ -289,13 +293,13 @@ pub extern "C" fn Java_com_perry_app_PerryBridge_nativeInvokeDropCallback(
 /// thread, so it pumps microtasks afterwards.
 #[no_mangle]
 pub extern "C" fn Java_com_perry_app_PerryBridge_nativeInvokeDragProvider<'local>(
-    env: jni::JNIEnv<'local>,
+    mut env: jni::EnvUnowned<'local>,
     _class: jni::objects::JClass<'local>,
     key: jni::sys::jlong,
 ) -> jni::objects::JString<'local> {
     let payload = drag_provider_payload(key as i64).unwrap_or_default();
     pump_microtasks();
-    env.new_string(payload).unwrap_or_default()
+    jni_bridge::with_unowned_env(&mut env, |env| env.new_string(payload).unwrap_or_default())
 }
 
 /// Invoke the provider closure registered under `key` and convert its return
@@ -316,7 +320,7 @@ fn drag_provider_payload(key: i64) -> Option<String> {
         if sh.is_null() {
             None
         } else {
-            Some(unsafe { str_from_header(sh) }.to_string())
+            Some(str_from_header(sh).to_string())
         }
     }
 }
@@ -324,19 +328,21 @@ fn drag_provider_payload(key: i64) -> Option<String> {
 // --- helpers -----------------------------------------------------------------
 
 /// Read a `String[]` JNI array into a `Vec<String>`, skipping null elements.
-fn read_string_array(env: &mut jni::JNIEnv, arr: &jni::objects::JObjectArray) -> Vec<String> {
+fn read_string_array(env: &mut jni::Env, arr: &jni::objects::JObjectArray) -> Vec<String> {
     let mut out = Vec::new();
     if arr.is_null() {
         return out;
     }
-    if let Ok(len) = env.get_array_length(arr) {
+    if let Ok(len) = arr.len(env) {
         for i in 0..len {
-            if let Ok(item) = env.get_object_array_element(arr, i) {
+            if let Ok(item) = arr.get_element(env, i) {
                 if item.is_null() {
                     continue;
                 }
-                let jstr: jni::objects::JString = item.into();
-                let s: Result<String, _> = env.get_string(&jstr).map(Into::into);
+                // The Java declaration is `String[]`; this is the same
+                // zero-call wrapper conversion used by jni 0.21.
+                let jstr = unsafe { jni::objects::JString::from_raw(env, item.into_raw()) };
+                let s = jstr.try_to_string(env);
                 if let Ok(s) = s {
                     out.push(s);
                 }

--- a/crates/perry-ui-android/src/fetch.rs
+++ b/crates/perry-ui-android/src/fetch.rs
@@ -3,7 +3,7 @@
 //! NetworkOnMainThreadException.
 
 use crate::jni_bridge;
-use jni::objects::JValue;
+use jni::JValue;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Mutex;
@@ -51,30 +51,30 @@ fn do_fetch(
     body: &str,
     headers_json: &str,
 ) -> Result<FetchResponse, String> {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
 
-    let jurl = env
-        .new_string(url)
-        .map_err(|e| format!("url string: {e}"))?;
-    let jmethod = env
-        .new_string(method)
-        .map_err(|e| format!("method string: {e}"))?;
-    let jbody = env
-        .new_string(body)
-        .map_err(|e| format!("body string: {e}"))?;
-    let jheaders = env
-        .new_string(headers_json)
-        .map_err(|e| format!("headers string: {e}"))?;
+        let jurl = env
+            .new_string(url)
+            .map_err(|e| format!("url string: {e}"))?;
+        let jmethod = env
+            .new_string(method)
+            .map_err(|e| format!("method string: {e}"))?;
+        let jbody = env
+            .new_string(body)
+            .map_err(|e| format!("body string: {e}"))?;
+        let jheaders = env
+            .new_string(headers_json)
+            .map_err(|e| format!("headers string: {e}"))?;
 
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
 
-    let result = env.call_static_method(
+        let result = env.call_static_method(
         bridge_cls,
-        "performFetchSync",
-        "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;",
+        jni::jni_str!("performFetchSync"),
+        jni::jni_sig!("(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;"),
         &[
             JValue::Object(&jurl),
             JValue::Object(&jmethod),
@@ -83,39 +83,40 @@ fn do_fetch(
         ],
     );
 
-    let result_obj = match result {
-        Ok(v) => v.l().map_err(|e| format!("result object: {e}"))?,
-        Err(e) => {
-            // Clear any pending JNI exception
-            if env.exception_check().unwrap_or(false) {
-                let _ = env.exception_clear();
+        let result_obj = match result {
+            Ok(v) => v.l().map_err(|e| format!("result object: {e}"))?,
+            Err(e) => {
+                // Clear any pending JNI exception
+                if env.exception_check() {
+                    let _ = env.exception_clear();
+                }
+                unsafe {
+                    let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+                }
+                return Err(format!("JNI call failed: {e}"));
             }
-            unsafe {
-                env.pop_local_frame(&jni::objects::JObject::null());
-            }
-            return Err(format!("JNI call failed: {e}"));
+        };
+
+        // Parse result: "STATUS_CODE\nSTATUS_TEXT\nBODY"
+        // `performFetch` is declared to return String; retype the owned local
+        // without adding an IsInstanceOf call.
+        let result_jstr = unsafe { jni::objects::JString::from_raw(env, result_obj.into_raw()) };
+        let result_str = result_jstr.try_to_string(env).unwrap_or_default();
+
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
         }
-    };
 
-    // Parse result: "STATUS_CODE\nSTATUS_TEXT\nBODY"
-    let result_str: String = env
-        .get_string((&result_obj).into())
-        .map(|s| s.into())
-        .unwrap_or_default();
+        let mut lines = result_str.splitn(3, '\n');
+        let status: u16 = lines.next().unwrap_or("0").parse().unwrap_or(0);
+        let status_text = lines.next().unwrap_or("").to_string();
+        let body = lines.next().unwrap_or("").as_bytes().to_vec();
 
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
-
-    let mut lines = result_str.splitn(3, '\n');
-    let status: u16 = lines.next().unwrap_or("0").parse().unwrap_or(0);
-    let status_text = lines.next().unwrap_or("").to_string();
-    let body = lines.next().unwrap_or("").as_bytes().to_vec();
-
-    Ok(FetchResponse {
-        status,
-        status_text,
-        body,
+        Ok(FetchResponse {
+            status,
+            status_text,
+            body,
+        })
     })
 }
 

--- a/crates/perry-ui-android/src/ffi/embed_misc.rs
+++ b/crates/perry-ui-android/src/ffi/embed_misc.rs
@@ -29,23 +29,24 @@ pub extern "C" fn perry_ui_embed_nsview(view_ptr: i64) -> i64 {
     }
     // On Android, the native view pointer is a raw JNI object pointer.
     // Convert it to a GlobalRef and register as a widget.
-    let env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
-    let obj = unsafe { jni::objects::JObject::from_raw(view_ptr as jni::sys::jobject) };
-    let global = match env.new_global_ref(obj) {
-        Ok(g) => g,
-        Err(_) => {
-            unsafe {
-                env.pop_local_frame(&jni::objects::JObject::null());
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
+        let obj = unsafe { jni::objects::JObject::from_raw(env, view_ptr as jni::sys::jobject) };
+        let global = match jni_bridge::new_global_ref(env, obj) {
+            Ok(g) => g,
+            Err(_) => {
+                unsafe {
+                    let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+                }
+                return 0;
             }
-            return 0;
+        };
+        let handle = widgets::register_widget(global);
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
         }
-    };
-    let handle = widgets::register_widget(global);
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
-    handle
+        handle
+    })
 }
 
 // =============================================================================
@@ -63,63 +64,76 @@ pub extern "C" fn perry_ui_frame_split_add_child(_parent: i64, _child: i64) {}
 /// Query display metrics from the Android system.
 /// Returns (widthDp, heightDp, density).
 fn query_display_metrics() -> (f64, f64, f64) {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(16);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 16);
 
-    // Get Application context: ActivityThread.currentApplication()
-    let result = (|| -> Option<(f64, f64, f64)> {
-        let app = env
-            .call_static_method(
-                "android/app/ActivityThread",
-                "currentApplication",
-                "()Landroid/app/Application;",
-                &[],
-            )
-            .ok()?
-            .l()
-            .ok()?;
-        if app.is_null() {
-            return None;
+        // Get Application context: ActivityThread.currentApplication()
+        let result = (|| -> Option<(f64, f64, f64)> {
+            let app = env
+                .call_static_method(
+                    jni::jni_str!("android/app/ActivityThread"),
+                    jni::jni_str!("currentApplication"),
+                    jni::jni_sig!("()Landroid/app/Application;"),
+                    &[],
+                )
+                .ok()?
+                .l()
+                .ok()?;
+            if app.is_null() {
+                return None;
+            }
+
+            // Get Resources
+            let res = env
+                .call_method(
+                    &app,
+                    jni::jni_str!("getResources"),
+                    jni::jni_sig!("()Landroid/content/res/Resources;"),
+                    &[],
+                )
+                .ok()?
+                .l()
+                .ok()?;
+            // Get DisplayMetrics
+            let dm = env
+                .call_method(
+                    &res,
+                    jni::jni_str!("getDisplayMetrics"),
+                    jni::jni_sig!("()Landroid/util/DisplayMetrics;"),
+                    &[],
+                )
+                .ok()?
+                .l()
+                .ok()?;
+
+            let width_px = env
+                .get_field(&dm, jni::jni_str!("widthPixels"), jni::jni_sig!("I"))
+                .ok()?
+                .i()
+                .ok()? as f64;
+            let height_px = env
+                .get_field(&dm, jni::jni_str!("heightPixels"), jni::jni_sig!("I"))
+                .ok()?
+                .i()
+                .ok()? as f64;
+            let density = env
+                .get_field(&dm, jni::jni_str!("density"), jni::jni_sig!("F"))
+                .ok()?
+                .f()
+                .ok()? as f64;
+
+            if density > 0.0 {
+                Some((width_px / density, height_px / density, density))
+            } else {
+                None
+            }
+        })();
+
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
         }
-
-        // Get Resources
-        let res = env
-            .call_method(
-                &app,
-                "getResources",
-                "()Landroid/content/res/Resources;",
-                &[],
-            )
-            .ok()?
-            .l()
-            .ok()?;
-        // Get DisplayMetrics
-        let dm = env
-            .call_method(
-                &res,
-                "getDisplayMetrics",
-                "()Landroid/util/DisplayMetrics;",
-                &[],
-            )
-            .ok()?
-            .l()
-            .ok()?;
-
-        let width_px = env.get_field(&dm, "widthPixels", "I").ok()?.i().ok()? as f64;
-        let height_px = env.get_field(&dm, "heightPixels", "I").ok()?.i().ok()? as f64;
-        let density = env.get_field(&dm, "density", "F").ok()?.f().ok()? as f64;
-
-        if density > 0.0 {
-            Some((width_px / density, height_px / density, density))
-        } else {
-            None
-        }
-    })();
-
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
-    result.unwrap_or((412.0, 915.0, 2.625))
+        result.unwrap_or((412.0, 915.0, 2.625))
+    })
 }
 
 #[no_mangle]
@@ -258,55 +272,68 @@ extern "C" {
 }
 
 fn get_app_files_dir_string() -> f64 {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(16);
-    let result = (|| -> Option<f64> {
-        let activity = env
-            .call_static_method(
-                "com/perry/app/PerryBridge",
-                "getActivity",
-                "()Landroid/app/Activity;",
-                &[],
-            )
-            .ok()?
-            .l()
-            .ok()?;
-        if activity.is_null() {
-            return None;
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 16);
+        let result = (|| -> Option<f64> {
+            let activity = env
+                .call_static_method(
+                    jni::jni_str!("com/perry/app/PerryBridge"),
+                    jni::jni_str!("getActivity"),
+                    jni::jni_sig!("()Landroid/app/Activity;"),
+                    &[],
+                )
+                .ok()?
+                .l()
+                .ok()?;
+            if activity.is_null() {
+                return None;
+            }
+            let files_dir = env
+                .call_method(
+                    &activity,
+                    jni::jni_str!("getFilesDir"),
+                    jni::jni_sig!("()Ljava/io/File;"),
+                    &[],
+                )
+                .ok()?
+                .l()
+                .ok()?;
+            if files_dir.is_null() {
+                return None;
+            }
+            let abs_path = env
+                .call_method(
+                    &files_dir,
+                    jni::jni_str!("getAbsolutePath"),
+                    jni::jni_sig!("()Ljava/lang/String;"),
+                    &[],
+                )
+                .ok()?
+                .l()
+                .ok()?;
+            let abs_path = unsafe { jni::objects::JString::from_raw(env, abs_path.into_raw()) };
+            let rust_str = abs_path.try_to_string(env).ok()?;
+            let bytes = rust_str.as_bytes();
+            if bytes.is_empty() {
+                return None;
+            }
+            // Append /workspace to the files dir
+            let mut path = String::from_utf8_lossy(bytes).to_string();
+            path.push_str("/workspace");
+            crate::log_debug(&format!("get_app_files_dir: path={}", path));
+            let path_bytes = path.as_bytes();
+            let str_ptr =
+                unsafe { js_string_from_bytes(path_bytes.as_ptr(), path_bytes.len() as i64) };
+            // NaN-box the string pointer so Perry can use it as a string value
+            let nanboxed = unsafe { js_nanbox_string(str_ptr) };
+            Some(nanboxed)
+        })();
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
         }
-        let files_dir = env
-            .call_method(&activity, "getFilesDir", "()Ljava/io/File;", &[])
-            .ok()?
-            .l()
-            .ok()?;
-        if files_dir.is_null() {
-            return None;
-        }
-        let abs_path = env
-            .call_method(&files_dir, "getAbsolutePath", "()Ljava/lang/String;", &[])
-            .ok()?
-            .l()
-            .ok()?;
-        let rust_str = env.get_string((&abs_path).into()).ok()?;
-        let bytes = rust_str.to_str().unwrap_or("").as_bytes();
-        if bytes.is_empty() {
-            return None;
-        }
-        // Append /workspace to the files dir
-        let mut path = String::from_utf8_lossy(bytes).to_string();
-        path.push_str("/workspace");
-        crate::log_debug(&format!("get_app_files_dir: path={}", path));
-        let path_bytes = path.as_bytes();
-        let str_ptr = unsafe { js_string_from_bytes(path_bytes.as_ptr(), path_bytes.len() as i64) };
-        // NaN-box the string pointer so Perry can use it as a string value
-        let nanboxed = unsafe { js_nanbox_string(str_ptr) };
-        Some(nanboxed)
-    })();
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
-    // Return empty string NaN-boxed (not 0, which is integer 0)
-    result.unwrap_or_else(|| unsafe { js_nanbox_string(std::ptr::null()) })
+        // Return empty string NaN-boxed (not 0, which is integer 0)
+        result.unwrap_or_else(|| unsafe { js_nanbox_string(std::ptr::null()) })
+    })
 }
 
 #[no_mangle]

--- a/crates/perry-ui-android/src/ffi/system_api.rs
+++ b/crates/perry-ui-android/src/ffi/system_api.rs
@@ -302,27 +302,41 @@ pub extern "C" fn perry_background_cancel(identifier_ptr: i64) {
 
 #[no_mangle]
 pub extern "C" fn perry_system_get_locale() -> i64 {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
-    let locale_class = env.find_class("java/util/Locale").expect("Locale class");
-    let default_locale = env
-        .call_static_method(locale_class, "getDefault", "()Ljava/util/Locale;", &[])
-        .expect("getDefault")
-        .l()
-        .expect("locale obj");
-    let lang = env
-        .call_method(&default_locale, "getLanguage", "()Ljava/lang/String;", &[])
-        .expect("getLanguage")
-        .l()
-        .expect("lang string");
-    let jstr: jni::objects::JString = lang.into();
-    let s: String = env.get_string(&jstr).expect("get string").into();
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
-    let bytes = s.as_bytes();
-    extern "C" {
-        fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
-    }
-    unsafe { js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64) as i64 }
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
+        let locale_class = env
+            .find_class(jni::jni_str!("java/util/Locale"))
+            .expect("Locale class");
+        let default_locale = env
+            .call_static_method(
+                locale_class,
+                jni::jni_str!("getDefault"),
+                jni::jni_sig!("()Ljava/util/Locale;"),
+                &[],
+            )
+            .expect("getDefault")
+            .l()
+            .expect("locale obj");
+        let lang = env
+            .call_method(
+                &default_locale,
+                jni::jni_str!("getLanguage"),
+                jni::jni_sig!("()Ljava/lang/String;"),
+                &[],
+            )
+            .expect("getLanguage")
+            .l()
+            .expect("lang string");
+        let jstr: jni::objects::JString =
+            unsafe { jni::objects::JString::from_raw(env, lang.into_raw()) };
+        let s: String = jstr.try_to_string(env).expect("get string").into();
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+        let bytes = s.as_bytes();
+        extern "C" {
+            fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
+        }
+        unsafe { js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64) as i64 }
+    })
 }

--- a/crates/perry-ui-android/src/ffi/tabbar_layout.rs
+++ b/crates/perry-ui-android/src/ffi/tabbar_layout.rs
@@ -160,43 +160,51 @@ pub extern "C" fn perry_ui_stack_set_distribution(handle: i64, distribution: f64
     if distribution as i64 == 1 {
         // FillEqually: set all children to weight=1
         if let Some(view_ref) = widgets::get_widget(handle) {
-            let mut env = jni_bridge::get_env();
-            let _ = env.push_local_frame(32);
-            let child_count = env
-                .call_method(view_ref.as_obj(), "getChildCount", "()I", &[])
-                .map(|v| v.i().unwrap_or(0))
-                .unwrap_or(0);
-            for i in 0..child_count {
-                let child = env.call_method(
-                    view_ref.as_obj(),
-                    "getChildAt",
-                    "(I)Landroid/view/View;",
-                    &[jni::objects::JValue::Int(i)],
-                );
-                if let Ok(child_val) = child {
-                    if let Ok(child_obj) = child_val.l() {
-                        if !child_obj.is_null() {
-                            if let Ok(lp) = env.call_method(
-                                &child_obj,
-                                "getLayoutParams",
-                                "()Landroid/view/ViewGroup$LayoutParams;",
-                                &[],
-                            ) {
-                                if let Ok(lp_obj) = lp.l() {
-                                    if !lp_obj.is_null() {
-                                        if env
-                                            .is_instance_of(
-                                                &lp_obj,
-                                                "android/widget/LinearLayout$LayoutParams",
-                                            )
-                                            .unwrap_or(false)
-                                        {
-                                            let _ = env.set_field(
-                                                &lp_obj,
-                                                "weight",
-                                                "F",
-                                                jni::objects::JValue::Float(1.0),
-                                            );
+            jni_bridge::with_env(|env| {
+                let _ = jni_bridge::push_local_frame(env, 32);
+                let child_count = env
+                    .call_method(
+                        view_ref.as_obj(),
+                        jni::jni_str!("getChildCount"),
+                        jni::jni_sig!("()I"),
+                        &[],
+                    )
+                    .map(|v| v.i().unwrap_or(0))
+                    .unwrap_or(0);
+                for i in 0..child_count {
+                    let child = env.call_method(
+                        view_ref.as_obj(),
+                        jni::jni_str!("getChildAt"),
+                        jni::jni_sig!("(I)Landroid/view/View;"),
+                        &[jni::JValue::Int(i)],
+                    );
+                    if let Ok(child_val) = child {
+                        if let Ok(child_obj) = child_val.l() {
+                            if !child_obj.is_null() {
+                                if let Ok(lp) = env.call_method(
+                                    &child_obj,
+                                    jni::jni_str!("getLayoutParams"),
+                                    jni::jni_sig!("()Landroid/view/ViewGroup$LayoutParams;"),
+                                    &[],
+                                ) {
+                                    if let Ok(lp_obj) = lp.l() {
+                                        if !lp_obj.is_null() {
+                                            if env
+                                                .is_instance_of(
+                                                    &lp_obj,
+                                                    jni::jni_str!(
+                                                        "android/widget/LinearLayout$LayoutParams"
+                                                    ),
+                                                )
+                                                .unwrap_or(false)
+                                            {
+                                                let _ = env.set_field(
+                                                    &lp_obj,
+                                                    jni::jni_str!("weight"),
+                                                    jni::jni_sig!("F"),
+                                                    jni::JValue::Float(1.0),
+                                                );
+                                            }
                                         }
                                     }
                                 }
@@ -204,10 +212,10 @@ pub extern "C" fn perry_ui_stack_set_distribution(handle: i64, distribution: f64
                         }
                     }
                 }
-            }
-            unsafe {
-                env.pop_local_frame(&jni::objects::JObject::null());
-            }
+                unsafe {
+                    let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+                }
+            })
         }
     }
 }
@@ -221,47 +229,53 @@ pub extern "C" fn perry_ui_stack_set_alignment(handle: i64, alignment: f64) {
     // Fill (0) means children stretch to fill the cross-axis — we don't set gravity
     // so that MATCH_PARENT on children takes effect.
     if let Some(view_ref) = widgets::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
 
-        // Determine orientation: 0=HORIZONTAL (HStack), 1=VERTICAL (VStack)
-        let orientation = env
-            .call_method(view_ref.as_obj(), "getOrientation", "()I", &[])
-            .map(|v| v.i().unwrap_or(0))
-            .unwrap_or(0);
+            // Determine orientation: 0=HORIZONTAL (HStack), 1=VERTICAL (VStack)
+            let orientation = env
+                .call_method(
+                    view_ref.as_obj(),
+                    jni::jni_str!("getOrientation"),
+                    jni::jni_sig!("()I"),
+                    &[],
+                )
+                .map(|v| v.i().unwrap_or(0))
+                .unwrap_or(0);
 
-        let align = alignment as i64;
-        let gravity = if orientation == 0 {
-            // HStack: cross-axis is vertical
-            match align {
-                0 => -1, // Fill — no gravity override (let children use MATCH_PARENT height)
-                1 => 48, // Leading → TOP
-                3 => 16, // Center → CENTER_VERTICAL
-                4 => 80, // Trailing → BOTTOM
-                _ => -1,
+            let align = alignment as i64;
+            let gravity = if orientation == 0 {
+                // HStack: cross-axis is vertical
+                match align {
+                    0 => -1, // Fill — no gravity override (let children use MATCH_PARENT height)
+                    1 => 48, // Leading → TOP
+                    3 => 16, // Center → CENTER_VERTICAL
+                    4 => 80, // Trailing → BOTTOM
+                    _ => -1,
+                }
+            } else {
+                // VStack: cross-axis is horizontal
+                match align {
+                    0 => -1, // Fill — no gravity override
+                    1 => 3,  // Leading → LEFT
+                    3 => 1,  // Center → CENTER_HORIZONTAL
+                    4 => 5,  // Trailing → RIGHT
+                    _ => -1,
+                }
+            };
+
+            if gravity >= 0 {
+                let _ = env.call_method(
+                    view_ref.as_obj(),
+                    jni::jni_str!("setGravity"),
+                    jni::jni_sig!("(I)V"),
+                    &[jni::JValue::Int(gravity)],
+                );
             }
-        } else {
-            // VStack: cross-axis is horizontal
-            match align {
-                0 => -1, // Fill — no gravity override
-                1 => 3,  // Leading → LEFT
-                3 => 1,  // Center → CENTER_HORIZONTAL
-                4 => 5,  // Trailing → RIGHT
-                _ => -1,
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
             }
-        };
-
-        if gravity >= 0 {
-            let _ = env.call_method(
-                view_ref.as_obj(),
-                "setGravity",
-                "(I)V",
-                &[jni::objects::JValue::Int(gravity)],
-            );
-        }
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+        })
     }
 }
 

--- a/crates/perry-ui-android/src/file_dialog.rs
+++ b/crates/perry-ui-android/src/file_dialog.rs
@@ -1,6 +1,6 @@
 use crate::callback;
 use crate::jni_bridge;
-use jni::objects::JValue;
+use jni::JValue;
 
 extern "C" {
     fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
@@ -13,43 +13,42 @@ extern "C" {
 /// or TAG_UNDEFINED if the user cancelled.
 pub fn open_dialog(cb: f64) {
     let cb_key = callback::register(cb);
-    let mut env = jni_bridge::get_env();
-
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let _ = env.call_static_method(
-        bridge_cls,
-        "openFileDialog",
-        "(J)V",
-        &[JValue::Long(cb_key)],
-    );
+    jni_bridge::with_env(|env| {
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("openFileDialog"),
+            jni::jni_sig!("(J)V"),
+            &[JValue::Long(cb_key)],
+        );
+    })
 }
 
 /// JNI entry point: called from Java when a file is selected.
 /// Receives the file content as a Java String (or null if cancelled).
 #[no_mangle]
 pub extern "C" fn Java_com_perry_app_PerryBridge_nativeFileDialogResult(
-    mut env: jni::JNIEnv,
+    mut env: jni::EnvUnowned,
     _class: jni::objects::JClass,
     key: jni::sys::jlong,
     content: jni::objects::JString,
 ) {
-    let arg = if content.is_null() {
-        // User cancelled — return TAG_UNDEFINED
-        f64::from_bits(0x7FFC_0000_0000_0001)
-    } else {
-        // Convert Java String to NaN-boxed Perry string
-        let rust_str: String = env
-            .get_string(&content)
-            .map(|s| s.into())
-            .unwrap_or_default();
-        let bytes = rust_str.as_bytes();
-        unsafe {
-            let str_ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
-            js_nanbox_string(str_ptr as i64)
-        }
-    };
+    jni_bridge::with_unowned_env(&mut env, |env| {
+        let arg = if content.is_null() {
+            // User cancelled — return TAG_UNDEFINED
+            f64::from_bits(0x7FFC_0000_0000_0001)
+        } else {
+            // Convert Java String to NaN-boxed Perry string
+            let rust_str = content.try_to_string(env).unwrap_or_default();
+            let bytes = rust_str.as_bytes();
+            unsafe {
+                let str_ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+                js_nanbox_string(str_ptr as i64)
+            }
+        };
 
-    callback::invoke1(key as i64, arg);
+        callback::invoke1(key as i64, arg);
+    });
 }

--- a/crates/perry-ui-android/src/geolocation.rs
+++ b/crates/perry-ui-android/src/geolocation.rs
@@ -7,7 +7,7 @@
 
 use crate::callback;
 use crate::jni_bridge;
-use jni::objects::JValue;
+use jni::JValue;
 
 /// Resolve the device's current position. `success_cb` receives
 /// (lat, lng, accuracy, timestamp_ms); `error_cb` receives a single
@@ -16,22 +16,23 @@ pub fn get_current(success_cb: f64, error_cb: f64) {
     let success_key = callback::register(success_cb);
     let error_key = callback::register(error_cb);
 
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(16);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 16);
 
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let _ = env.call_static_method(
-        bridge_cls,
-        "requestGeolocationGetCurrent",
-        "(JJ)V",
-        &[JValue::Long(success_key), JValue::Long(error_key)],
-    );
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("requestGeolocationGetCurrent"),
+            jni::jni_sig!("(JJ)V"),
+            &[JValue::Long(success_key), JValue::Long(error_key)],
+        );
 
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }
 
 /// Subscribe to position updates. Returns a numeric watch id; the Kotlin
@@ -40,47 +41,49 @@ pub fn get_current(success_cb: f64, error_cb: f64) {
 pub fn watch(callback_f64: f64) -> f64 {
     let key = callback::register(callback_f64);
 
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(16);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 16);
 
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let id: i64 = match env.call_static_method(
-        bridge_cls,
-        "requestGeolocationWatch",
-        "(J)J",
-        &[JValue::Long(key)],
-    ) {
-        Ok(v) => v.j().unwrap_or(0),
-        Err(_) => 0,
-    };
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let id: i64 = match env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("requestGeolocationWatch"),
+            jni::jni_sig!("(J)J"),
+            &[JValue::Long(key)],
+        ) {
+            Ok(v) => v.j().unwrap_or(0),
+            Err(_) => 0,
+        };
 
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
 
-    id as f64
+        id as f64
+    })
 }
 
 pub fn stop_watch(id: f64) {
     let id_long = id as i64;
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
 
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let _ = env.call_static_method(
-        bridge_cls,
-        "stopGeolocationWatch",
-        "(J)V",
-        &[JValue::Long(id_long)],
-    );
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("stopGeolocationWatch"),
+            jni::jni_sig!("(J)V"),
+            &[JValue::Long(id_long)],
+        );
 
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }
 
 /// Request location permission. Callback receives the status string
@@ -88,20 +91,21 @@ pub fn stop_watch(id: f64) {
 pub fn request_permission(callback_f64: f64) {
     let key = callback::register(callback_f64);
 
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
 
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let _ = env.call_static_method(
-        bridge_cls,
-        "requestGeolocationPermission",
-        "(J)V",
-        &[JValue::Long(key)],
-    );
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("requestGeolocationPermission"),
+            jni::jni_sig!("(J)V"),
+            &[JValue::Long(key)],
+        );
 
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }

--- a/crates/perry-ui-android/src/image_picker.rs
+++ b/crates/perry-ui-android/src/image_picker.rs
@@ -7,7 +7,7 @@
 
 use crate::callback;
 use crate::jni_bridge;
-use jni::objects::JValue;
+use jni::JValue;
 
 pub fn pick(max_count: f64, allow_multiple: f64, callback_f64: f64) {
     let key = callback::register(callback_f64);
@@ -26,24 +26,25 @@ pub fn pick(max_count: f64, allow_multiple: f64, callback_f64: f64) {
             && allow_multiple != 0.0
             && !allow_multiple.is_nan());
 
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(16);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 16);
 
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let _ = env.call_static_method(
-        bridge_cls,
-        "requestImagePickerPick",
-        "(IZJ)V",
-        &[
-            JValue::Int(max),
-            JValue::Bool(if allow_multi { 1 } else { 0 }),
-            JValue::Long(key),
-        ],
-    );
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("requestImagePickerPick"),
+            jni::jni_sig!("(IZJ)V"),
+            &[
+                JValue::Int(max),
+                JValue::Bool(allow_multi),
+                JValue::Long(key),
+            ],
+        );
 
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }

--- a/crates/perry-ui-android/src/jni_bridge.rs
+++ b/crates/perry-ui-android/src/jni_bridge.rs
@@ -1,7 +1,20 @@
-use jni::objects::{GlobalRef, JClass, JMethodID};
-use jni::{JNIEnv, JavaVM};
+use jni::ids::JMethodID;
+use jni::objects::{JClass, JObject};
+use jni::refs::{Global, Reference};
+use jni::signature::RuntimeMethodSignature;
+use jni::strings::JNIString;
+use jni::{AttachConfig, AttachmentExceptionPolicy, Env, EnvUnowned, JavaVM};
 use std::cell::RefCell;
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
+
+/// A shared, type-erased global object reference.
+///
+/// `jni` 0.21's `GlobalRef` used an internal `Arc`, so cloning it shared one
+/// JNI global reference. `jni` 0.22's `Global<T>` is no longer cloneable; the
+/// outer `Arc` retains the previous ownership and deletion semantics.
+pub type GlobalRef = Arc<Global<JObject<'static>>>;
+
+type ClassGlobal = Global<JClass<'static>>;
 
 /// The global JavaVM reference, set once during JNI_OnLoad.
 static JAVA_VM: OnceLock<JavaVM> = OnceLock::new();
@@ -10,27 +23,27 @@ static JAVA_VM: OnceLock<JavaVM> = OnceLock::new();
 /// These are populated lazily on first use per thread.
 pub struct JniCache {
     // --- Classes ---
-    pub text_view_class: GlobalRef,
-    pub button_class: GlobalRef,
-    pub linear_layout_class: GlobalRef,
-    pub scroll_view_class: GlobalRef,
-    pub edit_text_class: GlobalRef,
-    pub switch_class: GlobalRef,
-    pub seek_bar_class: GlobalRef,
-    pub space_class: GlobalRef,
-    pub view_class: GlobalRef,
-    pub color_class: GlobalRef,
-    pub typeface_class: GlobalRef,
-    pub popup_menu_class: GlobalRef,
-    pub clipboard_manager_class: GlobalRef,
-    pub context_class: GlobalRef,
-    pub frame_layout_class: GlobalRef,
-    pub view_group_class: GlobalRef,
-    pub view_group_layout_params_class: GlobalRef,
-    pub linear_layout_params_class: GlobalRef,
-    pub frame_layout_params_class: GlobalRef,
-    pub text_watcher_class: GlobalRef,
-    pub perry_bridge_class: GlobalRef,
+    pub text_view_class: ClassGlobal,
+    pub button_class: ClassGlobal,
+    pub linear_layout_class: ClassGlobal,
+    pub scroll_view_class: ClassGlobal,
+    pub edit_text_class: ClassGlobal,
+    pub switch_class: ClassGlobal,
+    pub seek_bar_class: ClassGlobal,
+    pub space_class: ClassGlobal,
+    pub view_class: ClassGlobal,
+    pub color_class: ClassGlobal,
+    pub typeface_class: ClassGlobal,
+    pub popup_menu_class: ClassGlobal,
+    pub clipboard_manager_class: ClassGlobal,
+    pub context_class: ClassGlobal,
+    pub frame_layout_class: ClassGlobal,
+    pub view_group_class: ClassGlobal,
+    pub view_group_layout_params_class: ClassGlobal,
+    pub linear_layout_params_class: ClassGlobal,
+    pub frame_layout_params_class: ClassGlobal,
+    pub text_watcher_class: ClassGlobal,
+    pub perry_bridge_class: ClassGlobal,
 
     // --- Constructor IDs ---
     pub text_view_init: JMethodID,
@@ -121,7 +134,7 @@ pub fn init_vm(vm: JavaVM) {
     let _ = JAVA_VM.set(vm);
 }
 
-/// Ensure the global JavaVM is cached, deriving it from a live `JNIEnv` when
+/// Ensure the global JavaVM is cached, deriving it from a live `Env` when
 /// Perry's own `JNI_OnLoad` never ran.
 ///
 /// This happens when the final `.so` also links a native library that defines
@@ -133,7 +146,7 @@ pub fn init_vm(vm: JavaVM) {
 /// `RegisterNatives`, so they still resolve regardless. But the JavaVM cache
 /// that `JNI_OnLoad` would have populated gets skipped. Calling this from
 /// `nativeInit` (which always runs, on a thread with a valid env) recovers it.
-pub fn ensure_vm(env: &JNIEnv) {
+pub fn ensure_vm(env: &Env) {
     if JAVA_VM.get().is_some() {
         return;
     }
@@ -142,17 +155,91 @@ pub fn ensure_vm(env: &JNIEnv) {
     }
 }
 
-/// Get a JNIEnv for the current thread.
-pub fn get_env() -> JNIEnv<'static> {
+/// Run with the JNI environment for the current thread.
+///
+/// The 0.21 code permanently attached threads and returned a `JNIEnv` without
+/// pushing a local frame or changing pending-exception handling. Use the 0.22
+/// closure API with matching attachment settings so all existing explicit
+/// local-frame boundaries remain authoritative.
+pub fn with_env<R>(f: impl for<'local> FnOnce(&mut Env<'local>) -> R) -> R {
+    try_with_env(f).expect("Failed to attach JNI thread")
+}
+
+/// Fallible form of [`with_env`] for call sites that previously handled an
+/// attachment failure explicitly.
+pub fn try_with_env<R>(
+    f: impl for<'local> FnOnce(&mut Env<'local>) -> R,
+) -> jni::errors::Result<R> {
     let vm = JAVA_VM.get().expect("JavaVM not initialized");
-    // attach_current_thread_permanently is safe to call multiple times
-    vm.attach_current_thread_permanently()
-        .expect("Failed to attach JNI thread")
+    vm.attach_current_thread_with_config(
+        || AttachConfig::new().exceptions_policy(AttachmentExceptionPolicy::Ignore),
+        None,
+        |env| Ok::<R, jni::errors::Error>(f(env)),
+    )
+}
+
+/// Upgrade the FFI-safe environment passed to a native method without adding
+/// a frame, catching exceptions, or changing the previous panic behavior.
+pub fn with_unowned_env<'local, R>(
+    env: &mut EnvUnowned<'local>,
+    f: impl FnOnce(&mut Env<'local>) -> R,
+) -> R {
+    match env
+        .with_env_no_catch(|env| Ok::<R, jni::errors::Error>(f(env)))
+        .into_outcome()
+    {
+        jni::Outcome::Ok(value) => value,
+        // `with_env_no_catch` only forwards the closure's result, and the
+        // closure above cannot return `Err` or synthesize `Outcome::Panic`.
+        jni::Outcome::Err(error) => unreachable!("infallible JNI closure failed: {error}"),
+        jni::Outcome::Panic(payload) => std::panic::resume_unwind(payload),
+    }
 }
 
 /// Get the JavaVM.
 pub fn get_vm() -> &'static JavaVM {
     JAVA_VM.get().expect("JavaVM not initialized")
+}
+
+/// Create a shared, type-erased global reference with the same clone semantics
+/// as `jni` 0.21's `GlobalRef`.
+pub fn new_global_ref<'local, O>(env: &Env, obj: O) -> jni::errors::Result<GlobalRef>
+where
+    O: Reference + AsRef<JObject<'local>>,
+{
+    let obj: &JObject<'local> = obj.as_ref();
+    env.new_global_ref(obj).map(Arc::new)
+}
+
+/// Compatibility binding for the explicit frame management used throughout
+/// this crate. `jni` 0.22 made the direct methods private in favor of scoped
+/// closures, but changing the lexical scope of these frames would change which
+/// local references they release.
+pub fn push_local_frame(env: &Env, capacity: i32) -> jni::errors::Result<()> {
+    let raw = env.get_raw();
+    // SAFETY: `raw` belongs to the live `Env`, and `PushLocalFrame` is valid
+    // for every JNI version supported by jni-rs.
+    let result = unsafe { ((**raw).v1_2.PushLocalFrame)(raw, capacity) };
+    jni::errors::jni_error_code_to_result(result)
+}
+
+/// Pop the current explicit local frame, optionally promoting `result` into
+/// its parent frame.
+///
+/// # Safety
+///
+/// As with `jni` 0.21's `JNIEnv::pop_local_frame`, callers must not use any
+/// local reference allocated since the matching `push_local_frame` afterward.
+pub unsafe fn pop_local_frame<'local>(
+    env: &Env<'local>,
+    result: &JObject,
+) -> jni::errors::Result<JObject<'local>> {
+    let raw = env.get_raw();
+    // SAFETY: the caller guarantees frame pairing and reference validity; the
+    // returned reference is promoted into the frame represented by `env`.
+    let promoted = unsafe { ((**raw).v1_2.PopLocalFrame)(raw, result.as_raw()) };
+    // SAFETY: JNI returns either null or a valid local in the parent frame.
+    Ok(unsafe { JObject::from_raw(env, promoted) })
 }
 
 /// `extern "C"` accessor used by external `perry.nativeLibrary`
@@ -167,14 +254,14 @@ pub fn get_vm() -> &'static JavaVM {
 #[no_mangle]
 pub extern "C" fn perry_android_jvm() -> *mut jni::sys::JavaVM {
     match JAVA_VM.get() {
-        Some(vm) => vm.get_java_vm_pointer(),
+        Some(vm) => vm.get_raw(),
         None => std::ptr::null_mut(),
     }
 }
 
 /// Initialize the JNI class/method cache for the current thread.
-/// Must be called after JavaVM is set and from a thread with a valid JNIEnv.
-pub fn init_cache(env: &mut JNIEnv) {
+/// Must be called after JavaVM is set and from a thread with a valid Env.
+pub fn init_cache(env: &mut Env) {
     JNI_CACHE.with(|cache| {
         if cache.borrow().is_some() {
             return;
@@ -195,8 +282,7 @@ where
         // Lazy-init: build cache on first access per thread
         let needs_init = cache.borrow().is_none();
         if needs_init {
-            let mut env = get_env();
-            let c = build_cache(&mut env);
+            let c = with_env(build_cache);
             *cache.borrow_mut() = Some(c);
         }
         let borrow = cache.borrow();
@@ -205,25 +291,29 @@ where
     })
 }
 
-fn find_class(env: &mut JNIEnv, name: &str) -> GlobalRef {
+fn find_class(env: &mut Env, name: &str) -> ClassGlobal {
     let class = env
-        .find_class(name)
+        .find_class(JNIString::new(name))
         .unwrap_or_else(|_| panic!("Failed to find class: {}", name));
     env.new_global_ref(class)
         .unwrap_or_else(|_| panic!("Failed to create global ref for: {}", name))
 }
 
-fn get_method(env: &mut JNIEnv, class: &GlobalRef, name: &str, sig: &str) -> JMethodID {
-    let cls: &JClass = class.as_obj().into();
-    env.get_method_id(cls, name, sig)
+fn get_method(env: &mut Env, class: &ClassGlobal, name: &str, sig: &str) -> JMethodID {
+    let jni_name = JNIString::new(name);
+    let parsed_sig = RuntimeMethodSignature::from_str(sig)
+        .unwrap_or_else(|_| panic!("Invalid method signature: {sig}"));
+    env.get_method_id(class, jni_name, parsed_sig.method_signature())
         .unwrap_or_else(|_| panic!("Failed to find method: {}::{} {}", "<class>", name, sig))
 }
 
-fn get_static_method(env: &mut JNIEnv, class: &GlobalRef, name: &str, sig: &str) -> JMethodID {
-    let cls: &JClass = class.as_obj().into();
+fn get_static_method(env: &mut Env, class: &ClassGlobal, name: &str, sig: &str) -> JMethodID {
+    let jni_name = JNIString::new(name);
+    let parsed_sig = RuntimeMethodSignature::from_str(sig)
+        .unwrap_or_else(|_| panic!("Invalid method signature: {sig}"));
     // Static method IDs are the same type as instance method IDs in jni-rs
     let mid = env
-        .get_static_method_id(cls, name, sig)
+        .get_static_method_id(class, jni_name, parsed_sig.method_signature())
         .unwrap_or_else(|_| {
             panic!(
                 "Failed to find static method: {}::{} {}",
@@ -234,7 +324,7 @@ fn get_static_method(env: &mut JNIEnv, class: &GlobalRef, name: &str, sig: &str)
     unsafe { std::mem::transmute(mid) }
 }
 
-fn build_cache(env: &mut JNIEnv) -> JniCache {
+fn build_cache(env: &mut Env) -> JniCache {
     // Find all classes
     let text_view_class = find_class(env, "android/widget/TextView");
     let button_class = find_class(env, "android/widget/Button");

--- a/crates/perry-ui-android/src/keyboard.rs
+++ b/crates/perry-ui-android/src/keyboard.rs
@@ -35,7 +35,7 @@ pub fn current_modifiers() -> u32 {
 /// `repeat_count` ≥ 1 marks the OS auto-repeat case.
 #[no_mangle]
 pub extern "C" fn Java_com_perry_app_PerryBridge_nativeDispatchKey(
-    _env: jni::JNIEnv,
+    _env: jni::EnvUnowned,
     _class: jni::objects::JClass,
     key_code: jni::sys::jint,
     action: jni::sys::jint,

--- a/crates/perry-ui-android/src/lib.rs
+++ b/crates/perry-ui-android/src/lib.rs
@@ -1,4 +1,8 @@
 #![cfg(target_os = "android")]
+// The crate's pre-existing runtime symbol declarations use caller-specific
+// Rust representations for the same C ABI values. Normalizing that ABI is a
+// separate change from the JNI migration.
+#![allow(clashing_extern_declarations)]
 
 // Issue #552: force libperry_ui_android.a to bundle perry-ext-sharp's
 // `js_sharp_*` symbols (resize / jpeg / toBuffer / etc). Without this `extern
@@ -132,7 +136,12 @@ pub(crate) fn catch_panic_void(name: &str, f: impl FnOnce() + std::panic::Unwind
 
 /// Called by the JVM when the native library is loaded via System.loadLibrary().
 #[no_mangle]
-pub extern "C" fn JNI_OnLoad(vm: jni::JavaVM, _reserved: *mut std::ffi::c_void) -> jni::sys::jint {
+pub extern "C" fn JNI_OnLoad(
+    vm: *mut jni::sys::JavaVM,
+    _reserved: *mut std::ffi::c_void,
+) -> jni::sys::jint {
+    // SAFETY: the JVM invokes JNI_OnLoad with its live VM interface pointer.
+    let vm = unsafe { jni::JavaVM::from_raw(vm) };
     gc::ensure_registered();
     unsafe {
         __android_log_print(
@@ -176,7 +185,7 @@ pub extern "C" fn JNI_OnLoad(vm: jni::JavaVM, _reserved: *mut std::ffi::c_void) 
 /// Initializes the JNI cache on the calling thread.
 #[no_mangle]
 pub extern "C" fn Java_com_perry_app_PerryBridge_nativeInit(
-    mut env: jni::JNIEnv,
+    mut env: jni::EnvUnowned,
     _class: jni::objects::JClass,
 ) {
     gc::ensure_registered();
@@ -189,14 +198,16 @@ pub extern "C" fn Java_com_perry_app_PerryBridge_nativeInit(
     unsafe {
         mallopt(-204, 0);
     }
-    jni_bridge::ensure_vm(&env);
-    jni_bridge::init_cache(&mut env);
+    jni_bridge::with_unowned_env(&mut env, |env| {
+        jni_bridge::ensure_vm(env);
+        jni_bridge::init_cache(env);
+    });
 }
 
 /// Called from PerryActivity when the Activity is being destroyed.
 #[no_mangle]
 pub extern "C" fn Java_com_perry_app_PerryBridge_nativeShutdown(
-    _env: jni::JNIEnv,
+    _env: jni::EnvUnowned,
     _class: jni::objects::JClass,
 ) {
     app::signal_shutdown();
@@ -209,7 +220,7 @@ pub extern "C" fn Java_com_perry_app_PerryBridge_nativeShutdown(
 /// the Activity's main thread, which owns the JS arena.
 #[no_mangle]
 pub extern "C" fn Java_com_perry_app_PerryBridge_nativeMemoryPressure(
-    _env: jni::JNIEnv,
+    _env: jni::EnvUnowned,
     _class: jni::objects::JClass,
     level: jni::sys::jint,
 ) {
@@ -236,43 +247,52 @@ extern "C" {
 #[cfg(not(test))]
 #[no_mangle]
 pub extern "C" fn Java_com_perry_app_PerryBridge_nativeMain(
-    _env: jni::JNIEnv,
+    _env: jni::EnvUnowned,
     _class: jni::objects::JClass,
 ) {
     // Set CWD to the app's internal files directory so that relative paths
     // (e.g. SQLite databases like "mango.db") resolve to a writable location.
     {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(16);
-        if let Ok(activity) = env.call_static_method(
-            "com/perry/app/PerryBridge",
-            "getActivity",
-            "()Landroid/app/Activity;",
-            &[],
-        ) {
-            if let Ok(act_obj) = activity.l() {
-                if let Ok(files_dir) =
-                    env.call_method(&act_obj, "getFilesDir", "()Ljava/io/File;", &[])
-                {
-                    if let Ok(fd_obj) = files_dir.l() {
-                        if let Ok(abs_val) =
-                            env.call_method(&fd_obj, "getAbsolutePath", "()Ljava/lang/String;", &[])
-                        {
-                            if let Ok(abs_obj) = abs_val.l() {
-                                if let Ok(path_str) = env.get_string((&abs_obj).into()) {
-                                    let path: String = path_str.into();
-                                    let _ = std::fs::create_dir_all(&path);
-                                    let _ = std::env::set_current_dir(&path);
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 16);
+            if let Ok(activity) = env.call_static_method(
+                jni::jni_str!("com/perry/app/PerryBridge"),
+                jni::jni_str!("getActivity"),
+                jni::jni_sig!("()Landroid/app/Activity;"),
+                &[],
+            ) {
+                if let Ok(act_obj) = activity.l() {
+                    if let Ok(files_dir) = env.call_method(
+                        &act_obj,
+                        jni::jni_str!("getFilesDir"),
+                        jni::jni_sig!("()Ljava/io/File;"),
+                        &[],
+                    ) {
+                        if let Ok(fd_obj) = files_dir.l() {
+                            if let Ok(abs_val) = env.call_method(
+                                &fd_obj,
+                                jni::jni_str!("getAbsolutePath"),
+                                jni::jni_sig!("()Ljava/lang/String;"),
+                                &[],
+                            ) {
+                                if let Ok(abs_obj) = abs_val.l() {
+                                    let abs_jstr = unsafe {
+                                        jni::objects::JString::from_raw(env, abs_obj.into_raw())
+                                    };
+                                    if let Ok(path) = abs_jstr.try_to_string(env) {
+                                        let _ = std::fs::create_dir_all(&path);
+                                        let _ = std::env::set_current_dir(&path);
+                                    }
                                 }
                             }
                         }
                     }
                 }
             }
-        }
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+        })
     }
 
     unsafe {

--- a/crates/perry-ui-android/src/location.rs
+++ b/crates/perry-ui-android/src/location.rs
@@ -2,23 +2,29 @@
 
 use crate::callback;
 use crate::jni_bridge;
-use jni::objects::JValue;
+use jni::JValue;
 
 /// Request a one-shot location. The callback receives (lat, lon) on success
 /// or (NaN, NaN) on error/denial. The Java side handles permission requests.
 pub fn request_location(callback_f64: f64) {
     let key = callback::register(callback_f64);
 
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(16);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 16);
 
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
 
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let _ = env.call_static_method(bridge_cls, "requestLocation", "(J)V", &[JValue::Long(key)]);
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("requestLocation"),
+            jni::jni_sig!("(J)V"),
+            &[JValue::Long(key)],
+        );
 
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }

--- a/crates/perry-ui-android/src/media_playback.rs
+++ b/crates/perry-ui-android/src/media_playback.rs
@@ -18,7 +18,9 @@
 //! A 10 Hz polling thread fires the JS state-change + time-update
 //! callbacks, matching the cross-platform contract.
 
-use jni::objects::{GlobalRef, JObject, JValue};
+use crate::jni_bridge::GlobalRef;
+use jni::objects::JObject;
+use jni::JValue;
 use std::cell::RefCell;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
@@ -133,90 +135,100 @@ pub fn create_player(url_ptr: *const u8) -> i64 {
     let prepared_w = Arc::clone(&prepared);
     let error_w = Arc::clone(&error);
     std::thread::spawn(move || {
-        let vm = jni_bridge::get_vm().clone();
-        let mut env = match vm.attach_current_thread_permanently() {
-            Ok(e) => e,
-            Err(_) => {
-                error_w.store(true, Ordering::Relaxed);
-                return;
-            }
-        };
-        let _ = env.push_local_frame(8);
+        if jni_bridge::try_with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
 
-        // new MediaPlayer()
-        let mp = match env.new_object("android/media/MediaPlayer", "()V", &[]) {
-            Ok(o) => o,
-            Err(_) => {
+            // new MediaPlayer()
+            let mp = match env.new_object(
+                jni::jni_str!("android/media/MediaPlayer"),
+                jni::jni_sig!("()V"),
+                &[],
+            ) {
+                Ok(o) => o,
+                Err(_) => {
+                    error_w.store(true, Ordering::Relaxed);
+                    unsafe {
+                        let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+                    }
+                    return;
+                }
+            };
+
+            // setDataSource(String url)
+            let url_jstr = match env.new_string(&url_owned) {
+                Ok(s) => s,
+                Err(_) => {
+                    error_w.store(true, Ordering::Relaxed);
+                    unsafe {
+                        let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+                    }
+                    return;
+                }
+            };
+            if env
+                .call_method(
+                    &mp,
+                    jni::jni_str!("setDataSource"),
+                    jni::jni_sig!("(Ljava/lang/String;)V"),
+                    &[JValue::Object(&url_jstr.into())],
+                )
+                .is_err()
+            {
+                let _ = env.exception_clear();
                 error_w.store(true, Ordering::Relaxed);
                 unsafe {
-                    env.pop_local_frame(&JObject::null());
+                    let _ = jni_bridge::pop_local_frame(env, &JObject::null());
                 }
                 return;
             }
-        };
 
-        // setDataSource(String url)
-        let url_jstr = match env.new_string(&url_owned) {
-            Ok(s) => s,
-            Err(_) => {
-                error_w.store(true, Ordering::Relaxed);
-                unsafe {
-                    env.pop_local_frame(&JObject::null());
-                }
-                return;
-            }
-        };
-        if env
-            .call_method(
+            // setAudioStreamType(STREAM_MUSIC=3) — deprecated since API 26 but
+            // still works; the modern AudioAttributes setter is more verbose
+            // and the deprecated path is a single call.
+            let _ = env.call_method(
                 &mp,
-                "setDataSource",
-                "(Ljava/lang/String;)V",
-                &[JValue::Object(&url_jstr.into())],
-            )
-            .is_err()
-        {
+                jni::jni_str!("setAudioStreamType"),
+                jni::jni_sig!("(I)V"),
+                &[JValue::Int(3)],
+            );
             let _ = env.exception_clear();
-            error_w.store(true, Ordering::Relaxed);
-            unsafe {
-                env.pop_local_frame(&JObject::null());
-            }
-            return;
-        }
 
-        // setAudioStreamType(STREAM_MUSIC=3) — deprecated since API 26 but
-        // still works; the modern AudioAttributes setter is more verbose
-        // and the deprecated path is a single call.
-        let _ = env.call_method(&mp, "setAudioStreamType", "(I)V", &[JValue::Int(3)]);
-        let _ = env.exception_clear();
-
-        // prepare() — synchronous. Blocks until the source is ready.
-        if env.call_method(&mp, "prepare", "()V", &[]).is_err() {
-            let _ = env.exception_clear();
-            error_w.store(true, Ordering::Relaxed);
-            unsafe {
-                env.pop_local_frame(&JObject::null());
-            }
-            return;
-        }
-
-        let global = match env.new_global_ref(&mp) {
-            Ok(g) => g,
-            Err(_) => {
+            // prepare() — synchronous. Blocks until the source is ready.
+            if env
+                .call_method(&mp, jni::jni_str!("prepare"), jni::jni_sig!("()V"), &[])
+                .is_err()
+            {
+                let _ = env.exception_clear();
                 error_w.store(true, Ordering::Relaxed);
                 unsafe {
-                    env.pop_local_frame(&JObject::null());
+                    let _ = jni_bridge::pop_local_frame(env, &JObject::null());
                 }
                 return;
             }
-        };
-        unsafe {
-            env.pop_local_frame(&JObject::null());
-        }
 
-        if let Ok(mut slot) = player_arc_w.lock() {
-            *slot = Some(global);
+            let global = match jni_bridge::new_global_ref(env, &mp) {
+                Ok(g) => g,
+                Err(_) => {
+                    error_w.store(true, Ordering::Relaxed);
+                    unsafe {
+                        let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+                    }
+                    return;
+                }
+            };
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+
+            if let Ok(mut slot) = player_arc_w.lock() {
+                *slot = Some(global);
+            }
+            prepared_w.store(true, Ordering::Relaxed);
+        })
+        .is_err()
+        {
+            error_w.store(true, Ordering::Relaxed);
         }
-        prepared_w.store(true, Ordering::Relaxed);
     });
 
     let entry = PlayerEntry {
@@ -253,7 +265,12 @@ pub fn play(handle: f64) {
     with_entry_mut(handle, |entry| {
         if let Some(global) = lock_player(&entry.player) {
             with_env(|env| {
-                let _ = env.call_method(global.as_obj(), "start", "()V", &[]);
+                let _ = env.call_method(
+                    global.as_obj(),
+                    jni::jni_str!("start"),
+                    jni::jni_sig!("()V"),
+                    &[],
+                );
                 let _ = env.exception_clear();
             });
             entry.has_started = true;
@@ -268,7 +285,12 @@ pub fn pause(handle: f64) {
     with_entry_mut(handle, |entry| {
         if let Some(global) = lock_player(&entry.player) {
             with_env(|env| {
-                let _ = env.call_method(global.as_obj(), "pause", "()V", &[]);
+                let _ = env.call_method(
+                    global.as_obj(),
+                    jni::jni_str!("pause"),
+                    jni::jni_sig!("()V"),
+                    &[],
+                );
                 let _ = env.exception_clear();
             });
         }
@@ -282,8 +304,18 @@ pub fn stop(handle: f64) {
     with_entry_mut(handle, |entry| {
         if let Some(global) = lock_player(&entry.player) {
             with_env(|env| {
-                let _ = env.call_method(global.as_obj(), "pause", "()V", &[]);
-                let _ = env.call_method(global.as_obj(), "seekTo", "(I)V", &[JValue::Int(0)]);
+                let _ = env.call_method(
+                    global.as_obj(),
+                    jni::jni_str!("pause"),
+                    jni::jni_sig!("()V"),
+                    &[],
+                );
+                let _ = env.call_method(
+                    global.as_obj(),
+                    jni::jni_str!("seekTo"),
+                    jni::jni_sig!("(I)V"),
+                    &[JValue::Int(0)],
+                );
                 let _ = env.exception_clear();
             });
             entry.has_started = false;
@@ -299,7 +331,12 @@ pub fn seek(handle: f64, seconds: f64) {
         if let Some(global) = lock_player(&entry.player) {
             let ms = (seconds * 1000.0).max(0.0) as i32;
             with_env(|env| {
-                let _ = env.call_method(global.as_obj(), "seekTo", "(I)V", &[JValue::Int(ms)]);
+                let _ = env.call_method(
+                    global.as_obj(),
+                    jni::jni_str!("seekTo"),
+                    jni::jni_sig!("(I)V"),
+                    &[JValue::Int(ms)],
+                );
                 let _ = env.exception_clear();
             });
         }
@@ -317,8 +354,8 @@ pub fn set_volume(handle: f64, volume: f64) {
             with_env(|env| {
                 let _ = env.call_method(
                     global.as_obj(),
-                    "setVolume",
-                    "(FF)V",
+                    jni::jni_str!("setVolume"),
+                    jni::jni_sig!("(FF)V"),
                     &[JValue::Float(v), JValue::Float(v)],
                 );
                 let _ = env.exception_clear();
@@ -334,14 +371,14 @@ pub fn set_rate(handle: f64, rate: f64) {
     with_entry_mut(handle, |entry| {
         if let Some(global) = lock_player(&entry.player) {
             with_env(|env| {
-                let pp_cls = match env.find_class("android/media/PlaybackParams") {
+                let pp_cls = match env.find_class(jni::jni_str!("android/media/PlaybackParams")) {
                     Ok(c) => c,
                     Err(_) => {
                         let _ = env.exception_clear();
                         return;
                     }
                 };
-                let pp = match env.new_object(pp_cls, "()V", &[]) {
+                let pp = match env.new_object(pp_cls, jni::jni_sig!("()V"), &[]) {
                     Ok(o) => o,
                     Err(_) => {
                         let _ = env.exception_clear();
@@ -351,8 +388,8 @@ pub fn set_rate(handle: f64, rate: f64) {
                 if env
                     .call_method(
                         &pp,
-                        "setSpeed",
-                        "(F)Landroid/media/PlaybackParams;",
+                        jni::jni_str!("setSpeed"),
+                        jni::jni_sig!("(F)Landroid/media/PlaybackParams;"),
                         &[JValue::Float(rate as f32)],
                     )
                     .is_err()
@@ -362,8 +399,8 @@ pub fn set_rate(handle: f64, rate: f64) {
                 }
                 let _ = env.call_method(
                     global.as_obj(),
-                    "setPlaybackParams",
-                    "(Landroid/media/PlaybackParams;)V",
+                    jni::jni_str!("setPlaybackParams"),
+                    jni::jni_sig!("(Landroid/media/PlaybackParams;)V"),
                     &[JValue::Object(&pp)],
                 );
                 let _ = env.exception_clear();
@@ -377,7 +414,12 @@ pub fn get_current_time(handle: f64) -> f64 {
         if let Some(global) = lock_player(&entry.player) {
             let mut out = 0.0;
             with_env(|env| {
-                if let Ok(v) = env.call_method(global.as_obj(), "getCurrentPosition", "()I", &[]) {
+                if let Ok(v) = env.call_method(
+                    global.as_obj(),
+                    jni::jni_str!("getCurrentPosition"),
+                    jni::jni_sig!("()I"),
+                    &[],
+                ) {
                     out = v.i().unwrap_or(0) as f64 / 1000.0;
                 }
                 let _ = env.exception_clear();
@@ -443,26 +485,26 @@ pub fn set_now_playing(
     };
 
     with_env(|env| {
-        let _ = env.push_local_frame(16);
+        let _ = jni_bridge::push_local_frame(env, 16);
 
         // MediaMetadataCompat.Builder — putString returns the builder,
         // build() returns the metadata.
         let builder = match env.new_object(
-            "android/support/v4/media/MediaMetadataCompat$Builder",
-            "()V",
+            jni::jni_str!("android/support/v4/media/MediaMetadataCompat$Builder"),
+            jni::jni_sig!("()V"),
             &[],
         ) {
             Ok(b) => b,
             Err(_) => {
                 let _ = env.exception_clear();
                 unsafe {
-                    env.pop_local_frame(&JObject::null());
+                    let _ = jni_bridge::pop_local_frame(env, &JObject::null());
                 }
                 return;
             }
         };
 
-        let put_string = |env: &mut jni::JNIEnv, key: &str, val: &str| {
+        let put_string = |env: &mut jni::Env, key: &str, val: &str| {
             if val.is_empty() {
                 return;
             }
@@ -482,8 +524,8 @@ pub fn set_now_playing(
             };
             let _ = env.call_method(
                 &builder,
-                "putString",
-                "(Ljava/lang/String;Ljava/lang/String;)Landroid/support/v4/media/MediaMetadataCompat$Builder;",
+                jni::jni_str!("putString"),
+                jni::jni_sig!("(Ljava/lang/String;Ljava/lang/String;)Landroid/support/v4/media/MediaMetadataCompat$Builder;"),
                 &[JValue::Object(&k.into()), JValue::Object(&v.into())],
             );
             let _ = env.exception_clear();
@@ -498,8 +540,8 @@ pub fn set_now_playing(
                 if let Ok(key) = env.new_string("android.media.metadata.ART") {
                     let _ = env.call_method(
                         &builder,
-                        "putBitmap",
-                        "(Ljava/lang/String;Landroid/graphics/Bitmap;)Landroid/support/v4/media/MediaMetadataCompat$Builder;",
+                        jni::jni_str!("putBitmap"),
+                        jni::jni_sig!("(Ljava/lang/String;Landroid/graphics/Bitmap;)Landroid/support/v4/media/MediaMetadataCompat$Builder;"),
                         &[JValue::Object(&key.into()), JValue::Object(&bitmap)],
                     );
                     let _ = env.exception_clear();
@@ -509,15 +551,15 @@ pub fn set_now_playing(
 
         let metadata = match env.call_method(
             &builder,
-            "build",
-            "()Landroid/support/v4/media/MediaMetadataCompat;",
+            jni::jni_str!("build"),
+            jni::jni_sig!("()Landroid/support/v4/media/MediaMetadataCompat;"),
             &[],
         ) {
             Ok(v) => match v.l() {
                 Ok(o) => o,
                 Err(_) => {
                     unsafe {
-                        env.pop_local_frame(&JObject::null());
+                        let _ = jni_bridge::pop_local_frame(env, &JObject::null());
                     }
                     return;
                 }
@@ -525,7 +567,7 @@ pub fn set_now_playing(
             Err(_) => {
                 let _ = env.exception_clear();
                 unsafe {
-                    env.pop_local_frame(&JObject::null());
+                    let _ = jni_bridge::pop_local_frame(env, &JObject::null());
                 }
                 return;
             }
@@ -533,14 +575,14 @@ pub fn set_now_playing(
 
         let _ = env.call_method(
             session.as_obj(),
-            "setMetadata",
-            "(Landroid/support/v4/media/MediaMetadataCompat;)V",
+            jni::jni_str!("setMetadata"),
+            jni::jni_sig!("(Landroid/support/v4/media/MediaMetadataCompat;)V"),
             &[JValue::Object(&metadata)],
         );
         let _ = env.exception_clear();
 
         unsafe {
-            env.pop_local_frame(&JObject::null());
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
         }
     });
 }
@@ -557,7 +599,12 @@ pub fn destroy(handle: f64) {
     if let Some(entry) = entry {
         if let Some(global) = lock_player(&entry.player) {
             with_env(|env| {
-                let _ = env.call_method(global.as_obj(), "release", "()V", &[]);
+                let _ = env.call_method(
+                    global.as_obj(),
+                    jni::jni_str!("release"),
+                    jni::jni_sig!("()V"),
+                    &[],
+                );
                 let _ = env.exception_clear();
             });
         }
@@ -602,9 +649,10 @@ fn lock_player(p: &Arc<Mutex<Option<GlobalRef>>>) -> Option<GlobalRef> {
     p.lock().ok()?.clone()
 }
 
-fn with_env<F: FnOnce(&mut jni::JNIEnv)>(f: F) {
-    let mut env = jni_bridge::get_env();
-    f(&mut env);
+fn with_env<F: FnOnce(&mut jni::Env)>(f: F) {
+    jni_bridge::with_env(|env| {
+        f(env);
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -644,14 +692,20 @@ fn poll_tick() {
             // -1 if unknown (live stream).
             if entry.prepared.load(Ordering::Relaxed) && entry.duration_seconds == 0.0 {
                 if let Some(global) = lock_player(&entry.player) {
-                    let mut env = jni_bridge::get_env();
-                    if let Ok(v) = env.call_method(global.as_obj(), "getDuration", "()I", &[]) {
-                        let ms = v.i().unwrap_or(0);
-                        if ms > 0 {
-                            entry.duration_seconds = ms as f64 / 1000.0;
+                    jni_bridge::with_env(|env| {
+                        if let Ok(v) = env.call_method(
+                            global.as_obj(),
+                            jni::jni_str!("getDuration"),
+                            jni::jni_sig!("()I"),
+                            &[],
+                        ) {
+                            let ms = v.i().unwrap_or(0);
+                            if ms > 0 {
+                                entry.duration_seconds = ms as f64 / 1000.0;
+                            }
                         }
-                    }
-                    let _ = env.exception_clear();
+                        let _ = env.exception_clear();
+                    })
                 }
             }
 
@@ -686,12 +740,19 @@ fn poll_tick() {
 
 fn current_time_seconds(entry: &PlayerEntry) -> f64 {
     if let Some(global) = lock_player(&entry.player) {
-        let mut env = jni_bridge::get_env();
-        if let Ok(v) = env.call_method(global.as_obj(), "getCurrentPosition", "()I", &[]) {
+        return jni_bridge::with_env(|env| {
+            if let Ok(v) = env.call_method(
+                global.as_obj(),
+                jni::jni_str!("getCurrentPosition"),
+                jni::jni_sig!("()I"),
+                &[],
+            ) {
+                let _ = env.exception_clear();
+                return v.i().unwrap_or(0) as f64 / 1000.0;
+            }
             let _ = env.exception_clear();
-            return v.i().unwrap_or(0) as f64 / 1000.0;
-        }
-        let _ = env.exception_clear();
+            0.0
+        });
     }
     0.0
 }
@@ -714,16 +775,23 @@ fn derive_state(entry: &PlayerEntry) -> MediaState {
         return MediaState::Ready;
     }
     if let Some(global) = lock_player(&entry.player) {
-        let mut env = jni_bridge::get_env();
-        if let Ok(v) = env.call_method(global.as_obj(), "isPlaying", "()Z", &[]) {
+        return jni_bridge::with_env(|env| {
+            if let Ok(v) = env.call_method(
+                global.as_obj(),
+                jni::jni_str!("isPlaying"),
+                jni::jni_sig!("()Z"),
+                &[],
+            ) {
+                let _ = env.exception_clear();
+                return if v.z().unwrap_or(false) {
+                    MediaState::Playing
+                } else {
+                    MediaState::Paused
+                };
+            }
             let _ = env.exception_clear();
-            return if v.z().unwrap_or(false) {
-                MediaState::Playing
-            } else {
-                MediaState::Paused
-            };
-        }
-        let _ = env.exception_clear();
+            MediaState::Paused
+        });
     }
     MediaState::Paused
 }
@@ -766,94 +834,109 @@ fn ensure_session() -> Option<GlobalRef> {
         }
     }
 
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
 
-    let activity = crate::widgets::get_activity(&mut env);
-    let tag = match env.new_string("perry-media") {
-        Ok(s) => s,
-        Err(_) => {
-            let _ = env.exception_clear();
-            unsafe {
-                env.pop_local_frame(&JObject::null());
+        let activity = crate::widgets::get_activity(env);
+        let tag = match env.new_string("perry-media") {
+            Ok(s) => s,
+            Err(_) => {
+                let _ = env.exception_clear();
+                unsafe {
+                    let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+                }
+                return None;
             }
-            return None;
-        }
-    };
+        };
 
-    let session = match env.new_object(
-        "android/support/v4/media/session/MediaSessionCompat",
-        "(Landroid/content/Context;Ljava/lang/String;)V",
-        &[JValue::Object(&activity), JValue::Object(&tag.into())],
-    ) {
-        Ok(o) => o,
-        Err(_) => {
-            let _ = env.exception_clear();
-            unsafe {
-                env.pop_local_frame(&JObject::null());
+        let session = match env.new_object(
+            jni::jni_str!("android/support/v4/media/session/MediaSessionCompat"),
+            jni::jni_sig!("(Landroid/content/Context;Ljava/lang/String;)V"),
+            &[JValue::Object(&activity), JValue::Object(&tag.into())],
+        ) {
+            Ok(o) => o,
+            Err(_) => {
+                let _ = env.exception_clear();
+                unsafe {
+                    let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+                }
+                return None;
             }
-            return None;
-        }
-    };
+        };
 
-    let _ = env.call_method(&session, "setActive", "(Z)V", &[JValue::Bool(1)]);
-    let _ = env.exception_clear();
-
-    // Wire the headphone/media-button callback. The Java helper class
-    // PerryMediaSessionCallback extends MediaSessionCompat.Callback and
-    // routes onPlay / onPause / onStop / onSeekTo to the native exports
-    // below.
-    if let Ok(callback) = env.new_object("com/perry/app/PerryMediaSessionCallback", "()V", &[]) {
         let _ = env.call_method(
             &session,
-            "setCallback",
-            "(Landroid/support/v4/media/session/MediaSessionCompat$Callback;)V",
-            &[JValue::Object(&callback)],
+            jni::jni_str!("setActive"),
+            jni::jni_sig!("(Z)V"),
+            &[JValue::Bool(true)],
         );
         let _ = env.exception_clear();
-    } else {
-        // The Java helper class isn't compiled into this APK — the
-        // session still works for metadata / state, but headphone keys
-        // will fall back to system defaults.
-        let _ = env.exception_clear();
-    }
 
-    let global = match env.new_global_ref(&session) {
-        Ok(g) => g,
-        Err(_) => {
-            unsafe {
-                env.pop_local_frame(&JObject::null());
-            }
-            return None;
+        // Wire the headphone/media-button callback. The Java helper class
+        // PerryMediaSessionCallback extends MediaSessionCompat.Callback and
+        // routes onPlay / onPause / onStop / onSeekTo to the native exports
+        // below.
+        if let Ok(callback) = env.new_object(
+            jni::jni_str!("com/perry/app/PerryMediaSessionCallback"),
+            jni::jni_sig!("()V"),
+            &[],
+        ) {
+            let _ = env.call_method(
+                &session,
+                jni::jni_str!("setCallback"),
+                jni::jni_sig!("(Landroid/support/v4/media/session/MediaSessionCompat$Callback;)V"),
+                &[JValue::Object(&callback)],
+            );
+            let _ = env.exception_clear();
+        } else {
+            // The Java helper class isn't compiled into this APK — the
+            // session still works for metadata / state, but headphone keys
+            // will fall back to system defaults.
+            let _ = env.exception_clear();
         }
-    };
-    unsafe {
-        env.pop_local_frame(&JObject::null());
-    }
 
-    if let Ok(mut slot) = cell.lock() {
-        *slot = Some(global.clone());
-    }
-    Some(global)
+        let global = match jni_bridge::new_global_ref(env, &session) {
+            Ok(g) => g,
+            Err(_) => {
+                unsafe {
+                    let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+                }
+                return None;
+            }
+        };
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+        }
+
+        if let Ok(mut slot) = cell.lock() {
+            *slot = Some(global.clone());
+        }
+        Some(global)
+    })
 }
 
 /// Decode an artwork URL into an Android Bitmap. Returns the local-ref
 /// JObject on success; failures (network error, decode failure, missing
 /// file) are silently swallowed so set_now_playing still publishes the
 /// title/artist/album metadata.
-fn decode_artwork<'a>(env: &mut jni::JNIEnv<'a>, url: &str) -> Option<JObject<'a>> {
+fn decode_artwork<'a>(env: &mut jni::Env<'a>, url: &str) -> Option<JObject<'a>> {
     let factory = "android/graphics/BitmapFactory";
 
     if url.starts_with("http://") || url.starts_with("https://") {
         let url_jstr = env.new_string(url).ok()?;
         let url_obj = env
             .new_object(
-                "java/net/URL",
-                "(Ljava/lang/String;)V",
+                jni::jni_str!("java/net/URL"),
+                jni::jni_sig!("(Ljava/lang/String;)V"),
                 &[JValue::Object(&url_jstr.into())],
             )
             .ok()?;
-        let stream = match env.call_method(&url_obj, "openStream", "()Ljava/io/InputStream;", &[]) {
+        let stream = match env.call_method(
+            &url_obj,
+            jni::jni_str!("openStream"),
+            jni::jni_sig!("()Ljava/io/InputStream;"),
+            &[],
+        ) {
             Ok(v) => v.l().ok()?,
             Err(_) => {
                 let _ = env.exception_clear();
@@ -861,9 +944,9 @@ fn decode_artwork<'a>(env: &mut jni::JNIEnv<'a>, url: &str) -> Option<JObject<'a
             }
         };
         let bitmap = match env.call_static_method(
-            factory,
-            "decodeStream",
-            "(Ljava/io/InputStream;)Landroid/graphics/Bitmap;",
+            jni::strings::JNIString::new(factory),
+            jni::jni_str!("decodeStream"),
+            jni::jni_sig!("(Ljava/io/InputStream;)Landroid/graphics/Bitmap;"),
             &[JValue::Object(&stream)],
         ) {
             Ok(v) => v.l().ok()?,
@@ -872,7 +955,7 @@ fn decode_artwork<'a>(env: &mut jni::JNIEnv<'a>, url: &str) -> Option<JObject<'a
                 return None;
             }
         };
-        let _ = env.call_method(&stream, "close", "()V", &[]);
+        let _ = env.call_method(&stream, jni::jni_str!("close"), jni::jni_sig!("()V"), &[]);
         let _ = env.exception_clear();
         if bitmap.is_null() {
             None
@@ -883,9 +966,9 @@ fn decode_artwork<'a>(env: &mut jni::JNIEnv<'a>, url: &str) -> Option<JObject<'a
         let path = url.strip_prefix("file://").unwrap_or(url);
         let path_jstr = env.new_string(path).ok()?;
         let bitmap = match env.call_static_method(
-            factory,
-            "decodeFile",
-            "(Ljava/lang/String;)Landroid/graphics/Bitmap;",
+            jni::strings::JNIString::new(factory),
+            jni::jni_str!("decodeFile"),
+            jni::jni_sig!("(Ljava/lang/String;)Landroid/graphics/Bitmap;"),
             &[JValue::Object(&path_jstr.into())],
         ) {
             Ok(v) => v.l().ok()?,
@@ -931,25 +1014,25 @@ fn push_playback_state(state: MediaState, position_seconds: f64) {
     let actions: i64 = 4 | 2 | 512 | 256 | 1 | 32 | 16;
 
     with_env(|env| {
-        let _ = env.push_local_frame(8);
+        let _ = jni_bridge::push_local_frame(env, 8);
         let builder = match env.new_object(
-            "android/support/v4/media/session/PlaybackStateCompat$Builder",
-            "()V",
+            jni::jni_str!("android/support/v4/media/session/PlaybackStateCompat$Builder"),
+            jni::jni_sig!("()V"),
             &[],
         ) {
             Ok(b) => b,
             Err(_) => {
                 let _ = env.exception_clear();
                 unsafe {
-                    env.pop_local_frame(&JObject::null());
+                    let _ = jni_bridge::pop_local_frame(env, &JObject::null());
                 }
                 return;
             }
         };
         let _ = env.call_method(
             &builder,
-            "setState",
-            "(IJF)Landroid/support/v4/media/session/PlaybackStateCompat$Builder;",
+            jni::jni_str!("setState"),
+            jni::jni_sig!("(IJF)Landroid/support/v4/media/session/PlaybackStateCompat$Builder;"),
             &[
                 JValue::Int(state_code),
                 JValue::Long(position_ms),
@@ -959,15 +1042,15 @@ fn push_playback_state(state: MediaState, position_seconds: f64) {
         let _ = env.exception_clear();
         let _ = env.call_method(
             &builder,
-            "setActions",
-            "(J)Landroid/support/v4/media/session/PlaybackStateCompat$Builder;",
+            jni::jni_str!("setActions"),
+            jni::jni_sig!("(J)Landroid/support/v4/media/session/PlaybackStateCompat$Builder;"),
             &[JValue::Long(actions)],
         );
         let _ = env.exception_clear();
         let built = match env.call_method(
             &builder,
-            "build",
-            "()Landroid/support/v4/media/session/PlaybackStateCompat;",
+            jni::jni_str!("build"),
+            jni::jni_sig!("()Landroid/support/v4/media/session/PlaybackStateCompat;"),
             &[],
         ) {
             Ok(v) => v.l().ok(),
@@ -979,14 +1062,14 @@ fn push_playback_state(state: MediaState, position_seconds: f64) {
         if let Some(ps) = built {
             let _ = env.call_method(
                 session.as_obj(),
-                "setPlaybackState",
-                "(Landroid/support/v4/media/session/PlaybackStateCompat;)V",
+                jni::jni_str!("setPlaybackState"),
+                jni::jni_sig!("(Landroid/support/v4/media/session/PlaybackStateCompat;)V"),
                 &[JValue::Object(&ps)],
             );
             let _ = env.exception_clear();
         }
         unsafe {
-            env.pop_local_frame(&JObject::null());
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
         }
     });
 }
@@ -1015,7 +1098,7 @@ fn first_active_player_handle() -> Option<f64> {
 
 #[no_mangle]
 pub extern "C" fn Java_com_perry_app_PerryMediaSessionCallback_nativeMediaSessionPlay(
-    _env: jni::JNIEnv,
+    _env: jni::EnvUnowned,
     _class: JObject,
 ) {
     if let Some(h) = first_active_player_handle() {
@@ -1025,7 +1108,7 @@ pub extern "C" fn Java_com_perry_app_PerryMediaSessionCallback_nativeMediaSessio
 
 #[no_mangle]
 pub extern "C" fn Java_com_perry_app_PerryMediaSessionCallback_nativeMediaSessionPause(
-    _env: jni::JNIEnv,
+    _env: jni::EnvUnowned,
     _class: JObject,
 ) {
     if let Some(h) = first_active_player_handle() {
@@ -1035,7 +1118,7 @@ pub extern "C" fn Java_com_perry_app_PerryMediaSessionCallback_nativeMediaSessio
 
 #[no_mangle]
 pub extern "C" fn Java_com_perry_app_PerryMediaSessionCallback_nativeMediaSessionStop(
-    _env: jni::JNIEnv,
+    _env: jni::EnvUnowned,
     _class: JObject,
 ) {
     if let Some(h) = first_active_player_handle() {
@@ -1045,7 +1128,7 @@ pub extern "C" fn Java_com_perry_app_PerryMediaSessionCallback_nativeMediaSessio
 
 #[no_mangle]
 pub extern "C" fn Java_com_perry_app_PerryMediaSessionCallback_nativeMediaSessionSeekTo(
-    _env: jni::JNIEnv,
+    _env: jni::EnvUnowned,
     _class: JObject,
     position_ms: jni::sys::jlong,
 ) {

--- a/crates/perry-ui-android/src/menu.rs
+++ b/crates/perry-ui-android/src/menu.rs
@@ -1,4 +1,4 @@
-use jni::objects::JValue;
+use jni::JValue;
 use std::cell::RefCell;
 use std::collections::HashMap;
 
@@ -55,16 +55,17 @@ pub fn set_context_menu(widget_handle: i64, menu_handle: i64) {
 
     // Set up long-click listener on the widget via PerryBridge
     if let Some(view_ref) = crate::widgets::get_widget(widget_handle) {
-        let mut env = jni_bridge::get_env();
-        let bridge_class =
-            jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-        let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-        let _ = env.call_static_method(
-            bridge_cls,
-            "setContextMenu",
-            "(Landroid/view/View;J)V",
-            &[JValue::Object(view_ref.as_obj()), JValue::Long(menu_handle)],
-        );
+        jni_bridge::with_env(|env| {
+            let bridge_class =
+                jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+            let bridge_cls: &jni::objects::JClass = &bridge_class;
+            let _ = env.call_static_method(
+                bridge_cls,
+                jni::jni_str!("setContextMenu"),
+                jni::jni_sig!("(Landroid/view/View;J)V"),
+                &[JValue::Object(view_ref.as_obj()), JValue::Long(menu_handle)],
+            );
+        })
     }
 }
 
@@ -72,7 +73,7 @@ pub fn set_context_menu(widget_handle: i64, menu_handle: i64) {
 /// Returns the number of menu items.
 #[no_mangle]
 pub extern "C" fn Java_com_perry_app_PerryBridge_nativeGetMenuItemCount(
-    _env: jni::JNIEnv,
+    _env: jni::EnvUnowned,
     _class: jni::objects::JClass,
     menu_handle: jni::sys::jlong,
 ) -> jni::sys::jint {
@@ -90,7 +91,7 @@ pub extern "C" fn Java_com_perry_app_PerryBridge_nativeGetMenuItemCount(
 /// JNI entry point: called from Java to get a menu item title.
 #[no_mangle]
 pub extern "C" fn Java_com_perry_app_PerryBridge_nativeGetMenuItemTitle(
-    env: jni::JNIEnv,
+    mut env: jni::EnvUnowned,
     _class: jni::objects::JClass,
     menu_handle: jni::sys::jlong,
     index: jni::sys::jint,
@@ -106,14 +107,17 @@ pub extern "C" fn Java_com_perry_app_PerryBridge_nativeGetMenuItemTitle(
         }
         String::new()
     });
-    let jstr = env.new_string(&title).expect("Failed to create JNI string");
-    jstr.into_raw()
+    jni_bridge::with_unowned_env(&mut env, |env| {
+        env.new_string(&title)
+            .expect("Failed to create JNI string")
+            .into_raw()
+    })
 }
 
 /// JNI entry point: called from Java when a context menu item is selected.
 #[no_mangle]
 pub extern "C" fn Java_com_perry_app_PerryBridge_nativeMenuItemSelected(
-    _env: jni::JNIEnv,
+    _env: jni::EnvUnowned,
     _class: jni::objects::JClass,
     menu_handle: jni::sys::jlong,
     index: jni::sys::jint,

--- a/crates/perry-ui-android/src/network.rs
+++ b/crates/perry-ui-android/src/network.rs
@@ -9,7 +9,7 @@
 
 use crate::callback;
 use crate::jni_bridge;
-use jni::objects::JValue;
+use jni::JValue;
 
 /// Read the current network status. The supplied callback fires synchronously
 /// with `(connected, kind)`. `kind` is one of
@@ -17,17 +17,23 @@ use jni::objects::JValue;
 pub fn get_status(cb: f64) {
     let key = callback::register(cb);
 
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
 
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let _ = env.call_static_method(bridge_cls, "networkGetStatus", "(J)V", &[JValue::Long(key)]);
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("networkGetStatus"),
+            jni::jni_sig!("(J)V"),
+            &[JValue::Long(key)],
+        );
 
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }
 
 /// Subscribe to network reachability change events. Returns a numeric id;
@@ -35,41 +41,47 @@ pub fn get_status(cb: f64) {
 pub fn on_change(cb: f64) -> f64 {
     let key = callback::register(cb);
 
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
 
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let id: i64 =
-        match env.call_static_method(bridge_cls, "networkOnChange", "(J)J", &[JValue::Long(key)]) {
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let id: i64 = match env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("networkOnChange"),
+            jni::jni_sig!("(J)J"),
+            &[JValue::Long(key)],
+        ) {
             Ok(v) => v.j().unwrap_or(0),
             Err(_) => 0,
         };
 
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
 
-    id as f64
+        id as f64
+    })
 }
 
 pub fn stop_on_change(id: f64) {
     let id_long = id as i64;
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
 
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let _ = env.call_static_method(
-        bridge_cls,
-        "networkStopOnChange",
-        "(J)V",
-        &[JValue::Long(id_long)],
-    );
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("networkStopOnChange"),
+            jni::jni_sig!("(J)V"),
+            &[JValue::Long(id_long)],
+        );
 
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }

--- a/crates/perry-ui-android/src/pointer.rs
+++ b/crates/perry-ui-android/src/pointer.rs
@@ -16,7 +16,7 @@
 
 use crate::callback;
 use crate::jni_bridge;
-use jni::objects::JValue;
+use jni::JValue;
 
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
@@ -32,7 +32,7 @@ const POINTER_TYPE_TOUCH: u32 = 1;
 /// finger touch).
 #[no_mangle]
 pub extern "C" fn Java_com_perry_app_PerryBridge_nativeInvokePointerCallback(
-    _env: jni::JNIEnv,
+    _env: jni::EnvUnowned,
     _class: jni::objects::JClass,
     key: jni::sys::jlong,
     x: jni::sys::jdouble,
@@ -57,25 +57,26 @@ fn install_touch_listener(handle: i64, down_key: i64, move_key: i64, up_key: i64
     let Some(view_ref) = crate::widgets::get_widget(handle) else {
         return;
     };
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let _ = env.call_static_method(
-        bridge_cls,
-        "setOnPointerCallbacks",
-        "(Landroid/view/View;JJJ)V",
-        &[
-            JValue::Object(view_ref.as_obj()),
-            JValue::Long(down_key),
-            JValue::Long(move_key),
-            JValue::Long(up_key),
-        ],
-    );
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("setOnPointerCallbacks"),
+            jni::jni_sig!("(Landroid/view/View;JJJ)V"),
+            &[
+                JValue::Object(view_ref.as_obj()),
+                JValue::Long(down_key),
+                JValue::Long(move_key),
+                JValue::Long(up_key),
+            ],
+        );
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }
 
 use std::cell::RefCell;

--- a/crates/perry-ui-android/src/screenshot.rs
+++ b/crates/perry-ui-android/src/screenshot.rs
@@ -4,7 +4,8 @@
 //! Draws the root view onto a Canvas-backed Bitmap, compresses to PNG,
 //! and returns the raw bytes via a malloc'd buffer.
 
-use jni::objects::{JObject, JValue};
+use jni::objects::JObject;
+use jni::JValue;
 
 use crate::jni_bridge;
 use crate::widgets;
@@ -15,185 +16,229 @@ pub extern "C" fn perry_ui_screenshot_capture(out_len: *mut usize) -> *mut u8 {
         *out_len = 0;
     }
 
-    let mut env = match std::panic::catch_unwind(|| jni_bridge::get_env()) {
-        Ok(env) => env,
-        Err(_) => return std::ptr::null_mut(),
-    };
+    if std::panic::catch_unwind(jni_bridge::get_vm).is_err() {
+        return std::ptr::null_mut();
+    }
 
-    let _ = env.push_local_frame(32);
+    jni_bridge::try_with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
 
-    let result = (|| -> Option<Vec<u8>> {
-        // Get the Activity
-        let activity = widgets::get_activity(&mut env);
-        if activity.is_null() {
-            return None;
-        }
+        let result = (|| -> Option<Vec<u8>> {
+            // Get the Activity
+            let activity = widgets::get_activity(env);
+            if activity.is_null() {
+                return None;
+            }
 
-        // Get the root view: activity.getWindow().getDecorView().getRootView()
-        let window = env
-            .call_method(&activity, "getWindow", "()Landroid/view/Window;", &[])
-            .ok()?
-            .l()
-            .ok()?;
-        if window.is_null() {
-            return None;
-        }
+            // Get the root view: activity.getWindow().getDecorView().getRootView()
+            let window = env
+                .call_method(
+                    &activity,
+                    jni::jni_str!("getWindow"),
+                    jni::jni_sig!("()Landroid/view/Window;"),
+                    &[],
+                )
+                .ok()?
+                .l()
+                .ok()?;
+            if window.is_null() {
+                return None;
+            }
 
-        let decor_view = env
-            .call_method(&window, "getDecorView", "()Landroid/view/View;", &[])
-            .ok()?
-            .l()
-            .ok()?;
-        if decor_view.is_null() {
-            return None;
-        }
+            let decor_view = env
+                .call_method(
+                    &window,
+                    jni::jni_str!("getDecorView"),
+                    jni::jni_sig!("()Landroid/view/View;"),
+                    &[],
+                )
+                .ok()?
+                .l()
+                .ok()?;
+            if decor_view.is_null() {
+                return None;
+            }
 
-        let root_view = env
-            .call_method(&decor_view, "getRootView", "()Landroid/view/View;", &[])
-            .ok()?
-            .l()
-            .ok()?;
-        if root_view.is_null() {
-            return None;
-        }
+            let root_view = env
+                .call_method(
+                    &decor_view,
+                    jni::jni_str!("getRootView"),
+                    jni::jni_sig!("()Landroid/view/View;"),
+                    &[],
+                )
+                .ok()?
+                .l()
+                .ok()?;
+            if root_view.is_null() {
+                return None;
+            }
 
-        // Get view dimensions
-        let width = env
-            .call_method(&root_view, "getWidth", "()I", &[])
-            .ok()?
-            .i()
-            .ok()?;
-        let height = env
-            .call_method(&root_view, "getHeight", "()I", &[])
-            .ok()?
-            .i()
-            .ok()?;
-        if width <= 0 || height <= 0 {
-            return None;
-        }
+            // Get view dimensions
+            let width = env
+                .call_method(
+                    &root_view,
+                    jni::jni_str!("getWidth"),
+                    jni::jni_sig!("()I"),
+                    &[],
+                )
+                .ok()?
+                .i()
+                .ok()?;
+            let height = env
+                .call_method(
+                    &root_view,
+                    jni::jni_str!("getHeight"),
+                    jni::jni_sig!("()I"),
+                    &[],
+                )
+                .ok()?
+                .i()
+                .ok()?;
+            if width <= 0 || height <= 0 {
+                return None;
+            }
 
-        // Create a Bitmap: Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
-        let bitmap_cls = env.find_class("android/graphics/Bitmap").ok()?;
-        let config_cls = env.find_class("android/graphics/Bitmap$Config").ok()?;
-        let argb_config = env
-            .get_static_field(&config_cls, "ARGB_8888", "Landroid/graphics/Bitmap$Config;")
-            .ok()?
-            .l()
-            .ok()?;
+            // Create a Bitmap: Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+            let bitmap_cls = env
+                .find_class(jni::jni_str!("android/graphics/Bitmap"))
+                .ok()?;
+            let config_cls = env
+                .find_class(jni::jni_str!("android/graphics/Bitmap$Config"))
+                .ok()?;
+            let argb_config = env
+                .get_static_field(
+                    &config_cls,
+                    jni::jni_str!("ARGB_8888"),
+                    jni::jni_sig!("Landroid/graphics/Bitmap$Config;"),
+                )
+                .ok()?
+                .l()
+                .ok()?;
 
-        let bitmap = env
-            .call_static_method(
-                &bitmap_cls,
-                "createBitmap",
-                "(IILandroid/graphics/Bitmap$Config;)Landroid/graphics/Bitmap;",
+            let bitmap = env
+                .call_static_method(
+                    &bitmap_cls,
+                    jni::jni_str!("createBitmap"),
+                    jni::jni_sig!("(IILandroid/graphics/Bitmap$Config;)Landroid/graphics/Bitmap;"),
+                    &[
+                        JValue::Int(width),
+                        JValue::Int(height),
+                        JValue::Object(&argb_config),
+                    ],
+                )
+                .ok()?
+                .l()
+                .ok()?;
+            if bitmap.is_null() {
+                return None;
+            }
+
+            // Create a Canvas from the bitmap and draw the view onto it
+            let canvas_cls = env
+                .find_class(jni::jni_str!("android/graphics/Canvas"))
+                .ok()?;
+            let canvas = env
+                .new_object(
+                    &canvas_cls,
+                    jni::jni_sig!("(Landroid/graphics/Bitmap;)V"),
+                    &[JValue::Object(&bitmap)],
+                )
+                .ok()?;
+
+            let _ = env.call_method(
+                &root_view,
+                jni::jni_str!("draw"),
+                jni::jni_sig!("(Landroid/graphics/Canvas;)V"),
+                &[JValue::Object(&canvas)],
+            );
+
+            // Clear any exception from draw (some views may throw)
+            if env.exception_check() {
+                let _ = env.exception_clear();
+            }
+
+            // Compress bitmap to PNG: bitmap.compress(CompressFormat.PNG, 100, outputStream)
+            let baos_cls = env
+                .find_class(jni::jni_str!("java/io/ByteArrayOutputStream"))
+                .ok()?;
+            let baos = env.new_object(&baos_cls, jni::jni_sig!("()V"), &[]).ok()?;
+
+            let compress_format_cls = env
+                .find_class(jni::jni_str!("android/graphics/Bitmap$CompressFormat"))
+                .ok()?;
+            let png_format = env
+                .get_static_field(
+                    &compress_format_cls,
+                    jni::jni_str!("PNG"),
+                    jni::jni_sig!("Landroid/graphics/Bitmap$CompressFormat;"),
+                )
+                .ok()?
+                .l()
+                .ok()?;
+
+            let _ = env.call_method(
+                &bitmap,
+                jni::jni_str!("compress"),
+                jni::jni_sig!("(Landroid/graphics/Bitmap$CompressFormat;ILjava/io/OutputStream;)Z"),
                 &[
-                    JValue::Int(width),
-                    JValue::Int(height),
-                    JValue::Object(&argb_config),
+                    JValue::Object(&png_format),
+                    JValue::Int(100),
+                    JValue::Object(&baos),
                 ],
-            )
-            .ok()?
-            .l()
-            .ok()?;
-        if bitmap.is_null() {
-            return None;
-        }
+            );
 
-        // Create a Canvas from the bitmap and draw the view onto it
-        let canvas_cls = env.find_class("android/graphics/Canvas").ok()?;
-        let canvas = env
-            .new_object(
-                &canvas_cls,
-                "(Landroid/graphics/Bitmap;)V",
-                &[JValue::Object(&bitmap)],
-            )
-            .ok()?;
-
-        let _ = env.call_method(
-            &root_view,
-            "draw",
-            "(Landroid/graphics/Canvas;)V",
-            &[JValue::Object(&canvas)],
-        );
-
-        // Clear any exception from draw (some views may throw)
-        if env.exception_check().unwrap_or(false) {
-            let _ = env.exception_clear();
-        }
-
-        // Compress bitmap to PNG: bitmap.compress(CompressFormat.PNG, 100, outputStream)
-        let baos_cls = env.find_class("java/io/ByteArrayOutputStream").ok()?;
-        let baos = env.new_object(&baos_cls, "()V", &[]).ok()?;
-
-        let compress_format_cls = env
-            .find_class("android/graphics/Bitmap$CompressFormat")
-            .ok()?;
-        let png_format = env
-            .get_static_field(
-                &compress_format_cls,
-                "PNG",
-                "Landroid/graphics/Bitmap$CompressFormat;",
-            )
-            .ok()?
-            .l()
-            .ok()?;
-
-        let _ = env.call_method(
-            &bitmap,
-            "compress",
-            "(Landroid/graphics/Bitmap$CompressFormat;ILjava/io/OutputStream;)Z",
-            &[
-                JValue::Object(&png_format),
-                JValue::Int(100),
-                JValue::Object(&baos),
-            ],
-        );
-
-        // Get byte array from ByteArrayOutputStream and convert to Vec<u8>
-        let byte_array_obj = env
-            .call_method(&baos, "toByteArray", "()[B", &[])
-            .ok()?
-            .l()
-            .ok()?;
-        if byte_array_obj.is_null() {
-            return None;
-        }
-
-        let byte_array: jni::objects::JByteArray = byte_array_obj.into();
-        let data = env.convert_byte_array(byte_array).ok()?;
-
-        // Recycle the bitmap to free native memory
-        let _ = env.call_method(&bitmap, "recycle", "()V", &[]);
-
-        // Clear any lingering JNI exception
-        if env.exception_check().unwrap_or(false) {
-            let _ = env.exception_clear();
-        }
-
-        if data.is_empty() {
-            None
-        } else {
-            Some(data)
-        }
-    })();
-
-    unsafe {
-        env.pop_local_frame(&JObject::null());
-    }
-
-    match result {
-        Some(data) => {
-            let len = data.len();
-            let buf = unsafe { libc::malloc(len) as *mut u8 };
-            if buf.is_null() {
-                return std::ptr::null_mut();
+            // Get byte array from ByteArrayOutputStream and convert to Vec<u8>
+            let byte_array_obj = env
+                .call_method(
+                    &baos,
+                    jni::jni_str!("toByteArray"),
+                    jni::jni_sig!("()[B"),
+                    &[],
+                )
+                .ok()?
+                .l()
+                .ok()?;
+            if byte_array_obj.is_null() {
+                return None;
             }
-            unsafe {
-                std::ptr::copy_nonoverlapping(data.as_ptr(), buf, len);
-                *out_len = len;
+
+            let byte_array: jni::objects::JByteArray = byte_array_obj.into();
+            let data = env.convert_byte_array(byte_array).ok()?;
+
+            // Recycle the bitmap to free native memory
+            let _ = env.call_method(&bitmap, jni::jni_str!("recycle"), jni::jni_sig!("()V"), &[]);
+
+            // Clear any lingering JNI exception
+            if env.exception_check() {
+                let _ = env.exception_clear();
             }
-            buf
+
+            if data.is_empty() {
+                None
+            } else {
+                Some(data)
+            }
+        })();
+
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
         }
-        None => std::ptr::null_mut(),
-    }
+
+        match result {
+            Some(data) => {
+                let len = data.len();
+                let buf = unsafe { libc::malloc(len) as *mut u8 };
+                if buf.is_null() {
+                    return std::ptr::null_mut();
+                }
+                unsafe {
+                    std::ptr::copy_nonoverlapping(data.as_ptr(), buf, len);
+                    *out_len = len;
+                }
+                buf
+            }
+            None => std::ptr::null_mut(),
+        }
+    })
+    .unwrap_or(std::ptr::null_mut())
 }

--- a/crates/perry-ui-android/src/sheet.rs
+++ b/crates/perry-ui-android/src/sheet.rs
@@ -1,13 +1,14 @@
 //! Sheet — Modal dialog on Android
 
 use crate::jni_bridge;
-use jni::objects::{GlobalRef, JValue};
+use crate::jni_bridge::GlobalRef;
+use jni::JValue;
 use std::cell::RefCell;
 use std::collections::HashMap;
 
 struct SheetState {
-    width: f64,
-    height: f64,
+    _width: f64,
+    _height: f64,
     body_handle: Option<i64>,
     dialog_ref: Option<GlobalRef>,
 }
@@ -33,8 +34,8 @@ pub fn create(body_handle: i64, width: f64, height: f64) -> i64 {
         s.borrow_mut().insert(
             id,
             SheetState {
-                width,
-                height,
+                _width: width,
+                _height: height,
                 body_handle: Some(body_handle),
                 dialog_ref: None,
             },
@@ -58,44 +59,44 @@ pub fn present(sheet_handle: i64) {
 
     if let Some(body_handle) = body {
         if let Some(view_ref) = crate::widgets::get_widget(body_handle) {
-            let mut env = jni_bridge::get_env();
-            let _ = env.push_local_frame(32);
+            jni_bridge::with_env(|env| {
+                let _ = jni_bridge::push_local_frame(env, 32);
 
-            let activity = crate::widgets::get_activity(&mut env);
+                let activity = crate::widgets::get_activity(env);
 
-            // Create Dialog
-            let dialog = env
-                .new_object(
-                    "android/app/Dialog",
-                    "(Landroid/content/Context;)V",
-                    &[JValue::Object(&activity)],
-                )
-                .expect("Failed to create Dialog");
+                // Create Dialog
+                let dialog = env
+                    .new_object(
+                        jni::jni_str!("android/app/Dialog"),
+                        jni::jni_sig!("(Landroid/content/Context;)V"),
+                        &[JValue::Object(&activity)],
+                    )
+                    .expect("Failed to create Dialog");
 
-            // Set content view
-            let _ = env.call_method(
-                &dialog,
-                "setContentView",
-                "(Landroid/view/View;)V",
-                &[JValue::Object(view_ref.as_obj())],
-            );
+                // Set content view
+                let _ = env.call_method(
+                    &dialog,
+                    jni::jni_str!("setContentView"),
+                    jni::jni_sig!("(Landroid/view/View;)V"),
+                    &[JValue::Object(view_ref.as_obj())],
+                );
 
-            // Show
-            let _ = env.call_method(&dialog, "show", "()V", &[]);
+                // Show
+                let _ = env.call_method(&dialog, jni::jni_str!("show"), jni::jni_sig!("()V"), &[]);
 
-            let global = env
-                .new_global_ref(dialog)
-                .expect("Failed to create global ref");
-            SHEETS.with(|s| {
-                let mut sheets = s.borrow_mut();
-                if let Some(state) = sheets.get_mut(&sheet_handle) {
-                    state.dialog_ref = Some(global);
+                let global =
+                    jni_bridge::new_global_ref(env, dialog).expect("Failed to create global ref");
+                SHEETS.with(|s| {
+                    let mut sheets = s.borrow_mut();
+                    if let Some(state) = sheets.get_mut(&sheet_handle) {
+                        state.dialog_ref = Some(global);
+                    }
+                });
+
+                unsafe {
+                    let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
                 }
-            });
-
-            unsafe {
-                env.pop_local_frame(&jni::objects::JObject::null());
-            }
+            })
         }
     }
 }
@@ -109,11 +110,17 @@ pub fn dismiss(sheet_handle: i64) {
     });
 
     if let Some(dialog_ref) = dialog {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let _ = env.call_method(dialog_ref.as_obj(), "dismiss", "()V", &[]);
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let _ = env.call_method(
+                dialog_ref.as_obj(),
+                jni::jni_str!("dismiss"),
+                jni::jni_sig!("()V"),
+                &[],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+        })
     }
 }

--- a/crates/perry-ui-android/src/system.rs
+++ b/crates/perry-ui-android/src/system.rs
@@ -1,7 +1,7 @@
 //! System APIs — open_url, dark mode, preferences, keychain, notifications
 
 use crate::jni_bridge;
-use jni::objects::JValue;
+use jni::JValue;
 
 use perry_ffi::copy_string_from_raw as str_from_header;
 
@@ -13,154 +13,157 @@ extern "C" {
 /// Open a URL in the default browser via Intent.ACTION_VIEW.
 pub fn open_url(url_ptr: *const u8) {
     let url = unsafe { str_from_header(url_ptr) };
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
 
-    let activity = crate::widgets::get_activity(&mut env);
+        let activity = crate::widgets::get_activity(env);
 
-    let jurl = env.new_string(url).expect("Failed to create JNI string");
-    let uri = env
-        .call_static_method(
-            "android/net/Uri",
-            "parse",
-            "(Ljava/lang/String;)Landroid/net/Uri;",
-            &[JValue::Object(&jurl)],
-        )
-        .expect("Uri.parse")
-        .l()
-        .expect("uri");
+        let jurl = env.new_string(url).expect("Failed to create JNI string");
+        let uri = env
+            .call_static_method(
+                jni::jni_str!("android/net/Uri"),
+                jni::jni_str!("parse"),
+                jni::jni_sig!("(Ljava/lang/String;)Landroid/net/Uri;"),
+                &[JValue::Object(&jurl)],
+            )
+            .expect("Uri.parse")
+            .l()
+            .expect("uri");
 
-    let action = env
-        .new_string("android.intent.action.VIEW")
-        .expect("action string");
-    let intent = env
-        .new_object(
-            "android/content/Intent",
-            "(Ljava/lang/String;Landroid/net/Uri;)V",
-            &[JValue::Object(&action), JValue::Object(&uri)],
-        )
-        .expect("Intent");
+        let action = env
+            .new_string("android.intent.action.VIEW")
+            .expect("action string");
+        let intent = env
+            .new_object(
+                jni::jni_str!("android/content/Intent"),
+                jni::jni_sig!("(Ljava/lang/String;Landroid/net/Uri;)V"),
+                &[JValue::Object(&action), JValue::Object(&uri)],
+            )
+            .expect("Intent");
 
-    let _ = env.call_method(
-        &activity,
-        "startActivity",
-        "(Landroid/content/Intent;)V",
-        &[JValue::Object(&intent)],
-    );
+        let _ = env.call_method(
+            &activity,
+            jni::jni_str!("startActivity"),
+            jni::jni_sig!("(Landroid/content/Intent;)V"),
+            &[JValue::Object(&intent)],
+        );
 
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }
 
 /// Check if dark mode is enabled via Configuration.uiMode.
 pub fn is_dark_mode() -> i64 {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(16);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 16);
 
-    let activity = crate::widgets::get_activity(&mut env);
+        let activity = crate::widgets::get_activity(env);
 
-    let resources = env
-        .call_method(
-            &activity,
-            "getResources",
-            "()Landroid/content/res/Resources;",
-            &[],
-        )
-        .expect("getResources")
-        .l()
-        .expect("resources");
+        let resources = env
+            .call_method(
+                &activity,
+                jni::jni_str!("getResources"),
+                jni::jni_sig!("()Landroid/content/res/Resources;"),
+                &[],
+            )
+            .expect("getResources")
+            .l()
+            .expect("resources");
 
-    let config = env
-        .call_method(
-            &resources,
-            "getConfiguration",
-            "()Landroid/content/res/Configuration;",
-            &[],
-        )
-        .expect("getConfiguration")
-        .l()
-        .expect("configuration");
+        let config = env
+            .call_method(
+                &resources,
+                jni::jni_str!("getConfiguration"),
+                jni::jni_sig!("()Landroid/content/res/Configuration;"),
+                &[],
+            )
+            .expect("getConfiguration")
+            .l()
+            .expect("configuration");
 
-    let ui_mode = env
-        .get_field(&config, "uiMode", "I")
-        .expect("uiMode")
-        .i()
-        .expect("int");
+        let ui_mode = env
+            .get_field(&config, jni::jni_str!("uiMode"), jni::jni_sig!("I"))
+            .expect("uiMode")
+            .i()
+            .expect("int");
 
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
 
-    // UI_MODE_NIGHT_MASK = 0x30, UI_MODE_NIGHT_YES = 0x20
-    if (ui_mode & 0x30) == 0x20 {
-        1
-    } else {
-        0
-    }
+        // UI_MODE_NIGHT_MASK = 0x30, UI_MODE_NIGHT_YES = 0x20
+        if (ui_mode & 0x30) == 0x20 {
+            1
+        } else {
+            0
+        }
+    })
 }
 
 /// Set a preference value using SharedPreferences.
 pub fn preferences_set(key_ptr: *const u8, value: f64) {
     let key = unsafe { str_from_header(key_ptr) };
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(16);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 16);
 
-    let activity = crate::widgets::get_activity(&mut env);
-    let pref_name = env.new_string("perry_prefs").expect("pref name");
-    let prefs = env
-        .call_method(
-            &activity,
-            "getSharedPreferences",
-            "(Ljava/lang/String;I)Landroid/content/SharedPreferences;",
-            &[JValue::Object(&pref_name), JValue::Int(0)], // MODE_PRIVATE = 0
-        )
-        .expect("getSharedPreferences")
-        .l()
-        .expect("prefs");
+        let activity = crate::widgets::get_activity(env);
+        let pref_name = env.new_string("perry_prefs").expect("pref name");
+        let prefs = env
+            .call_method(
+                &activity,
+                jni::jni_str!("getSharedPreferences"),
+                jni::jni_sig!("(Ljava/lang/String;I)Landroid/content/SharedPreferences;"),
+                &[JValue::Object(&pref_name), JValue::Int(0)], // MODE_PRIVATE = 0
+            )
+            .expect("getSharedPreferences")
+            .l()
+            .expect("prefs");
 
-    let editor = env
-        .call_method(
-            &prefs,
-            "edit",
-            "()Landroid/content/SharedPreferences$Editor;",
-            &[],
-        )
-        .expect("edit")
-        .l()
-        .expect("editor");
+        let editor = env
+            .call_method(
+                &prefs,
+                jni::jni_str!("edit"),
+                jni::jni_sig!("()Landroid/content/SharedPreferences$Editor;"),
+                &[],
+            )
+            .expect("edit")
+            .l()
+            .expect("editor");
 
-    let jkey = env.new_string(key).expect("key string");
+        let jkey = env.new_string(key).expect("key string");
 
-    // Check if value is a NaN-boxed string
-    let bits = value.to_bits();
-    let tag = (bits >> 48) as u16;
-    if tag == 0x7FFF {
-        // String value — extract and store as string
-        let ptr = (bits & 0x0000_FFFF_FFFF_FFFF) as *const u8;
-        let s = unsafe { str_from_header(ptr) };
-        let jval = env.new_string(s).expect("value string");
-        let _ = env.call_method(
-            &editor,
-            "putString",
-            "(Ljava/lang/String;Ljava/lang/String;)Landroid/content/SharedPreferences$Editor;",
-            &[JValue::Object(&jkey), JValue::Object(&jval)],
-        );
-    } else {
-        // Numeric value
-        let _ = env.call_method(
-            &editor,
-            "putFloat",
-            "(Ljava/lang/String;F)Landroid/content/SharedPreferences$Editor;",
-            &[JValue::Object(&jkey), JValue::Float(value as f32)],
-        );
-    }
+        // Check if value is a NaN-boxed string
+        let bits = value.to_bits();
+        let tag = (bits >> 48) as u16;
+        if tag == 0x7FFF {
+            // String value — extract and store as string
+            let ptr = (bits & 0x0000_FFFF_FFFF_FFFF) as *const u8;
+            let s = unsafe { str_from_header(ptr) };
+            let jval = env.new_string(s).expect("value string");
+            let _ = env.call_method(
+                &editor,
+                jni::jni_str!("putString"),
+                jni::jni_sig!("(Ljava/lang/String;Ljava/lang/String;)Landroid/content/SharedPreferences$Editor;"),
+                &[JValue::Object(&jkey), JValue::Object(&jval)],
+            );
+        } else {
+            // Numeric value
+            let _ = env.call_method(
+                &editor,
+                jni::jni_str!("putFloat"),
+                jni::jni_sig!("(Ljava/lang/String;F)Landroid/content/SharedPreferences$Editor;"),
+                &[JValue::Object(&jkey), JValue::Float(value as f32)],
+            );
+        }
 
-    let _ = env.call_method(&editor, "apply", "()V", &[]);
+        let _ = env.call_method(&editor, jni::jni_str!("apply"), jni::jni_sig!("()V"), &[]);
 
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }
 
 /// Get a preference value from SharedPreferences.
@@ -173,263 +176,293 @@ pub fn preferences_set(key_ptr: *const u8, value: f64) {
 /// clear any leftover exception before returning.
 pub fn preferences_get(key_ptr: *const u8) -> f64 {
     let key = unsafe { str_from_header(key_ptr) };
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(24);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 24);
 
-    let finish = |env: &mut jni::JNIEnv, result: f64| -> f64 {
-        if env.exception_check().unwrap_or(false) {
-            let _ = env.exception_clear();
-        }
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
-        result
-    };
-
-    let activity = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        crate::widgets::get_activity(&mut env)
-    })) {
-        Ok(a) => a,
-        Err(_) => return finish(&mut env, 0.0),
-    };
-
-    let pref_name = match env.new_string("perry_prefs") {
-        Ok(s) => s,
-        Err(_) => return finish(&mut env, 0.0),
-    };
-    let prefs = match env.call_method(
-        &activity,
-        "getSharedPreferences",
-        "(Ljava/lang/String;I)Landroid/content/SharedPreferences;",
-        &[JValue::Object(&pref_name), JValue::Int(0)],
-    ) {
-        Ok(v) => match v.l() {
-            Ok(o) => o,
-            Err(_) => return finish(&mut env, 0.0),
-        },
-        Err(_) => return finish(&mut env, 0.0),
-    };
-
-    let jkey = match env.new_string(key) {
-        Ok(s) => s,
-        Err(_) => return finish(&mut env, 0.0),
-    };
-
-    // getAll avoids ClassCastException from typed getters.
-    let map = match env.call_method(&prefs, "getAll", "()Ljava/util/Map;", &[]) {
-        Ok(v) => match v.l() {
-            Ok(o) => o,
-            Err(_) => return finish(&mut env, 0.0),
-        },
-        Err(_) => return finish(&mut env, 0.0),
-    };
-
-    let entry = match env.call_method(
-        &map,
-        "get",
-        "(Ljava/lang/Object;)Ljava/lang/Object;",
-        &[JValue::Object(&jkey)],
-    ) {
-        Ok(v) => match v.l() {
-            Ok(o) => o,
-            Err(_) => return finish(&mut env, 0.0),
-        },
-        Err(_) => return finish(&mut env, 0.0),
-    };
-
-    if entry.is_null() {
-        return finish(&mut env, 0.0);
-    }
-
-    // Branch on runtime type without throwing.
-    if let Ok(true) = env.is_instance_of(&entry, "java/lang/String") {
-        let jstr: jni::objects::JString = entry.into();
-        if let Ok(java_str) = env.get_string(&jstr) {
-            let s: String = java_str.into();
-            let bytes = s.as_bytes();
-            let ptr = unsafe { js_string_from_bytes(bytes.as_ptr(), bytes.len()) };
-            let result = unsafe { js_nanbox_string(ptr) };
-            return finish(&mut env, result);
-        }
-        return finish(&mut env, 0.0);
-    }
-
-    if let Ok(true) = env.is_instance_of(&entry, "java/lang/Float") {
-        if let Ok(f) = env.call_method(&entry, "floatValue", "()F", &[]) {
-            if let Ok(v) = f.f() {
-                return finish(&mut env, v as f64);
+        let finish = |env: &mut jni::Env, result: f64| -> f64 {
+            if env.exception_check() {
+                let _ = env.exception_clear();
             }
-        }
-        return finish(&mut env, 0.0);
-    }
-
-    if let Ok(true) = env.is_instance_of(&entry, "java/lang/Double") {
-        if let Ok(d) = env.call_method(&entry, "doubleValue", "()D", &[]) {
-            if let Ok(v) = d.d() {
-                return finish(&mut env, v);
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
             }
-        }
-        return finish(&mut env, 0.0);
-    }
+            result
+        };
 
-    if let Ok(true) = env.is_instance_of(&entry, "java/lang/Integer") {
-        if let Ok(i) = env.call_method(&entry, "intValue", "()I", &[]) {
-            if let Ok(v) = i.i() {
-                return finish(&mut env, v as f64);
+        let activity = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            crate::widgets::get_activity(env)
+        })) {
+            Ok(a) => a,
+            Err(_) => return finish(env, 0.0),
+        };
+
+        let pref_name = match env.new_string("perry_prefs") {
+            Ok(s) => s,
+            Err(_) => return finish(env, 0.0),
+        };
+        let prefs = match env.call_method(
+            &activity,
+            jni::jni_str!("getSharedPreferences"),
+            jni::jni_sig!("(Ljava/lang/String;I)Landroid/content/SharedPreferences;"),
+            &[JValue::Object(&pref_name), JValue::Int(0)],
+        ) {
+            Ok(v) => match v.l() {
+                Ok(o) => o,
+                Err(_) => return finish(env, 0.0),
+            },
+            Err(_) => return finish(env, 0.0),
+        };
+
+        let jkey = match env.new_string(key) {
+            Ok(s) => s,
+            Err(_) => return finish(env, 0.0),
+        };
+
+        // getAll avoids ClassCastException from typed getters.
+        let map = match env.call_method(
+            &prefs,
+            jni::jni_str!("getAll"),
+            jni::jni_sig!("()Ljava/util/Map;"),
+            &[],
+        ) {
+            Ok(v) => match v.l() {
+                Ok(o) => o,
+                Err(_) => return finish(env, 0.0),
+            },
+            Err(_) => return finish(env, 0.0),
+        };
+
+        let entry = match env.call_method(
+            &map,
+            jni::jni_str!("get"),
+            jni::jni_sig!("(Ljava/lang/Object;)Ljava/lang/Object;"),
+            &[JValue::Object(&jkey)],
+        ) {
+            Ok(v) => match v.l() {
+                Ok(o) => o,
+                Err(_) => return finish(env, 0.0),
+            },
+            Err(_) => return finish(env, 0.0),
+        };
+
+        if entry.is_null() {
+            return finish(env, 0.0);
+        }
+
+        // Branch on runtime type without throwing.
+        if let Ok(true) = env.is_instance_of(&entry, jni::jni_str!("java/lang/String")) {
+            let jstr: jni::objects::JString =
+                unsafe { jni::objects::JString::from_raw(env, entry.into_raw()) };
+            if let Ok(java_str) = jstr.try_to_string(env) {
+                let s: String = java_str.into();
+                let bytes = s.as_bytes();
+                let ptr = unsafe { js_string_from_bytes(bytes.as_ptr(), bytes.len()) };
+                let result = unsafe { js_nanbox_string(ptr) };
+                return finish(env, result);
             }
+            return finish(env, 0.0);
         }
-        return finish(&mut env, 0.0);
-    }
 
-    if let Ok(true) = env.is_instance_of(&entry, "java/lang/Long") {
-        if let Ok(l) = env.call_method(&entry, "longValue", "()J", &[]) {
-            if let Ok(v) = l.j() {
-                return finish(&mut env, v as f64);
+        if let Ok(true) = env.is_instance_of(&entry, jni::jni_str!("java/lang/Float")) {
+            if let Ok(f) = env.call_method(
+                &entry,
+                jni::jni_str!("floatValue"),
+                jni::jni_sig!("()F"),
+                &[],
+            ) {
+                if let Ok(v) = f.f() {
+                    return finish(env, v as f64);
+                }
             }
+            return finish(env, 0.0);
         }
-        return finish(&mut env, 0.0);
-    }
 
-    finish(&mut env, 0.0)
+        if let Ok(true) = env.is_instance_of(&entry, jni::jni_str!("java/lang/Double")) {
+            if let Ok(d) = env.call_method(
+                &entry,
+                jni::jni_str!("doubleValue"),
+                jni::jni_sig!("()D"),
+                &[],
+            ) {
+                if let Ok(v) = d.d() {
+                    return finish(env, v);
+                }
+            }
+            return finish(env, 0.0);
+        }
+
+        if let Ok(true) = env.is_instance_of(&entry, jni::jni_str!("java/lang/Integer")) {
+            if let Ok(i) =
+                env.call_method(&entry, jni::jni_str!("intValue"), jni::jni_sig!("()I"), &[])
+            {
+                if let Ok(v) = i.i() {
+                    return finish(env, v as f64);
+                }
+            }
+            return finish(env, 0.0);
+        }
+
+        if let Ok(true) = env.is_instance_of(&entry, jni::jni_str!("java/lang/Long")) {
+            if let Ok(l) = env.call_method(
+                &entry,
+                jni::jni_str!("longValue"),
+                jni::jni_sig!("()J"),
+                &[],
+            ) {
+                if let Ok(v) = l.j() {
+                    return finish(env, v as f64);
+                }
+            }
+            return finish(env, 0.0);
+        }
+
+        finish(env, 0.0)
+    })
 }
 
 /// Save a value to the keychain (SharedPreferences with private mode).
 pub fn keychain_save(key_ptr: *const u8, value_ptr: *const u8) {
     let key = unsafe { str_from_header(key_ptr) };
     let value = unsafe { str_from_header(value_ptr) };
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(16);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 16);
 
-    let activity = crate::widgets::get_activity(&mut env);
-    let pref_name = env.new_string("perry_keychain").expect("pref name");
-    let prefs = env
-        .call_method(
-            &activity,
-            "getSharedPreferences",
-            "(Ljava/lang/String;I)Landroid/content/SharedPreferences;",
-            &[JValue::Object(&pref_name), JValue::Int(0)],
-        )
-        .expect("getSharedPreferences")
-        .l()
-        .expect("prefs");
+        let activity = crate::widgets::get_activity(env);
+        let pref_name = env.new_string("perry_keychain").expect("pref name");
+        let prefs = env
+            .call_method(
+                &activity,
+                jni::jni_str!("getSharedPreferences"),
+                jni::jni_sig!("(Ljava/lang/String;I)Landroid/content/SharedPreferences;"),
+                &[JValue::Object(&pref_name), JValue::Int(0)],
+            )
+            .expect("getSharedPreferences")
+            .l()
+            .expect("prefs");
 
-    let editor = env
-        .call_method(
-            &prefs,
-            "edit",
-            "()Landroid/content/SharedPreferences$Editor;",
-            &[],
-        )
-        .expect("edit")
-        .l()
-        .expect("editor");
+        let editor = env
+            .call_method(
+                &prefs,
+                jni::jni_str!("edit"),
+                jni::jni_sig!("()Landroid/content/SharedPreferences$Editor;"),
+                &[],
+            )
+            .expect("edit")
+            .l()
+            .expect("editor");
 
-    let jkey = env.new_string(key).expect("key string");
-    let jval = env.new_string(value).expect("value string");
-    let _ = env.call_method(
-        &editor,
-        "putString",
-        "(Ljava/lang/String;Ljava/lang/String;)Landroid/content/SharedPreferences$Editor;",
-        &[JValue::Object(&jkey), JValue::Object(&jval)],
-    );
-    let _ = env.call_method(&editor, "apply", "()V", &[]);
+        let jkey = env.new_string(key).expect("key string");
+        let jval = env.new_string(value).expect("value string");
+        let _ = env.call_method(
+            &editor,
+            jni::jni_str!("putString"),
+            jni::jni_sig!(
+                "(Ljava/lang/String;Ljava/lang/String;)Landroid/content/SharedPreferences$Editor;"
+            ),
+            &[JValue::Object(&jkey), JValue::Object(&jval)],
+        );
+        let _ = env.call_method(&editor, jni::jni_str!("apply"), jni::jni_sig!("()V"), &[]);
 
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }
 
 /// Get a value from the keychain.
 pub fn keychain_get(key_ptr: *const u8) -> f64 {
     let key = unsafe { str_from_header(key_ptr) };
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(16);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 16);
 
-    let activity = crate::widgets::get_activity(&mut env);
-    let pref_name = env.new_string("perry_keychain").expect("pref name");
-    let prefs = env
-        .call_method(
-            &activity,
-            "getSharedPreferences",
-            "(Ljava/lang/String;I)Landroid/content/SharedPreferences;",
-            &[JValue::Object(&pref_name), JValue::Int(0)],
-        )
-        .expect("getSharedPreferences")
-        .l()
-        .expect("prefs");
+        let activity = crate::widgets::get_activity(env);
+        let pref_name = env.new_string("perry_keychain").expect("pref name");
+        let prefs = env
+            .call_method(
+                &activity,
+                jni::jni_str!("getSharedPreferences"),
+                jni::jni_sig!("(Ljava/lang/String;I)Landroid/content/SharedPreferences;"),
+                &[JValue::Object(&pref_name), JValue::Int(0)],
+            )
+            .expect("getSharedPreferences")
+            .l()
+            .expect("prefs");
 
-    let jkey = env.new_string(key).expect("key string");
-    let result = env.call_method(
-        &prefs,
-        "getString",
-        "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;",
-        &[
-            JValue::Object(&jkey),
-            JValue::Object(&jni::objects::JObject::null()),
-        ],
-    );
+        let jkey = env.new_string(key).expect("key string");
+        let result = env.call_method(
+            &prefs,
+            jni::jni_str!("getString"),
+            jni::jni_sig!("(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;"),
+            &[
+                JValue::Object(&jkey),
+                JValue::Object(&jni::objects::JObject::null()),
+            ],
+        );
 
-    let mut ret_val = f64::from_bits(0x7FFC_0000_0000_0001u64); // undefined
-    if let Ok(val) = result {
-        if let Ok(obj) = val.l() {
-            if !obj.is_null() {
-                let jstr: jni::objects::JString = obj.into();
-                let s: String = env.get_string(&jstr).expect("get string").into();
-                let bytes = s.as_bytes();
-                let ptr = unsafe { js_string_from_bytes(bytes.as_ptr(), bytes.len()) };
-                ret_val = unsafe { js_nanbox_string(ptr) };
+        let mut ret_val = f64::from_bits(0x7FFC_0000_0000_0001u64); // undefined
+        if let Ok(val) = result {
+            if let Ok(obj) = val.l() {
+                if !obj.is_null() {
+                    let jstr: jni::objects::JString =
+                        unsafe { jni::objects::JString::from_raw(env, obj.into_raw()) };
+                    let s: String = jstr.try_to_string(env).expect("get string").into();
+                    let bytes = s.as_bytes();
+                    let ptr = unsafe { js_string_from_bytes(bytes.as_ptr(), bytes.len()) };
+                    ret_val = unsafe { js_nanbox_string(ptr) };
+                }
             }
         }
-    }
 
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
-    ret_val
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+        ret_val
+    })
 }
 
 /// Delete a value from the keychain.
 pub fn keychain_delete(key_ptr: *const u8) {
     let key = unsafe { str_from_header(key_ptr) };
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(16);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 16);
 
-    let activity = crate::widgets::get_activity(&mut env);
-    let pref_name = env.new_string("perry_keychain").expect("pref name");
-    let prefs = env
-        .call_method(
-            &activity,
-            "getSharedPreferences",
-            "(Ljava/lang/String;I)Landroid/content/SharedPreferences;",
-            &[JValue::Object(&pref_name), JValue::Int(0)],
-        )
-        .expect("getSharedPreferences")
-        .l()
-        .expect("prefs");
+        let activity = crate::widgets::get_activity(env);
+        let pref_name = env.new_string("perry_keychain").expect("pref name");
+        let prefs = env
+            .call_method(
+                &activity,
+                jni::jni_str!("getSharedPreferences"),
+                jni::jni_sig!("(Ljava/lang/String;I)Landroid/content/SharedPreferences;"),
+                &[JValue::Object(&pref_name), JValue::Int(0)],
+            )
+            .expect("getSharedPreferences")
+            .l()
+            .expect("prefs");
 
-    let editor = env
-        .call_method(
-            &prefs,
-            "edit",
-            "()Landroid/content/SharedPreferences$Editor;",
-            &[],
-        )
-        .expect("edit")
-        .l()
-        .expect("editor");
+        let editor = env
+            .call_method(
+                &prefs,
+                jni::jni_str!("edit"),
+                jni::jni_sig!("()Landroid/content/SharedPreferences$Editor;"),
+                &[],
+            )
+            .expect("edit")
+            .l()
+            .expect("editor");
 
-    let jkey = env.new_string(key).expect("key string");
-    let _ = env.call_method(
-        &editor,
-        "remove",
-        "(Ljava/lang/String;)Landroid/content/SharedPreferences$Editor;",
-        &[JValue::Object(&jkey)],
-    );
-    let _ = env.call_method(&editor, "apply", "()V", &[]);
+        let jkey = env.new_string(key).expect("key string");
+        let _ = env.call_method(
+            &editor,
+            jni::jni_str!("remove"),
+            jni::jni_sig!("(Ljava/lang/String;)Landroid/content/SharedPreferences$Editor;"),
+            &[JValue::Object(&jkey)],
+        );
+        let _ = env.call_method(&editor, jni::jni_str!("apply"), jni::jni_sig!("()V"), &[]);
 
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }
 
 /// Play a haptic feedback effect via the system Vibrator service
@@ -458,22 +491,23 @@ pub fn haptic_play(type_ptr: *const u8) {
         _ => 20,
     };
 
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
 
-    // Haptics are fire-and-forget: any JNI failure (no vibrator
-    // service, missing VIBRATE permission, exotic OEM builds) degrades
-    // to the documented no-op instead of panicking the runtime.
-    if haptic_play_inner(&mut env, effect_id, fallback_ms).is_none() {
-        let _ = env.exception_clear();
-    }
+        // Haptics are fire-and-forget: any JNI failure (no vibrator
+        // service, missing VIBRATE permission, exotic OEM builds) degrades
+        // to the documented no-op instead of panicking the runtime.
+        if haptic_play_inner(env, effect_id, fallback_ms).is_none() {
+            let _ = env.exception_clear();
+        }
 
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }
 
-fn haptic_play_inner(env: &mut jni::JNIEnv, effect_id: i32, fallback_ms: i64) -> Option<()> {
+fn haptic_play_inner(env: &mut jni::Env, effect_id: i32, fallback_ms: i64) -> Option<()> {
     let activity = crate::widgets::get_activity(env);
 
     // Context.VIBRATOR_SERVICE = "vibrator". Deprecated in favor of
@@ -483,8 +517,8 @@ fn haptic_play_inner(env: &mut jni::JNIEnv, effect_id: i32, fallback_ms: i64) ->
     let vibrator = env
         .call_method(
             &activity,
-            "getSystemService",
-            "(Ljava/lang/String;)Ljava/lang/Object;",
+            jni::jni_str!("getSystemService"),
+            jni::jni_sig!("(Ljava/lang/String;)Ljava/lang/Object;"),
             &[JValue::Object(&service_name)],
         )
         .ok()?
@@ -495,7 +529,11 @@ fn haptic_play_inner(env: &mut jni::JNIEnv, effect_id: i32, fallback_ms: i64) ->
     }
 
     let sdk_int = env
-        .get_static_field("android/os/Build$VERSION", "SDK_INT", "I")
+        .get_static_field(
+            jni::jni_str!("android/os/Build$VERSION"),
+            jni::jni_str!("SDK_INT"),
+            jni::jni_sig!("I"),
+        )
         .ok()?
         .i()
         .ok()?;
@@ -504,9 +542,9 @@ fn haptic_play_inner(env: &mut jni::JNIEnv, effect_id: i32, fallback_ms: i64) ->
         // VibrationEffect.createPredefined(int) + vibrate(VibrationEffect).
         let effect = env
             .call_static_method(
-                "android/os/VibrationEffect",
-                "createPredefined",
-                "(I)Landroid/os/VibrationEffect;",
+                jni::jni_str!("android/os/VibrationEffect"),
+                jni::jni_str!("createPredefined"),
+                jni::jni_sig!("(I)Landroid/os/VibrationEffect;"),
                 &[JValue::Int(effect_id)],
             )
             .ok()?
@@ -514,15 +552,20 @@ fn haptic_play_inner(env: &mut jni::JNIEnv, effect_id: i32, fallback_ms: i64) ->
             .ok()?;
         env.call_method(
             &vibrator,
-            "vibrate",
-            "(Landroid/os/VibrationEffect;)V",
+            jni::jni_str!("vibrate"),
+            jni::jni_sig!("(Landroid/os/VibrationEffect;)V"),
             &[JValue::Object(&effect)],
         )
         .ok()?;
     } else {
         // Pre-29: the deprecated-but-present one-shot vibrate(long).
-        env.call_method(&vibrator, "vibrate", "(J)V", &[JValue::Long(fallback_ms)])
-            .ok()?;
+        env.call_method(
+            &vibrator,
+            jni::jni_str!("vibrate"),
+            jni::jni_sig!("(J)V"),
+            &[JValue::Long(fallback_ms)],
+        )
+        .ok()?;
     }
     Some(())
 }
@@ -573,7 +616,7 @@ pub fn notification_on_tap(callback: f64) {
 /// side.
 #[no_mangle]
 pub extern "C" fn Java_com_perry_app_PerryBridge_nativeNotificationTap(
-    mut env: jni::JNIEnv,
+    mut env: jni::EnvUnowned,
     _class: jni::objects::JClass,
     id: jni::objects::JString,
 ) {
@@ -582,17 +625,19 @@ pub extern "C" fn Java_com_perry_app_PerryBridge_nativeNotificationTap(
         return;
     }
 
-    let rust_str: String = env.get_string(&id).map(|s| s.into()).unwrap_or_default();
-    let bytes = rust_str.as_bytes();
-    let id_value = unsafe {
-        let ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len());
-        js_nanbox_string(ptr)
-    };
-    // `action` is always undefined until #97 follow-up wires action buttons.
-    const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
-    let action_value = f64::from_bits(TAG_UNDEFINED);
+    jni_bridge::with_unowned_env(&mut env, |env| {
+        let rust_str = id.try_to_string(env).unwrap_or_default();
+        let bytes = rust_str.as_bytes();
+        let id_value = unsafe {
+            let ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len());
+            js_nanbox_string(ptr)
+        };
+        // `action` is always undefined until #97 follow-up wires action buttons.
+        const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
+        let action_value = f64::from_bits(TAG_UNDEFINED);
 
-    crate::callback::invoke2(key, id_value, action_value);
+        crate::callback::invoke2(key, id_value, action_value);
+    });
 }
 
 /// Register the JS closure that fires when FCM hands us a device token
@@ -608,21 +653,22 @@ pub fn notification_register_remote(callback: f64) {
     let key = crate::callback::register(callback);
     NOTIFICATION_REMOTE_TOKEN_KEY.store(key, std::sync::atomic::Ordering::Relaxed);
 
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
-    let activity = crate::widgets::get_activity(&mut env);
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let _ = env.call_static_method(
-        bridge_cls,
-        "registerForRemoteNotifications",
-        "(Landroid/app/Activity;)V",
-        &[JValue::Object(&activity)],
-    );
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
+        let activity = crate::widgets::get_activity(env);
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("registerForRemoteNotifications"),
+            jni::jni_sig!("(Landroid/app/Activity;)V"),
+            &[JValue::Object(&activity)],
+        );
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }
 
 /// Register the JS closure that fires for foreground FCM payloads (#95).
@@ -653,7 +699,7 @@ pub fn notification_on_background_receive(callback: f64) {
 /// callback and invokes it with the token NaN-boxed string.
 #[no_mangle]
 pub extern "C" fn Java_com_perry_app_PerryBridge_nativeNotificationToken(
-    mut env: jni::JNIEnv,
+    mut env: jni::EnvUnowned,
     _class: jni::objects::JClass,
     token: jni::objects::JString,
 ) {
@@ -661,13 +707,15 @@ pub extern "C" fn Java_com_perry_app_PerryBridge_nativeNotificationToken(
     if key == 0 {
         return;
     }
-    let rust_str: String = env.get_string(&token).map(|s| s.into()).unwrap_or_default();
-    let bytes = rust_str.as_bytes();
-    let token_value = unsafe {
-        let ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len());
-        js_nanbox_string(ptr)
-    };
-    crate::callback::invoke1(key, token_value);
+    jni_bridge::with_unowned_env(&mut env, |env| {
+        let rust_str = token.try_to_string(env).unwrap_or_default();
+        let bytes = rust_str.as_bytes();
+        let token_value = unsafe {
+            let ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len());
+            js_nanbox_string(ptr)
+        };
+        crate::callback::invoke1(key, token_value);
+    });
 }
 
 /// JNI: FCM foreground push (#95). Parses the JSON payload via the runtime's
@@ -675,7 +723,7 @@ pub extern "C" fn Java_com_perry_app_PerryBridge_nativeNotificationToken(
 /// receive callback with it.
 #[no_mangle]
 pub extern "C" fn Java_com_perry_app_PerryBridge_nativeNotificationReceive(
-    mut env: jni::JNIEnv,
+    mut env: jni::EnvUnowned,
     _class: jni::objects::JClass,
     payload_json: jni::objects::JString,
 ) {
@@ -683,21 +731,20 @@ pub extern "C" fn Java_com_perry_app_PerryBridge_nativeNotificationReceive(
     if key == 0 {
         return;
     }
-    let rust_str: String = env
-        .get_string(&payload_json)
-        .map(|s| s.into())
-        .unwrap_or_default();
-    let bytes = rust_str.as_bytes();
+    jni_bridge::with_unowned_env(&mut env, |env| {
+        let rust_str = payload_json.try_to_string(env).unwrap_or_default();
+        let bytes = rust_str.as_bytes();
 
-    extern "C" {
-        fn js_json_parse(text_ptr: *const u8) -> u64;
-    }
-    let payload_value = unsafe {
-        let str_ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len());
-        let bits = js_json_parse(str_ptr);
-        f64::from_bits(bits)
-    };
-    crate::callback::invoke1(key, payload_value);
+        extern "C" {
+            fn js_json_parse(text_ptr: *const u8) -> u64;
+        }
+        let payload_value = unsafe {
+            let str_ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len());
+            let bits = js_json_parse(str_ptr);
+            f64::from_bits(bits)
+        };
+        crate::callback::invoke1(key, payload_value);
+    });
 }
 
 /// JNI: FCM background push (#98). Same JSON→object shape as
@@ -711,7 +758,7 @@ pub extern "C" fn Java_com_perry_app_PerryBridge_nativeNotificationReceive(
 /// when the OS suspends the process; v1 limitation, document for users.
 #[no_mangle]
 pub extern "C" fn Java_com_perry_app_PerryBridge_nativeNotificationBackgroundReceive(
-    mut env: jni::JNIEnv,
+    mut env: jni::EnvUnowned,
     _class: jni::objects::JClass,
     payload_json: jni::objects::JString,
 ) {
@@ -719,34 +766,33 @@ pub extern "C" fn Java_com_perry_app_PerryBridge_nativeNotificationBackgroundRec
     if key == 0 {
         return;
     }
-    let rust_str: String = env
-        .get_string(&payload_json)
-        .map(|s| s.into())
-        .unwrap_or_default();
-    let bytes = rust_str.as_bytes();
+    jni_bridge::with_unowned_env(&mut env, |env| {
+        let rust_str = payload_json.try_to_string(env).unwrap_or_default();
+        let bytes = rust_str.as_bytes();
 
-    extern "C" {
-        fn js_json_parse(text_ptr: *const u8) -> u64;
-        fn js_promise_run_microtasks() -> i32;
-    }
-    let payload_value = unsafe {
-        let str_ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len());
-        let bits = js_json_parse(str_ptr);
-        f64::from_bits(bits)
-    };
-    crate::callback::invoke1(key, payload_value);
-
-    // Drive the microtask pump a few times so an async callback that awaits
-    // already-resolved Promises (e.g., a cached value, an in-memory write)
-    // gets a chance to finish before we hand control back to the FCM service.
-    // Each tick may schedule new work, so loop until it stabilizes (or we hit
-    // the cap, to keep this call bounded).
-    for _ in 0..8 {
-        let drained = unsafe { js_promise_run_microtasks() };
-        if drained == 0 {
-            break;
+        extern "C" {
+            fn js_json_parse(text_ptr: *const u8) -> u64;
+            fn js_promise_run_microtasks() -> i32;
         }
-    }
+        let payload_value = unsafe {
+            let str_ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len());
+            let bits = js_json_parse(str_ptr);
+            f64::from_bits(bits)
+        };
+        crate::callback::invoke1(key, payload_value);
+
+        // Drive the microtask pump a few times so an async callback that awaits
+        // already-resolved Promises (e.g., a cached value, an in-memory write)
+        // gets a chance to finish before we hand control back to the FCM service.
+        // Each tick may schedule new work, so loop until it stabilizes (or we hit
+        // the cap, to keep this call bounded).
+        for _ in 0..8 {
+            let drained = unsafe { js_promise_run_microtasks() };
+            if drained == 0 {
+                break;
+            }
+        }
+    });
 }
 
 /// Schedule a fire-after-N-seconds notification via PerryBridge (#96).
@@ -766,31 +812,34 @@ pub fn notification_schedule_interval(
     let title = unsafe { str_from_header(title_ptr) };
     let body = unsafe { str_from_header(body_ptr) };
 
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(16);
-    let activity = crate::widgets::get_activity(&mut env);
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let jid = env.new_string(id).expect("id");
-    let jtitle = env.new_string(title).expect("title");
-    let jbody = env.new_string(body).expect("body");
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let _ = env.call_static_method(
-        bridge_cls,
-        "scheduleInterval",
-        "(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;DZ)V",
-        &[
-            JValue::Object(&activity),
-            JValue::Object(&jid),
-            JValue::Object(&jtitle),
-            JValue::Object(&jbody),
-            JValue::Double(seconds),
-            JValue::Bool(if repeats_bool { 1u8 } else { 0u8 }),
-        ],
-    );
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 16);
+        let activity = crate::widgets::get_activity(env);
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let jid = env.new_string(id).expect("id");
+        let jtitle = env.new_string(title).expect("title");
+        let jbody = env.new_string(body).expect("body");
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("scheduleInterval"),
+            jni::jni_sig!(
+                "(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;DZ)V"
+            ),
+            &[
+                JValue::Object(&activity),
+                JValue::Object(&jid),
+                JValue::Object(&jtitle),
+                JValue::Object(&jbody),
+                JValue::Double(seconds),
+                JValue::Bool(repeats_bool),
+            ],
+        );
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }
 
 /// Schedule a fire-at-wallclock-ms notification via PerryBridge (#96).
@@ -804,30 +853,33 @@ pub fn notification_schedule_calendar(
     let title = unsafe { str_from_header(title_ptr) };
     let body = unsafe { str_from_header(body_ptr) };
 
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(16);
-    let activity = crate::widgets::get_activity(&mut env);
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let jid = env.new_string(id).expect("id");
-    let jtitle = env.new_string(title).expect("title");
-    let jbody = env.new_string(body).expect("body");
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let _ = env.call_static_method(
-        bridge_cls,
-        "scheduleCalendar",
-        "(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;D)V",
-        &[
-            JValue::Object(&activity),
-            JValue::Object(&jid),
-            JValue::Object(&jtitle),
-            JValue::Object(&jbody),
-            JValue::Double(timestamp_ms),
-        ],
-    );
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 16);
+        let activity = crate::widgets::get_activity(env);
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let jid = env.new_string(id).expect("id");
+        let jtitle = env.new_string(title).expect("title");
+        let jbody = env.new_string(body).expect("body");
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("scheduleCalendar"),
+            jni::jni_sig!(
+                "(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;D)V"
+            ),
+            &[
+                JValue::Object(&activity),
+                JValue::Object(&jid),
+                JValue::Object(&jtitle),
+                JValue::Object(&jbody),
+                JValue::Double(timestamp_ms),
+            ],
+        );
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }
 
 /// Logged no-op — Geofencing requires `FUSED_LOCATION_PROVIDER` + a
@@ -859,51 +911,53 @@ pub fn notification_schedule_location(
 pub fn notification_cancel(id_ptr: *const u8) {
     let id = unsafe { str_from_header(id_ptr) };
 
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
-    let activity = crate::widgets::get_activity(&mut env);
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let jid = env.new_string(id).expect("id");
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let _ = env.call_static_method(
-        bridge_cls,
-        "cancelNotification",
-        "(Landroid/app/Activity;Ljava/lang/String;)V",
-        &[JValue::Object(&activity), JValue::Object(&jid)],
-    );
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
+        let activity = crate::widgets::get_activity(env);
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let jid = env.new_string(id).expect("id");
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("cancelNotification"),
+            jni::jni_sig!("(Landroid/app/Activity;Ljava/lang/String;)V"),
+            &[JValue::Object(&activity), JValue::Object(&jid)],
+        );
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }
 
 /// Send a notification via PerryBridge.
 pub fn notification_send(title_ptr: *const u8, body_ptr: *const u8) {
     let title = unsafe { str_from_header(title_ptr) };
     let body = unsafe { str_from_header(body_ptr) };
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(16);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 16);
 
-    let activity = crate::widgets::get_activity(&mut env);
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
+        let activity = crate::widgets::get_activity(env);
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
 
-    let jtitle = env.new_string(title).expect("title string");
-    let jbody = env.new_string(body).expect("body string");
+        let jtitle = env.new_string(title).expect("title string");
+        let jbody = env.new_string(body).expect("body string");
 
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let _ = env.call_static_method(
-        bridge_cls,
-        "sendNotification",
-        "(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;)V",
-        &[
-            JValue::Object(&activity),
-            JValue::Object(&jtitle),
-            JValue::Object(&jbody),
-        ],
-    );
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("sendNotification"),
+            jni::jni_sig!("(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;)V"),
+            &[
+                JValue::Object(&activity),
+                JValue::Object(&jtitle),
+                JValue::Object(&jbody),
+            ],
+        );
 
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }

--- a/crates/perry-ui-android/src/toolbar.rs
+++ b/crates/perry-ui-android/src/toolbar.rs
@@ -2,7 +2,7 @@
 
 use crate::callback;
 use crate::jni_bridge;
-use jni::objects::JValue;
+use jni::JValue;
 use std::cell::RefCell;
 use std::collections::HashMap;
 
@@ -18,65 +18,69 @@ thread_local! {
 }
 
 pub fn create() -> i64 {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
 
-    let activity = crate::widgets::get_activity(&mut env);
+        let activity = crate::widgets::get_activity(env);
 
-    // Create horizontal LinearLayout for toolbar
-    let layout = env
-        .new_object(
-            "android/widget/LinearLayout",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("Failed to create LinearLayout");
+        // Create horizontal LinearLayout for toolbar
+        let layout = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("Failed to create LinearLayout");
 
-    // Horizontal orientation
-    let _ = env.call_method(&layout, "setOrientation", "(I)V", &[JValue::Int(0)]);
+        // Horizontal orientation
+        let _ = env.call_method(
+            &layout,
+            jni::jni_str!("setOrientation"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(0)],
+        );
 
-    // Padding
-    let pad = crate::widgets::dp_to_px(&mut env, 8.0);
-    let _ = env.call_method(
-        &layout,
-        "setPadding",
-        "(IIII)V",
-        &[
-            JValue::Int(pad),
-            JValue::Int(pad),
-            JValue::Int(pad),
-            JValue::Int(pad),
-        ],
-    );
+        // Padding
+        let pad = crate::widgets::dp_to_px(env, 8.0);
+        let _ = env.call_method(
+            &layout,
+            jni::jni_str!("setPadding"),
+            jni::jni_sig!("(IIII)V"),
+            &[
+                JValue::Int(pad),
+                JValue::Int(pad),
+                JValue::Int(pad),
+                JValue::Int(pad),
+            ],
+        );
 
-    // Background color (light gray)
-    let _ = env.call_method(
-        &layout,
-        "setBackgroundColor",
-        "(I)V",
-        &[JValue::Int(0xFFE0E0E0u32 as i32)],
-    );
+        // Background color (light gray)
+        let _ = env.call_method(
+            &layout,
+            jni::jni_str!("setBackgroundColor"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(0xFFE0E0E0u32 as i32)],
+        );
 
-    let global = env
-        .new_global_ref(layout)
-        .expect("Failed to create global ref");
-    let widget_handle = crate::widgets::register_widget(global);
+        let global = jni_bridge::new_global_ref(env, layout).expect("Failed to create global ref");
+        let widget_handle = crate::widgets::register_widget(global);
 
-    let id = NEXT_TOOLBAR_ID.with(|n| {
-        let mut n = n.borrow_mut();
-        let id = *n;
-        *n += 1;
+        let id = NEXT_TOOLBAR_ID.with(|n| {
+            let mut n = n.borrow_mut();
+            let id = *n;
+            *n += 1;
+            id
+        });
+
+        TOOLBARS.with(|t| {
+            t.borrow_mut().insert(id, ToolbarState { widget_handle });
+        });
+
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
         id
-    });
-
-    TOOLBARS.with(|t| {
-        t.borrow_mut().insert(id, ToolbarState { widget_handle });
-    });
-
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
-    id
+    })
 }
 
 pub fn add_item(toolbar_handle: i64, label_ptr: *const u8, _icon_ptr: *const u8, on_press: f64) {
@@ -85,56 +89,56 @@ pub fn add_item(toolbar_handle: i64, label_ptr: *const u8, _icon_ptr: *const u8,
     let widget_handle = TOOLBARS.with(|t| t.borrow().get(&toolbar_handle).map(|s| s.widget_handle));
 
     if let Some(wh) = widget_handle {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(32);
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 32);
 
-        let activity = crate::widgets::get_activity(&mut env);
+            let activity = crate::widgets::get_activity(env);
 
-        // Create button
-        let button = env
-            .new_object(
-                "android/widget/Button",
-                "(Landroid/content/Context;)V",
-                &[JValue::Object(&activity)],
-            )
-            .expect("Failed to create Button");
+            // Create button
+            let button = env
+                .new_object(
+                    jni::jni_str!("android/widget/Button"),
+                    jni::jni_sig!("(Landroid/content/Context;)V"),
+                    &[JValue::Object(&activity)],
+                )
+                .expect("Failed to create Button");
 
-        let jstr = env.new_string(label).expect("Failed to create JNI string");
-        let _ = env.call_method(
-            &button,
-            "setText",
-            "(Ljava/lang/CharSequence;)V",
-            &[JValue::Object(&jstr)],
-        );
-
-        // Register callback
-        if on_press != 0.0 {
-            let cb_key = callback::register(on_press);
-            let bridge_class = jni_bridge::with_cache(|c| {
-                env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap()
-            });
-            let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-            let _ = env.call_static_method(
-                bridge_cls,
-                "setOnClickCallback",
-                "(Landroid/view/View;J)V",
-                &[JValue::Object(&button), JValue::Long(cb_key)],
-            );
-        }
-
-        // Add to toolbar
-        if let Some(toolbar_ref) = crate::widgets::get_widget(wh) {
+            let jstr = env.new_string(label).expect("Failed to create JNI string");
             let _ = env.call_method(
-                toolbar_ref.as_obj(),
-                "addView",
-                "(Landroid/view/View;)V",
-                &[JValue::Object(&button)],
+                &button,
+                jni::jni_str!("setText"),
+                jni::jni_sig!("(Ljava/lang/CharSequence;)V"),
+                &[JValue::Object(&jstr)],
             );
-        }
 
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+            // Register callback
+            if on_press != 0.0 {
+                let cb_key = callback::register(on_press);
+                let bridge_class =
+                    jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+                let bridge_cls: &jni::objects::JClass = &bridge_class;
+                let _ = env.call_static_method(
+                    bridge_cls,
+                    jni::jni_str!("setOnClickCallback"),
+                    jni::jni_sig!("(Landroid/view/View;J)V"),
+                    &[JValue::Object(&button), JValue::Long(cb_key)],
+                );
+            }
+
+            // Add to toolbar
+            if let Some(toolbar_ref) = crate::widgets::get_widget(wh) {
+                let _ = env.call_method(
+                    toolbar_ref.as_obj(),
+                    jni::jni_str!("addView"),
+                    jni::jni_sig!("(Landroid/view/View;)V"),
+                    &[JValue::Object(&button)],
+                );
+            }
+
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+        })
     }
 }
 

--- a/crates/perry-ui-android/src/widgets/adbanner.rs
+++ b/crates/perry-ui-android/src/widgets/adbanner.rs
@@ -9,7 +9,7 @@
 //! API parity but unused by the placeholder.
 
 use crate::jni_bridge;
-use jni::objects::JValue;
+use jni::JValue;
 
 use perry_ffi::copy_string_from_raw as str_from_header;
 
@@ -31,40 +31,39 @@ pub fn create(unit_id_ptr: *const u8, size_ptr: *const u8) -> i64 {
     let size_key = unsafe { str_from_header(size_ptr) };
     let (w_dp, h_dp) = banner_size_dp(&size_key);
 
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
-    let activity = super::get_activity(&mut env);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
+        let activity = super::get_activity(env);
 
-    let view = env
-        .new_object(
-            "android/view/View",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("Failed to create View");
+        let view = env
+            .new_object(
+                jni::jni_str!("android/view/View"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("Failed to create View");
 
-    let width_px = super::dp_to_px(&mut env, w_dp);
-    let height_px = super::dp_to_px(&mut env, h_dp);
-    let params = env
-        .new_object(
-            "android/widget/LinearLayout$LayoutParams",
-            "(II)V",
-            &[JValue::Int(width_px), JValue::Int(height_px)],
-        )
-        .expect("Failed to create LayoutParams");
-    let _ = env.call_method(
-        &view,
-        "setLayoutParams",
-        "(Landroid/view/ViewGroup$LayoutParams;)V",
-        &[JValue::Object(&params)],
-    );
+        let width_px = super::dp_to_px(env, w_dp);
+        let height_px = super::dp_to_px(env, h_dp);
+        let params = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout$LayoutParams"),
+                jni::jni_sig!("(II)V"),
+                &[JValue::Int(width_px), JValue::Int(height_px)],
+            )
+            .expect("Failed to create LayoutParams");
+        let _ = env.call_method(
+            &view,
+            jni::jni_str!("setLayoutParams"),
+            jni::jni_sig!("(Landroid/view/ViewGroup$LayoutParams;)V"),
+            &[JValue::Object(&params)],
+        );
 
-    let global = env
-        .new_global_ref(view)
-        .expect("Failed to create global ref");
-    let handle = super::register_widget(global);
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
-    handle
+        let global = jni_bridge::new_global_ref(env, view).expect("Failed to create global ref");
+        let handle = super::register_widget(global);
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+        handle
+    })
 }

--- a/crates/perry-ui-android/src/widgets/attributed_text.rs
+++ b/crates/perry-ui-android/src/widgets/attributed_text.rs
@@ -5,8 +5,9 @@
 //! for explicit font size).
 
 use crate::jni_bridge;
-use jni::objects::{GlobalRef, JObject, JValue};
-use jni::JNIEnv;
+use crate::jni_bridge::GlobalRef;
+use jni::objects::JObject;
+use jni::{Env, JValue};
 use std::cell::RefCell;
 use std::collections::HashMap;
 
@@ -27,39 +28,44 @@ use perry_ffi::copy_string_from_raw as str_from_header;
 
 /// Create an empty `TextView` ready to receive `append` runs.
 pub fn create() -> i64 {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(16);
-    let activity = super::get_activity(&mut env);
-    let tv = env
-        .new_object(
-            "android/widget/TextView",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("AttributedText TextView");
-    let global = env.new_global_ref(&tv).expect("TextView global ref");
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 16);
+        let activity = super::get_activity(env);
+        let tv = env
+            .new_object(
+                jni::jni_str!("android/widget/TextView"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("AttributedText TextView");
+        let global = jni_bridge::new_global_ref(env, &tv).expect("TextView global ref");
 
-    // Empty SpannableStringBuilder.
-    let ssb = env
-        .new_object("android/text/SpannableStringBuilder", "()V", &[])
-        .expect("SpannableStringBuilder()");
-    let ssb_global = env.new_global_ref(&ssb).expect("SSB global ref");
+        // Empty SpannableStringBuilder.
+        let ssb = env
+            .new_object(
+                jni::jni_str!("android/text/SpannableStringBuilder"),
+                jni::jni_sig!("()V"),
+                &[],
+            )
+            .expect("SpannableStringBuilder()");
+        let ssb_global = jni_bridge::new_global_ref(env, &ssb).expect("SSB global ref");
 
-    let handle = super::register_widget(global);
-    BUFFERS.with(|b| {
-        b.borrow_mut().insert(
-            handle,
-            Buffer {
-                builder: ssb_global,
-                len: 0,
-            },
-        );
-    });
+        let handle = super::register_widget(global);
+        BUFFERS.with(|b| {
+            b.borrow_mut().insert(
+                handle,
+                Buffer {
+                    builder: ssb_global,
+                    len: 0,
+                },
+            );
+        });
 
-    unsafe {
-        env.pop_local_frame(&JObject::null());
-    }
-    handle
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+        }
+        handle
+    })
 }
 
 /// Append one styled run. See iOS/macOS twin for parameter semantics.
@@ -94,99 +100,97 @@ pub fn append(
         None => return,
     };
 
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
 
-    // Append the raw text to the SSB; the returned object is the SSB
-    // itself but we don't need the return value.
-    let java_text = match env.new_string(&text) {
-        Ok(s) => s,
-        Err(_) => {
-            unsafe {
-                env.pop_local_frame(&JObject::null());
+        // Append the raw text to the SSB; the returned object is the SSB
+        // itself but we don't need the return value.
+        let java_text = match env.new_string(&text) {
+            Ok(s) => s,
+            Err(_) => {
+                unsafe {
+                    let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+                }
+                return;
             }
-            return;
+        };
+        let _ = env.call_method(
+            ssb_ref.as_obj(),
+            jni::jni_str!("append"),
+            jni::jni_sig!("(Ljava/lang/CharSequence;)Landroid/text/SpannableStringBuilder;"),
+            &[JValue::Object(&java_text)],
+        );
+
+        let end = start + text.chars().count() as i32;
+
+        // SPAN_EXCLUSIVE_EXCLUSIVE = 33 — the conventional flag for static
+        // run spans that don't expand when adjacent text is inserted.
+        const SPAN_FLAG: i32 = 33;
+
+        if bold != 0 || italic != 0 {
+            // Build a Typeface style int: BOLD = 1, ITALIC = 2, BOLD_ITALIC = 3.
+            let style: i32 = (bold != 0) as i32 | ((italic != 0) as i32) << 1;
+            if let Ok(style_span) = env.new_object(
+                jni::jni_str!("android/text/style/StyleSpan"),
+                jni::jni_sig!("(I)V"),
+                &[JValue::Int(style)],
+            ) {
+                set_span(env, ssb_ref.as_obj(), &style_span, start, end, SPAN_FLAG);
+            }
         }
-    };
-    let _ = env.call_method(
-        ssb_ref.as_obj(),
-        "append",
-        "(Ljava/lang/CharSequence;)Landroid/text/SpannableStringBuilder;",
-        &[JValue::Object(&java_text)],
-    );
 
-    let end = start + text.chars().count() as i32;
-
-    // SPAN_EXCLUSIVE_EXCLUSIVE = 33 — the conventional flag for static
-    // run spans that don't expand when adjacent text is inserted.
-    const SPAN_FLAG: i32 = 33;
-
-    if bold != 0 || italic != 0 {
-        // Build a Typeface style int: BOLD = 1, ITALIC = 2, BOLD_ITALIC = 3.
-        let style: i32 = (bold != 0) as i32 | ((italic != 0) as i32) << 1;
-        if let Ok(style_span) = env.new_object(
-            "android/text/style/StyleSpan",
-            "(I)V",
-            &[JValue::Int(style)],
-        ) {
-            set_span(
-                &mut env,
-                ssb_ref.as_obj(),
-                &style_span,
-                start,
-                end,
-                SPAN_FLAG,
-            );
+        if underline != 0 {
+            if let Ok(u_span) = env.new_object(
+                jni::jni_str!("android/text/style/UnderlineSpan"),
+                jni::jni_sig!("()V"),
+                &[],
+            ) {
+                set_span(env, ssb_ref.as_obj(), &u_span, start, end, SPAN_FLAG);
+            }
         }
-    }
 
-    if underline != 0 {
-        if let Ok(u_span) = env.new_object("android/text/style/UnderlineSpan", "()V", &[]) {
-            set_span(&mut env, ssb_ref.as_obj(), &u_span, start, end, SPAN_FLAG);
+        if a > 0.0 {
+            let argb = rgba_to_argb(r, g, b, a);
+            if let Ok(c_span) = env.new_object(
+                jni::jni_str!("android/text/style/ForegroundColorSpan"),
+                jni::jni_sig!("(I)V"),
+                &[JValue::Int(argb)],
+            ) {
+                set_span(env, ssb_ref.as_obj(), &c_span, start, end, SPAN_FLAG);
+            }
         }
-    }
 
-    if a > 0.0 {
-        let argb = rgba_to_argb(r, g, b, a);
-        if let Ok(c_span) = env.new_object(
-            "android/text/style/ForegroundColorSpan",
-            "(I)V",
-            &[JValue::Int(argb)],
-        ) {
-            set_span(&mut env, ssb_ref.as_obj(), &c_span, start, end, SPAN_FLAG);
+        if font_size > 0.0 {
+            // AbsoluteSizeSpan(size, dip) — dip=true means the int is in dp.
+            if let Ok(sz_span) = env.new_object(
+                jni::jni_str!("android/text/style/AbsoluteSizeSpan"),
+                jni::jni_sig!("(IZ)V"),
+                &[JValue::Int(font_size.round() as i32), JValue::Bool(true)],
+            ) {
+                set_span(env, ssb_ref.as_obj(), &sz_span, start, end, SPAN_FLAG);
+            }
         }
-    }
 
-    if font_size > 0.0 {
-        // AbsoluteSizeSpan(size, dip) — dip=true means the int is in dp.
-        if let Ok(sz_span) = env.new_object(
-            "android/text/style/AbsoluteSizeSpan",
-            "(IZ)V",
-            &[JValue::Int(font_size.round() as i32), JValue::Bool(1)],
-        ) {
-            set_span(&mut env, ssb_ref.as_obj(), &sz_span, start, end, SPAN_FLAG);
+        // Push the buffer onto the TextView. Calling setText(CharSequence)
+        // copies-on-write internally on most Android versions; safer to do
+        // it every append rather than try to incrementally update.
+        let _ = env.call_method(
+            view_ref.as_obj(),
+            jni::jni_str!("setText"),
+            jni::jni_sig!("(Ljava/lang/CharSequence;)V"),
+            &[JValue::Object(ssb_ref.as_obj())],
+        );
+
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
         }
-    }
 
-    // Push the buffer onto the TextView. Calling setText(CharSequence)
-    // copies-on-write internally on most Android versions; safer to do
-    // it every append rather than try to incrementally update.
-    let _ = env.call_method(
-        view_ref.as_obj(),
-        "setText",
-        "(Ljava/lang/CharSequence;)V",
-        &[JValue::Object(ssb_ref.as_obj())],
-    );
-
-    unsafe {
-        env.pop_local_frame(&JObject::null());
-    }
-
-    BUFFERS.with(|b| {
-        if let Some(buf) = b.borrow_mut().get_mut(&handle) {
-            buf.len = end;
-        }
-    });
+        BUFFERS.with(|b| {
+            if let Some(buf) = b.borrow_mut().get_mut(&handle) {
+                buf.len = end;
+            }
+        });
+    })
 }
 
 /// Reset the buffer back to empty.
@@ -195,43 +199,48 @@ pub fn clear(handle: i64) {
         return;
     };
 
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(16);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 16);
 
-    let ssb = match env.new_object("android/text/SpannableStringBuilder", "()V", &[]) {
-        Ok(o) => o,
-        Err(_) => {
-            unsafe {
-                env.pop_local_frame(&JObject::null());
+        let ssb = match env.new_object(
+            jni::jni_str!("android/text/SpannableStringBuilder"),
+            jni::jni_sig!("()V"),
+            &[],
+        ) {
+            Ok(o) => o,
+            Err(_) => {
+                unsafe {
+                    let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+                }
+                return;
             }
-            return;
-        }
-    };
-    let _ = env.call_method(
-        view_ref.as_obj(),
-        "setText",
-        "(Ljava/lang/CharSequence;)V",
-        &[JValue::Object(&ssb)],
-    );
-    let global = env.new_global_ref(&ssb).expect("SSB global ref");
+        };
+        let _ = env.call_method(
+            view_ref.as_obj(),
+            jni::jni_str!("setText"),
+            jni::jni_sig!("(Ljava/lang/CharSequence;)V"),
+            &[JValue::Object(&ssb)],
+        );
+        let global = jni_bridge::new_global_ref(env, &ssb).expect("SSB global ref");
 
-    BUFFERS.with(|b| {
-        if let Some(buf) = b.borrow_mut().get_mut(&handle) {
-            buf.builder = global;
-            buf.len = 0;
-        }
-    });
+        BUFFERS.with(|b| {
+            if let Some(buf) = b.borrow_mut().get_mut(&handle) {
+                buf.builder = global;
+                buf.len = 0;
+            }
+        });
 
-    unsafe {
-        env.pop_local_frame(&JObject::null());
-    }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+        }
+    })
 }
 
-fn set_span(env: &mut JNIEnv, ssb: &JObject, span: &JObject, start: i32, end: i32, flags: i32) {
+fn set_span(env: &mut Env, ssb: &JObject, span: &JObject, start: i32, end: i32, flags: i32) {
     let _ = env.call_method(
         ssb,
-        "setSpan",
-        "(Ljava/lang/Object;III)V",
+        jni::jni_str!("setSpan"),
+        jni::jni_sig!("(Ljava/lang/Object;III)V"),
         &[
             JValue::Object(span),
             JValue::Int(start),
@@ -251,7 +260,7 @@ fn rgba_to_argb(r: f64, g: f64, b: f64, a: f64) -> i32 {
 /// JNI `GlobalRef` is not `Clone`, but `as_obj` returns the underlying
 /// `JObject<'static>` we can re-wrap as a new global via JNIEnv.
 fn env_clone_global(g: &GlobalRef) -> GlobalRef {
-    let env = jni_bridge::get_env();
-    env.new_global_ref(g.as_obj())
-        .expect("clone SSB global ref")
+    jni_bridge::with_env(|env| {
+        jni_bridge::new_global_ref(env, g.as_obj()).expect("clone SSB global ref")
+    })
 }

--- a/crates/perry-ui-android/src/widgets/bloomview.rs
+++ b/crates/perry-ui-android/src/widgets/bloomview.rs
@@ -11,7 +11,7 @@
 //! host should attach after the view is on screen (or retry).
 
 use crate::jni_bridge;
-use jni::objects::JValue;
+use jni::JValue;
 use std::sync::Mutex;
 
 // NDK libandroid: turn a Java `android.view.Surface` into a native window the
@@ -35,49 +35,60 @@ static BLOOM_WINDOWS: Mutex<Vec<(i64, i64)>> = Mutex::new(Vec::new());
 /// Create a BloomView host sized `width` × `height` dp. Returns the widget
 /// handle, or 0 on JNI failure.
 pub fn create(width: f64, height: f64) -> i64 {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
 
-    let activity = super::get_activity(&mut env);
-    let view = match env.new_object(
-        "android/view/SurfaceView",
-        "(Landroid/content/Context;)V",
-        &[JValue::Object(&activity)],
-    ) {
-        Ok(v) => v,
-        Err(_) => {
-            unsafe {
-                let _ = env.pop_local_frame(&jni::objects::JObject::null());
+        let activity = super::get_activity(env);
+        let view = match env.new_object(
+            jni::jni_str!("android/view/SurfaceView"),
+            jni::jni_sig!("(Landroid/content/Context;)V"),
+            &[JValue::Object(&activity)],
+        ) {
+            Ok(v) => v,
+            Err(_) => {
+                unsafe {
+                    let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+                }
+                return 0;
             }
-            return 0;
-        }
-    };
+        };
 
-    // Let the host view take focus so the attached engine can route key/touch.
-    let _ = env.call_method(&view, "setFocusable", "(Z)V", &[JValue::Bool(1)]);
-    let _ = env.call_method(&view, "setFocusableInTouchMode", "(Z)V", &[JValue::Bool(1)]);
+        // Let the host view take focus so the attached engine can route key/touch.
+        let _ = env.call_method(
+            &view,
+            jni::jni_str!("setFocusable"),
+            jni::jni_sig!("(Z)V"),
+            &[JValue::Bool(true)],
+        );
+        let _ = env.call_method(
+            &view,
+            jni::jni_str!("setFocusableInTouchMode"),
+            jni::jni_sig!("(Z)V"),
+            &[JValue::Bool(true)],
+        );
 
-    let global_ref = match env.new_global_ref(&view) {
-        Ok(g) => g,
-        Err(_) => {
-            unsafe {
-                let _ = env.pop_local_frame(&jni::objects::JObject::null());
+        let global_ref = match jni_bridge::new_global_ref(env, &view) {
+            Ok(g) => g,
+            Err(_) => {
+                unsafe {
+                    let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+                }
+                return 0;
             }
-            return 0;
+        };
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
         }
-    };
-    unsafe {
-        let _ = env.pop_local_frame(&jni::objects::JObject::null());
-    }
 
-    let handle = super::register_widget(global_ref);
-    if width.is_finite() && width >= 1.0 {
-        super::set_width(handle, width);
-    }
-    if height.is_finite() && height >= 1.0 {
-        super::set_height(handle, height);
-    }
-    handle
+        let handle = super::register_widget(global_ref);
+        if width.is_finite() && width >= 1.0 {
+            super::set_width(handle, width);
+        }
+        if height.is_finite() && height >= 1.0 {
+            super::set_height(handle, height);
+        }
+        handle
+    })
 }
 
 /// Return the `ANativeWindow*` of the BloomView's `Surface` as an integer, for
@@ -99,57 +110,68 @@ pub fn get_native_handle(handle: i64) -> i64 {
     let Some(view_ref) = super::get_widget(handle) else {
         return 0;
     };
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
 
-    let result = (|| -> Option<i64> {
-        // holder = surfaceView.getHolder()
-        let holder = env
-            .call_method(
-                view_ref.as_obj(),
-                "getHolder",
-                "()Landroid/view/SurfaceHolder;",
-                &[],
-            )
-            .ok()?
-            .l()
-            .ok()?;
-        // surface = holder.getSurface()
-        let surface = env
-            .call_method(&holder, "getSurface", "()Landroid/view/Surface;", &[])
-            .ok()?
-            .l()
-            .ok()?;
-        // Bail unless the surface is backed by a live buffer queue.
-        let valid = env
-            .call_method(&surface, "isValid", "()Z", &[])
-            .ok()?
-            .z()
-            .ok()?;
-        if !valid {
-            return None;
-        }
-        let env_raw = env.get_native_interface();
-        let win = unsafe { ANativeWindow_fromSurface(env_raw, surface.as_raw()) };
-        if win.is_null() {
-            None
-        } else {
-            Some(win as i64)
-        }
-    })();
-
-    unsafe {
-        let _ = env.pop_local_frame(&jni::objects::JObject::null());
-    }
-    // Cache the window so the next poll reuses this reference instead of
-    // acquiring a fresh one (only on success — keep retrying while not ready).
-    if let Some(win) = result {
-        if let Ok(mut cache) = BLOOM_WINDOWS.lock() {
-            if !cache.iter().any(|&(h, _)| h == handle) {
-                cache.push((handle, win));
+        let result = (|| -> Option<i64> {
+            // holder = surfaceView.getHolder()
+            let holder = env
+                .call_method(
+                    view_ref.as_obj(),
+                    jni::jni_str!("getHolder"),
+                    jni::jni_sig!("()Landroid/view/SurfaceHolder;"),
+                    &[],
+                )
+                .ok()?
+                .l()
+                .ok()?;
+            // surface = holder.getSurface()
+            let surface = env
+                .call_method(
+                    &holder,
+                    jni::jni_str!("getSurface"),
+                    jni::jni_sig!("()Landroid/view/Surface;"),
+                    &[],
+                )
+                .ok()?
+                .l()
+                .ok()?;
+            // Bail unless the surface is backed by a live buffer queue.
+            let valid = env
+                .call_method(
+                    &surface,
+                    jni::jni_str!("isValid"),
+                    jni::jni_sig!("()Z"),
+                    &[],
+                )
+                .ok()?
+                .z()
+                .ok()?;
+            if !valid {
+                return None;
             }
+            let env_raw = env.get_raw();
+            let win = unsafe { ANativeWindow_fromSurface(env_raw, surface.as_raw()) };
+            if win.is_null() {
+                None
+            } else {
+                Some(win as i64)
+            }
+        })();
+
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
         }
-        return win;
-    }
-    0
+        // Cache the window so the next poll reuses this reference instead of
+        // acquiring a fresh one (only on success — keep retrying while not ready).
+        if let Some(win) = result {
+            if let Ok(mut cache) = BLOOM_WINDOWS.lock() {
+                if !cache.iter().any(|&(h, _)| h == handle) {
+                    cache.push((handle, win));
+                }
+            }
+            return win;
+        }
+        0
+    })
 }

--- a/crates/perry-ui-android/src/widgets/bottom_nav.rs
+++ b/crates/perry-ui-android/src/widgets/bottom_nav.rs
@@ -8,7 +8,8 @@
 
 use crate::callback;
 use crate::jni_bridge;
-use jni::objects::{JObject, JValue};
+use jni::objects::JObject;
+use jni::JValue;
 use std::cell::RefCell;
 use std::collections::HashMap;
 
@@ -38,453 +39,502 @@ thread_local! {
 
 /// Create a BottomNavigation bar.
 pub fn create(on_select: f64) -> i64 {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
-    let activity = super::get_activity(&mut env);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
+        let activity = super::get_activity(env);
 
-    // Wrapper: vertical LinearLayout with thin top divider + tab row.
-    let divider = env
-        .new_object(
-            "android/view/View",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("BottomNav divider");
-    let _ = env.call_method(
-        &divider,
-        "setBackgroundColor",
-        "(I)V",
-        &[JValue::Int(0xFFE0E0E0u32 as i32)],
-    );
-    let dp1 = super::dp_to_px(&mut env, 1.0);
-    let dlp = env
-        .new_object(
-            "android/widget/LinearLayout$LayoutParams",
-            "(II)V",
-            &[JValue::Int(-1), JValue::Int(dp1)],
-        )
-        .expect("dlp");
-    let _ = env.call_method(
-        &divider,
-        "setLayoutParams",
-        "(Landroid/view/ViewGroup$LayoutParams;)V",
-        &[JValue::Object(&dlp)],
-    );
-
-    let row = env
-        .new_object(
-            "android/widget/LinearLayout",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("BottomNav row");
-    let _ = env.call_method(&row, "setOrientation", "(I)V", &[JValue::Int(0)]); // HORIZONTAL
-    let _ = env.call_method(
-        &row,
-        "setBackgroundColor",
-        "(I)V",
-        &[JValue::Int(0xFFFFFFFFu32 as i32)],
-    );
-
-    let wrapper = env
-        .new_object(
-            "android/widget/LinearLayout",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("BottomNav wrapper");
-    let _ = env.call_method(&wrapper, "setOrientation", "(I)V", &[JValue::Int(1)]); // VERTICAL
-    let _ = env.call_method(
-        &wrapper,
-        "addView",
-        "(Landroid/view/View;)V",
-        &[JValue::Object(&divider)],
-    );
-    let _ = env.call_method(
-        &wrapper,
-        "addView",
-        "(Landroid/view/View;)V",
-        &[JValue::Object(&row)],
-    );
-    let wp = env
-        .new_object(
-            "android/widget/LinearLayout$LayoutParams",
-            "(II)V",
-            &[JValue::Int(-1), JValue::Int(-2)],
-        )
-        .expect("wp");
-    let _ = env.call_method(
-        &wrapper,
-        "setLayoutParams",
-        "(Landroid/view/ViewGroup$LayoutParams;)V",
-        &[JValue::Object(&wp)],
-    );
-
-    let global = env.new_global_ref(wrapper).expect("BottomNav ref");
-    let handle = super::register_widget(global);
-    let row_global = env.new_global_ref(row).expect("BottomNav row ref");
-    let layout_handle = super::register_widget(row_global);
-
-    let cb_key = callback::register(on_select);
-    STATES.with(|s| {
-        s.borrow_mut().insert(
-            handle,
-            BottomNavState {
-                layout_handle,
-                items: Vec::new(),
-                callback_key: cb_key,
-                selected: 0,
-                selected_tint: None,
-                unselected_tint: None,
-            },
+        // Wrapper: vertical LinearLayout with thin top divider + tab row.
+        let divider = env
+            .new_object(
+                jni::jni_str!("android/view/View"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("BottomNav divider");
+        let _ = env.call_method(
+            &divider,
+            jni::jni_str!("setBackgroundColor"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(0xFFE0E0E0u32 as i32)],
         );
-    });
+        let dp1 = super::dp_to_px(env, 1.0);
+        let dlp = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout$LayoutParams"),
+                jni::jni_sig!("(II)V"),
+                &[JValue::Int(-1), JValue::Int(dp1)],
+            )
+            .expect("dlp");
+        let _ = env.call_method(
+            &divider,
+            jni::jni_str!("setLayoutParams"),
+            jni::jni_sig!("(Landroid/view/ViewGroup$LayoutParams;)V"),
+            &[JValue::Object(&dlp)],
+        );
 
-    unsafe {
-        let _ = env.pop_local_frame(&JObject::null());
-    }
-    handle
+        let row = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("BottomNav row");
+        let _ = env.call_method(
+            &row,
+            jni::jni_str!("setOrientation"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(0)],
+        ); // HORIZONTAL
+        let _ = env.call_method(
+            &row,
+            jni::jni_str!("setBackgroundColor"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(0xFFFFFFFFu32 as i32)],
+        );
+
+        let wrapper = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("BottomNav wrapper");
+        let _ = env.call_method(
+            &wrapper,
+            jni::jni_str!("setOrientation"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(1)],
+        ); // VERTICAL
+        let _ = env.call_method(
+            &wrapper,
+            jni::jni_str!("addView"),
+            jni::jni_sig!("(Landroid/view/View;)V"),
+            &[JValue::Object(&divider)],
+        );
+        let _ = env.call_method(
+            &wrapper,
+            jni::jni_str!("addView"),
+            jni::jni_sig!("(Landroid/view/View;)V"),
+            &[JValue::Object(&row)],
+        );
+        let wp = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout$LayoutParams"),
+                jni::jni_sig!("(II)V"),
+                &[JValue::Int(-1), JValue::Int(-2)],
+            )
+            .expect("wp");
+        let _ = env.call_method(
+            &wrapper,
+            jni::jni_str!("setLayoutParams"),
+            jni::jni_sig!("(Landroid/view/ViewGroup$LayoutParams;)V"),
+            &[JValue::Object(&wp)],
+        );
+
+        let global = jni_bridge::new_global_ref(env, wrapper).expect("BottomNav ref");
+        let handle = super::register_widget(global);
+        let row_global = jni_bridge::new_global_ref(env, row).expect("BottomNav row ref");
+        let layout_handle = super::register_widget(row_global);
+
+        let cb_key = callback::register(on_select);
+        STATES.with(|s| {
+            s.borrow_mut().insert(
+                handle,
+                BottomNavState {
+                    layout_handle,
+                    items: Vec::new(),
+                    callback_key: cb_key,
+                    selected: 0,
+                    selected_tint: None,
+                    unselected_tint: None,
+                },
+            );
+        });
+
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+        }
+        handle
+    })
 }
 
 /// Add a tab item (icon drawable name + label).
 pub fn add_item(handle: i64, icon_ptr: *const u8, label_ptr: *const u8) {
     let icon = unsafe { crate::app::str_from_header(icon_ptr) };
     let label = unsafe { crate::app::str_from_header(label_ptr) };
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
-    let activity = super::get_activity(&mut env);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
+        let activity = super::get_activity(env);
 
-    let (layout_handle, cb_key, idx) = STATES.with(|s| {
-        let map = s.borrow();
-        match map.get(&handle) {
-            Some(st) => (st.layout_handle, st.callback_key, st.items.len() as i64),
-            None => (0, 0, 0),
-        }
-    });
-    let Some(layout_ref) = super::get_widget(layout_handle) else {
-        unsafe {
-            let _ = env.pop_local_frame(&JObject::null());
-        }
-        return;
-    };
+        let (layout_handle, cb_key, idx) = STATES.with(|s| {
+            let map = s.borrow();
+            match map.get(&handle) {
+                Some(st) => (st.layout_handle, st.callback_key, st.items.len() as i64),
+                None => (0, 0, 0),
+            }
+        });
+        let Some(layout_ref) = super::get_widget(layout_handle) else {
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+            return;
+        };
 
-    // Tab container: vertical LinearLayout with icon on top, label below.
-    let tab = env
-        .new_object(
-            "android/widget/LinearLayout",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("Tab container");
-    let _ = env.call_method(&tab, "setOrientation", "(I)V", &[JValue::Int(1)]); // VERTICAL
-    let _ = env.call_method(&tab, "setGravity", "(I)V", &[JValue::Int(17)]); // CENTER
-    let _ = env.call_method(&tab, "setClickable", "(Z)V", &[JValue::Bool(1)]);
+        // Tab container: vertical LinearLayout with icon on top, label below.
+        let tab = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("Tab container");
+        let _ = env.call_method(
+            &tab,
+            jni::jni_str!("setOrientation"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(1)],
+        ); // VERTICAL
+        let _ = env.call_method(
+            &tab,
+            jni::jni_str!("setGravity"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(17)],
+        ); // CENTER
+        let _ = env.call_method(
+            &tab,
+            jni::jni_str!("setClickable"),
+            jni::jni_sig!("(Z)V"),
+            &[JValue::Bool(true)],
+        );
 
-    let dp8 = super::dp_to_px(&mut env, 8.0);
-    let _ = env.call_method(
-        &tab,
-        "setPadding",
-        "(IIII)V",
-        &[
-            JValue::Int(dp8),
-            JValue::Int(dp8),
-            JValue::Int(dp8),
-            JValue::Int(dp8),
-        ],
-    );
+        let dp8 = super::dp_to_px(env, 8.0);
+        let _ = env.call_method(
+            &tab,
+            jni::jni_str!("setPadding"),
+            jni::jni_sig!("(IIII)V"),
+            &[
+                JValue::Int(dp8),
+                JValue::Int(dp8),
+                JValue::Int(dp8),
+                JValue::Int(dp8),
+            ],
+        );
 
-    // Equal-weight layout params so each tab gets the same width.
-    let lp = env
-        .new_object(
-            "android/widget/LinearLayout$LayoutParams",
-            "(IIF)V",
-            &[JValue::Int(0), JValue::Int(-2), JValue::Float(1.0)],
-        )
-        .expect("tab lp");
-    let _ = env.call_method(
-        &tab,
-        "setLayoutParams",
-        "(Landroid/view/ViewGroup$LayoutParams;)V",
-        &[JValue::Object(&lp)],
-    );
+        // Equal-weight layout params so each tab gets the same width.
+        let lp = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout$LayoutParams"),
+                jni::jni_sig!("(IIF)V"),
+                &[JValue::Int(0), JValue::Int(-2), JValue::Float(1.0)],
+            )
+            .expect("tab lp");
+        let _ = env.call_method(
+            &tab,
+            jni::jni_str!("setLayoutParams"),
+            jni::jni_sig!("(Landroid/view/ViewGroup$LayoutParams;)V"),
+            &[JValue::Object(&lp)],
+        );
 
-    // Icon: ImageView with drawable lookup by resource name.
-    let iv = env
-        .new_object(
-            "android/widget/ImageView",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("icon iv");
-    let dp24 = super::dp_to_px(&mut env, 24.0);
-    let icon_lp = env
-        .new_object(
-            "android/widget/LinearLayout$LayoutParams",
-            "(II)V",
-            &[JValue::Int(dp24), JValue::Int(dp24)],
-        )
-        .expect("icon lp");
-    let _ = env.call_method(
-        &iv,
-        "setLayoutParams",
-        "(Landroid/view/ViewGroup$LayoutParams;)V",
-        &[JValue::Object(&icon_lp)],
-    );
-    if !icon.is_empty() {
-        // Resources.getIdentifier(icon, "drawable", pkg)
-        if let Ok(resources) = env.call_method(
-            &activity,
-            "getResources",
-            "()Landroid/content/res/Resources;",
-            &[],
-        ) {
-            if let Ok(res_obj) = resources.l() {
-                let pkg = env
-                    .call_method(&activity, "getPackageName", "()Ljava/lang/String;", &[])
-                    .ok()
-                    .and_then(|p| p.l().ok());
-                let icon_str = env.new_string(&icon).ok();
-                let drawable_str = env.new_string("drawable").ok();
-                if let (Some(pkg_obj), Some(icon_str), Some(drawable_str)) =
-                    (pkg, icon_str, drawable_str)
-                {
-                    let id = env
+        // Icon: ImageView with drawable lookup by resource name.
+        let iv = env
+            .new_object(
+                jni::jni_str!("android/widget/ImageView"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("icon iv");
+        let dp24 = super::dp_to_px(env, 24.0);
+        let icon_lp = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout$LayoutParams"),
+                jni::jni_sig!("(II)V"),
+                &[JValue::Int(dp24), JValue::Int(dp24)],
+            )
+            .expect("icon lp");
+        let _ = env.call_method(
+            &iv,
+            jni::jni_str!("setLayoutParams"),
+            jni::jni_sig!("(Landroid/view/ViewGroup$LayoutParams;)V"),
+            &[JValue::Object(&icon_lp)],
+        );
+        if !icon.is_empty() {
+            // Resources.getIdentifier(icon, "drawable", pkg)
+            if let Ok(resources) = env.call_method(
+                &activity,
+                jni::jni_str!("getResources"),
+                jni::jni_sig!("()Landroid/content/res/Resources;"),
+                &[],
+            ) {
+                if let Ok(res_obj) = resources.l() {
+                    let pkg = env
                         .call_method(
-                            &res_obj,
-                            "getIdentifier",
-                            "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)I",
-                            &[
-                                JValue::Object(&icon_str),
-                                JValue::Object(&drawable_str),
-                                JValue::Object(&pkg_obj),
-                            ],
+                            &activity,
+                            jni::jni_str!("getPackageName"),
+                            jni::jni_sig!("()Ljava/lang/String;"),
+                            &[],
                         )
                         .ok()
-                        .and_then(|v| v.i().ok())
-                        .unwrap_or(0);
-                    if id != 0 {
-                        let _ =
-                            env.call_method(&iv, "setImageResource", "(I)V", &[JValue::Int(id)]);
+                        .and_then(|p| p.l().ok());
+                    let icon_str = env.new_string(&icon).ok();
+                    let drawable_str = env.new_string("drawable").ok();
+                    if let (Some(pkg_obj), Some(icon_str), Some(drawable_str)) =
+                        (pkg, icon_str, drawable_str)
+                    {
+                        let id = env
+                            .call_method(
+                                &res_obj,
+                                jni::jni_str!("getIdentifier"),
+                                jni::jni_sig!(
+                                    "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)I"
+                                ),
+                                &[
+                                    JValue::Object(&icon_str),
+                                    JValue::Object(&drawable_str),
+                                    JValue::Object(&pkg_obj),
+                                ],
+                            )
+                            .ok()
+                            .and_then(|v| v.i().ok())
+                            .unwrap_or(0);
+                        if id != 0 {
+                            let _ = env.call_method(
+                                &iv,
+                                jni::jni_str!("setImageResource"),
+                                jni::jni_sig!("(I)V"),
+                                &[JValue::Int(id)],
+                            );
+                        }
                     }
                 }
             }
         }
-    }
-    // Initial tint: gray.
-    let _ = env.call_method(
-        &iv,
-        "setColorFilter",
-        "(I)V",
-        &[JValue::Int(0xFF6B7280u32 as i32)],
-    );
-
-    let _ = env.call_method(
-        &tab,
-        "addView",
-        "(Landroid/view/View;)V",
-        &[JValue::Object(&iv)],
-    );
-
-    // Label
-    let tv = env
-        .new_object(
-            "android/widget/TextView",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("Tab TV");
-    let jstr = env.new_string(&label).expect("tab label str");
-    let _ = env.call_method(
-        &tv,
-        "setText",
-        "(Ljava/lang/CharSequence;)V",
-        &[JValue::Object(&jstr)],
-    );
-    let _ = env.call_method(
-        &tv,
-        "setTextSize",
-        "(IF)V",
-        &[JValue::Int(2), JValue::Float(11.0)],
-    );
-    let _ = env.call_method(&tv, "setGravity", "(I)V", &[JValue::Int(17)]);
-    let _ = env.call_method(
-        &tv,
-        "setTextColor",
-        "(I)V",
-        &[JValue::Int(0xFF6B7280u32 as i32)],
-    );
-    let _ = env.call_method(
-        &tab,
-        "addView",
-        "(Landroid/view/View;)V",
-        &[JValue::Object(&tv)],
-    );
-
-    let _ = env.call_method(
-        layout_ref.as_obj(),
-        "addView",
-        "(Landroid/view/View;)V",
-        &[JValue::Object(&tab)],
-    );
-
-    let tab_global = env.new_global_ref(tab).expect("tab ref");
-    let tab_handle = super::register_widget(tab_global);
-    let iv_global = env.new_global_ref(iv).expect("icon ref");
-    let icon_handle = super::register_widget(iv_global);
-    let tv_global = env.new_global_ref(tv).expect("label ref");
-    let label_handle = super::register_widget(tv_global);
-
-    // Click handler.
-    if let Some(tab_ref) = super::get_widget(tab_handle) {
-        let bridge_class =
-            jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-        let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-        let _ = env.call_static_method(
-            bridge_cls,
-            "setOnClickCallbackWithArg",
-            "(Landroid/view/View;JD)V",
-            &[
-                JValue::Object(tab_ref.as_obj()),
-                JValue::Long(cb_key),
-                JValue::Double(idx as f64),
-            ],
+        // Initial tint: gray.
+        let _ = env.call_method(
+            &iv,
+            jni::jni_str!("setColorFilter"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(0xFF6B7280u32 as i32)],
         );
-    }
 
-    STATES.with(|s| {
-        if let Some(state) = s.borrow_mut().get_mut(&handle) {
-            state.items.push(ItemViews {
-                container: tab_handle,
-                icon: icon_handle,
-                label: label_handle,
-                badge: None,
-            });
+        let _ = env.call_method(
+            &tab,
+            jni::jni_str!("addView"),
+            jni::jni_sig!("(Landroid/view/View;)V"),
+            &[JValue::Object(&iv)],
+        );
+
+        // Label
+        let tv = env
+            .new_object(
+                jni::jni_str!("android/widget/TextView"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("Tab TV");
+        let jstr = env.new_string(&label).expect("tab label str");
+        let _ = env.call_method(
+            &tv,
+            jni::jni_str!("setText"),
+            jni::jni_sig!("(Ljava/lang/CharSequence;)V"),
+            &[JValue::Object(&jstr)],
+        );
+        let _ = env.call_method(
+            &tv,
+            jni::jni_str!("setTextSize"),
+            jni::jni_sig!("(IF)V"),
+            &[JValue::Int(2), JValue::Float(11.0)],
+        );
+        let _ = env.call_method(
+            &tv,
+            jni::jni_str!("setGravity"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(17)],
+        );
+        let _ = env.call_method(
+            &tv,
+            jni::jni_str!("setTextColor"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(0xFF6B7280u32 as i32)],
+        );
+        let _ = env.call_method(
+            &tab,
+            jni::jni_str!("addView"),
+            jni::jni_sig!("(Landroid/view/View;)V"),
+            &[JValue::Object(&tv)],
+        );
+
+        let _ = env.call_method(
+            layout_ref.as_obj(),
+            jni::jni_str!("addView"),
+            jni::jni_sig!("(Landroid/view/View;)V"),
+            &[JValue::Object(&tab)],
+        );
+
+        let tab_global = jni_bridge::new_global_ref(env, tab).expect("tab ref");
+        let tab_handle = super::register_widget(tab_global);
+        let iv_global = jni_bridge::new_global_ref(env, iv).expect("icon ref");
+        let icon_handle = super::register_widget(iv_global);
+        let tv_global = jni_bridge::new_global_ref(env, tv).expect("label ref");
+        let label_handle = super::register_widget(tv_global);
+
+        // Click handler.
+        if let Some(tab_ref) = super::get_widget(tab_handle) {
+            let bridge_class =
+                jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+            let bridge_cls: &jni::objects::JClass = &bridge_class;
+            let _ = env.call_static_method(
+                bridge_cls,
+                jni::jni_str!("setOnClickCallbackWithArg"),
+                jni::jni_sig!("(Landroid/view/View;JD)V"),
+                &[
+                    JValue::Object(tab_ref.as_obj()),
+                    JValue::Long(cb_key),
+                    JValue::Double(idx as f64),
+                ],
+            );
         }
-    });
-    apply_styling(handle);
 
-    unsafe {
-        let _ = env.pop_local_frame(&JObject::null());
-    }
+        STATES.with(|s| {
+            if let Some(state) = s.borrow_mut().get_mut(&handle) {
+                state.items.push(ItemViews {
+                    container: tab_handle,
+                    icon: icon_handle,
+                    label: label_handle,
+                    badge: None,
+                });
+            }
+        });
+        apply_styling(handle);
+
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+        }
+    })
 }
 
 /// Set or clear the badge string on a tab. Empty clears the badge.
 pub fn set_badge(handle: i64, index: i64, badge_ptr: *const u8) {
     let badge = unsafe { crate::app::str_from_header(badge_ptr) };
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(16);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 16);
 
-    let (item_container, existing_badge) = STATES.with(|s| {
-        let map = s.borrow();
-        match map.get(&handle).and_then(|st| st.items.get(index as usize)) {
-            Some(item) => (item.container, item.badge),
-            None => (0, None),
+        let (item_container, existing_badge) = STATES.with(|s| {
+            let map = s.borrow();
+            match map.get(&handle).and_then(|st| st.items.get(index as usize)) {
+                Some(item) => (item.container, item.badge),
+                None => (0, None),
+            }
+        });
+        if item_container == 0 {
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+            return;
         }
-    });
-    if item_container == 0 {
-        unsafe {
-            let _ = env.pop_local_frame(&JObject::null());
-        }
-        return;
-    }
 
-    // Remove existing badge.
-    if let Some(existing) = existing_badge {
-        if let Some(badge_ref) = super::get_widget(existing) {
-            // Detach from parent: ((ViewGroup) badge.getParent()).removeView(badge)
-            if let Ok(parent) = env.call_method(
-                badge_ref.as_obj(),
-                "getParent",
-                "()Landroid/view/ViewParent;",
-                &[],
-            ) {
-                if let Ok(parent_obj) = parent.l() {
-                    let _ = env.call_method(
-                        &parent_obj,
-                        "removeView",
-                        "(Landroid/view/View;)V",
-                        &[JValue::Object(badge_ref.as_obj())],
-                    );
+        // Remove existing badge.
+        if let Some(existing) = existing_badge {
+            if let Some(badge_ref) = super::get_widget(existing) {
+                // Detach from parent: ((ViewGroup) badge.getParent()).removeView(badge)
+                if let Ok(parent) = env.call_method(
+                    badge_ref.as_obj(),
+                    jni::jni_str!("getParent"),
+                    jni::jni_sig!("()Landroid/view/ViewParent;"),
+                    &[],
+                ) {
+                    if let Ok(parent_obj) = parent.l() {
+                        let _ = env.call_method(
+                            &parent_obj,
+                            jni::jni_str!("removeView"),
+                            jni::jni_sig!("(Landroid/view/View;)V"),
+                            &[JValue::Object(badge_ref.as_obj())],
+                        );
+                    }
                 }
             }
         }
-    }
 
-    let new_badge_handle = if badge.is_empty() {
-        None
-    } else {
-        // Append a small TextView with red background as a badge.
-        let activity = super::get_activity(&mut env);
-        let tv = env
-            .new_object(
-                "android/widget/TextView",
-                "(Landroid/content/Context;)V",
-                &[JValue::Object(&activity)],
-            )
-            .expect("badge TV");
-        let jstr = env.new_string(&badge).expect("badge str");
-        let _ = env.call_method(
-            &tv,
-            "setText",
-            "(Ljava/lang/CharSequence;)V",
-            &[JValue::Object(&jstr)],
-        );
-        let _ = env.call_method(
-            &tv,
-            "setTextSize",
-            "(IF)V",
-            &[JValue::Int(2), JValue::Float(9.0)],
-        );
-        let _ = env.call_method(
-            &tv,
-            "setTextColor",
-            "(I)V",
-            &[JValue::Int(0xFFFFFFFFu32 as i32)],
-        );
-        let _ = env.call_method(
-            &tv,
-            "setBackgroundColor",
-            "(I)V",
-            &[JValue::Int(0xFFD83333u32 as i32)],
-        );
-        let dp4 = super::dp_to_px(&mut env, 4.0);
-        let _ = env.call_method(
-            &tv,
-            "setPadding",
-            "(IIII)V",
-            &[
-                JValue::Int(dp4),
-                JValue::Int(0),
-                JValue::Int(dp4),
-                JValue::Int(0),
-            ],
-        );
-        let _ = env.call_method(&tv, "setGravity", "(I)V", &[JValue::Int(17)]);
-
-        if let Some(tab_ref) = super::get_widget(item_container) {
+        let new_badge_handle = if badge.is_empty() {
+            None
+        } else {
+            // Append a small TextView with red background as a badge.
+            let activity = super::get_activity(env);
+            let tv = env
+                .new_object(
+                    jni::jni_str!("android/widget/TextView"),
+                    jni::jni_sig!("(Landroid/content/Context;)V"),
+                    &[JValue::Object(&activity)],
+                )
+                .expect("badge TV");
+            let jstr = env.new_string(&badge).expect("badge str");
             let _ = env.call_method(
-                tab_ref.as_obj(),
-                "addView",
-                "(Landroid/view/View;)V",
-                &[JValue::Object(&tv)],
+                &tv,
+                jni::jni_str!("setText"),
+                jni::jni_sig!("(Ljava/lang/CharSequence;)V"),
+                &[JValue::Object(&jstr)],
             );
-        }
-        let badge_global = env.new_global_ref(tv).expect("badge ref");
-        let badge_handle = super::register_widget(badge_global);
-        Some(badge_handle)
-    };
+            let _ = env.call_method(
+                &tv,
+                jni::jni_str!("setTextSize"),
+                jni::jni_sig!("(IF)V"),
+                &[JValue::Int(2), JValue::Float(9.0)],
+            );
+            let _ = env.call_method(
+                &tv,
+                jni::jni_str!("setTextColor"),
+                jni::jni_sig!("(I)V"),
+                &[JValue::Int(0xFFFFFFFFu32 as i32)],
+            );
+            let _ = env.call_method(
+                &tv,
+                jni::jni_str!("setBackgroundColor"),
+                jni::jni_sig!("(I)V"),
+                &[JValue::Int(0xFFD83333u32 as i32)],
+            );
+            let dp4 = super::dp_to_px(env, 4.0);
+            let _ = env.call_method(
+                &tv,
+                jni::jni_str!("setPadding"),
+                jni::jni_sig!("(IIII)V"),
+                &[
+                    JValue::Int(dp4),
+                    JValue::Int(0),
+                    JValue::Int(dp4),
+                    JValue::Int(0),
+                ],
+            );
+            let _ = env.call_method(
+                &tv,
+                jni::jni_str!("setGravity"),
+                jni::jni_sig!("(I)V"),
+                &[JValue::Int(17)],
+            );
 
-    STATES.with(|s| {
-        if let Some(state) = s.borrow_mut().get_mut(&handle) {
-            if let Some(item) = state.items.get_mut(index as usize) {
-                item.badge = new_badge_handle;
+            if let Some(tab_ref) = super::get_widget(item_container) {
+                let _ = env.call_method(
+                    tab_ref.as_obj(),
+                    jni::jni_str!("addView"),
+                    jni::jni_sig!("(Landroid/view/View;)V"),
+                    &[JValue::Object(&tv)],
+                );
             }
-        }
-    });
+            let badge_global = jni_bridge::new_global_ref(env, tv).expect("badge ref");
+            let badge_handle = super::register_widget(badge_global);
+            Some(badge_handle)
+        };
 
-    unsafe {
-        let _ = env.pop_local_frame(&JObject::null());
-    }
+        STATES.with(|s| {
+            if let Some(state) = s.borrow_mut().get_mut(&handle) {
+                if let Some(item) = state.items.get_mut(index as usize) {
+                    item.badge = new_badge_handle;
+                }
+            }
+        });
+
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+        }
+    })
 }
 
 pub fn set_selected(handle: i64, index: i64) {
@@ -512,35 +562,36 @@ fn apply_styling(handle: i64) {
             None => (Vec::new(), 0, None, None),
         }
     });
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(16);
-    for (i, (icon_handle, label_handle)) in items.iter().enumerate() {
-        let is_sel = i as i64 == selected;
-        let color = if is_sel {
-            selected_tint.unwrap_or(0xFF2563EBu32 as i32)
-        } else {
-            unselected_tint.unwrap_or(0xFF6B7280u32 as i32)
-        };
-        if let Some(icon_ref) = super::get_widget(*icon_handle) {
-            let _ = env.call_method(
-                icon_ref.as_obj(),
-                "setColorFilter",
-                "(I)V",
-                &[JValue::Int(color)],
-            );
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 16);
+        for (i, (icon_handle, label_handle)) in items.iter().enumerate() {
+            let is_sel = i as i64 == selected;
+            let color = if is_sel {
+                selected_tint.unwrap_or(0xFF2563EBu32 as i32)
+            } else {
+                unselected_tint.unwrap_or(0xFF6B7280u32 as i32)
+            };
+            if let Some(icon_ref) = super::get_widget(*icon_handle) {
+                let _ = env.call_method(
+                    icon_ref.as_obj(),
+                    jni::jni_str!("setColorFilter"),
+                    jni::jni_sig!("(I)V"),
+                    &[JValue::Int(color)],
+                );
+            }
+            if let Some(label_ref) = super::get_widget(*label_handle) {
+                let _ = env.call_method(
+                    label_ref.as_obj(),
+                    jni::jni_str!("setTextColor"),
+                    jni::jni_sig!("(I)V"),
+                    &[JValue::Int(color)],
+                );
+            }
         }
-        if let Some(label_ref) = super::get_widget(*label_handle) {
-            let _ = env.call_method(
-                label_ref.as_obj(),
-                "setTextColor",
-                "(I)V",
-                &[JValue::Int(color)],
-            );
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
         }
-    }
-    unsafe {
-        let _ = env.pop_local_frame(&JObject::null());
-    }
+    })
 }
 
 /// Pack RGBA 0..1 into Android ARGB int (`0xAARRGGBB`).

--- a/crates/perry-ui-android/src/widgets/button.rs
+++ b/crates/perry-ui-android/src/widgets/button.rs
@@ -1,7 +1,7 @@
 use crate::app::str_from_header;
 use crate::callback;
 use crate::jni_bridge;
-use jni::objects::JValue;
+use jni::JValue;
 
 extern "C" {
     fn __android_log_print(prio: i32, tag: *const u8, fmt: *const u8, ...) -> i32;
@@ -18,166 +18,169 @@ pub fn create(label_ptr: *const u8, on_press: f64) -> i64 {
             label.as_ptr(),
         );
     }
-    let mut env = jni_bridge::get_env();
-
-    // Check for pending exception from prior JNI calls
-    if env.exception_check().unwrap_or(false) {
-        unsafe {
-            __android_log_print(
-                6,
-                b"PerryButton\0".as_ptr(),
-                b"create: PENDING EXCEPTION before get_activity!\0".as_ptr(),
-            );
-        }
-        let _ = env.exception_describe();
-        let _ = env.exception_clear();
-    }
-
-    // Ensure we have local ref space
-    let _ = env.push_local_frame(32);
-
-    let activity = super::get_activity(&mut env);
-    unsafe {
-        __android_log_print(
-            3,
-            b"PerryButton\0".as_ptr(),
-            b"create: got activity, using cached constructor\0".as_ptr(),
-        );
-    }
-
-    // Use cached class and constructor to avoid FindClass overhead
-    let button_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.button_class.as_obj()).unwrap());
-    let ctor_id = jni_bridge::with_cache(|c| c.button_init);
-    let button_cls: &jni::objects::JClass = (&button_class).into();
-
-    unsafe {
-        __android_log_print(
-            3,
-            b"PerryButton\0".as_ptr(),
-            b"create: calling NewObject with cached ctor\0".as_ptr(),
-        );
-    }
-
-    let button = match unsafe {
-        env.new_object_unchecked(button_cls, ctor_id, &[JValue::Object(&activity).as_jni()])
-    } {
-        Ok(b) => b,
-        Err(e) => {
-            let msg = format!("Failed to create Button: {:?}\0", e);
+    jni_bridge::with_env(|env| {
+        // Check for pending exception from prior JNI calls
+        if env.exception_check() {
             unsafe {
                 __android_log_print(
                     6,
                     b"PerryButton\0".as_ptr(),
-                    b"create: FAILED: %s\0".as_ptr(),
-                    msg.as_ptr(),
+                    b"create: PENDING EXCEPTION before get_activity!\0".as_ptr(),
                 );
             }
-            if env.exception_check().unwrap_or(false) {
-                let _ = env.exception_describe();
-                let _ = env.exception_clear();
+            let _ = env.exception_describe();
+            let _ = env.exception_clear();
+        }
+
+        // Ensure we have local ref space
+        let _ = jni_bridge::push_local_frame(env, 32);
+
+        let activity = super::get_activity(env);
+        unsafe {
+            __android_log_print(
+                3,
+                b"PerryButton\0".as_ptr(),
+                b"create: got activity, using cached constructor\0".as_ptr(),
+            );
+        }
+
+        // Use cached class and constructor to avoid FindClass overhead
+        let button_class = jni_bridge::with_cache(|c| env.new_local_ref(&c.button_class).unwrap());
+        let ctor_id = jni_bridge::with_cache(|c| c.button_init);
+        let button_cls: &jni::objects::JClass = &button_class;
+
+        unsafe {
+            __android_log_print(
+                3,
+                b"PerryButton\0".as_ptr(),
+                b"create: calling NewObject with cached ctor\0".as_ptr(),
+            );
+        }
+
+        let button = match unsafe {
+            env.new_object_unchecked(button_cls, ctor_id, &[JValue::Object(&activity).as_jni()])
+        } {
+            Ok(b) => b,
+            Err(e) => {
+                let msg = format!("Failed to create Button: {:?}\0", e);
+                unsafe {
+                    __android_log_print(
+                        6,
+                        b"PerryButton\0".as_ptr(),
+                        b"create: FAILED: %s\0".as_ptr(),
+                        msg.as_ptr(),
+                    );
+                }
+                if env.exception_check() {
+                    let _ = env.exception_describe();
+                    let _ = env.exception_clear();
+                }
+                unsafe {
+                    let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+                }
+                panic!("Failed to create Button: {:?}", e);
+            }
+        };
+        unsafe {
+            __android_log_print(
+                3,
+                b"PerryButton\0".as_ptr(),
+                b"create: Button created OK\0".as_ptr(),
+            );
+        }
+
+        // Set label text
+        let jstr = env.new_string(label).expect("Failed to create JNI string");
+        let _ = env.call_method(
+            &button,
+            jni::jni_str!("setText"),
+            jni::jni_sig!("(Ljava/lang/CharSequence;)V"),
+            &[JValue::Object(&jstr)],
+        );
+
+        // Disable ALL CAPS (Material default) to match iOS mixed-case behavior
+        let _ = env.call_method(
+            &button,
+            jni::jni_str!("setAllCaps"),
+            jni::jni_sig!("(Z)V"),
+            &[JValue::Bool(false)],
+        );
+
+        // Register callback and set up OnClickListener via PerryBridge
+        let cb_key = callback::register(on_press);
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("setOnClickCallback"),
+            jni::jni_sig!("(Landroid/view/View;J)V"),
+            &[JValue::Object(&button), JValue::Long(cb_key)],
+        );
+
+        let global = jni_bridge::new_global_ref(env, button).expect("Failed to create global ref");
+        let handle = super::register_widget(global);
+        #[cfg(feature = "geisterhand")]
+        {
+            extern "C" {
+                fn perry_geisterhand_register(h: i64, wt: u8, ck: u8, cb: f64, lbl: *const u8);
             }
             unsafe {
-                let _ = env.pop_local_frame(&jni::objects::JObject::null());
+                perry_geisterhand_register(handle, 0, 0, on_press, label_ptr);
             }
-            panic!("Failed to create Button: {:?}", e);
-        }
-    };
-    unsafe {
-        __android_log_print(
-            3,
-            b"PerryButton\0".as_ptr(),
-            b"create: Button created OK\0".as_ptr(),
-        );
-    }
-
-    // Set label text
-    let jstr = env.new_string(label).expect("Failed to create JNI string");
-    let _ = env.call_method(
-        &button,
-        "setText",
-        "(Ljava/lang/CharSequence;)V",
-        &[JValue::Object(&jstr)],
-    );
-
-    // Disable ALL CAPS (Material default) to match iOS mixed-case behavior
-    let _ = env.call_method(&button, "setAllCaps", "(Z)V", &[JValue::Bool(0)]);
-
-    // Register callback and set up OnClickListener via PerryBridge
-    let cb_key = callback::register(on_press);
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let _ = env.call_static_method(
-        bridge_cls,
-        "setOnClickCallback",
-        "(Landroid/view/View;J)V",
-        &[JValue::Object(&button), JValue::Long(cb_key)],
-    );
-
-    let global = env
-        .new_global_ref(button)
-        .expect("Failed to create global ref");
-    let handle = super::register_widget(global);
-    #[cfg(feature = "geisterhand")]
-    {
-        extern "C" {
-            fn perry_geisterhand_register(h: i64, wt: u8, ck: u8, cb: f64, lbl: *const u8);
         }
         unsafe {
-            perry_geisterhand_register(handle, 0, 0, on_press, label_ptr);
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
         }
-    }
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
-    handle
+        handle
+    })
 }
 
 /// Set whether a button has a border.
 /// On Android, buttons always have a background; toggle between Material styles.
 pub fn set_bordered(handle: i64, bordered: bool) {
     if let Some(view_ref) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        if !bordered {
-            // Set a flat/borderless style by making background transparent
-            let bridge_class = jni_bridge::with_cache(|c| {
-                env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap()
-            });
-            let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-            let _ = env.call_static_method(
-                bridge_cls,
-                "setButtonBorderless",
-                "(Landroid/view/View;Z)V",
-                &[JValue::Object(view_ref.as_obj()), JValue::Bool(0)],
-            );
-        }
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            if !bordered {
+                // Set a flat/borderless style by making background transparent
+                let bridge_class =
+                    jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+                let bridge_cls: &jni::objects::JClass = &bridge_class;
+                let _ = env.call_static_method(
+                    bridge_cls,
+                    jni::jni_str!("setButtonBorderless"),
+                    jni::jni_sig!("(Landroid/view/View;Z)V"),
+                    &[JValue::Object(view_ref.as_obj()), JValue::Bool(false)],
+                );
+            }
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+        })
     }
 }
 
 /// Set the text color of a button.
 pub fn set_text_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
     if let Some(view_ref) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let ai = (a * 255.0) as u32;
-        let ri = (r * 255.0) as u32;
-        let gi = (g * 255.0) as u32;
-        let bi = (b * 255.0) as u32;
-        let color = ((ai << 24) | (ri << 16) | (gi << 8) | bi) as i32;
-        let _ = env.call_method(
-            view_ref.as_obj(),
-            "setTextColor",
-            "(I)V",
-            &[JValue::Int(color)],
-        );
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let ai = (a * 255.0) as u32;
+            let ri = (r * 255.0) as u32;
+            let gi = (g * 255.0) as u32;
+            let bi = (b * 255.0) as u32;
+            let color = ((ai << 24) | (ri << 16) | (gi << 8) | bi) as i32;
+            let _ = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("setTextColor"),
+                jni::jni_sig!("(I)V"),
+                &[JValue::Int(color)],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+        })
     }
 }
 
@@ -185,18 +188,19 @@ pub fn set_text_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
 pub fn set_title(handle: i64, title_ptr: *const u8) {
     let title = unsafe { str_from_header(title_ptr) };
     if let Some(view_ref) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let jstr = env.new_string(title).expect("Failed to create JNI string");
-        let _ = env.call_method(
-            view_ref.as_obj(),
-            "setText",
-            "(Ljava/lang/CharSequence;)V",
-            &[JValue::Object(&jstr)],
-        );
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let jstr = env.new_string(title).expect("Failed to create JNI string");
+            let _ = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("setText"),
+                jni::jni_sig!("(Ljava/lang/CharSequence;)V"),
+                &[JValue::Object(&jstr)],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+        })
     }
 }
 
@@ -272,28 +276,29 @@ pub fn sf_symbol_to_emoji(name: &str) -> Option<&'static str> {
 pub fn set_image(handle: i64, name_ptr: *const u8) {
     let name = unsafe { str_from_header(name_ptr) };
     if let Some(view_ref) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(16);
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 16);
 
-        let icon_str = if let Some(emoji) = sf_symbol_to_emoji(&name) {
-            emoji.to_string()
-        } else {
-            // Fallback: use the symbol name itself (truncated)
-            let fallback: String = name.chars().take(3).collect();
-            fallback
-        };
+            let icon_str = if let Some(emoji) = sf_symbol_to_emoji(&name) {
+                emoji.to_string()
+            } else {
+                // Fallback: use the symbol name itself (truncated)
+                let fallback: String = name.chars().take(3).collect();
+                fallback
+            };
 
-        let jstr = env.new_string(&icon_str).expect("icon string");
-        let _ = env.call_method(
-            view_ref.as_obj(),
-            "setText",
-            "(Ljava/lang/CharSequence;)V",
-            &[JValue::Object(&jstr)],
-        );
+            let jstr = env.new_string(&icon_str).expect("icon string");
+            let _ = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("setText"),
+                jni::jni_sig!("(Ljava/lang/CharSequence;)V"),
+                &[JValue::Object(&jstr)],
+            );
 
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+        })
     }
 }
 
@@ -315,20 +320,21 @@ pub fn set_content_tint_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
 /// Set a single-tap handler for the button.
 pub fn set_on_tap(handle: i64, callback: f64) {
     if let Some(view_ref) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let cb_key = callback::register(callback);
-        let bridge_class =
-            jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-        let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-        let _ = env.call_static_method(
-            bridge_cls,
-            "setOnClickCallback",
-            "(Landroid/view/View;J)V",
-            &[JValue::Object(view_ref.as_obj()), JValue::Long(cb_key)],
-        );
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let cb_key = callback::register(callback);
+            let bridge_class =
+                jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+            let bridge_cls: &jni::objects::JClass = &bridge_class;
+            let _ = env.call_static_method(
+                bridge_cls,
+                jni::jni_str!("setOnClickCallback"),
+                jni::jni_sig!("(Landroid/view/View;J)V"),
+                &[JValue::Object(view_ref.as_obj()), JValue::Long(cb_key)],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+        })
     }
 }

--- a/crates/perry-ui-android/src/widgets/calendar.rs
+++ b/crates/perry-ui-android/src/widgets/calendar.rs
@@ -8,7 +8,8 @@
 
 use crate::callback;
 use crate::jni_bridge;
-use jni::objects::{JObject, JValue};
+use jni::objects::JObject;
+use jni::JValue;
 
 extern "C" {
     fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
@@ -22,86 +23,87 @@ const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
 /// `on_change` is the Perry closure invoked with a `yyyy-MM-dd` string each
 /// time the user picks a new date.
 pub fn create(year: i64, month: i64, on_change: f64) -> i64 {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(16);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 16);
 
-    let cb_key = if on_change != 0.0 {
-        callback::register(on_change)
-    } else {
-        0
-    };
-
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-
-    let result = env.call_static_method(
-        bridge_cls,
-        "calendarCreate",
-        "(JJJ)Landroid/widget/CalendarView;",
-        &[
-            JValue::Long(year),
-            JValue::Long(month),
-            JValue::Long(cb_key),
-        ],
-    );
-
-    let handle = match result {
-        Ok(jv) => match jv.l() {
-            Ok(obj) if !obj.is_null() => {
-                let g = env
-                    .new_global_ref(obj)
-                    .expect("Failed to global-ref CalendarView");
-                super::register_widget(g)
-            }
-            _ => 0,
-        },
-        Err(e) => {
-            unsafe {
-                let msg = format!("calendarCreate failed: {:?}\0", e);
-                __android_log_print(
-                    6,
-                    b"PerryCalendar\0".as_ptr(),
-                    b"%s\0".as_ptr(),
-                    msg.as_ptr(),
-                );
-                if env.exception_check().unwrap_or(false) {
-                    let _ = env.exception_describe();
-                    let _ = env.exception_clear();
-                }
-            }
+        let cb_key = if on_change != 0.0 {
+            callback::register(on_change)
+        } else {
             0
-        }
-    };
+        };
 
-    unsafe {
-        env.pop_local_frame(&JObject::null());
-    }
-    handle
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+
+        let result = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("calendarCreate"),
+            jni::jni_sig!("(JJJ)Landroid/widget/CalendarView;"),
+            &[
+                JValue::Long(year),
+                JValue::Long(month),
+                JValue::Long(cb_key),
+            ],
+        );
+
+        let handle = match result {
+            Ok(jv) => match jv.l() {
+                Ok(obj) if !obj.is_null() => {
+                    let g = jni_bridge::new_global_ref(env, obj)
+                        .expect("Failed to global-ref CalendarView");
+                    super::register_widget(g)
+                }
+                _ => 0,
+            },
+            Err(e) => {
+                unsafe {
+                    let msg = format!("calendarCreate failed: {:?}\0", e);
+                    __android_log_print(
+                        6,
+                        b"PerryCalendar\0".as_ptr(),
+                        b"%s\0".as_ptr(),
+                        msg.as_ptr(),
+                    );
+                    if env.exception_check() {
+                        let _ = env.exception_describe();
+                        let _ = env.exception_clear();
+                    }
+                }
+                0
+            }
+        };
+
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+        }
+        handle
+    })
 }
 
 /// Programmatically set the selected date (year, 1-based month, day).
 pub fn set_date(handle: i64, year: i64, month: i64, day: i64) {
     if let Some(view) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let bridge_class =
-            jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-        let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-        let _ = env.call_static_method(
-            bridge_cls,
-            "calendarSetDate",
-            "(Landroid/widget/CalendarView;JJJ)V",
-            &[
-                JValue::Object(view.as_obj()),
-                JValue::Long(year),
-                JValue::Long(month),
-                JValue::Long(day),
-            ],
-        );
-        unsafe {
-            env.pop_local_frame(&JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let bridge_class =
+                jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+            let bridge_cls: &jni::objects::JClass = &bridge_class;
+            let _ = env.call_static_method(
+                bridge_cls,
+                jni::jni_str!("calendarSetDate"),
+                jni::jni_sig!("(Landroid/widget/CalendarView;JJJ)V"),
+                &[
+                    JValue::Object(view.as_obj()),
+                    JValue::Long(year),
+                    JValue::Long(month),
+                    JValue::Long(day),
+                ],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }
 
@@ -111,38 +113,40 @@ pub fn get_selected_date(handle: i64) -> f64 {
     let Some(view) = super::get_widget(handle) else {
         return f64::from_bits(TAG_UNDEFINED);
     };
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let result = env.call_static_method(
-        bridge_cls,
-        "calendarGetSelectedDate",
-        "(Landroid/widget/CalendarView;)Ljava/lang/String;",
-        &[JValue::Object(view.as_obj())],
-    );
-    let date_str: Option<String> = match result {
-        Ok(jv) => match jv.l() {
-            Ok(obj) if !obj.is_null() => {
-                let jstr: jni::objects::JString = obj.into();
-                env.get_string(&jstr).map(|s| s.into()).ok()
-            }
-            _ => None,
-        },
-        Err(_) => None,
-    };
-    unsafe {
-        env.pop_local_frame(&JObject::null());
-    }
-    match date_str {
-        Some(s) if !s.is_empty() => {
-            let bytes = s.as_bytes();
-            unsafe {
-                let ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
-                js_nanbox_string(ptr as i64)
-            }
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let result = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("calendarGetSelectedDate"),
+            jni::jni_sig!("(Landroid/widget/CalendarView;)Ljava/lang/String;"),
+            &[JValue::Object(view.as_obj())],
+        );
+        let date_str: Option<String> = match result {
+            Ok(jv) => match jv.l() {
+                Ok(obj) if !obj.is_null() => {
+                    let jstr: jni::objects::JString =
+                        unsafe { jni::objects::JString::from_raw(env, obj.into_raw()) };
+                    jstr.try_to_string(env).map(|s| s.into()).ok()
+                }
+                _ => None,
+            },
+            Err(_) => None,
+        };
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
         }
-        _ => f64::from_bits(TAG_UNDEFINED),
-    }
+        match date_str {
+            Some(s) if !s.is_empty() => {
+                let bytes = s.as_bytes();
+                unsafe {
+                    let ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+                    js_nanbox_string(ptr as i64)
+                }
+            }
+            _ => f64::from_bits(TAG_UNDEFINED),
+        }
+    })
 }

--- a/crates/perry-ui-android/src/widgets/canvas.rs
+++ b/crates/perry-ui-android/src/widgets/canvas.rs
@@ -1,7 +1,9 @@
 //! Canvas — ImageView with Bitmap-backed Canvas drawing
 
 use crate::jni_bridge;
-use jni::objects::{GlobalRef, JObject, JValue};
+use crate::jni_bridge::GlobalRef;
+use jni::objects::JObject;
+use jni::JValue;
 use std::collections::HashMap;
 use std::ffi::c_void;
 use std::sync::atomic::{AtomicI64, Ordering};
@@ -54,7 +56,6 @@ const JS_TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
 extern "C" {
     fn js_object_alloc(class_id: u32, field_count: u32) -> *mut c_void;
     fn js_object_set_field_by_name(obj: *mut c_void, key: *const c_void, value: f64);
-    fn js_object_get_field_by_name_f64(obj: *mut c_void, key: *const c_void) -> f64;
     fn js_string_from_bytes(data: *const u8, len: u32) -> *mut c_void;
     fn js_nanbox_pointer(ptr: i64) -> f64;
     fn js_nanbox_string(ptr: i64) -> f64;
@@ -95,19 +96,6 @@ fn rejected_image_promise(message: &str) -> i64 {
     }
 }
 
-fn image_handle_from_arg(image: i64) -> i64 {
-    if image <= 0 {
-        return image;
-    }
-    let key = js_key(b"__perryImageHandle");
-    let value = unsafe { js_object_get_field_by_name_f64(image as *mut c_void, key) };
-    if value.is_finite() && value > 0.0 {
-        value as i64
-    } else {
-        image
-    }
-}
-
 fn command_batch_renders(commands: &[DrawCmd]) -> bool {
     commands.iter().any(|cmd| {
         matches!(
@@ -118,120 +106,124 @@ fn command_batch_renders(commands: &[DrawCmd]) -> bool {
 }
 
 pub fn create(width: f64, height: f64) -> i64 {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
 
-    let activity = super::get_activity(&mut env);
+        let activity = super::get_activity(env);
 
-    // Get display density to convert dp to px
-    let resources = env
-        .call_method(
-            &activity,
-            "getResources",
-            "()Landroid/content/res/Resources;",
-            &[],
-        )
-        .expect("getResources")
-        .l()
-        .expect("resources");
-    let display_metrics = env
-        .call_method(
-            &resources,
-            "getDisplayMetrics",
-            "()Landroid/util/DisplayMetrics;",
-            &[],
-        )
-        .expect("getDisplayMetrics")
-        .l()
-        .expect("displayMetrics");
-    let density = env
-        .get_field(&display_metrics, "density", "F")
-        .expect("density")
-        .f()
-        .expect("float");
+        // Get display density to convert dp to px
+        let resources = env
+            .call_method(
+                &activity,
+                jni::jni_str!("getResources"),
+                jni::jni_sig!("()Landroid/content/res/Resources;"),
+                &[],
+            )
+            .expect("getResources")
+            .l()
+            .expect("resources");
+        let display_metrics = env
+            .call_method(
+                &resources,
+                jni::jni_str!("getDisplayMetrics"),
+                jni::jni_sig!("()Landroid/util/DisplayMetrics;"),
+                &[],
+            )
+            .expect("getDisplayMetrics")
+            .l()
+            .expect("displayMetrics");
+        let density = env
+            .get_field(
+                &display_metrics,
+                jni::jni_str!("density"),
+                jni::jni_sig!("F"),
+            )
+            .expect("density")
+            .f()
+            .expect("float");
 
-    let w = (width as f32 * density) as i32;
-    let h = (height as f32 * density) as i32;
+        let w = (width as f32 * density) as i32;
+        let h = (height as f32 * density) as i32;
 
-    // Create ImageView
-    let image_view = env
-        .new_object(
-            "android/widget/ImageView",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("Failed to create ImageView");
+        // Create ImageView
+        let image_view = env
+            .new_object(
+                jni::jni_str!("android/widget/ImageView"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("Failed to create ImageView");
 
-    // Set explicit layout params so the ImageView has a visible size
-    let layout_params = env
-        .new_object(
-            "android/widget/LinearLayout$LayoutParams",
-            "(II)V",
-            &[JValue::Int(w), JValue::Int(h)],
-        )
-        .expect("Failed to create LayoutParams");
-    let _ = env.call_method(
-        &image_view,
-        "setLayoutParams",
-        "(Landroid/view/ViewGroup$LayoutParams;)V",
-        &[JValue::Object(&layout_params)],
-    );
+        // Set explicit layout params so the ImageView has a visible size
+        let layout_params = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout$LayoutParams"),
+                jni::jni_sig!("(II)V"),
+                &[JValue::Int(w), JValue::Int(h)],
+            )
+            .expect("Failed to create LayoutParams");
+        let _ = env.call_method(
+            &image_view,
+            jni::jni_str!("setLayoutParams"),
+            jni::jni_sig!("(Landroid/view/ViewGroup$LayoutParams;)V"),
+            &[JValue::Object(&layout_params)],
+        );
 
-    // Scale type: FIT_XY so the bitmap fills the allocated space
-    let scale_class = env
-        .find_class("android/widget/ImageView$ScaleType")
-        .expect("ScaleType");
-    let fit_xy = env
-        .get_static_field(
-            &scale_class,
-            "FIT_XY",
-            "Landroid/widget/ImageView$ScaleType;",
-        )
-        .expect("FIT_XY")
-        .l()
-        .expect("scale type");
-    let _ = env.call_method(
-        &image_view,
-        "setScaleType",
-        "(Landroid/widget/ImageView$ScaleType;)V",
-        &[JValue::Object(&fit_xy)],
-    );
+        // Scale type: FIT_XY so the bitmap fills the allocated space
+        let scale_class = env
+            .find_class(jni::jni_str!("android/widget/ImageView$ScaleType"))
+            .expect("ScaleType");
+        let fit_xy = env
+            .get_static_field(
+                &scale_class,
+                jni::jni_str!("FIT_XY"),
+                jni::jni_sig!("Landroid/widget/ImageView$ScaleType;"),
+            )
+            .expect("FIT_XY")
+            .l()
+            .expect("scale type");
+        let _ = env.call_method(
+            &image_view,
+            jni::jni_str!("setScaleType"),
+            jni::jni_sig!("(Landroid/widget/ImageView$ScaleType;)V"),
+            &[JValue::Object(&fit_xy)],
+        );
 
-    // Create initial bitmap and set it
-    create_and_set_bitmap(&mut env, &image_view, w, h);
+        // Create initial bitmap and set it
+        create_and_set_bitmap(env, &image_view, w, h);
 
-    let global = env
-        .new_global_ref(image_view)
-        .expect("Failed to create global ref");
-    let handle = super::register_widget(global);
+        let global =
+            jni_bridge::new_global_ref(env, image_view).expect("Failed to create global ref");
+        let handle = super::register_widget(global);
 
-    CANVAS_STATES.lock().unwrap().insert(
-        handle,
-        CanvasState {
-            width: w,
-            height: h,
-            density,
-            cmds: Vec::new(),
-            last_cmds: Vec::new(),
-        },
-    );
+        CANVAS_STATES.lock().unwrap().insert(
+            handle,
+            CanvasState {
+                width: w,
+                height: h,
+                density,
+                cmds: Vec::new(),
+                last_cmds: Vec::new(),
+            },
+        );
 
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
-    handle
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+        handle
+    })
 }
 
-fn create_and_set_bitmap(env: &mut jni::JNIEnv, image_view: &JObject, w: i32, h: i32) {
+fn create_and_set_bitmap(env: &mut jni::Env, image_view: &JObject, w: i32, h: i32) {
     // Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
     let config_class = env
-        .find_class("android/graphics/Bitmap$Config")
+        .find_class(jni::jni_str!("android/graphics/Bitmap$Config"))
         .expect("Bitmap$Config");
     let argb_config = env
         .get_static_field(
             &config_class,
-            "ARGB_8888",
-            "Landroid/graphics/Bitmap$Config;",
+            jni::jni_str!("ARGB_8888"),
+            jni::jni_sig!("Landroid/graphics/Bitmap$Config;"),
         )
         .expect("ARGB_8888")
         .l()
@@ -239,9 +231,9 @@ fn create_and_set_bitmap(env: &mut jni::JNIEnv, image_view: &JObject, w: i32, h:
 
     let bitmap = env
         .call_static_method(
-            "android/graphics/Bitmap",
-            "createBitmap",
-            "(IILandroid/graphics/Bitmap$Config;)Landroid/graphics/Bitmap;",
+            jni::jni_str!("android/graphics/Bitmap"),
+            jni::jni_str!("createBitmap"),
+            jni::jni_sig!("(IILandroid/graphics/Bitmap$Config;)Landroid/graphics/Bitmap;"),
             &[JValue::Int(w), JValue::Int(h), JValue::Object(&argb_config)],
         )
         .expect("createBitmap")
@@ -250,8 +242,8 @@ fn create_and_set_bitmap(env: &mut jni::JNIEnv, image_view: &JObject, w: i32, h:
 
     let _ = env.call_method(
         image_view,
-        "setImageBitmap",
-        "(Landroid/graphics/Bitmap;)V",
+        jni::jni_str!("setImageBitmap"),
+        jni::jni_sig!("(Landroid/graphics/Bitmap;)V"),
         &[JValue::Object(&bitmap)],
     );
 }
@@ -273,296 +265,339 @@ fn repaint(handle: i64) {
 
     if let Some((w, h, cmds)) = cmds {
         if let Some(view_ref) = super::get_widget(handle) {
-            let mut env = jni_bridge::get_env();
-            let _ = env.push_local_frame(64);
+            jni_bridge::with_env(|env| {
+                let _ = jni_bridge::push_local_frame(env, 64);
 
-            // Create fresh bitmap
-            let config_class = env
-                .find_class("android/graphics/Bitmap$Config")
-                .expect("Bitmap$Config");
-            let argb_config = env
-                .get_static_field(
-                    &config_class,
-                    "ARGB_8888",
-                    "Landroid/graphics/Bitmap$Config;",
-                )
-                .expect("ARGB_8888")
-                .l()
-                .expect("config object");
+                // Create fresh bitmap
+                let config_class = env
+                    .find_class(jni::jni_str!("android/graphics/Bitmap$Config"))
+                    .expect("Bitmap$Config");
+                let argb_config = env
+                    .get_static_field(
+                        &config_class,
+                        jni::jni_str!("ARGB_8888"),
+                        jni::jni_sig!("Landroid/graphics/Bitmap$Config;"),
+                    )
+                    .expect("ARGB_8888")
+                    .l()
+                    .expect("config object");
 
-            let bitmap = env
-                .call_static_method(
-                    "android/graphics/Bitmap",
-                    "createBitmap",
-                    "(IILandroid/graphics/Bitmap$Config;)Landroid/graphics/Bitmap;",
-                    &[JValue::Int(w), JValue::Int(h), JValue::Object(&argb_config)],
-                )
-                .expect("createBitmap")
-                .l()
-                .expect("bitmap");
+                let bitmap = env
+                    .call_static_method(
+                        jni::jni_str!("android/graphics/Bitmap"),
+                        jni::jni_str!("createBitmap"),
+                        jni::jni_sig!(
+                            "(IILandroid/graphics/Bitmap$Config;)Landroid/graphics/Bitmap;"
+                        ),
+                        &[JValue::Int(w), JValue::Int(h), JValue::Object(&argb_config)],
+                    )
+                    .expect("createBitmap")
+                    .l()
+                    .expect("bitmap");
 
-            // Create Canvas from bitmap
-            let canvas = env
-                .new_object(
-                    "android/graphics/Canvas",
-                    "(Landroid/graphics/Bitmap;)V",
-                    &[JValue::Object(&bitmap)],
-                )
-                .expect("Failed to create Canvas");
+                // Create Canvas from bitmap
+                let canvas = env
+                    .new_object(
+                        jni::jni_str!("android/graphics/Canvas"),
+                        jni::jni_sig!("(Landroid/graphics/Bitmap;)V"),
+                        &[JValue::Object(&bitmap)],
+                    )
+                    .expect("Failed to create Canvas");
 
-            // Create Paint
-            let paint = env
-                .new_object("android/graphics/Paint", "()V", &[])
-                .expect("Failed to create Paint");
+                // Create Paint
+                let paint = env
+                    .new_object(
+                        jni::jni_str!("android/graphics/Paint"),
+                        jni::jni_sig!("()V"),
+                        &[],
+                    )
+                    .expect("Failed to create Paint");
 
-            // Anti-alias
-            let _ = env.call_method(&paint, "setAntiAlias", "(Z)V", &[JValue::Bool(1)]);
+                // Anti-alias
+                let _ = env.call_method(
+                    &paint,
+                    jni::jni_str!("setAntiAlias"),
+                    jni::jni_sig!("(Z)V"),
+                    &[JValue::Bool(true)],
+                );
 
-            // Replay commands
-            let mut path_points: Vec<(f32, f32)> = Vec::new();
+                // Replay commands
+                let mut path_points: Vec<(f32, f32)> = Vec::new();
 
-            for cmd in &cmds {
-                match cmd {
-                    DrawCmd::Clear => {
-                        // Fill with transparent (clear the bitmap)
-                        // Use PorterDuff.Mode.CLEAR to erase all pixels
-                        let mode_class = env
-                            .find_class("android/graphics/PorterDuff$Mode")
-                            .expect("PorterDuff$Mode");
-                        let clear_mode = env
-                            .get_static_field(
-                                &mode_class,
-                                "CLEAR",
-                                "Landroid/graphics/PorterDuff$Mode;",
-                            )
-                            .expect("CLEAR")
-                            .l()
-                            .expect("mode");
-                        let _ = env.call_method(
-                            &canvas,
-                            "drawColor",
-                            "(ILandroid/graphics/PorterDuff$Mode;)V",
-                            &[JValue::Int(0), JValue::Object(&clear_mode)],
-                        );
-                    }
-                    DrawCmd::BeginPath => {
-                        path_points.clear();
-                    }
-                    DrawCmd::MoveTo(x, y) => {
-                        path_points.push((*x, *y));
-                    }
-                    DrawCmd::LineTo(x, y) => {
-                        path_points.push((*x, *y));
-                    }
-                    DrawCmd::Stroke(color, line_width) => {
-                        let _ = env.call_method(&paint, "setColor", "(I)V", &[JValue::Int(*color)]);
-                        let _ = env.call_method(
-                            &paint,
-                            "setStrokeWidth",
-                            "(F)V",
-                            &[JValue::Float(*line_width)],
-                        );
-                        // Paint.Style.STROKE = 1
-                        let style_class = env
-                            .find_class("android/graphics/Paint$Style")
-                            .expect("Paint$Style");
-                        let stroke_style = env
-                            .get_static_field(
-                                &style_class,
-                                "STROKE",
-                                "Landroid/graphics/Paint$Style;",
-                            )
-                            .expect("STROKE")
-                            .l()
-                            .expect("style");
-                        let _ = env.call_method(
-                            &paint,
-                            "setStyle",
-                            "(Landroid/graphics/Paint$Style;)V",
-                            &[JValue::Object(&stroke_style)],
-                        );
-
-                        for i in 1..path_points.len() {
-                            let (x1, y1) = path_points[i - 1];
-                            let (x2, y2) = path_points[i];
+                for cmd in &cmds {
+                    match cmd {
+                        DrawCmd::Clear => {
+                            // Fill with transparent (clear the bitmap)
+                            // Use PorterDuff.Mode.CLEAR to erase all pixels
+                            let mode_class = env
+                                .find_class(jni::jni_str!("android/graphics/PorterDuff$Mode"))
+                                .expect("PorterDuff$Mode");
+                            let clear_mode = env
+                                .get_static_field(
+                                    &mode_class,
+                                    jni::jni_str!("CLEAR"),
+                                    jni::jni_sig!("Landroid/graphics/PorterDuff$Mode;"),
+                                )
+                                .expect("CLEAR")
+                                .l()
+                                .expect("mode");
                             let _ = env.call_method(
                                 &canvas,
-                                "drawLine",
-                                "(FFFFLandroid/graphics/Paint;)V",
-                                &[
-                                    JValue::Float(x1),
-                                    JValue::Float(y1),
-                                    JValue::Float(x2),
-                                    JValue::Float(y2),
-                                    JValue::Object(&paint),
-                                ],
+                                jni::jni_str!("drawColor"),
+                                jni::jni_sig!("(ILandroid/graphics/PorterDuff$Mode;)V"),
+                                &[JValue::Int(0), JValue::Object(&clear_mode)],
                             );
                         }
-                    }
-                    DrawCmd::FillGradient(color1, color2, direction) => {
-                        if path_points.len() >= 3 {
-                            // Build Android Path from accumulated path_points
-                            let path = env
-                                .new_object("android/graphics/Path", "()V", &[])
-                                .expect("Failed to create Path");
-                            let (sx, sy) = path_points[0];
+                        DrawCmd::BeginPath => {
+                            path_points.clear();
+                        }
+                        DrawCmd::MoveTo(x, y) => {
+                            path_points.push((*x, *y));
+                        }
+                        DrawCmd::LineTo(x, y) => {
+                            path_points.push((*x, *y));
+                        }
+                        DrawCmd::Stroke(color, line_width) => {
                             let _ = env.call_method(
-                                &path,
-                                "moveTo",
-                                "(FF)V",
-                                &[JValue::Float(sx), JValue::Float(sy)],
+                                &paint,
+                                jni::jni_str!("setColor"),
+                                jni::jni_sig!("(I)V"),
+                                &[JValue::Int(*color)],
                             );
-                            for i in 1..path_points.len() {
-                                let (px, py) = path_points[i];
-                                let _ = env.call_method(
-                                    &path,
-                                    "lineTo",
-                                    "(FF)V",
-                                    &[JValue::Float(px), JValue::Float(py)],
-                                );
-                            }
-                            let _ = env.call_method(&path, "close", "()V", &[]);
-
-                            // Create LinearGradient shader
-                            let (x1, y1, x2, y2) = if *direction < 0.5 {
-                                (0.0f32, 0.0f32, 0.0f32, h as f32) // vertical
-                            } else {
-                                (0.0f32, 0.0f32, w as f32, 0.0f32) // horizontal
-                            };
-
-                            let tile_class = env
-                                .find_class("android/graphics/Shader$TileMode")
-                                .expect("TileMode");
-                            let clamp = env
+                            let _ = env.call_method(
+                                &paint,
+                                jni::jni_str!("setStrokeWidth"),
+                                jni::jni_sig!("(F)V"),
+                                &[JValue::Float(*line_width)],
+                            );
+                            // Paint.Style.STROKE = 1
+                            let style_class = env
+                                .find_class(jni::jni_str!("android/graphics/Paint$Style"))
+                                .expect("Paint$Style");
+                            let stroke_style = env
                                 .get_static_field(
-                                    &tile_class,
-                                    "CLAMP",
-                                    "Landroid/graphics/Shader$TileMode;",
+                                    &style_class,
+                                    jni::jni_str!("STROKE"),
+                                    jni::jni_sig!("Landroid/graphics/Paint$Style;"),
                                 )
-                                .expect("CLAMP")
+                                .expect("STROKE")
                                 .l()
-                                .expect("clamp");
+                                .expect("style");
+                            let _ = env.call_method(
+                                &paint,
+                                jni::jni_str!("setStyle"),
+                                jni::jni_sig!("(Landroid/graphics/Paint$Style;)V"),
+                                &[JValue::Object(&stroke_style)],
+                            );
 
-                            let gradient = env
-                                .new_object(
-                                    "android/graphics/LinearGradient",
-                                    "(FFFFIILandroid/graphics/Shader$TileMode;)V",
+                            for i in 1..path_points.len() {
+                                let (x1, y1) = path_points[i - 1];
+                                let (x2, y2) = path_points[i];
+                                let _ = env.call_method(
+                                    &canvas,
+                                    jni::jni_str!("drawLine"),
+                                    jni::jni_sig!("(FFFFLandroid/graphics/Paint;)V"),
                                     &[
                                         JValue::Float(x1),
                                         JValue::Float(y1),
                                         JValue::Float(x2),
                                         JValue::Float(y2),
-                                        JValue::Int(*color1),
-                                        JValue::Int(*color2),
-                                        JValue::Object(&clamp),
+                                        JValue::Object(&paint),
+                                    ],
+                                );
+                            }
+                        }
+                        DrawCmd::FillGradient(color1, color2, direction) => {
+                            if path_points.len() >= 3 {
+                                // Build Android Path from accumulated path_points
+                                let path = env
+                                    .new_object(
+                                        jni::jni_str!("android/graphics/Path"),
+                                        jni::jni_sig!("()V"),
+                                        &[],
+                                    )
+                                    .expect("Failed to create Path");
+                                let (sx, sy) = path_points[0];
+                                let _ = env.call_method(
+                                    &path,
+                                    jni::jni_str!("moveTo"),
+                                    jni::jni_sig!("(FF)V"),
+                                    &[JValue::Float(sx), JValue::Float(sy)],
+                                );
+                                for i in 1..path_points.len() {
+                                    let (px, py) = path_points[i];
+                                    let _ = env.call_method(
+                                        &path,
+                                        jni::jni_str!("lineTo"),
+                                        jni::jni_sig!("(FF)V"),
+                                        &[JValue::Float(px), JValue::Float(py)],
+                                    );
+                                }
+                                let _ = env.call_method(
+                                    &path,
+                                    jni::jni_str!("close"),
+                                    jni::jni_sig!("()V"),
+                                    &[],
+                                );
+
+                                // Create LinearGradient shader
+                                let (x1, y1, x2, y2) = if *direction < 0.5 {
+                                    (0.0f32, 0.0f32, 0.0f32, h as f32) // vertical
+                                } else {
+                                    (0.0f32, 0.0f32, w as f32, 0.0f32) // horizontal
+                                };
+
+                                let tile_class = env
+                                    .find_class(jni::jni_str!("android/graphics/Shader$TileMode"))
+                                    .expect("TileMode");
+                                let clamp = env
+                                    .get_static_field(
+                                        &tile_class,
+                                        jni::jni_str!("CLAMP"),
+                                        jni::jni_sig!("Landroid/graphics/Shader$TileMode;"),
+                                    )
+                                    .expect("CLAMP")
+                                    .l()
+                                    .expect("clamp");
+
+                                let gradient = env
+                                    .new_object(
+                                        jni::jni_str!("android/graphics/LinearGradient"),
+                                        jni::jni_sig!(
+                                            "(FFFFIILandroid/graphics/Shader$TileMode;)V"
+                                        ),
+                                        &[
+                                            JValue::Float(x1),
+                                            JValue::Float(y1),
+                                            JValue::Float(x2),
+                                            JValue::Float(y2),
+                                            JValue::Int(*color1),
+                                            JValue::Int(*color2),
+                                            JValue::Object(&clamp),
+                                        ],
+                                    )
+                                    .expect("LinearGradient");
+
+                                let _ = env.call_method(
+                                    &paint,
+                                    jni::jni_str!("setShader"),
+                                    jni::jni_sig!(
+                                        "(Landroid/graphics/Shader;)Landroid/graphics/Shader;"
+                                    ),
+                                    &[JValue::Object(&gradient)],
+                                );
+
+                                // Set FILL style
+                                let style_class = env
+                                    .find_class(jni::jni_str!("android/graphics/Paint$Style"))
+                                    .expect("Paint$Style");
+                                let fill_style = env
+                                    .get_static_field(
+                                        &style_class,
+                                        jni::jni_str!("FILL"),
+                                        jni::jni_sig!("Landroid/graphics/Paint$Style;"),
+                                    )
+                                    .expect("FILL")
+                                    .l()
+                                    .expect("style");
+                                let _ = env.call_method(
+                                    &paint,
+                                    jni::jni_str!("setStyle"),
+                                    jni::jni_sig!("(Landroid/graphics/Paint$Style;)V"),
+                                    &[JValue::Object(&fill_style)],
+                                );
+
+                                let _ = env.call_method(
+                                    &canvas,
+                                    jni::jni_str!("drawPath"),
+                                    jni::jni_sig!(
+                                        "(Landroid/graphics/Path;Landroid/graphics/Paint;)V"
+                                    ),
+                                    &[JValue::Object(&path), JValue::Object(&paint)],
+                                );
+
+                                // Clear shader
+                                let _ = env.call_method(
+                                    &paint,
+                                    jni::jni_str!("setShader"),
+                                    jni::jni_sig!(
+                                        "(Landroid/graphics/Shader;)Landroid/graphics/Shader;"
+                                    ),
+                                    &[JValue::Object(&jni::objects::JObject::null())],
+                                );
+                            }
+                        }
+                        DrawCmd::DrawImage {
+                            image,
+                            sx,
+                            sy,
+                            sw,
+                            sh,
+                            dx,
+                            dy,
+                            dw,
+                            dh,
+                        } => {
+                            let images = CANVAS_IMAGES.lock().unwrap();
+                            let Some(bitmap_ref) = images.get(image) else {
+                                continue;
+                            };
+                            let bitmap_obj = bitmap_ref.as_obj();
+                            let bitmap_w = env
+                                .call_method(
+                                    bitmap_obj,
+                                    jni::jni_str!("getWidth"),
+                                    jni::jni_sig!("()I"),
+                                    &[],
+                                )
+                                .ok()
+                                .and_then(|v| v.i().ok())
+                                .unwrap_or(0) as f32;
+                            let bitmap_h = env
+                                .call_method(
+                                    bitmap_obj,
+                                    jni::jni_str!("getHeight"),
+                                    jni::jni_sig!("()I"),
+                                    &[],
+                                )
+                                .ok()
+                                .and_then(|v| v.i().ok())
+                                .unwrap_or(0) as f32;
+                            let src_w = if *sw > 0.0 { *sw } else { bitmap_w };
+                            let src_h = if *sh > 0.0 { *sh } else { bitmap_h };
+                            let dst_w = if *dw > 0.0 { *dw } else { src_w };
+                            let dst_h = if *dh > 0.0 { *dh } else { src_h };
+                            if src_w <= 0.0 || src_h <= 0.0 || dst_w <= 0.0 || dst_h <= 0.0 {
+                                continue;
+                            }
+                            let src_rect = env
+                                .new_object(
+                                    jni::jni_str!("android/graphics/Rect"),
+                                    jni::jni_sig!("(IIII)V"),
+                                    &[
+                                        JValue::Int(*sx as i32),
+                                        JValue::Int(*sy as i32),
+                                        JValue::Int((*sx + src_w) as i32),
+                                        JValue::Int((*sy + src_h) as i32),
                                     ],
                                 )
-                                .expect("LinearGradient");
-
-                            let _ = env.call_method(
-                                &paint,
-                                "setShader",
-                                "(Landroid/graphics/Shader;)Landroid/graphics/Shader;",
-                                &[JValue::Object(&gradient)],
-                            );
-
-                            // Set FILL style
-                            let style_class = env
-                                .find_class("android/graphics/Paint$Style")
-                                .expect("Paint$Style");
-                            let fill_style = env
-                                .get_static_field(
-                                    &style_class,
-                                    "FILL",
-                                    "Landroid/graphics/Paint$Style;",
+                                .expect("Rect");
+                            let dst_rect = env
+                                .new_object(
+                                    jni::jni_str!("android/graphics/RectF"),
+                                    jni::jni_sig!("(FFFF)V"),
+                                    &[
+                                        JValue::Float(*dx),
+                                        JValue::Float(*dy),
+                                        JValue::Float(*dx + dst_w),
+                                        JValue::Float(*dy + dst_h),
+                                    ],
                                 )
-                                .expect("FILL")
-                                .l()
-                                .expect("style");
+                                .expect("RectF");
                             let _ = env.call_method(
-                                &paint,
-                                "setStyle",
-                                "(Landroid/graphics/Paint$Style;)V",
-                                &[JValue::Object(&fill_style)],
-                            );
-
-                            let _ = env.call_method(
-                                &canvas,
-                                "drawPath",
-                                "(Landroid/graphics/Path;Landroid/graphics/Paint;)V",
-                                &[JValue::Object(&path), JValue::Object(&paint)],
-                            );
-
-                            // Clear shader
-                            let _ = env.call_method(
-                                &paint,
-                                "setShader",
-                                "(Landroid/graphics/Shader;)Landroid/graphics/Shader;",
-                                &[JValue::Object(&jni::objects::JObject::null())],
-                            );
-                        }
-                    }
-                    DrawCmd::DrawImage {
-                        image,
-                        sx,
-                        sy,
-                        sw,
-                        sh,
-                        dx,
-                        dy,
-                        dw,
-                        dh,
-                    } => {
-                        let images = CANVAS_IMAGES.lock().unwrap();
-                        let Some(bitmap_ref) = images.get(image) else {
-                            continue;
-                        };
-                        let bitmap_obj = bitmap_ref.as_obj();
-                        let bitmap_w = env
-                            .call_method(bitmap_obj, "getWidth", "()I", &[])
-                            .ok()
-                            .and_then(|v| v.i().ok())
-                            .unwrap_or(0) as f32;
-                        let bitmap_h = env
-                            .call_method(bitmap_obj, "getHeight", "()I", &[])
-                            .ok()
-                            .and_then(|v| v.i().ok())
-                            .unwrap_or(0) as f32;
-                        let src_w = if *sw > 0.0 { *sw } else { bitmap_w };
-                        let src_h = if *sh > 0.0 { *sh } else { bitmap_h };
-                        let dst_w = if *dw > 0.0 { *dw } else { src_w };
-                        let dst_h = if *dh > 0.0 { *dh } else { src_h };
-                        if src_w <= 0.0 || src_h <= 0.0 || dst_w <= 0.0 || dst_h <= 0.0 {
-                            continue;
-                        }
-                        let src_rect = env
-                            .new_object(
-                                "android/graphics/Rect",
-                                "(IIII)V",
-                                &[
-                                    JValue::Int(*sx as i32),
-                                    JValue::Int(*sy as i32),
-                                    JValue::Int((*sx + src_w) as i32),
-                                    JValue::Int((*sy + src_h) as i32),
-                                ],
-                            )
-                            .expect("Rect");
-                        let dst_rect = env
-                            .new_object(
-                                "android/graphics/RectF",
-                                "(FFFF)V",
-                                &[
-                                    JValue::Float(*dx),
-                                    JValue::Float(*dy),
-                                    JValue::Float(*dx + dst_w),
-                                    JValue::Float(*dy + dst_h),
-                                ],
-                            )
-                            .expect("RectF");
-                        let _ = env.call_method(
                             &canvas,
-                            "drawBitmap",
-                            "(Landroid/graphics/Bitmap;Landroid/graphics/Rect;Landroid/graphics/RectF;Landroid/graphics/Paint;)V",
+                            jni::jni_str!("drawBitmap"),
+                            jni::jni_sig!("(Landroid/graphics/Bitmap;Landroid/graphics/Rect;Landroid/graphics/RectF;Landroid/graphics/Paint;)V"),
                             &[
                                 JValue::Object(bitmap_obj),
                                 JValue::Object(&src_rect),
@@ -570,21 +605,22 @@ fn repaint(handle: i64) {
                                 JValue::Object(&paint),
                             ],
                         );
+                        }
                     }
                 }
-            }
 
-            // Set bitmap on ImageView
-            let _ = env.call_method(
-                view_ref.as_obj(),
-                "setImageBitmap",
-                "(Landroid/graphics/Bitmap;)V",
-                &[JValue::Object(&bitmap)],
-            );
+                // Set bitmap on ImageView
+                let _ = env.call_method(
+                    view_ref.as_obj(),
+                    jni::jni_str!("setImageBitmap"),
+                    jni::jni_sig!("(Landroid/graphics/Bitmap;)V"),
+                    &[JValue::Object(&bitmap)],
+                );
 
-            unsafe {
-                env.pop_local_frame(&jni::objects::JObject::null());
-            }
+                unsafe {
+                    let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+                }
+            })
         }
     }
 }
@@ -689,88 +725,105 @@ pub fn load_image(path_ptr: *const u8) -> i64 {
         }
         return rejected_image_promise("Cached Canvas image handle was missing");
     }
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
-    let activity = super::get_activity(&mut env);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
+        let activity = super::get_activity(env);
 
-    let mut bitmap = JObject::null();
-    if !path.starts_with('/') {
-        if let Ok(asset_mgr) = env.call_method(
-            &activity,
-            "getAssets",
-            "()Landroid/content/res/AssetManager;",
-            &[],
-        ) {
-            if let Ok(mgr) = asset_mgr.l() {
-                let jpath = env.new_string(&path).expect("asset path string");
-                if let Ok(stream_val) = env.call_method(
-                    &mgr,
-                    "open",
-                    "(Ljava/lang/String;)Ljava/io/InputStream;",
-                    &[JValue::Object(&jpath)],
-                ) {
-                    if let Ok(stream_obj) = stream_val.l() {
-                        if !stream_obj.is_null() {
-                            if let Ok(bmp_val) = env.call_static_method(
-                                "android/graphics/BitmapFactory",
-                                "decodeStream",
-                                "(Ljava/io/InputStream;)Landroid/graphics/Bitmap;",
-                                &[JValue::Object(&stream_obj)],
-                            ) {
-                                bitmap = bmp_val.l().unwrap_or_else(|_| JObject::null());
+        let mut bitmap = JObject::null();
+        if !path.starts_with('/') {
+            if let Ok(asset_mgr) = env.call_method(
+                &activity,
+                jni::jni_str!("getAssets"),
+                jni::jni_sig!("()Landroid/content/res/AssetManager;"),
+                &[],
+            ) {
+                if let Ok(mgr) = asset_mgr.l() {
+                    let jpath = env.new_string(&path).expect("asset path string");
+                    if let Ok(stream_val) = env.call_method(
+                        &mgr,
+                        jni::jni_str!("open"),
+                        jni::jni_sig!("(Ljava/lang/String;)Ljava/io/InputStream;"),
+                        &[JValue::Object(&jpath)],
+                    ) {
+                        if let Ok(stream_obj) = stream_val.l() {
+                            if !stream_obj.is_null() {
+                                if let Ok(bmp_val) = env.call_static_method(
+                                    jni::jni_str!("android/graphics/BitmapFactory"),
+                                    jni::jni_str!("decodeStream"),
+                                    jni::jni_sig!(
+                                        "(Ljava/io/InputStream;)Landroid/graphics/Bitmap;"
+                                    ),
+                                    &[JValue::Object(&stream_obj)],
+                                ) {
+                                    bitmap = bmp_val.l().unwrap_or_else(|_| JObject::null());
+                                }
+                                let _ = env.call_method(
+                                    &stream_obj,
+                                    jni::jni_str!("close"),
+                                    jni::jni_sig!("()V"),
+                                    &[],
+                                );
                             }
-                            let _ = env.call_method(&stream_obj, "close", "()V", &[]);
                         }
                     }
-                }
-                if env.exception_check().unwrap_or(false) {
-                    let _ = env.exception_clear();
+                    if env.exception_check() {
+                        let _ = env.exception_clear();
+                    }
                 }
             }
         }
-    }
 
-    if bitmap.is_null() {
-        let jpath = env.new_string(&path).expect("bitmap path string");
-        if let Ok(bmp_val) = env.call_static_method(
-            "android/graphics/BitmapFactory",
-            "decodeFile",
-            "(Ljava/lang/String;)Landroid/graphics/Bitmap;",
-            &[JValue::Object(&jpath)],
-        ) {
-            bitmap = bmp_val.l().unwrap_or_else(|_| JObject::null());
+        if bitmap.is_null() {
+            let jpath = env.new_string(&path).expect("bitmap path string");
+            if let Ok(bmp_val) = env.call_static_method(
+                jni::jni_str!("android/graphics/BitmapFactory"),
+                jni::jni_str!("decodeFile"),
+                jni::jni_sig!("(Ljava/lang/String;)Landroid/graphics/Bitmap;"),
+                &[JValue::Object(&jpath)],
+            ) {
+                bitmap = bmp_val.l().unwrap_or_else(|_| JObject::null());
+            }
         }
-    }
 
-    let result = if bitmap.is_null() {
-        rejected_image_promise(&format!("Failed to load image: {path}"))
-    } else {
-        let width = env
-            .call_method(&bitmap, "getWidth", "()I", &[])
-            .ok()
-            .and_then(|v| v.i().ok())
-            .unwrap_or(0) as f64;
-        let height = env
-            .call_method(&bitmap, "getHeight", "()I", &[])
-            .ok()
-            .and_then(|v| v.i().ok())
-            .unwrap_or(0) as f64;
-        let global = env
-            .new_global_ref(bitmap)
-            .expect("Failed to create image global ref");
-        let handle = NEXT_IMAGE_HANDLE.fetch_add(1, Ordering::Relaxed);
-        CANVAS_IMAGES.lock().unwrap().insert(handle, global);
-        CANVAS_IMAGE_SIZES
-            .lock()
-            .unwrap()
-            .insert(handle, (width, height));
-        IMAGE_CACHE.lock().unwrap().insert(path, handle);
-        resolved_image_promise(handle, width, height)
-    };
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
-    result
+        let result = if bitmap.is_null() {
+            rejected_image_promise(&format!("Failed to load image: {path}"))
+        } else {
+            let width = env
+                .call_method(
+                    &bitmap,
+                    jni::jni_str!("getWidth"),
+                    jni::jni_sig!("()I"),
+                    &[],
+                )
+                .ok()
+                .and_then(|v| v.i().ok())
+                .unwrap_or(0) as f64;
+            let height = env
+                .call_method(
+                    &bitmap,
+                    jni::jni_str!("getHeight"),
+                    jni::jni_sig!("()I"),
+                    &[],
+                )
+                .ok()
+                .and_then(|v| v.i().ok())
+                .unwrap_or(0) as f64;
+            let global =
+                jni_bridge::new_global_ref(env, bitmap).expect("Failed to create image global ref");
+            let handle = NEXT_IMAGE_HANDLE.fetch_add(1, Ordering::Relaxed);
+            CANVAS_IMAGES.lock().unwrap().insert(handle, global);
+            CANVAS_IMAGE_SIZES
+                .lock()
+                .unwrap()
+                .insert(handle, (width, height));
+            IMAGE_CACHE.lock().unwrap().insert(path, handle);
+            resolved_image_promise(handle, width, height)
+        };
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+        result
+    })
 }
 
 pub fn draw_image(

--- a/crates/perry-ui-android/src/widgets/chart.rs
+++ b/crates/perry-ui-android/src/widgets/chart.rs
@@ -10,121 +10,132 @@
 
 use crate::app::str_from_header;
 use crate::jni_bridge;
-use jni::objects::{JObject, JValue};
+use jni::objects::JObject;
+use jni::JValue;
 
 /// Create a PerryChartView with the requested kind (0=line, 1=bar, 2=pie)
 /// and layout size hint.
 pub fn create(kind: i64, width: f64, height: f64) -> i64 {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let result = env.call_static_method(
-        bridge_cls,
-        "chartCreate",
-        "(JDD)Landroid/view/View;",
-        &[
-            JValue::Long(kind),
-            JValue::Double(width),
-            JValue::Double(height),
-        ],
-    );
-    let handle = match result {
-        Ok(jv) => match jv.l() {
-            Ok(obj) if !obj.is_null() => {
-                let g = env.new_global_ref(obj).expect("global-ref Chart");
-                super::register_widget(g)
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let result = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("chartCreate"),
+            jni::jni_sig!("(JDD)Landroid/view/View;"),
+            &[
+                JValue::Long(kind),
+                JValue::Double(width),
+                JValue::Double(height),
+            ],
+        );
+        let handle = match result {
+            Ok(jv) => match jv.l() {
+                Ok(obj) if !obj.is_null() => {
+                    let g = jni_bridge::new_global_ref(env, obj).expect("global-ref Chart");
+                    super::register_widget(g)
+                }
+                _ => 0,
+            },
+            Err(_) => {
+                if env.exception_check() {
+                    let _ = env.exception_describe();
+                    let _ = env.exception_clear();
+                }
+                0
             }
-            _ => 0,
-        },
-        Err(_) => {
-            if env.exception_check().unwrap_or(false) {
-                let _ = env.exception_describe();
-                let _ = env.exception_clear();
-            }
-            0
+        };
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
         }
-    };
-    unsafe {
-        env.pop_local_frame(&JObject::null());
-    }
-    handle
+        handle
+    })
 }
 
 pub fn add_data_point(handle: i64, label_ptr: *const u8, value: f64) {
     let label = unsafe { str_from_header(label_ptr) };
     if let Some(view) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let jlabel = env.new_string(label).expect("chart label string");
-        let bridge_class =
-            jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-        let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-        let _ = env.call_static_method(
-            bridge_cls,
-            "chartAddDataPoint",
-            "(Landroid/view/View;Ljava/lang/String;D)V",
-            &[
-                JValue::Object(view.as_obj()),
-                JValue::Object(&jlabel),
-                JValue::Double(value),
-            ],
-        );
-        unsafe {
-            env.pop_local_frame(&JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let jlabel = env.new_string(label).expect("chart label string");
+            let bridge_class =
+                jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+            let bridge_cls: &jni::objects::JClass = &bridge_class;
+            let _ = env.call_static_method(
+                bridge_cls,
+                jni::jni_str!("chartAddDataPoint"),
+                jni::jni_sig!("(Landroid/view/View;Ljava/lang/String;D)V"),
+                &[
+                    JValue::Object(view.as_obj()),
+                    JValue::Object(&jlabel),
+                    JValue::Double(value),
+                ],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }
 
 pub fn clear_data(handle: i64) {
     if let Some(view) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let bridge_class =
-            jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-        let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-        let _ = env.call_static_method(
-            bridge_cls,
-            "chartClearData",
-            "(Landroid/view/View;)V",
-            &[JValue::Object(view.as_obj())],
-        );
-        unsafe {
-            env.pop_local_frame(&JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let bridge_class =
+                jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+            let bridge_cls: &jni::objects::JClass = &bridge_class;
+            let _ = env.call_static_method(
+                bridge_cls,
+                jni::jni_str!("chartClearData"),
+                jni::jni_sig!("(Landroid/view/View;)V"),
+                &[JValue::Object(view.as_obj())],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }
 
 pub fn set_title(handle: i64, title_ptr: *const u8) {
     let title = unsafe { str_from_header(title_ptr) };
     if let Some(view) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let jtitle = env.new_string(title).expect("chart title string");
-        let bridge_class =
-            jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-        let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-        let _ = env.call_static_method(
-            bridge_cls,
-            "chartSetTitle",
-            "(Landroid/view/View;Ljava/lang/String;)V",
-            &[JValue::Object(view.as_obj()), JValue::Object(&jtitle)],
-        );
-        unsafe {
-            env.pop_local_frame(&JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let jtitle = env.new_string(title).expect("chart title string");
+            let bridge_class =
+                jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+            let bridge_cls: &jni::objects::JClass = &bridge_class;
+            let _ = env.call_static_method(
+                bridge_cls,
+                jni::jni_str!("chartSetTitle"),
+                jni::jni_sig!("(Landroid/view/View;Ljava/lang/String;)V"),
+                &[JValue::Object(view.as_obj()), JValue::Object(&jtitle)],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }
 
 pub fn reload(handle: i64) {
     if let Some(view) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        // PerryChartView extends View; invalidate() schedules onDraw.
-        let _ = env.call_method(view.as_obj(), "postInvalidate", "()V", &[]);
-        unsafe {
-            env.pop_local_frame(&JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            // PerryChartView extends View; invalidate() schedules onDraw.
+            let _ = env.call_method(
+                view.as_obj(),
+                jni::jni_str!("postInvalidate"),
+                jni::jni_sig!("()V"),
+                &[],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }

--- a/crates/perry-ui-android/src/widgets/combobox.rs
+++ b/crates/perry-ui-android/src/widgets/combobox.rs
@@ -11,7 +11,8 @@
 use crate::app::str_from_header;
 use crate::callback;
 use crate::jni_bridge;
-use jni::objects::{JObject, JValue};
+use jni::objects::JObject;
+use jni::JValue;
 
 extern "C" {
     fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
@@ -23,67 +24,68 @@ const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
 /// Create an AutoCompleteTextView with an initial value and on_change callback.
 pub fn create(initial_ptr: *const u8, on_change: f64) -> i64 {
     let initial = unsafe { str_from_header(initial_ptr) };
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(16);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 16);
 
-    let cb_key = if on_change != 0.0 {
-        callback::register(on_change)
-    } else {
-        0
-    };
-    let jinitial = env.new_string(initial).expect("combobox initial string");
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let result = env.call_static_method(
-        bridge_cls,
-        "comboboxCreate",
-        "(Ljava/lang/String;J)Landroid/widget/AutoCompleteTextView;",
-        &[JValue::Object(&jinitial), JValue::Long(cb_key)],
-    );
-    let handle = match result {
-        Ok(jv) => match jv.l() {
-            Ok(obj) if !obj.is_null() => {
-                let g = env
-                    .new_global_ref(obj)
-                    .expect("global-ref AutoCompleteTextView");
-                super::register_widget(g)
-            }
-            _ => 0,
-        },
-        Err(_) => {
-            if env.exception_check().unwrap_or(false) {
-                let _ = env.exception_describe();
-                let _ = env.exception_clear();
-            }
+        let cb_key = if on_change != 0.0 {
+            callback::register(on_change)
+        } else {
             0
+        };
+        let jinitial = env.new_string(initial).expect("combobox initial string");
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let result = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("comboboxCreate"),
+            jni::jni_sig!("(Ljava/lang/String;J)Landroid/widget/AutoCompleteTextView;"),
+            &[JValue::Object(&jinitial), JValue::Long(cb_key)],
+        );
+        let handle = match result {
+            Ok(jv) => match jv.l() {
+                Ok(obj) if !obj.is_null() => {
+                    let g = jni_bridge::new_global_ref(env, obj)
+                        .expect("global-ref AutoCompleteTextView");
+                    super::register_widget(g)
+                }
+                _ => 0,
+            },
+            Err(_) => {
+                if env.exception_check() {
+                    let _ = env.exception_describe();
+                    let _ = env.exception_clear();
+                }
+                0
+            }
+        };
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
         }
-    };
-    unsafe {
-        env.pop_local_frame(&JObject::null());
-    }
-    handle
+        handle
+    })
 }
 
 /// Append one suggestion item to the combobox.
 pub fn add_item(handle: i64, value_ptr: *const u8) {
     let value = unsafe { str_from_header(value_ptr) };
     if let Some(view) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let jvalue = env.new_string(value).expect("combobox value string");
-        let bridge_class =
-            jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-        let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-        let _ = env.call_static_method(
-            bridge_cls,
-            "comboboxAddItem",
-            "(Landroid/widget/AutoCompleteTextView;Ljava/lang/String;)V",
-            &[JValue::Object(view.as_obj()), JValue::Object(&jvalue)],
-        );
-        unsafe {
-            env.pop_local_frame(&JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let jvalue = env.new_string(value).expect("combobox value string");
+            let bridge_class =
+                jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+            let bridge_cls: &jni::objects::JClass = &bridge_class;
+            let _ = env.call_static_method(
+                bridge_cls,
+                jni::jni_str!("comboboxAddItem"),
+                jni::jni_sig!("(Landroid/widget/AutoCompleteTextView;Ljava/lang/String;)V"),
+                &[JValue::Object(view.as_obj()), JValue::Object(&jvalue)],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }
 
@@ -91,21 +93,22 @@ pub fn add_item(handle: i64, value_ptr: *const u8) {
 pub fn set_value(handle: i64, value_ptr: *const u8) {
     let value = unsafe { str_from_header(value_ptr) };
     if let Some(view) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let jvalue = env.new_string(value).expect("combobox value string");
-        let bridge_class =
-            jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-        let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-        let _ = env.call_static_method(
-            bridge_cls,
-            "comboboxSetValue",
-            "(Landroid/widget/AutoCompleteTextView;Ljava/lang/String;)V",
-            &[JValue::Object(view.as_obj()), JValue::Object(&jvalue)],
-        );
-        unsafe {
-            env.pop_local_frame(&JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let jvalue = env.new_string(value).expect("combobox value string");
+            let bridge_class =
+                jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+            let bridge_cls: &jni::objects::JClass = &bridge_class;
+            let _ = env.call_static_method(
+                bridge_cls,
+                jni::jni_str!("comboboxSetValue"),
+                jni::jni_sig!("(Landroid/widget/AutoCompleteTextView;Ljava/lang/String;)V"),
+                &[JValue::Object(view.as_obj()), JValue::Object(&jvalue)],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }
 
@@ -114,38 +117,40 @@ pub fn get_value(handle: i64) -> f64 {
     let Some(view) = super::get_widget(handle) else {
         return f64::from_bits(TAG_UNDEFINED);
     };
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let result = env.call_static_method(
-        bridge_cls,
-        "comboboxGetValue",
-        "(Landroid/widget/AutoCompleteTextView;)Ljava/lang/String;",
-        &[JValue::Object(view.as_obj())],
-    );
-    let text: Option<String> = match result {
-        Ok(jv) => match jv.l() {
-            Ok(obj) if !obj.is_null() => {
-                let jstr: jni::objects::JString = obj.into();
-                env.get_string(&jstr).map(|s| s.into()).ok()
-            }
-            _ => None,
-        },
-        Err(_) => None,
-    };
-    unsafe {
-        env.pop_local_frame(&JObject::null());
-    }
-    match text {
-        Some(s) => {
-            let bytes = s.as_bytes();
-            unsafe {
-                let p = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
-                js_nanbox_string(p as i64)
-            }
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let result = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("comboboxGetValue"),
+            jni::jni_sig!("(Landroid/widget/AutoCompleteTextView;)Ljava/lang/String;"),
+            &[JValue::Object(view.as_obj())],
+        );
+        let text: Option<String> = match result {
+            Ok(jv) => match jv.l() {
+                Ok(obj) if !obj.is_null() => {
+                    let jstr: jni::objects::JString =
+                        unsafe { jni::objects::JString::from_raw(env, obj.into_raw()) };
+                    jstr.try_to_string(env).map(|s| s.into()).ok()
+                }
+                _ => None,
+            },
+            Err(_) => None,
+        };
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
         }
-        None => f64::from_bits(TAG_UNDEFINED),
-    }
+        match text {
+            Some(s) => {
+                let bytes = s.as_bytes();
+                unsafe {
+                    let p = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+                    js_nanbox_string(p as i64)
+                }
+            }
+            None => f64::from_bits(TAG_UNDEFINED),
+        }
+    })
 }

--- a/crates/perry-ui-android/src/widgets/date_picker.rs
+++ b/crates/perry-ui-android/src/widgets/date_picker.rs
@@ -9,7 +9,8 @@
 
 use crate::callback;
 use crate::jni_bridge;
-use jni::objects::{JObject, JValue};
+use jni::objects::JObject;
+use jni::JValue;
 
 extern "C" {
     fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
@@ -23,86 +24,87 @@ const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
 /// `on_change` is the Perry closure invoked with a `yyyy-MM-dd` string each
 /// time the user picks a new date.
 pub fn create(year: i64, month: i64, on_change: f64) -> i64 {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(16);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 16);
 
-    let cb_key = if on_change != 0.0 {
-        callback::register(on_change)
-    } else {
-        0
-    };
-
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-
-    let result = env.call_static_method(
-        bridge_cls,
-        "datePickerCreate",
-        "(JJJ)Landroid/widget/DatePicker;",
-        &[
-            JValue::Long(year),
-            JValue::Long(month),
-            JValue::Long(cb_key),
-        ],
-    );
-
-    let handle = match result {
-        Ok(jv) => match jv.l() {
-            Ok(obj) if !obj.is_null() => {
-                let g = env
-                    .new_global_ref(obj)
-                    .expect("Failed to global-ref DatePicker");
-                super::register_widget(g)
-            }
-            _ => 0,
-        },
-        Err(e) => {
-            unsafe {
-                let msg = format!("datePickerCreate failed: {:?}\0", e);
-                __android_log_print(
-                    6,
-                    b"PerryDatePicker\0".as_ptr(),
-                    b"%s\0".as_ptr(),
-                    msg.as_ptr(),
-                );
-                if env.exception_check().unwrap_or(false) {
-                    let _ = env.exception_describe();
-                    let _ = env.exception_clear();
-                }
-            }
+        let cb_key = if on_change != 0.0 {
+            callback::register(on_change)
+        } else {
             0
-        }
-    };
+        };
 
-    unsafe {
-        env.pop_local_frame(&JObject::null());
-    }
-    handle
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+
+        let result = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("datePickerCreate"),
+            jni::jni_sig!("(JJJ)Landroid/widget/DatePicker;"),
+            &[
+                JValue::Long(year),
+                JValue::Long(month),
+                JValue::Long(cb_key),
+            ],
+        );
+
+        let handle = match result {
+            Ok(jv) => match jv.l() {
+                Ok(obj) if !obj.is_null() => {
+                    let g = jni_bridge::new_global_ref(env, obj)
+                        .expect("Failed to global-ref DatePicker");
+                    super::register_widget(g)
+                }
+                _ => 0,
+            },
+            Err(e) => {
+                unsafe {
+                    let msg = format!("datePickerCreate failed: {:?}\0", e);
+                    __android_log_print(
+                        6,
+                        b"PerryDatePicker\0".as_ptr(),
+                        b"%s\0".as_ptr(),
+                        msg.as_ptr(),
+                    );
+                    if env.exception_check() {
+                        let _ = env.exception_describe();
+                        let _ = env.exception_clear();
+                    }
+                }
+                0
+            }
+        };
+
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+        }
+        handle
+    })
 }
 
 /// Programmatically set the selected date (year, 1-based month, day).
 pub fn set_date(handle: i64, year: i64, month: i64, day: i64) {
     if let Some(view) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let bridge_class =
-            jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-        let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-        let _ = env.call_static_method(
-            bridge_cls,
-            "datePickerSetDate",
-            "(Landroid/widget/DatePicker;JJJ)V",
-            &[
-                JValue::Object(view.as_obj()),
-                JValue::Long(year),
-                JValue::Long(month),
-                JValue::Long(day),
-            ],
-        );
-        unsafe {
-            env.pop_local_frame(&JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let bridge_class =
+                jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+            let bridge_cls: &jni::objects::JClass = &bridge_class;
+            let _ = env.call_static_method(
+                bridge_cls,
+                jni::jni_str!("datePickerSetDate"),
+                jni::jni_sig!("(Landroid/widget/DatePicker;JJJ)V"),
+                &[
+                    JValue::Object(view.as_obj()),
+                    JValue::Long(year),
+                    JValue::Long(month),
+                    JValue::Long(day),
+                ],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }
 
@@ -112,38 +114,40 @@ pub fn get_selected_date(handle: i64) -> f64 {
     let Some(view) = super::get_widget(handle) else {
         return f64::from_bits(TAG_UNDEFINED);
     };
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let result = env.call_static_method(
-        bridge_cls,
-        "datePickerGetSelectedDate",
-        "(Landroid/widget/DatePicker;)Ljava/lang/String;",
-        &[JValue::Object(view.as_obj())],
-    );
-    let date_str: Option<String> = match result {
-        Ok(jv) => match jv.l() {
-            Ok(obj) if !obj.is_null() => {
-                let jstr: jni::objects::JString = obj.into();
-                env.get_string(&jstr).map(|s| s.into()).ok()
-            }
-            _ => None,
-        },
-        Err(_) => None,
-    };
-    unsafe {
-        env.pop_local_frame(&JObject::null());
-    }
-    match date_str {
-        Some(s) if !s.is_empty() => {
-            let bytes = s.as_bytes();
-            unsafe {
-                let ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
-                js_nanbox_string(ptr as i64)
-            }
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let result = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("datePickerGetSelectedDate"),
+            jni::jni_sig!("(Landroid/widget/DatePicker;)Ljava/lang/String;"),
+            &[JValue::Object(view.as_obj())],
+        );
+        let date_str: Option<String> = match result {
+            Ok(jv) => match jv.l() {
+                Ok(obj) if !obj.is_null() => {
+                    let jstr: jni::objects::JString =
+                        unsafe { jni::objects::JString::from_raw(env, obj.into_raw()) };
+                    jstr.try_to_string(env).map(|s| s.into()).ok()
+                }
+                _ => None,
+            },
+            Err(_) => None,
+        };
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
         }
-        _ => f64::from_bits(TAG_UNDEFINED),
-    }
+        match date_str {
+            Some(s) if !s.is_empty() => {
+                let bytes = s.as_bytes();
+                unsafe {
+                    let ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+                    js_nanbox_string(ptr as i64)
+                }
+            }
+            _ => f64::from_bits(TAG_UNDEFINED),
+        }
+    })
 }

--- a/crates/perry-ui-android/src/widgets/divider.rs
+++ b/crates/perry-ui-android/src/widgets/divider.rs
@@ -1,46 +1,50 @@
 use crate::jni_bridge;
-use jni::objects::JValue;
+use jni::JValue;
 
 /// Create a horizontal divider (1dp height View with separator color).
 pub fn create() -> i64 {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
-    let activity = super::get_activity(&mut env);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
+        let activity = super::get_activity(env);
 
-    let view = env
-        .new_object(
-            "android/view/View",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("Failed to create View");
+        let view = env
+            .new_object(
+                jni::jni_str!("android/view/View"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("Failed to create View");
 
-    // Light gray separator color (0xFFCCCCCC)
-    let color: i32 = 0xFFCCCCCCu32 as i32;
-    let _ = env.call_method(&view, "setBackgroundColor", "(I)V", &[JValue::Int(color)]);
+        // Light gray separator color (0xFFCCCCCC)
+        let color: i32 = 0xFFCCCCCCu32 as i32;
+        let _ = env.call_method(
+            &view,
+            jni::jni_str!("setBackgroundColor"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(color)],
+        );
 
-    // 1dp height, MATCH_PARENT width
-    let height_px = super::dp_to_px(&mut env, 1.0);
-    let params = env
-        .new_object(
-            "android/widget/LinearLayout$LayoutParams",
-            "(II)V",
-            &[JValue::Int(-1), JValue::Int(height_px)], // MATCH_PARENT, 1dp
-        )
-        .expect("Failed to create LayoutParams");
-    let _ = env.call_method(
-        &view,
-        "setLayoutParams",
-        "(Landroid/view/ViewGroup$LayoutParams;)V",
-        &[JValue::Object(&params)],
-    );
+        // 1dp height, MATCH_PARENT width
+        let height_px = super::dp_to_px(env, 1.0);
+        let params = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout$LayoutParams"),
+                jni::jni_sig!("(II)V"),
+                &[JValue::Int(-1), JValue::Int(height_px)], // MATCH_PARENT, 1dp
+            )
+            .expect("Failed to create LayoutParams");
+        let _ = env.call_method(
+            &view,
+            jni::jni_str!("setLayoutParams"),
+            jni::jni_sig!("(Landroid/view/ViewGroup$LayoutParams;)V"),
+            &[JValue::Object(&params)],
+        );
 
-    let global = env
-        .new_global_ref(view)
-        .expect("Failed to create global ref");
-    let handle = super::register_widget(global);
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
-    handle
+        let global = jni_bridge::new_global_ref(env, view).expect("Failed to create global ref");
+        let handle = super::register_widget(global);
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+        handle
+    })
 }

--- a/crates/perry-ui-android/src/widgets/form.rs
+++ b/crates/perry-ui-android/src/widgets/form.rs
@@ -1,146 +1,154 @@
 //! Form / Section — LinearLayout containers with styling
 
 use crate::jni_bridge;
-use jni::objects::JValue;
+use jni::JValue;
 
 use perry_ffi::copy_string_from_raw as str_from_header;
 
 /// Create a Form — vertical LinearLayout with padding.
 pub fn create() -> i64 {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
 
-    let activity = super::get_activity(&mut env);
-    let layout = env
-        .new_object(
-            "android/widget/LinearLayout",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("Failed to create LinearLayout");
+        let activity = super::get_activity(env);
+        let layout = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("Failed to create LinearLayout");
 
-    // Set vertical orientation
-    let _ = env.call_method(&layout, "setOrientation", "(I)V", &[JValue::Int(1)]);
+        // Set vertical orientation
+        let _ = env.call_method(
+            &layout,
+            jni::jni_str!("setOrientation"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(1)],
+        );
 
-    // Set padding (16dp)
-    let pad = super::dp_to_px(&mut env, 16.0);
-    let _ = env.call_method(
-        &layout,
-        "setPadding",
-        "(IIII)V",
-        &[
-            JValue::Int(pad),
-            JValue::Int(pad),
-            JValue::Int(pad),
-            JValue::Int(pad),
-        ],
-    );
+        // Set padding (16dp)
+        let pad = super::dp_to_px(env, 16.0);
+        let _ = env.call_method(
+            &layout,
+            jni::jni_str!("setPadding"),
+            jni::jni_sig!("(IIII)V"),
+            &[
+                JValue::Int(pad),
+                JValue::Int(pad),
+                JValue::Int(pad),
+                JValue::Int(pad),
+            ],
+        );
 
-    let global = env
-        .new_global_ref(layout)
-        .expect("Failed to create global ref");
-    let handle = super::register_widget(global);
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
-    handle
+        let global = jni_bridge::new_global_ref(env, layout).expect("Failed to create global ref");
+        let handle = super::register_widget(global);
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+        handle
+    })
 }
 
 /// Create a Section — vertical LinearLayout with a title label.
 pub fn section_create(title_ptr: *const u8) -> i64 {
     let title = unsafe { str_from_header(title_ptr) };
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
 
-    let activity = super::get_activity(&mut env);
+        let activity = super::get_activity(env);
 
-    // Outer layout
-    let layout = env
-        .new_object(
-            "android/widget/LinearLayout",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("Failed to create LinearLayout");
-    let _ = env.call_method(&layout, "setOrientation", "(I)V", &[JValue::Int(1)]);
-
-    let pad = super::dp_to_px(&mut env, 8.0);
-    let _ = env.call_method(
-        &layout,
-        "setPadding",
-        "(IIII)V",
-        &[
-            JValue::Int(pad),
-            JValue::Int(pad),
-            JValue::Int(pad),
-            JValue::Int(pad),
-        ],
-    );
-
-    // Add title label
-    if !title.is_empty() {
-        let title_view = env
+        // Outer layout
+        let layout = env
             .new_object(
-                "android/widget/TextView",
-                "(Landroid/content/Context;)V",
+                jni::jni_str!("android/widget/LinearLayout"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
                 &[JValue::Object(&activity)],
             )
-            .expect("Failed to create TextView");
-
-        let jstr = env.new_string(title).expect("Failed to create JNI string");
-        let _ = env.call_method(
-            &title_view,
-            "setText",
-            "(Ljava/lang/CharSequence;)V",
-            &[JValue::Object(&jstr)],
-        );
-
-        // Bold title
-        let _ = env.call_method(
-            &title_view,
-            "setTypeface",
-            "(Landroid/graphics/Typeface;I)V",
-            &[
-                JValue::Object(&jni::objects::JObject::null()),
-                JValue::Int(1),
-            ],
-        );
-
-        // setTextSize(TypedValue.COMPLEX_UNIT_SP=2, 14)
-        let _ = env.call_method(
-            &title_view,
-            "setTextSize",
-            "(IF)V",
-            &[JValue::Int(2), JValue::Float(14.0)],
-        );
-
-        let bottom_pad = super::dp_to_px(&mut env, 4.0);
-        let _ = env.call_method(
-            &title_view,
-            "setPadding",
-            "(IIII)V",
-            &[
-                JValue::Int(0),
-                JValue::Int(0),
-                JValue::Int(0),
-                JValue::Int(bottom_pad),
-            ],
-        );
-
+            .expect("Failed to create LinearLayout");
         let _ = env.call_method(
             &layout,
-            "addView",
-            "(Landroid/view/View;)V",
-            &[JValue::Object(&title_view)],
+            jni::jni_str!("setOrientation"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(1)],
         );
-    }
 
-    let global = env
-        .new_global_ref(layout)
-        .expect("Failed to create global ref");
-    let handle = super::register_widget(global);
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
-    handle
+        let pad = super::dp_to_px(env, 8.0);
+        let _ = env.call_method(
+            &layout,
+            jni::jni_str!("setPadding"),
+            jni::jni_sig!("(IIII)V"),
+            &[
+                JValue::Int(pad),
+                JValue::Int(pad),
+                JValue::Int(pad),
+                JValue::Int(pad),
+            ],
+        );
+
+        // Add title label
+        if !title.is_empty() {
+            let title_view = env
+                .new_object(
+                    jni::jni_str!("android/widget/TextView"),
+                    jni::jni_sig!("(Landroid/content/Context;)V"),
+                    &[JValue::Object(&activity)],
+                )
+                .expect("Failed to create TextView");
+
+            let jstr = env.new_string(title).expect("Failed to create JNI string");
+            let _ = env.call_method(
+                &title_view,
+                jni::jni_str!("setText"),
+                jni::jni_sig!("(Ljava/lang/CharSequence;)V"),
+                &[JValue::Object(&jstr)],
+            );
+
+            // Bold title
+            let _ = env.call_method(
+                &title_view,
+                jni::jni_str!("setTypeface"),
+                jni::jni_sig!("(Landroid/graphics/Typeface;I)V"),
+                &[
+                    JValue::Object(&jni::objects::JObject::null()),
+                    JValue::Int(1),
+                ],
+            );
+
+            // setTextSize(TypedValue.COMPLEX_UNIT_SP=2, 14)
+            let _ = env.call_method(
+                &title_view,
+                jni::jni_str!("setTextSize"),
+                jni::jni_sig!("(IF)V"),
+                &[JValue::Int(2), JValue::Float(14.0)],
+            );
+
+            let bottom_pad = super::dp_to_px(env, 4.0);
+            let _ = env.call_method(
+                &title_view,
+                jni::jni_str!("setPadding"),
+                jni::jni_sig!("(IIII)V"),
+                &[
+                    JValue::Int(0),
+                    JValue::Int(0),
+                    JValue::Int(0),
+                    JValue::Int(bottom_pad),
+                ],
+            );
+
+            let _ = env.call_method(
+                &layout,
+                jni::jni_str!("addView"),
+                jni::jni_sig!("(Landroid/view/View;)V"),
+                &[JValue::Object(&title_view)],
+            );
+        }
+
+        let global = jni_bridge::new_global_ref(env, layout).expect("Failed to create global ref");
+        let handle = super::register_widget(global);
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+        handle
+    })
 }

--- a/crates/perry-ui-android/src/widgets/hstack.rs
+++ b/crates/perry-ui-android/src/widgets/hstack.rs
@@ -1,126 +1,144 @@
 use crate::jni_bridge;
-use jni::objects::JValue;
+use jni::JValue;
 
 /// Create a LinearLayout with HORIZONTAL orientation.
 pub fn create(spacing: f64) -> i64 {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
-    let activity = super::get_activity(&mut env);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
+        let activity = super::get_activity(env);
 
-    let layout = env
-        .new_object(
-            "android/widget/LinearLayout",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("Failed to create LinearLayout");
+        let layout = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("Failed to create LinearLayout");
 
-    // HORIZONTAL = 0
-    let _ = env.call_method(&layout, "setOrientation", "(I)V", &[JValue::Int(0)]);
+        // HORIZONTAL = 0
+        let _ = env.call_method(
+            &layout,
+            jni::jni_str!("setOrientation"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(0)],
+        );
 
-    // Set vertical centering: gravity = Gravity.CENTER_VERTICAL = 16
-    let _ = env.call_method(&layout, "setGravity", "(I)V", &[JValue::Int(16)]);
+        // Set vertical centering: gravity = Gravity.CENTER_VERTICAL = 16
+        let _ = env.call_method(
+            &layout,
+            jni::jni_str!("setGravity"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(16)],
+        );
 
-    let spacing_px = super::dp_to_px(&mut env, spacing as f32);
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let _ = env.call_static_method(
-        bridge_cls,
-        "setLinearLayoutSpacing",
-        "(Landroid/widget/LinearLayout;I)V",
-        &[JValue::Object(&layout), JValue::Int(spacing_px)],
-    );
+        let spacing_px = super::dp_to_px(env, spacing as f32);
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("setLinearLayoutSpacing"),
+            jni::jni_sig!("(Landroid/widget/LinearLayout;I)V"),
+            &[JValue::Object(&layout), JValue::Int(spacing_px)],
+        );
 
-    let params = env
-        .new_object(
-            "android/widget/LinearLayout$LayoutParams",
-            "(II)V",
-            &[JValue::Int(-1), JValue::Int(-2)], // MATCH_PARENT, WRAP_CONTENT
-        )
-        .expect("Failed to create LayoutParams");
-    let _ = env.call_method(
-        &layout,
-        "setLayoutParams",
-        "(Landroid/view/ViewGroup$LayoutParams;)V",
-        &[JValue::Object(&params)],
-    );
+        let params = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout$LayoutParams"),
+                jni::jni_sig!("(II)V"),
+                &[JValue::Int(-1), JValue::Int(-2)], // MATCH_PARENT, WRAP_CONTENT
+            )
+            .expect("Failed to create LayoutParams");
+        let _ = env.call_method(
+            &layout,
+            jni::jni_str!("setLayoutParams"),
+            jni::jni_sig!("(Landroid/view/ViewGroup$LayoutParams;)V"),
+            &[JValue::Object(&params)],
+        );
 
-    let global = env
-        .new_global_ref(layout)
-        .expect("Failed to create global ref");
-    let handle = super::register_widget(global);
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
-    handle
+        let global = jni_bridge::new_global_ref(env, layout).expect("Failed to create global ref");
+        let handle = super::register_widget(global);
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+        handle
+    })
 }
 
 /// Create a LinearLayout with HORIZONTAL orientation and custom padding.
 pub fn create_with_insets(spacing: f64, top: f64, left: f64, bottom: f64, right: f64) -> i64 {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
-    let activity = super::get_activity(&mut env);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
+        let activity = super::get_activity(env);
 
-    let layout = env
-        .new_object(
-            "android/widget/LinearLayout",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("Failed to create LinearLayout");
+        let layout = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("Failed to create LinearLayout");
 
-    // HORIZONTAL = 0
-    let _ = env.call_method(&layout, "setOrientation", "(I)V", &[JValue::Int(0)]);
-    let _ = env.call_method(&layout, "setGravity", "(I)V", &[JValue::Int(16)]);
+        // HORIZONTAL = 0
+        let _ = env.call_method(
+            &layout,
+            jni::jni_str!("setOrientation"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(0)],
+        );
+        let _ = env.call_method(
+            &layout,
+            jni::jni_str!("setGravity"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(16)],
+        );
 
-    let spacing_px = super::dp_to_px(&mut env, spacing as f32);
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let _ = env.call_static_method(
-        bridge_cls,
-        "setLinearLayoutSpacing",
-        "(Landroid/widget/LinearLayout;I)V",
-        &[JValue::Object(&layout), JValue::Int(spacing_px)],
-    );
+        let spacing_px = super::dp_to_px(env, spacing as f32);
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("setLinearLayoutSpacing"),
+            jni::jni_sig!("(Landroid/widget/LinearLayout;I)V"),
+            &[JValue::Object(&layout), JValue::Int(spacing_px)],
+        );
 
-    let top_px = super::dp_to_px(&mut env, top as f32);
-    let left_px = super::dp_to_px(&mut env, left as f32);
-    let bottom_px = super::dp_to_px(&mut env, bottom as f32);
-    let right_px = super::dp_to_px(&mut env, right as f32);
-    let _ = env.call_method(
-        &layout,
-        "setPadding",
-        "(IIII)V",
-        &[
-            JValue::Int(left_px),
-            JValue::Int(top_px),
-            JValue::Int(right_px),
-            JValue::Int(bottom_px),
-        ],
-    );
+        let top_px = super::dp_to_px(env, top as f32);
+        let left_px = super::dp_to_px(env, left as f32);
+        let bottom_px = super::dp_to_px(env, bottom as f32);
+        let right_px = super::dp_to_px(env, right as f32);
+        let _ = env.call_method(
+            &layout,
+            jni::jni_str!("setPadding"),
+            jni::jni_sig!("(IIII)V"),
+            &[
+                JValue::Int(left_px),
+                JValue::Int(top_px),
+                JValue::Int(right_px),
+                JValue::Int(bottom_px),
+            ],
+        );
 
-    let params = env
-        .new_object(
-            "android/widget/LinearLayout$LayoutParams",
-            "(II)V",
-            &[JValue::Int(-1), JValue::Int(-2)],
-        )
-        .expect("Failed to create LayoutParams");
-    let _ = env.call_method(
-        &layout,
-        "setLayoutParams",
-        "(Landroid/view/ViewGroup$LayoutParams;)V",
-        &[JValue::Object(&params)],
-    );
+        let params = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout$LayoutParams"),
+                jni::jni_sig!("(II)V"),
+                &[JValue::Int(-1), JValue::Int(-2)],
+            )
+            .expect("Failed to create LayoutParams");
+        let _ = env.call_method(
+            &layout,
+            jni::jni_str!("setLayoutParams"),
+            jni::jni_sig!("(Landroid/view/ViewGroup$LayoutParams;)V"),
+            &[JValue::Object(&params)],
+        );
 
-    let global = env
-        .new_global_ref(layout)
-        .expect("Failed to create global ref");
-    let handle = super::register_widget(global);
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
-    handle
+        let global = jni_bridge::new_global_ref(env, layout).expect("Failed to create global ref");
+        let handle = super::register_widget(global);
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+        handle
+    })
 }

--- a/crates/perry-ui-android/src/widgets/image.rs
+++ b/crates/perry-ui-android/src/widgets/image.rs
@@ -1,7 +1,7 @@
 //! Image — ImageView for file images and system icons
 
 use crate::jni_bridge;
-use jni::objects::JValue;
+use jni::JValue;
 
 use perry_ffi::copy_string_from_raw as str_from_header;
 
@@ -11,253 +11,271 @@ use perry_ffi::copy_string_from_raw as str_from_header;
 pub fn create_file(path_ptr: *const u8) -> i64 {
     let path = unsafe { str_from_header(path_ptr) };
     crate::log_debug(&format!("image create_file: path={}", path));
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
 
-    let activity = super::get_activity(&mut env);
-    let image_view = env
-        .new_object(
-            "android/widget/ImageView",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("Failed to create ImageView");
+        let activity = super::get_activity(env);
+        let image_view = env
+            .new_object(
+                jni::jni_str!("android/widget/ImageView"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("Failed to create ImageView");
 
-    // Ensure the ImageView adjusts bounds to its LayoutParams and scales content
-    let _ = env.call_method(
-        &image_view,
-        "setAdjustViewBounds",
-        "(Z)V",
-        &[JValue::Bool(1)],
-    );
-    // ScaleType.FIT_CENTER = enum ordinal → use setScaleType with enum constant
-    let scale_type_class = env
-        .find_class("android/widget/ImageView$ScaleType")
-        .expect("ScaleType");
-    let fit_center = env
-        .get_static_field(
-            &scale_type_class,
-            "FIT_CENTER",
-            "Landroid/widget/ImageView$ScaleType;",
-        )
-        .expect("FIT_CENTER")
-        .l()
-        .expect("scale type");
-    let _ = env.call_method(
-        &image_view,
-        "setScaleType",
-        "(Landroid/widget/ImageView$ScaleType;)V",
-        &[JValue::Object(&fit_center)],
-    );
+        // Ensure the ImageView adjusts bounds to its LayoutParams and scales content
+        let _ = env.call_method(
+            &image_view,
+            jni::jni_str!("setAdjustViewBounds"),
+            jni::jni_sig!("(Z)V"),
+            &[JValue::Bool(true)],
+        );
+        // ScaleType.FIT_CENTER = enum ordinal → use setScaleType with enum constant
+        let scale_type_class = env
+            .find_class(jni::jni_str!("android/widget/ImageView$ScaleType"))
+            .expect("ScaleType");
+        let fit_center = env
+            .get_static_field(
+                &scale_type_class,
+                jni::jni_str!("FIT_CENTER"),
+                jni::jni_sig!("Landroid/widget/ImageView$ScaleType;"),
+            )
+            .expect("FIT_CENTER")
+            .l()
+            .expect("scale type");
+        let _ = env.call_method(
+            &image_view,
+            jni::jni_str!("setScaleType"),
+            jni::jni_sig!("(Landroid/widget/ImageView$ScaleType;)V"),
+            &[JValue::Object(&fit_center)],
+        );
 
-    let mut loaded = false;
+        let mut loaded = false;
 
-    // For relative paths, try loading from APK assets first
-    if !path.starts_with('/') {
-        if let Ok(asset_mgr) = env.call_method(
-            &activity,
-            "getAssets",
-            "()Landroid/content/res/AssetManager;",
-            &[],
-        ) {
-            if let Ok(mgr) = asset_mgr.l() {
-                if !mgr.is_null() {
-                    let jpath = env.new_string(&path).expect("asset path string");
-                    // AssetManager.open(path) -> InputStream
-                    let stream = env.call_method(
-                        &mgr,
-                        "open",
-                        "(Ljava/lang/String;)Ljava/io/InputStream;",
-                        &[JValue::Object(&jpath)],
-                    );
-                    if let Ok(stream_val) = stream {
-                        if let Ok(stream_obj) = stream_val.l() {
-                            if !stream_obj.is_null() {
-                                // BitmapFactory.decodeStream(inputStream)
-                                let bitmap = env.call_static_method(
-                                    "android/graphics/BitmapFactory",
-                                    "decodeStream",
-                                    "(Ljava/io/InputStream;)Landroid/graphics/Bitmap;",
-                                    &[JValue::Object(&stream_obj)],
-                                );
-                                if let Ok(bmp_val) = bitmap {
-                                    if let Ok(bmp) = bmp_val.l() {
-                                        if !bmp.is_null() {
-                                            let _ = env.call_method(
-                                                &image_view,
-                                                "setImageBitmap",
-                                                "(Landroid/graphics/Bitmap;)V",
-                                                &[JValue::Object(&bmp)],
-                                            );
-                                            loaded = true;
-                                            crate::log_debug(
-                                                "image create_file: loaded from assets",
-                                            );
+        // For relative paths, try loading from APK assets first
+        if !path.starts_with('/') {
+            if let Ok(asset_mgr) = env.call_method(
+                &activity,
+                jni::jni_str!("getAssets"),
+                jni::jni_sig!("()Landroid/content/res/AssetManager;"),
+                &[],
+            ) {
+                if let Ok(mgr) = asset_mgr.l() {
+                    if !mgr.is_null() {
+                        let jpath = env.new_string(&path).expect("asset path string");
+                        // AssetManager.open(path) -> InputStream
+                        let stream = env.call_method(
+                            &mgr,
+                            jni::jni_str!("open"),
+                            jni::jni_sig!("(Ljava/lang/String;)Ljava/io/InputStream;"),
+                            &[JValue::Object(&jpath)],
+                        );
+                        if let Ok(stream_val) = stream {
+                            if let Ok(stream_obj) = stream_val.l() {
+                                if !stream_obj.is_null() {
+                                    // BitmapFactory.decodeStream(inputStream)
+                                    let bitmap = env.call_static_method(
+                                        jni::jni_str!("android/graphics/BitmapFactory"),
+                                        jni::jni_str!("decodeStream"),
+                                        jni::jni_sig!(
+                                            "(Ljava/io/InputStream;)Landroid/graphics/Bitmap;"
+                                        ),
+                                        &[JValue::Object(&stream_obj)],
+                                    );
+                                    if let Ok(bmp_val) = bitmap {
+                                        if let Ok(bmp) = bmp_val.l() {
+                                            if !bmp.is_null() {
+                                                let _ = env.call_method(
+                                                    &image_view,
+                                                    jni::jni_str!("setImageBitmap"),
+                                                    jni::jni_sig!("(Landroid/graphics/Bitmap;)V"),
+                                                    &[JValue::Object(&bmp)],
+                                                );
+                                                loaded = true;
+                                                crate::log_debug(
+                                                    "image create_file: loaded from assets",
+                                                );
+                                            }
                                         }
                                     }
+                                    let _ = env.call_method(
+                                        &stream_obj,
+                                        jni::jni_str!("close"),
+                                        jni::jni_sig!("()V"),
+                                        &[],
+                                    );
                                 }
-                                let _ = env.call_method(&stream_obj, "close", "()V", &[]);
                             }
                         }
-                    }
-                    // Clear any FileNotFoundException from assets.open()
-                    if env.exception_check().unwrap_or(false) {
-                        let _ = env.exception_clear();
+                        // Clear any FileNotFoundException from assets.open()
+                        if env.exception_check() {
+                            let _ = env.exception_clear();
+                        }
                     }
                 }
             }
         }
-    }
 
-    // Fall back to filesystem (absolute path or if assets failed)
-    if !loaded {
-        let jpath = env.new_string(path).expect("Failed to create JNI string");
-        let bitmap = env.call_static_method(
-            "android/graphics/BitmapFactory",
-            "decodeFile",
-            "(Ljava/lang/String;)Landroid/graphics/Bitmap;",
-            &[JValue::Object(&jpath)],
-        );
-        if let Ok(bmp_val) = bitmap {
-            if let Ok(bmp) = bmp_val.l() {
-                if !bmp.is_null() {
-                    let _ = env.call_method(
-                        &image_view,
-                        "setImageBitmap",
-                        "(Landroid/graphics/Bitmap;)V",
-                        &[JValue::Object(&bmp)],
-                    );
+        // Fall back to filesystem (absolute path or if assets failed)
+        if !loaded {
+            let jpath = env.new_string(path).expect("Failed to create JNI string");
+            let bitmap = env.call_static_method(
+                jni::jni_str!("android/graphics/BitmapFactory"),
+                jni::jni_str!("decodeFile"),
+                jni::jni_sig!("(Ljava/lang/String;)Landroid/graphics/Bitmap;"),
+                &[JValue::Object(&jpath)],
+            );
+            if let Ok(bmp_val) = bitmap {
+                if let Ok(bmp) = bmp_val.l() {
+                    if !bmp.is_null() {
+                        let _ = env.call_method(
+                            &image_view,
+                            jni::jni_str!("setImageBitmap"),
+                            jni::jni_sig!("(Landroid/graphics/Bitmap;)V"),
+                            &[JValue::Object(&bmp)],
+                        );
+                    }
                 }
             }
         }
-    }
 
-    let global = env
-        .new_global_ref(image_view)
-        .expect("Failed to create global ref");
-    let handle = super::register_widget(global);
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
-    handle
+        let global =
+            jni_bridge::new_global_ref(env, image_view).expect("Failed to create global ref");
+        let handle = super::register_widget(global);
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+        handle
+    })
 }
 
 /// Create an image from a named system icon (SF Symbol name → Material Icon).
 /// Uses the same SF Symbol → Material Icons mapping as button.rs.
 pub fn create_symbol(name_ptr: *const u8) -> i64 {
     let name = unsafe { str_from_header(name_ptr) };
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
 
-    let activity = super::get_activity(&mut env);
+        let activity = super::get_activity(env);
 
-    // Use a TextView styled as an icon (Material Icons font) since Android
-    // doesn't have SF Symbols and resource-based icons require compile-time R.id
-    let text_view = env
-        .new_object(
-            "android/widget/TextView",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("Failed to create TextView for symbol");
+        // Use a TextView styled as an icon (Material Icons font) since Android
+        // doesn't have SF Symbols and resource-based icons require compile-time R.id
+        let text_view = env
+            .new_object(
+                jni::jni_str!("android/widget/TextView"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("Failed to create TextView for symbol");
 
-    // Map SF Symbol name to emoji/Unicode character
-    let icon_str = if let Some(emoji) = super::button::sf_symbol_to_emoji(&name) {
-        emoji.to_string()
-    } else {
-        name.chars().take(3).collect()
-    };
-    let jstr = env.new_string(&icon_str).expect("icon string");
-    let _ = env.call_method(
-        &text_view,
-        "setText",
-        "(Ljava/lang/CharSequence;)V",
-        &[JValue::Object(&jstr)],
-    );
+        // Map SF Symbol name to emoji/Unicode character
+        let icon_str = if let Some(emoji) = super::button::sf_symbol_to_emoji(&name) {
+            emoji.to_string()
+        } else {
+            name.chars().take(3).collect()
+        };
+        let jstr = env.new_string(&icon_str).expect("icon string");
+        let _ = env.call_method(
+            &text_view,
+            jni::jni_str!("setText"),
+            jni::jni_sig!("(Ljava/lang/CharSequence;)V"),
+            &[JValue::Object(&jstr)],
+        );
 
-    // Set default size (24sp)
-    let _ = env.call_method(
-        &text_view,
-        "setTextSize",
-        "(IF)V",
-        &[JValue::Int(2), JValue::Float(24.0)],
-    ); // COMPLEX_UNIT_SP=2
+        // Set default size (24sp)
+        let _ = env.call_method(
+            &text_view,
+            jni::jni_str!("setTextSize"),
+            jni::jni_sig!("(IF)V"),
+            &[JValue::Int(2), JValue::Float(24.0)],
+        ); // COMPLEX_UNIT_SP=2
 
-    // Center gravity
-    let _ = env.call_method(&text_view, "setGravity", "(I)V", &[JValue::Int(0x11)]); // Gravity.CENTER = 0x11
+        // Center gravity
+        let _ = env.call_method(
+            &text_view,
+            jni::jni_str!("setGravity"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(0x11)],
+        ); // Gravity.CENTER = 0x11
 
-    let global = env
-        .new_global_ref(text_view)
-        .expect("Failed to create global ref");
-    let handle = super::register_widget(global);
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
-    handle
+        let global =
+            jni_bridge::new_global_ref(env, text_view).expect("Failed to create global ref");
+        let handle = super::register_widget(global);
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+        handle
+    })
 }
 
 /// Set the size of an image widget.
 pub fn set_size(handle: i64, width: f64, height: f64) {
     if let Some(view_ref) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(16);
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 16);
 
-        let w = super::dp_to_px(&mut env, width as f32);
-        let h = super::dp_to_px(&mut env, height as f32);
+            let w = super::dp_to_px(env, width as f32);
+            let h = super::dp_to_px(env, height as f32);
 
-        // Create LayoutParams
-        let params = env
-            .new_object(
-                "android/view/ViewGroup$LayoutParams",
-                "(II)V",
-                &[JValue::Int(w), JValue::Int(h)],
-            )
-            .expect("LayoutParams");
+            // Create LayoutParams
+            let params = env
+                .new_object(
+                    jni::jni_str!("android/view/ViewGroup$LayoutParams"),
+                    jni::jni_sig!("(II)V"),
+                    &[JValue::Int(w), JValue::Int(h)],
+                )
+                .expect("LayoutParams");
 
-        let _ = env.call_method(
-            view_ref.as_obj(),
-            "setLayoutParams",
-            "(Landroid/view/ViewGroup$LayoutParams;)V",
-            &[JValue::Object(&params)],
-        );
+            let _ = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("setLayoutParams"),
+                jni::jni_sig!("(Landroid/view/ViewGroup$LayoutParams;)V"),
+                &[JValue::Object(&params)],
+            );
 
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+        })
     }
 }
 
 /// Set the tint color of an image.
 pub fn set_tint(handle: i64, r: f64, g: f64, b: f64, a: f64) {
     if let Some(view_ref) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
 
-        let ai = (a * 255.0) as u32;
-        let ri = (r * 255.0) as u32;
-        let gi = (g * 255.0) as u32;
-        let bi = (b * 255.0) as u32;
-        let color = ((ai << 24) | (ri << 16) | (gi << 8) | bi) as i32;
+            let ai = (a * 255.0) as u32;
+            let ri = (r * 255.0) as u32;
+            let gi = (g * 255.0) as u32;
+            let bi = (b * 255.0) as u32;
+            let color = ((ai << 24) | (ri << 16) | (gi << 8) | bi) as i32;
 
-        // setColorFilter(int color, PorterDuff.Mode mode)
-        let mode_class = env
-            .find_class("android/graphics/PorterDuff$Mode")
-            .expect("PorterDuff$Mode");
-        let src_in = env
-            .get_static_field(&mode_class, "SRC_IN", "Landroid/graphics/PorterDuff$Mode;")
-            .expect("SRC_IN")
-            .l()
-            .expect("mode");
+            // setColorFilter(int color, PorterDuff.Mode mode)
+            let mode_class = env
+                .find_class(jni::jni_str!("android/graphics/PorterDuff$Mode"))
+                .expect("PorterDuff$Mode");
+            let src_in = env
+                .get_static_field(
+                    &mode_class,
+                    jni::jni_str!("SRC_IN"),
+                    jni::jni_sig!("Landroid/graphics/PorterDuff$Mode;"),
+                )
+                .expect("SRC_IN")
+                .l()
+                .expect("mode");
 
-        let _ = env.call_method(
-            view_ref.as_obj(),
-            "setColorFilter",
-            "(ILandroid/graphics/PorterDuff$Mode;)V",
-            &[JValue::Int(color), JValue::Object(&src_in)],
-        );
+            let _ = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("setColorFilter"),
+                jni::jni_sig!("(ILandroid/graphics/PorterDuff$Mode;)V"),
+                &[JValue::Int(color), JValue::Object(&src_in)],
+            );
 
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+        })
     }
 }

--- a/crates/perry-ui-android/src/widgets/image_gallery.rs
+++ b/crates/perry-ui-android/src/widgets/image_gallery.rs
@@ -8,14 +8,15 @@
 
 use crate::callback;
 use crate::jni_bridge;
-use jni::objects::{JObject, JValue};
+use jni::objects::JObject;
+use jni::JValue;
 use std::cell::RefCell;
 use std::collections::HashMap;
 
 const PAGE_DP: f32 = 320.0;
 
 struct GalleryState {
-    scroll_handle: i64,
+    _scroll_handle: i64,
     inner_handle: i64, // horizontal LinearLayout containing the image views
     image_handles: Vec<i64>,
     callback_key: i64,
@@ -28,202 +29,213 @@ thread_local! {
 }
 
 pub fn create(on_index_change: f64) -> i64 {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
-    let activity = super::get_activity(&mut env);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
+        let activity = super::get_activity(env);
 
-    let scroll = env
-        .new_object(
-            "android/widget/HorizontalScrollView",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("HorizontalScrollView");
-    // Hide scroll bar — gallery should look like a paged carousel.
-    let _ = env.call_method(
-        &scroll,
-        "setHorizontalScrollBarEnabled",
-        "(Z)V",
-        &[JValue::Bool(0)],
-    );
-
-    let row = env
-        .new_object(
-            "android/widget/LinearLayout",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("Gallery row");
-    let _ = env.call_method(&row, "setOrientation", "(I)V", &[JValue::Int(0)]); // HORIZONTAL
-    let _ = env.call_method(
-        &scroll,
-        "addView",
-        "(Landroid/view/View;)V",
-        &[JValue::Object(&row)],
-    );
-
-    let page_px = super::dp_to_px(&mut env, PAGE_DP);
-    let scroll_lp = env
-        .new_object(
-            "android/widget/LinearLayout$LayoutParams",
-            "(II)V",
-            &[JValue::Int(-1), JValue::Int(page_px)],
-        )
-        .expect("scroll lp");
-    let _ = env.call_method(
-        &scroll,
-        "setLayoutParams",
-        "(Landroid/view/ViewGroup$LayoutParams;)V",
-        &[JValue::Object(&scroll_lp)],
-    );
-
-    let scroll_global = env.new_global_ref(scroll).expect("scroll ref");
-    let scroll_handle = super::register_widget(scroll_global);
-    let row_global = env.new_global_ref(row).expect("row ref");
-    let inner_handle = super::register_widget(row_global);
-
-    let cb_key = callback::register(on_index_change);
-    STATES.with(|s| {
-        s.borrow_mut().insert(
-            scroll_handle,
-            GalleryState {
-                scroll_handle,
-                inner_handle,
-                image_handles: Vec::new(),
-                callback_key: cb_key,
-                page_width_px: page_px,
-                current_index: 0,
-            },
+        let scroll = env
+            .new_object(
+                jni::jni_str!("android/widget/HorizontalScrollView"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("HorizontalScrollView");
+        // Hide scroll bar — gallery should look like a paged carousel.
+        let _ = env.call_method(
+            &scroll,
+            jni::jni_str!("setHorizontalScrollBarEnabled"),
+            jni::jni_sig!("(Z)V"),
+            &[JValue::Bool(false)],
         );
-    });
 
-    unsafe {
-        let _ = env.pop_local_frame(&JObject::null());
-    }
-    scroll_handle
+        let row = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("Gallery row");
+        let _ = env.call_method(
+            &row,
+            jni::jni_str!("setOrientation"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(0)],
+        ); // HORIZONTAL
+        let _ = env.call_method(
+            &scroll,
+            jni::jni_str!("addView"),
+            jni::jni_sig!("(Landroid/view/View;)V"),
+            &[JValue::Object(&row)],
+        );
+
+        let page_px = super::dp_to_px(env, PAGE_DP);
+        let scroll_lp = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout$LayoutParams"),
+                jni::jni_sig!("(II)V"),
+                &[JValue::Int(-1), JValue::Int(page_px)],
+            )
+            .expect("scroll lp");
+        let _ = env.call_method(
+            &scroll,
+            jni::jni_str!("setLayoutParams"),
+            jni::jni_sig!("(Landroid/view/ViewGroup$LayoutParams;)V"),
+            &[JValue::Object(&scroll_lp)],
+        );
+
+        let scroll_global = jni_bridge::new_global_ref(env, scroll).expect("scroll ref");
+        let scroll_handle = super::register_widget(scroll_global);
+        let row_global = jni_bridge::new_global_ref(env, row).expect("row ref");
+        let inner_handle = super::register_widget(row_global);
+
+        let cb_key = callback::register(on_index_change);
+        STATES.with(|s| {
+            s.borrow_mut().insert(
+                scroll_handle,
+                GalleryState {
+                    _scroll_handle: scroll_handle,
+                    inner_handle,
+                    image_handles: Vec::new(),
+                    callback_key: cb_key,
+                    page_width_px: page_px,
+                    current_index: 0,
+                },
+            );
+        });
+
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+        }
+        scroll_handle
+    })
 }
 
 pub fn add_image(handle: i64, url_ptr: *const u8, alt_ptr: *const u8) {
     let url = unsafe { crate::app::str_from_header(url_ptr) };
     let alt = unsafe { crate::app::str_from_header(alt_ptr) };
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
-    let activity = super::get_activity(&mut env);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
+        let activity = super::get_activity(env);
 
-    let (inner_handle, page_px) = STATES.with(|s| {
-        let map = s.borrow();
-        match map.get(&handle) {
-            Some(st) => (st.inner_handle, st.page_width_px),
-            None => (0, super::dp_to_px(&mut jni_bridge::get_env(), PAGE_DP)),
-        }
-    });
-    let Some(inner_ref) = super::get_widget(inner_handle) else {
-        unsafe {
-            let _ = env.pop_local_frame(&JObject::null());
-        }
-        return;
-    };
+        let (inner_handle, page_px) = STATES.with(|s| {
+            let map = s.borrow();
+            match map.get(&handle) {
+                Some(st) => (st.inner_handle, st.page_width_px),
+                None => (0, super::dp_to_px(env, PAGE_DP)),
+            }
+        });
+        let Some(inner_ref) = super::get_widget(inner_handle) else {
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+            return;
+        };
 
-    let iv = env
-        .new_object(
-            "android/widget/ImageView",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("Gallery iv");
-    // ScaleType.FIT_CENTER ordinal = 5 — but android docs say use the static
-    // android.widget.ImageView$ScaleType enum. Use string-named lookup
-    // through setScaleType(ImageView.ScaleType) reflection for simplicity.
-    // Easier: use FIT_CENTER which is index 3 in the enum's natural order.
-    if let Ok(scaletype_cls) = env.find_class("android/widget/ImageView$ScaleType") {
-        if let Ok(field) = env.get_static_field(
-            scaletype_cls,
-            "FIT_CENTER",
-            "Landroid/widget/ImageView$ScaleType;",
-        ) {
-            if let Ok(field_obj) = field.l() {
-                let _ = env.call_method(
-                    &iv,
-                    "setScaleType",
-                    "(Landroid/widget/ImageView$ScaleType;)V",
-                    &[JValue::Object(&field_obj)],
-                );
+        let iv = env
+            .new_object(
+                jni::jni_str!("android/widget/ImageView"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("Gallery iv");
+        // ScaleType.FIT_CENTER ordinal = 5 — but android docs say use the static
+        // android.widget.ImageView$ScaleType enum. Use string-named lookup
+        // through setScaleType(ImageView.ScaleType) reflection for simplicity.
+        // Easier: use FIT_CENTER which is index 3 in the enum's natural order.
+        if let Ok(scaletype_cls) =
+            env.find_class(jni::jni_str!("android/widget/ImageView$ScaleType"))
+        {
+            if let Ok(field) = env.get_static_field(
+                scaletype_cls,
+                jni::jni_str!("FIT_CENTER"),
+                jni::jni_sig!("Landroid/widget/ImageView$ScaleType;"),
+            ) {
+                if let Ok(field_obj) = field.l() {
+                    let _ = env.call_method(
+                        &iv,
+                        jni::jni_str!("setScaleType"),
+                        jni::jni_sig!("(Landroid/widget/ImageView$ScaleType;)V"),
+                        &[JValue::Object(&field_obj)],
+                    );
+                }
             }
         }
-    }
 
-    if !alt.is_empty() {
-        let jstr = env.new_string(&alt).expect("alt str");
+        if !alt.is_empty() {
+            let jstr = env.new_string(&alt).expect("alt str");
+            let _ = env.call_method(
+                &iv,
+                jni::jni_str!("setContentDescription"),
+                jni::jni_sig!("(Ljava/lang/CharSequence;)V"),
+                &[JValue::Object(&jstr)],
+            );
+        }
+
+        if !url.is_empty() && !url.starts_with("http://") && !url.starts_with("https://") {
+            // Local path — decode synchronously on the calling thread.
+            let bf_cls = env
+                .find_class(jni::jni_str!("android/graphics/BitmapFactory"))
+                .ok();
+            let path_str = env.new_string(&url).ok();
+            if let (Some(bf_cls), Some(path_str)) = (bf_cls, path_str) {
+                let bitmap = env
+                    .call_static_method(
+                        bf_cls,
+                        jni::jni_str!("decodeFile"),
+                        jni::jni_sig!("(Ljava/lang/String;)Landroid/graphics/Bitmap;"),
+                        &[JValue::Object(&path_str)],
+                    )
+                    .ok()
+                    .and_then(|v| v.l().ok());
+                if let Some(bm) = bitmap {
+                    let _ = env.call_method(
+                        &iv,
+                        jni::jni_str!("setImageBitmap"),
+                        jni::jni_sig!("(Landroid/graphics/Bitmap;)V"),
+                        &[JValue::Object(&bm)],
+                    );
+                }
+            }
+        }
+        // Remote URLs are skipped here for simplicity; production code routes
+        // those through the existing perry-stdlib/fetch pipeline + a separate
+        // setImageBitmap once the bytes arrive. Local paths are the common
+        // case (fs.readFileSync followed by image decoding).
+
+        // Equal-page LayoutParams.
+        let lp = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout$LayoutParams"),
+                jni::jni_sig!("(II)V"),
+                &[JValue::Int(page_px), JValue::Int(page_px)],
+            )
+            .expect("iv lp");
         let _ = env.call_method(
             &iv,
-            "setContentDescription",
-            "(Ljava/lang/CharSequence;)V",
-            &[JValue::Object(&jstr)],
+            jni::jni_str!("setLayoutParams"),
+            jni::jni_sig!("(Landroid/view/ViewGroup$LayoutParams;)V"),
+            &[JValue::Object(&lp)],
         );
-    }
 
-    if !url.is_empty() && !url.starts_with("http://") && !url.starts_with("https://") {
-        // Local path — decode synchronously on the calling thread.
-        let bf_cls = env.find_class("android/graphics/BitmapFactory").ok();
-        let path_str = env.new_string(&url).ok();
-        if let (Some(bf_cls), Some(path_str)) = (bf_cls, path_str) {
-            let bitmap = env
-                .call_static_method(
-                    bf_cls,
-                    "decodeFile",
-                    "(Ljava/lang/String;)Landroid/graphics/Bitmap;",
-                    &[JValue::Object(&path_str)],
-                )
-                .ok()
-                .and_then(|v| v.l().ok());
-            if let Some(bm) = bitmap {
-                let _ = env.call_method(
-                    &iv,
-                    "setImageBitmap",
-                    "(Landroid/graphics/Bitmap;)V",
-                    &[JValue::Object(&bm)],
-                );
+        let _ = env.call_method(
+            inner_ref.as_obj(),
+            jni::jni_str!("addView"),
+            jni::jni_sig!("(Landroid/view/View;)V"),
+            &[JValue::Object(&iv)],
+        );
+
+        let iv_global = jni_bridge::new_global_ref(env, iv).expect("iv ref");
+        let iv_handle = super::register_widget(iv_global);
+        STATES.with(|s| {
+            if let Some(state) = s.borrow_mut().get_mut(&handle) {
+                state.image_handles.push(iv_handle);
             }
+        });
+
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
         }
-    }
-    // Remote URLs are skipped here for simplicity; production code routes
-    // those through the existing perry-stdlib/fetch pipeline + a separate
-    // setImageBitmap once the bytes arrive. Local paths are the common
-    // case (fs.readFileSync followed by image decoding).
-
-    // Equal-page LayoutParams.
-    let lp = env
-        .new_object(
-            "android/widget/LinearLayout$LayoutParams",
-            "(II)V",
-            &[JValue::Int(page_px), JValue::Int(page_px)],
-        )
-        .expect("iv lp");
-    let _ = env.call_method(
-        &iv,
-        "setLayoutParams",
-        "(Landroid/view/ViewGroup$LayoutParams;)V",
-        &[JValue::Object(&lp)],
-    );
-
-    let _ = env.call_method(
-        inner_ref.as_obj(),
-        "addView",
-        "(Landroid/view/View;)V",
-        &[JValue::Object(&iv)],
-    );
-
-    let iv_global = env.new_global_ref(iv).expect("iv ref");
-    let iv_handle = super::register_widget(iv_global);
-    STATES.with(|s| {
-        if let Some(state) = s.borrow_mut().get_mut(&handle) {
-            state.image_handles.push(iv_handle);
-        }
-    });
-
-    unsafe {
-        let _ = env.pop_local_frame(&JObject::null());
-    }
+    })
 }
 
 pub fn set_index(handle: i64, index: i64) {
@@ -238,25 +250,26 @@ pub fn set_index(handle: i64, index: i64) {
         return;
     }
     if let Some(scroll_ref) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let _ = env.call_method(
-            scroll_ref.as_obj(),
-            "smoothScrollTo",
-            "(II)V",
-            &[JValue::Int(page_px * index as i32), JValue::Int(0)],
-        );
-        unsafe {
-            let _ = env.pop_local_frame(&JObject::null());
-        }
-        STATES.with(|s| {
-            if let Some(state) = s.borrow_mut().get_mut(&handle) {
-                state.current_index = index;
-                let cb = state.callback_key;
-                if cb != 0 {
-                    callback::invoke1(cb, index as f64);
-                }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let _ = env.call_method(
+                scroll_ref.as_obj(),
+                jni::jni_str!("smoothScrollTo"),
+                jni::jni_sig!("(II)V"),
+                &[JValue::Int(page_px * index as i32), JValue::Int(0)],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
             }
-        });
+            STATES.with(|s| {
+                if let Some(state) = s.borrow_mut().get_mut(&handle) {
+                    state.current_index = index;
+                    let cb = state.callback_key;
+                    if cb != 0 {
+                        callback::invoke1(cb, index as f64);
+                    }
+                }
+            });
+        })
     }
 }

--- a/crates/perry-ui-android/src/widgets/lazyvstack.rs
+++ b/crates/perry-ui-android/src/widgets/lazyvstack.rs
@@ -8,7 +8,7 @@ extern "C" {
 }
 
 struct LazyState {
-    scroll_handle: i64,
+    _scroll_handle: i64,
     container_handle: i64,
     render_closure: f64,
 }
@@ -39,7 +39,7 @@ pub fn create(count: f64, render_closure: f64) -> i64 {
         s.borrow_mut().insert(
             scroll_handle,
             LazyState {
-                scroll_handle,
+                _scroll_handle: scroll_handle,
                 container_handle,
                 render_closure,
             },

--- a/crates/perry-ui-android/src/widgets/map_view.rs
+++ b/crates/perry-ui-android/src/widgets/map_view.rs
@@ -7,27 +7,36 @@
 
 use crate::app::str_from_header;
 use crate::jni_bridge;
-use jni::objects::{JObject, JValue};
+use jni::objects::JObject;
+use jni::signature::RuntimeMethodSignature;
+use jni::strings::JNIString;
+use jni::JValue;
 
 extern "C" {
     fn __android_log_print(prio: i32, tag: *const u8, fmt: *const u8, ...) -> i32;
 }
 
 unsafe fn call_bridge_static_object<'a>(
-    env: &mut jni::JNIEnv<'a>,
+    env: &mut jni::Env<'a>,
     name: &str,
     sig: &str,
     args: &[JValue],
 ) -> Option<JObject<'a>> {
     let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let cls: &jni::objects::JClass = (&bridge_class).into();
-    match env.call_static_method(cls, name, sig, args) {
+        jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+    let cls: &jni::objects::JClass = &bridge_class;
+    let parsed_sig = RuntimeMethodSignature::from_str(sig).expect("valid PerryBridge signature");
+    match env.call_static_method(
+        cls,
+        JNIString::new(name),
+        parsed_sig.method_signature(),
+        args,
+    ) {
         Ok(jvalue) => jvalue.l().ok(),
         Err(e) => {
             let msg = format!("PerryBridge.{} failed: {:?}\0", name, e);
             __android_log_print(6, b"PerryMap\0".as_ptr(), b"%s\0".as_ptr(), msg.as_ptr());
-            if env.exception_check().unwrap_or(false) {
+            if env.exception_check() {
                 let _ = env.exception_describe();
                 let _ = env.exception_clear();
             }
@@ -36,14 +45,20 @@ unsafe fn call_bridge_static_object<'a>(
     }
 }
 
-unsafe fn call_bridge_static_void(env: &mut jni::JNIEnv, name: &str, sig: &str, args: &[JValue]) {
+unsafe fn call_bridge_static_void(env: &mut jni::Env, name: &str, sig: &str, args: &[JValue]) {
     let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let cls: &jni::objects::JClass = (&bridge_class).into();
-    if let Err(e) = env.call_static_method(cls, name, sig, args) {
+        jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+    let cls: &jni::objects::JClass = &bridge_class;
+    let parsed_sig = RuntimeMethodSignature::from_str(sig).expect("valid PerryBridge signature");
+    if let Err(e) = env.call_static_method(
+        cls,
+        JNIString::new(name),
+        parsed_sig.method_signature(),
+        args,
+    ) {
         let msg = format!("PerryBridge.{} failed: {:?}\0", name, e);
         __android_log_print(6, b"PerryMap\0".as_ptr(), b"%s\0".as_ptr(), msg.as_ptr());
-        if env.exception_check().unwrap_or(false) {
+        if env.exception_check() {
             let _ = env.exception_describe();
             let _ = env.exception_clear();
         }
@@ -51,107 +66,111 @@ unsafe fn call_bridge_static_void(env: &mut jni::JNIEnv, name: &str, sig: &str, 
 }
 
 pub fn create(width: f64, height: f64) -> i64 {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
-    let map_view = unsafe {
-        call_bridge_static_object(
-            &mut env,
-            "mapViewCreate",
-            "(DD)Lcom/google/android/gms/maps/MapView;",
-            &[JValue::Double(width), JValue::Double(height)],
-        )
-    };
-    let handle = match map_view {
-        Some(obj) => {
-            let global = env
-                .new_global_ref(obj)
-                .expect("Failed to global-ref MapView");
-            super::register_widget(global)
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
+        let map_view = unsafe {
+            call_bridge_static_object(
+                env,
+                "mapViewCreate",
+                "(DD)Lcom/google/android/gms/maps/MapView;",
+                &[JValue::Double(width), JValue::Double(height)],
+            )
+        };
+        let handle = match map_view {
+            Some(obj) => {
+                let global =
+                    jni_bridge::new_global_ref(env, obj).expect("Failed to global-ref MapView");
+                super::register_widget(global)
+            }
+            None => 0,
+        };
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
         }
-        None => 0,
-    };
-    unsafe {
-        env.pop_local_frame(&JObject::null());
-    }
-    handle
+        handle
+    })
 }
 
 pub fn set_region(handle: i64, lat: f64, lon: f64, lat_span: f64, lon_span: f64) {
     if let Some(view) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(4);
-        unsafe {
-            call_bridge_static_void(
-                &mut env,
-                "mapViewSetRegion",
-                "(Lcom/google/android/gms/maps/MapView;DDDD)V",
-                &[
-                    JValue::Object(view.as_obj()),
-                    JValue::Double(lat),
-                    JValue::Double(lon),
-                    JValue::Double(lat_span),
-                    JValue::Double(lon_span),
-                ],
-            );
-            env.pop_local_frame(&JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 4);
+            unsafe {
+                call_bridge_static_void(
+                    env,
+                    "mapViewSetRegion",
+                    "(Lcom/google/android/gms/maps/MapView;DDDD)V",
+                    &[
+                        JValue::Object(view.as_obj()),
+                        JValue::Double(lat),
+                        JValue::Double(lon),
+                        JValue::Double(lat_span),
+                        JValue::Double(lon_span),
+                    ],
+                );
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }
 
 pub fn add_pin(handle: i64, lat: f64, lon: f64, title_ptr: *const u8) {
     if let Some(view) = super::get_widget(handle) {
         let title = unsafe { str_from_header(title_ptr) };
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(4);
-        let jstr = match env.new_string(title) {
-            Ok(s) => s,
-            Err(_) => return,
-        };
-        unsafe {
-            call_bridge_static_void(
-                &mut env,
-                "mapViewAddPin",
-                "(Lcom/google/android/gms/maps/MapView;DDLjava/lang/String;)V",
-                &[
-                    JValue::Object(view.as_obj()),
-                    JValue::Double(lat),
-                    JValue::Double(lon),
-                    JValue::Object(&jstr),
-                ],
-            );
-            env.pop_local_frame(&JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 4);
+            let jstr = match env.new_string(title) {
+                Ok(s) => s,
+                Err(_) => return,
+            };
+            unsafe {
+                call_bridge_static_void(
+                    env,
+                    "mapViewAddPin",
+                    "(Lcom/google/android/gms/maps/MapView;DDLjava/lang/String;)V",
+                    &[
+                        JValue::Object(view.as_obj()),
+                        JValue::Double(lat),
+                        JValue::Double(lon),
+                        JValue::Object(&jstr),
+                    ],
+                );
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }
 
 pub fn clear_pins(handle: i64) {
     if let Some(view) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(4);
-        unsafe {
-            call_bridge_static_void(
-                &mut env,
-                "mapViewClearPins",
-                "(Lcom/google/android/gms/maps/MapView;)V",
-                &[JValue::Object(view.as_obj())],
-            );
-            env.pop_local_frame(&JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 4);
+            unsafe {
+                call_bridge_static_void(
+                    env,
+                    "mapViewClearPins",
+                    "(Lcom/google/android/gms/maps/MapView;)V",
+                    &[JValue::Object(view.as_obj())],
+                );
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }
 
 pub fn set_map_type(handle: i64, style: i64) {
     if let Some(view) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(4);
-        unsafe {
-            call_bridge_static_void(
-                &mut env,
-                "mapViewSetMapType",
-                "(Lcom/google/android/gms/maps/MapView;J)V",
-                &[JValue::Object(view.as_obj()), JValue::Long(style)],
-            );
-            env.pop_local_frame(&JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 4);
+            unsafe {
+                call_bridge_static_void(
+                    env,
+                    "mapViewSetMapType",
+                    "(Lcom/google/android/gms/maps/MapView;J)V",
+                    &[JValue::Object(view.as_obj()), JValue::Long(style)],
+                );
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }

--- a/crates/perry-ui-android/src/widgets/mod.rs
+++ b/crates/perry-ui-android/src/widgets/mod.rs
@@ -38,7 +38,9 @@ pub mod webview;
 pub mod wheel_picker;
 pub mod zstack;
 
-use jni::objects::{GlobalRef, JObject, JValue};
+use crate::jni_bridge::GlobalRef;
+use jni::objects::JObject;
+use jni::JValue;
 use std::sync::Mutex;
 
 use crate::jni_bridge;
@@ -122,18 +124,19 @@ pub fn get_widget(handle: i64) -> Option<GlobalRef> {
 /// Set the hidden state of a widget (View.VISIBLE=0, View.GONE=8).
 pub fn set_hidden(handle: i64, hidden: bool) {
     if let Some(view_ref) = get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let visibility = if hidden { 8i32 } else { 0i32 }; // View.GONE=8, View.VISIBLE=0
-        let _ = env.call_method(
-            view_ref.as_obj(),
-            "setVisibility",
-            "(I)V",
-            &[JValue::Int(visibility)],
-        );
-        unsafe {
-            env.pop_local_frame(&JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let visibility = if hidden { 8i32 } else { 0i32 }; // View.GONE=8, View.VISIBLE=0
+            let _ = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("setVisibility"),
+                jni::jni_sig!("(I)V"),
+                &[JValue::Int(visibility)],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }
 
@@ -144,33 +147,39 @@ pub fn clear_children(handle: i64) {
     // Track the first widget that gets clearChildren called — it's the root
     crate::app::track_root_candidate(handle);
     if let Some(parent_ref) = get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let _ = env.call_method(parent_ref.as_obj(), "removeAllViews", "()V", &[]);
-        unsafe {
-            if env.exception_check().unwrap_or(false) {
-                let _ = env.exception_describe();
-                let _ = env.exception_clear();
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let _ = env.call_method(
+                parent_ref.as_obj(),
+                jni::jni_str!("removeAllViews"),
+                jni::jni_sig!("()V"),
+                &[],
+            );
+            unsafe {
+                if env.exception_check() {
+                    let _ = env.exception_describe();
+                    let _ = env.exception_clear();
+                }
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
             }
-            env.pop_local_frame(&JObject::null());
-        }
 
-        // Only truncate widget handles when ALL of the following are true:
-        // 1. The app has completed its initial build (app_set_body called)
-        // 2. The handle being cleared is the root body widget
-        // During init, clearChildren may be called on non-root containers (e.g.
-        // refreshConnectionList) while sibling widgets are still being created.
-        // Truncating during init would destroy those handles.
-        if crate::app::is_initialized() {
-            let root = crate::app::get_root_handle();
-            if handle == root {
-                let idx = (handle - 1) as usize;
-                let mut widgets = WIDGETS.lock().unwrap();
-                if idx < widgets.len() {
-                    widgets.truncate(idx + 1);
+            // Only truncate widget handles when ALL of the following are true:
+            // 1. The app has completed its initial build (app_set_body called)
+            // 2. The handle being cleared is the root body widget
+            // During init, clearChildren may be called on non-root containers (e.g.
+            // refreshConnectionList) while sibling widgets are still being created.
+            // Truncating during init would destroy those handles.
+            if crate::app::is_initialized() {
+                let root = crate::app::get_root_handle();
+                if handle == root {
+                    let idx = (handle - 1) as usize;
+                    let mut widgets = WIDGETS.lock().unwrap();
+                    if idx < widgets.len() {
+                        widgets.truncate(idx + 1);
+                    }
                 }
             }
-        }
+        })
     }
 }
 
@@ -181,101 +190,142 @@ pub fn add_child(parent_handle: i64, child_handle: i64) {
     if let (Some(parent_ref), Some(child_ref)) =
         (get_widget(parent_handle), get_widget(child_handle))
     {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(16);
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 16);
 
-        // Debug: log parent/child handles and child class
-        unsafe {
-            __android_log_print(
-                3,
-                b"PerryWidgets\0".as_ptr(),
-                b"add_child: parent=%lld child=%lld\0".as_ptr(),
-                parent_handle,
-                child_handle,
+            // Debug: log parent/child handles and child class
+            unsafe {
+                __android_log_print(
+                    3,
+                    b"PerryWidgets\0".as_ptr(),
+                    b"add_child: parent=%lld child=%lld\0".as_ptr(),
+                    parent_handle,
+                    child_handle,
+                );
+            }
+
+            let result = env.call_method(
+                parent_ref.as_obj(),
+                jni::jni_str!("addView"),
+                jni::jni_sig!("(Landroid/view/View;)V"),
+                &[JValue::Object(child_ref.as_obj())],
             );
-        }
 
-        let result = env.call_method(
-            parent_ref.as_obj(),
-            "addView",
-            "(Landroid/view/View;)V",
-            &[JValue::Object(child_ref.as_obj())],
-        );
-
-        // Match iOS UIStackView fill alignment: adjust child LayoutParams
-        // based on parent type
-        if result.is_ok() {
-            if env
-                .is_instance_of(parent_ref.as_obj(), "android/widget/FrameLayout")
-                .unwrap_or(false)
-                && !env
-                    .is_instance_of(parent_ref.as_obj(), "android/widget/LinearLayout")
+            // Match iOS UIStackView fill alignment: adjust child LayoutParams
+            // based on parent type
+            if result.is_ok() {
+                if env
+                    .is_instance_of(
+                        parent_ref.as_obj(),
+                        jni::jni_str!("android/widget/FrameLayout"),
+                    )
                     .unwrap_or(false)
-            {
-                // FrameLayout (ZStack): children fill parent by default (match iOS ZStack behavior)
-                if let Ok(lp) = env.call_method(
-                    child_ref.as_obj(),
-                    "getLayoutParams",
-                    "()Landroid/view/ViewGroup$LayoutParams;",
-                    &[],
-                ) {
-                    if let Ok(lp_obj) = lp.l() {
-                        if !lp_obj.is_null() {
-                            let _ = env.set_field(&lp_obj, "width", "I", JValue::Int(-1)); // MATCH_PARENT
-                            let _ = env.set_field(&lp_obj, "height", "I", JValue::Int(-1)); // MATCH_PARENT
-                            let _ = env.call_method(
-                                child_ref.as_obj(),
-                                "setLayoutParams",
-                                "(Landroid/view/ViewGroup$LayoutParams;)V",
-                                &[JValue::Object(&lp_obj)],
-                            );
+                    && !env
+                        .is_instance_of(
+                            parent_ref.as_obj(),
+                            jni::jni_str!("android/widget/LinearLayout"),
+                        )
+                        .unwrap_or(false)
+                {
+                    // FrameLayout (ZStack): children fill parent by default (match iOS ZStack behavior)
+                    if let Ok(lp) = env.call_method(
+                        child_ref.as_obj(),
+                        jni::jni_str!("getLayoutParams"),
+                        jni::jni_sig!("()Landroid/view/ViewGroup$LayoutParams;"),
+                        &[],
+                    ) {
+                        if let Ok(lp_obj) = lp.l() {
+                            if !lp_obj.is_null() {
+                                let _ = env.set_field(
+                                    &lp_obj,
+                                    jni::jni_str!("width"),
+                                    jni::jni_sig!("I"),
+                                    JValue::Int(-1),
+                                ); // MATCH_PARENT
+                                let _ = env.set_field(
+                                    &lp_obj,
+                                    jni::jni_str!("height"),
+                                    jni::jni_sig!("I"),
+                                    JValue::Int(-1),
+                                ); // MATCH_PARENT
+                                let _ = env.call_method(
+                                    child_ref.as_obj(),
+                                    jni::jni_str!("setLayoutParams"),
+                                    jni::jni_sig!("(Landroid/view/ViewGroup$LayoutParams;)V"),
+                                    &[JValue::Object(&lp_obj)],
+                                );
+                            }
                         }
                     }
-                }
-            } else if env
-                .is_instance_of(parent_ref.as_obj(), "android/widget/LinearLayout")
-                .unwrap_or(false)
-            {
-                let orientation = env
-                    .call_method(parent_ref.as_obj(), "getOrientation", "()I", &[])
-                    .map(|v| v.i().unwrap_or(-1))
-                    .unwrap_or(-1);
-                if let Ok(lp) = env.call_method(
-                    child_ref.as_obj(),
-                    "getLayoutParams",
-                    "()Landroid/view/ViewGroup$LayoutParams;",
-                    &[],
-                ) {
-                    if let Ok(lp_obj) = lp.l() {
-                        if !lp_obj.is_null() {
-                            if orientation == 1 {
-                                // VERTICAL — stretch children to fill width
-                                let _ = env.set_field(&lp_obj, "width", "I", JValue::Int(-1));
-                            // MATCH_PARENT
-                            } else if orientation == 0 {
-                                // HORIZONTAL — share space equally
-                                // If child has MATCH_PARENT width, convert to weight-based
-                                // so multiple children share the HStack evenly
-                                let cur_w = env
-                                    .get_field(&lp_obj, "width", "I")
-                                    .map(|v| v.i().unwrap_or(0))
-                                    .unwrap_or(0);
-                                if cur_w == -1 {
-                                    // MATCH_PARENT
-                                    let _ = env.set_field(&lp_obj, "width", "I", JValue::Int(0));
-                                    if env
-                                        .is_instance_of(
+                } else if env
+                    .is_instance_of(
+                        parent_ref.as_obj(),
+                        jni::jni_str!("android/widget/LinearLayout"),
+                    )
+                    .unwrap_or(false)
+                {
+                    let orientation = env
+                        .call_method(
+                            parent_ref.as_obj(),
+                            jni::jni_str!("getOrientation"),
+                            jni::jni_sig!("()I"),
+                            &[],
+                        )
+                        .map(|v| v.i().unwrap_or(-1))
+                        .unwrap_or(-1);
+                    if let Ok(lp) = env.call_method(
+                        child_ref.as_obj(),
+                        jni::jni_str!("getLayoutParams"),
+                        jni::jni_sig!("()Landroid/view/ViewGroup$LayoutParams;"),
+                        &[],
+                    ) {
+                        if let Ok(lp_obj) = lp.l() {
+                            if !lp_obj.is_null() {
+                                if orientation == 1 {
+                                    // VERTICAL — stretch children to fill width
+                                    let _ = env.set_field(
+                                        &lp_obj,
+                                        jni::jni_str!("width"),
+                                        jni::jni_sig!("I"),
+                                        JValue::Int(-1),
+                                    );
+                                // MATCH_PARENT
+                                } else if orientation == 0 {
+                                    // HORIZONTAL — share space equally
+                                    // If child has MATCH_PARENT width, convert to weight-based
+                                    // so multiple children share the HStack evenly
+                                    let cur_w = env
+                                        .get_field(
                                             &lp_obj,
-                                            "android/widget/LinearLayout$LayoutParams",
+                                            jni::jni_str!("width"),
+                                            jni::jni_sig!("I"),
                                         )
-                                        .unwrap_or(false)
-                                    {
+                                        .map(|v| v.i().unwrap_or(0))
+                                        .unwrap_or(0);
+                                    if cur_w == -1 {
+                                        // MATCH_PARENT
                                         let _ = env.set_field(
                                             &lp_obj,
-                                            "weight",
-                                            "F",
-                                            JValue::Float(1.0),
+                                            jni::jni_str!("width"),
+                                            jni::jni_sig!("I"),
+                                            JValue::Int(0),
                                         );
+                                        if env
+                                            .is_instance_of(
+                                                &lp_obj,
+                                                jni::jni_str!(
+                                                    "android/widget/LinearLayout$LayoutParams"
+                                                ),
+                                            )
+                                            .unwrap_or(false)
+                                        {
+                                            let _ = env.set_field(
+                                                &lp_obj,
+                                                jni::jni_str!("weight"),
+                                                jni::jni_sig!("F"),
+                                                JValue::Float(1.0),
+                                            );
+                                        }
                                     }
                                 }
                             }
@@ -283,20 +333,20 @@ pub fn add_child(parent_handle: i64, child_handle: i64) {
                     }
                 }
             }
-        }
 
-        unsafe {
-            if env.exception_check().unwrap_or(false) {
-                __android_log_print(
-                    6,
-                    b"PerryWidgets\0".as_ptr(),
-                    b"add_child: JNI EXCEPTION!\0".as_ptr(),
-                );
-                let _ = env.exception_describe();
-                let _ = env.exception_clear();
+            unsafe {
+                if env.exception_check() {
+                    __android_log_print(
+                        6,
+                        b"PerryWidgets\0".as_ptr(),
+                        b"add_child: JNI EXCEPTION!\0".as_ptr(),
+                    );
+                    let _ = env.exception_describe();
+                    let _ = env.exception_clear();
+                }
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
             }
-            env.pop_local_frame(&JObject::null());
-        }
+        })
     }
 }
 
@@ -305,30 +355,36 @@ pub fn add_child_at(parent_handle: i64, child_handle: i64, index: i64) {
     if let (Some(parent_ref), Some(child_ref)) =
         (get_widget(parent_handle), get_widget(child_handle))
     {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let _ = env.call_method(
-            parent_ref.as_obj(),
-            "addView",
-            "(Landroid/view/View;I)V",
-            &[
-                JValue::Object(child_ref.as_obj()),
-                JValue::Int(index as i32),
-            ],
-        );
-        unsafe {
-            env.pop_local_frame(&JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let _ = env.call_method(
+                parent_ref.as_obj(),
+                jni::jni_str!("addView"),
+                jni::jni_sig!("(Landroid/view/View;I)V"),
+                &[
+                    JValue::Object(child_ref.as_obj()),
+                    JValue::Int(index as i32),
+                ],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }
 
 /// Get the Activity context via PerryBridge.
-pub fn get_activity<'a>(env: &mut jni::JNIEnv<'a>) -> JObject<'a> {
+pub fn get_activity<'a>(env: &mut jni::Env<'a>) -> JObject<'a> {
     let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
+        jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+    let bridge_cls: &jni::objects::JClass = &bridge_class;
     let result = env
-        .call_static_method(bridge_cls, "getActivity", "()Landroid/app/Activity;", &[])
+        .call_static_method(
+            bridge_cls,
+            jni::jni_str!("getActivity"),
+            jni::jni_sig!("()Landroid/app/Activity;"),
+            &[],
+        )
         .expect("Failed to get Activity");
     result.l().expect("Activity is not an object")
 }
@@ -336,17 +392,18 @@ pub fn get_activity<'a>(env: &mut jni::JNIEnv<'a>) -> JObject<'a> {
 /// Set enabled/disabled on a widget.
 pub fn set_enabled(handle: i64, enabled: bool) {
     if let Some(view_ref) = get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let _ = env.call_method(
-            view_ref.as_obj(),
-            "setEnabled",
-            "(Z)V",
-            &[JValue::Bool(enabled as u8)],
-        );
-        unsafe {
-            env.pop_local_frame(&JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let _ = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("setEnabled"),
+                jni::jni_sig!("(Z)V"),
+                &[JValue::Bool(enabled)],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }
 
@@ -354,47 +411,49 @@ pub fn set_enabled(handle: i64, enabled: bool) {
 pub fn set_tooltip(handle: i64, text_ptr: *const u8) {
     let text = unsafe { crate::app::str_from_header(text_ptr) };
     if let Some(view_ref) = get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let jstr = env.new_string(text).expect("tooltip string");
-        let _ = env.call_method(
-            view_ref.as_obj(),
-            "setTooltipText",
-            "(Ljava/lang/CharSequence;)V",
-            &[JValue::Object(&jstr)],
-        );
-        unsafe {
-            env.pop_local_frame(&JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let jstr = env.new_string(text).expect("tooltip string");
+            let _ = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("setTooltipText"),
+                jni::jni_sig!("(Ljava/lang/CharSequence;)V"),
+                &[JValue::Object(&jstr)],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }
 
 /// Set control size (map to scale).
 pub fn set_control_size(handle: i64, size: i64) {
     if let Some(view_ref) = get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let scale = match size {
-            0 => 0.75f32, // mini
-            1 => 0.85f32, // small
-            3 => 1.15f32, // large
-            _ => 1.0f32,  // regular
-        };
-        let _ = env.call_method(
-            view_ref.as_obj(),
-            "setScaleX",
-            "(F)V",
-            &[JValue::Float(scale)],
-        );
-        let _ = env.call_method(
-            view_ref.as_obj(),
-            "setScaleY",
-            "(F)V",
-            &[JValue::Float(scale)],
-        );
-        unsafe {
-            env.pop_local_frame(&JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let scale = match size {
+                0 => 0.75f32, // mini
+                1 => 0.85f32, // small
+                3 => 1.15f32, // large
+                _ => 1.0f32,  // regular
+            };
+            let _ = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("setScaleX"),
+                jni::jni_sig!("(F)V"),
+                &[JValue::Float(scale)],
+            );
+            let _ = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("setScaleY"),
+                jni::jni_sig!("(F)V"),
+                &[JValue::Float(scale)],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }
 
@@ -403,57 +462,75 @@ pub fn set_control_size(handle: i64, size: i64) {
 /// (preserving the existing color). Otherwise creates a new transparent GradientDrawable.
 pub fn set_corner_radius(handle: i64, radius: f64) {
     if let Some(view_ref) = get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(16);
-        let radius_px = dp_to_px(&mut env, radius as f32) as f32;
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 16);
+            let radius_px = dp_to_px(env, radius as f32) as f32;
 
-        // Try to reuse existing GradientDrawable background (preserving color)
-        let mut reused = false;
-        if let Ok(bg) = env.call_method(
-            view_ref.as_obj(),
-            "getBackground",
-            "()Landroid/graphics/drawable/Drawable;",
-            &[],
-        ) {
-            if let Ok(bg_obj) = bg.l() {
-                if !bg_obj.is_null() {
-                    if env
-                        .is_instance_of(&bg_obj, "android/graphics/drawable/GradientDrawable")
-                        .unwrap_or(false)
-                    {
-                        let _ = env.call_method(
-                            &bg_obj,
-                            "setCornerRadius",
-                            "(F)V",
-                            &[JValue::Float(radius_px)],
-                        );
-                        reused = true;
+            // Try to reuse existing GradientDrawable background (preserving color)
+            let mut reused = false;
+            if let Ok(bg) = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("getBackground"),
+                jni::jni_sig!("()Landroid/graphics/drawable/Drawable;"),
+                &[],
+            ) {
+                if let Ok(bg_obj) = bg.l() {
+                    if !bg_obj.is_null() {
+                        if env
+                            .is_instance_of(
+                                &bg_obj,
+                                jni::jni_str!("android/graphics/drawable/GradientDrawable"),
+                            )
+                            .unwrap_or(false)
+                        {
+                            let _ = env.call_method(
+                                &bg_obj,
+                                jni::jni_str!("setCornerRadius"),
+                                jni::jni_sig!("(F)V"),
+                                &[JValue::Float(radius_px)],
+                            );
+                            reused = true;
+                        }
                     }
                 }
             }
-        }
-        if !reused {
-            let gd = env
-                .new_object("android/graphics/drawable/GradientDrawable", "()V", &[])
-                .expect("GradientDrawable");
-            let _ = env.call_method(&gd, "setCornerRadius", "(F)V", &[JValue::Float(radius_px)]);
-            let _ = env.call_method(&gd, "setColor", "(I)V", &[JValue::Int(0)]);
+            if !reused {
+                let gd = env
+                    .new_object(
+                        jni::jni_str!("android/graphics/drawable/GradientDrawable"),
+                        jni::jni_sig!("()V"),
+                        &[],
+                    )
+                    .expect("GradientDrawable");
+                let _ = env.call_method(
+                    &gd,
+                    jni::jni_str!("setCornerRadius"),
+                    jni::jni_sig!("(F)V"),
+                    &[JValue::Float(radius_px)],
+                );
+                let _ = env.call_method(
+                    &gd,
+                    jni::jni_str!("setColor"),
+                    jni::jni_sig!("(I)V"),
+                    &[JValue::Int(0)],
+                );
+                let _ = env.call_method(
+                    view_ref.as_obj(),
+                    jni::jni_str!("setBackground"),
+                    jni::jni_sig!("(Landroid/graphics/drawable/Drawable;)V"),
+                    &[JValue::Object(&gd)],
+                );
+            }
             let _ = env.call_method(
                 view_ref.as_obj(),
-                "setBackground",
-                "(Landroid/graphics/drawable/Drawable;)V",
-                &[JValue::Object(&gd)],
+                jni::jni_str!("setClipToOutline"),
+                jni::jni_sig!("(Z)V"),
+                &[JValue::Bool(true)],
             );
-        }
-        let _ = env.call_method(
-            view_ref.as_obj(),
-            "setClipToOutline",
-            "(Z)V",
-            &[JValue::Bool(1)],
-        );
-        unsafe {
-            env.pop_local_frame(&JObject::null());
-        }
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }
 
@@ -477,90 +554,113 @@ pub fn set_background_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
         );
     }
     if let Some(view_ref) = get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(24);
-        let color = argb_color(a, r, g, b);
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 24);
+            let color = argb_color(a, r, g, b);
 
-        // Clear backgroundTint so MaterialButton doesn't paint over our drawable.
-        // Signature: setBackgroundTintList(ColorStateList?) — pass null.
-        let _ = env.call_method(
-            view_ref.as_obj(),
-            "setBackgroundTintList",
-            "(Landroid/content/res/ColorStateList;)V",
-            &[JValue::Object(&JObject::null())],
-        );
-        if env.exception_check().unwrap_or(false) {
-            let _ = env.exception_clear();
-        }
+            // Clear backgroundTint so MaterialButton doesn't paint over our drawable.
+            // Signature: setBackgroundTintList(ColorStateList?) — pass null.
+            let _ = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("setBackgroundTintList"),
+                jni::jni_sig!("(Landroid/content/res/ColorStateList;)V"),
+                &[JValue::Object(&JObject::null())],
+            );
+            if env.exception_check() {
+                let _ = env.exception_clear();
+            }
 
-        // Prefer GradientDrawable so corner radius can share the same bg.
-        let mut reused = false;
-        if let Ok(bg) = env.call_method(
-            view_ref.as_obj(),
-            "getBackground",
-            "()Landroid/graphics/drawable/Drawable;",
-            &[],
-        ) {
-            if let Ok(bg_obj) = bg.l() {
-                if !bg_obj.is_null() {
-                    if env
-                        .is_instance_of(&bg_obj, "android/graphics/drawable/GradientDrawable")
-                        .unwrap_or(false)
-                    {
-                        let _ = env.call_method(&bg_obj, "setColor", "(I)V", &[JValue::Int(color)]);
-                        reused = true;
+            // Prefer GradientDrawable so corner radius can share the same bg.
+            let mut reused = false;
+            if let Ok(bg) = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("getBackground"),
+                jni::jni_sig!("()Landroid/graphics/drawable/Drawable;"),
+                &[],
+            ) {
+                if let Ok(bg_obj) = bg.l() {
+                    if !bg_obj.is_null() {
+                        if env
+                            .is_instance_of(
+                                &bg_obj,
+                                jni::jni_str!("android/graphics/drawable/GradientDrawable"),
+                            )
+                            .unwrap_or(false)
+                        {
+                            let _ = env.call_method(
+                                &bg_obj,
+                                jni::jni_str!("setColor"),
+                                jni::jni_sig!("(I)V"),
+                                &[JValue::Int(color)],
+                            );
+                            reused = true;
+                        }
                     }
                 }
             }
-        }
-        if !reused {
-            let gd = env
-                .new_object("android/graphics/drawable/GradientDrawable", "()V", &[])
-                .expect("GradientDrawable");
-            let _ = env.call_method(&gd, "setColor", "(I)V", &[JValue::Int(color)]);
-            // solid shape rect
-            let _ = env.call_method(&gd, "setShape", "(I)V", &[JValue::Int(0)]);
-            let _ = env.call_method(
-                view_ref.as_obj(),
-                "setBackground",
-                "(Landroid/graphics/drawable/Drawable;)V",
-                &[JValue::Object(&gd)],
-            );
-        }
-
-        // MaterialButton: the real paint path is backgroundTintList.
-        // Set it to our solid color so the button actually shows DaisyUI fills.
-        if let Ok(csl) = env.call_static_method(
-            "android/content/res/ColorStateList",
-            "valueOf",
-            "(I)Landroid/content/res/ColorStateList;",
-            &[JValue::Int(color)],
-        ) {
-            if let Ok(csl_obj) = csl.l() {
+            if !reused {
+                let gd = env
+                    .new_object(
+                        jni::jni_str!("android/graphics/drawable/GradientDrawable"),
+                        jni::jni_sig!("()V"),
+                        &[],
+                    )
+                    .expect("GradientDrawable");
+                let _ = env.call_method(
+                    &gd,
+                    jni::jni_str!("setColor"),
+                    jni::jni_sig!("(I)V"),
+                    &[JValue::Int(color)],
+                );
+                // solid shape rect
+                let _ = env.call_method(
+                    &gd,
+                    jni::jni_str!("setShape"),
+                    jni::jni_sig!("(I)V"),
+                    &[JValue::Int(0)],
+                );
                 let _ = env.call_method(
                     view_ref.as_obj(),
-                    "setBackgroundTintList",
-                    "(Landroid/content/res/ColorStateList;)V",
-                    &[JValue::Object(&csl_obj)],
+                    jni::jni_str!("setBackground"),
+                    jni::jni_sig!("(Landroid/graphics/drawable/Drawable;)V"),
+                    &[JValue::Object(&gd)],
                 );
             }
-        }
-        if env.exception_check().unwrap_or(false) {
-            let _ = env.exception_clear();
-        }
 
-        unsafe {
-            __android_log_print(
-                3,
-                b"PerryStyle\0".as_ptr(),
-                b"set_bg applied handle=%lld color=0x%08x\0".as_ptr(),
-                handle,
-                color as u32,
-            );
-        }
-        unsafe {
-            env.pop_local_frame(&JObject::null());
-        }
+            // MaterialButton: the real paint path is backgroundTintList.
+            // Set it to our solid color so the button actually shows DaisyUI fills.
+            if let Ok(csl) = env.call_static_method(
+                jni::jni_str!("android/content/res/ColorStateList"),
+                jni::jni_str!("valueOf"),
+                jni::jni_sig!("(I)Landroid/content/res/ColorStateList;"),
+                &[JValue::Int(color)],
+            ) {
+                if let Ok(csl_obj) = csl.l() {
+                    let _ = env.call_method(
+                        view_ref.as_obj(),
+                        jni::jni_str!("setBackgroundTintList"),
+                        jni::jni_sig!("(Landroid/content/res/ColorStateList;)V"),
+                        &[JValue::Object(&csl_obj)],
+                    );
+                }
+            }
+            if env.exception_check() {
+                let _ = env.exception_clear();
+            }
+
+            unsafe {
+                __android_log_print(
+                    3,
+                    b"PerryStyle\0".as_ptr(),
+                    b"set_bg applied handle=%lld color=0x%08x\0".as_ptr(),
+                    handle,
+                    color as u32,
+                );
+            }
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     } else {
         unsafe {
             __android_log_print(
@@ -602,38 +702,39 @@ pub fn set_shadow(
     _offset_y: f64,
 ) {
     if let Some(view_ref) = get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
 
-        let elevation_dp = (blur / 2.0).max(0.0) as f32;
-        let elevation_px = dp_to_px(&mut env, elevation_dp) as f32;
-        let _ = env.call_method(
-            view_ref.as_obj(),
-            "setElevation",
-            "(F)V",
-            &[JValue::Float(elevation_px)],
-        );
+            let elevation_dp = (blur / 2.0).max(0.0) as f32;
+            let elevation_px = dp_to_px(env, elevation_dp) as f32;
+            let _ = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("setElevation"),
+                jni::jni_sig!("(F)V"),
+                &[JValue::Float(elevation_px)],
+            );
 
-        // API 28+ shadow tinting; both call_method results are ignored
-        // because older API levels just don't have the method and we
-        // accept the system default in that case.
-        let color = argb_color(a, r, g, b);
-        let _ = env.call_method(
-            view_ref.as_obj(),
-            "setOutlineSpotShadowColor",
-            "(I)V",
-            &[JValue::Int(color)],
-        );
-        let _ = env.call_method(
-            view_ref.as_obj(),
-            "setOutlineAmbientShadowColor",
-            "(I)V",
-            &[JValue::Int(color)],
-        );
+            // API 28+ shadow tinting; both call_method results are ignored
+            // because older API levels just don't have the method and we
+            // accept the system default in that case.
+            let color = argb_color(a, r, g, b);
+            let _ = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("setOutlineSpotShadowColor"),
+                jni::jni_sig!("(I)V"),
+                &[JValue::Int(color)],
+            );
+            let _ = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("setOutlineAmbientShadowColor"),
+                jni::jni_sig!("(I)V"),
+                &[JValue::Int(color)],
+            );
 
-        unsafe {
-            env.pop_local_frame(&JObject::null());
-        }
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }
 
@@ -651,56 +752,68 @@ pub fn set_background_gradient(
     direction: f64,
 ) {
     if let Some(view_ref) = get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(16);
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 16);
 
-        let c1 = argb_color(a1, r1, g1, b1);
-        let c2 = argb_color(a2, r2, g2, b2);
+            let c1 = argb_color(a1, r1, g1, b1);
+            let c2 = argb_color(a2, r2, g2, b2);
 
-        let gd = env
-            .new_object("android/graphics/drawable/GradientDrawable", "()V", &[])
-            .expect("GradientDrawable");
+            let gd = env
+                .new_object(
+                    jni::jni_str!("android/graphics/drawable/GradientDrawable"),
+                    jni::jni_sig!("()V"),
+                    &[],
+                )
+                .expect("GradientDrawable");
 
-        // Set colors
-        let colors = env.new_int_array(2).expect("int array");
-        let _ = env.set_int_array_region(&colors, 0, &[c1, c2]);
-        let _ = env.call_method(&gd, "setColors", "([I)V", &[JValue::Object(&colors)]);
+            // Set colors
+            let colors = env.new_int_array(2).expect("int array");
+            let _ = colors.set_region(env, 0, &[c1, c2]);
+            let _ = env.call_method(
+                &gd,
+                jni::jni_str!("setColors"),
+                jni::jni_sig!("([I)V"),
+                &[JValue::Object(&colors)],
+            );
 
-        // Set orientation
-        let orient_name = if direction < 0.5 {
-            "TOP_BOTTOM"
-        } else {
-            "LEFT_RIGHT"
-        };
-        let orient_class = env
-            .find_class("android/graphics/drawable/GradientDrawable$Orientation")
-            .expect("Orientation");
-        let orient = env
-            .get_static_field(
-                &orient_class,
-                orient_name,
-                "Landroid/graphics/drawable/GradientDrawable$Orientation;",
-            )
-            .expect("orient")
-            .l()
-            .expect("orient obj");
-        let _ = env.call_method(
-            &gd,
-            "setOrientation",
-            "(Landroid/graphics/drawable/GradientDrawable$Orientation;)V",
-            &[JValue::Object(&orient)],
-        );
+            // Set orientation
+            let orient_name = if direction < 0.5 {
+                "TOP_BOTTOM"
+            } else {
+                "LEFT_RIGHT"
+            };
+            let orient_class = env
+                .find_class(jni::jni_str!(
+                    "android/graphics/drawable/GradientDrawable$Orientation"
+                ))
+                .expect("Orientation");
+            let orient = env
+                .get_static_field(
+                    &orient_class,
+                    jni::strings::JNIString::new(orient_name),
+                    jni::jni_sig!("Landroid/graphics/drawable/GradientDrawable$Orientation;"),
+                )
+                .expect("orient")
+                .l()
+                .expect("orient obj");
+            let _ = env.call_method(
+                &gd,
+                jni::jni_str!("setOrientation"),
+                jni::jni_sig!("(Landroid/graphics/drawable/GradientDrawable$Orientation;)V"),
+                &[JValue::Object(&orient)],
+            );
 
-        let _ = env.call_method(
-            view_ref.as_obj(),
-            "setBackground",
-            "(Landroid/graphics/drawable/Drawable;)V",
-            &[JValue::Object(&gd)],
-        );
+            let _ = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("setBackground"),
+                jni::jni_sig!("(Landroid/graphics/drawable/Drawable;)V"),
+                &[JValue::Object(&gd)],
+            );
 
-        unsafe {
-            env.pop_local_frame(&JObject::null());
-        }
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }
 
@@ -722,172 +835,194 @@ pub fn set_on_double_click(_handle: i64, _callback: f64) {
 /// Animate opacity. `duration_secs` is in seconds.
 pub fn animate_opacity(handle: i64, target: f64, duration_secs: f64) {
     if let Some(view_ref) = get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let animator = env
-            .call_method(
-                view_ref.as_obj(),
-                "animate",
-                "()Landroid/view/ViewPropertyAnimator;",
-                &[],
-            )
-            .expect("animate")
-            .l()
-            .expect("animator");
-        let dur_ms = (duration_secs * 1000.0) as i64;
-        let _ = env.call_method(
-            &animator,
-            "alpha",
-            "(F)Landroid/view/ViewPropertyAnimator;",
-            &[JValue::Float(target as f32)],
-        );
-        let _ = env.call_method(
-            &animator,
-            "setDuration",
-            "(J)Landroid/view/ViewPropertyAnimator;",
-            &[JValue::Long(dur_ms)],
-        );
-        let _ = env.call_method(&animator, "start", "()V", &[]);
-        unsafe {
-            env.pop_local_frame(&JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let animator = env
+                .call_method(
+                    view_ref.as_obj(),
+                    jni::jni_str!("animate"),
+                    jni::jni_sig!("()Landroid/view/ViewPropertyAnimator;"),
+                    &[],
+                )
+                .expect("animate")
+                .l()
+                .expect("animator");
+            let dur_ms = (duration_secs * 1000.0) as i64;
+            let _ = env.call_method(
+                &animator,
+                jni::jni_str!("alpha"),
+                jni::jni_sig!("(F)Landroid/view/ViewPropertyAnimator;"),
+                &[JValue::Float(target as f32)],
+            );
+            let _ = env.call_method(
+                &animator,
+                jni::jni_str!("setDuration"),
+                jni::jni_sig!("(J)Landroid/view/ViewPropertyAnimator;"),
+                &[JValue::Long(dur_ms)],
+            );
+            let _ = env.call_method(&animator, jni::jni_str!("start"), jni::jni_sig!("()V"), &[]);
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }
 
 /// Animate position. `duration_secs` is in seconds.
 pub fn animate_position(handle: i64, dx: f64, dy: f64, duration_secs: f64) {
     if let Some(view_ref) = get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let animator = env
-            .call_method(
-                view_ref.as_obj(),
-                "animate",
-                "()Landroid/view/ViewPropertyAnimator;",
-                &[],
-            )
-            .expect("animate")
-            .l()
-            .expect("animator");
-        let dur_ms = (duration_secs * 1000.0) as i64;
-        let _ = env.call_method(
-            &animator,
-            "translationXBy",
-            "(F)Landroid/view/ViewPropertyAnimator;",
-            &[JValue::Float(dx as f32)],
-        );
-        let _ = env.call_method(
-            &animator,
-            "translationYBy",
-            "(F)Landroid/view/ViewPropertyAnimator;",
-            &[JValue::Float(dy as f32)],
-        );
-        let _ = env.call_method(
-            &animator,
-            "setDuration",
-            "(J)Landroid/view/ViewPropertyAnimator;",
-            &[JValue::Long(dur_ms)],
-        );
-        let _ = env.call_method(&animator, "start", "()V", &[]);
-        unsafe {
-            env.pop_local_frame(&JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let animator = env
+                .call_method(
+                    view_ref.as_obj(),
+                    jni::jni_str!("animate"),
+                    jni::jni_sig!("()Landroid/view/ViewPropertyAnimator;"),
+                    &[],
+                )
+                .expect("animate")
+                .l()
+                .expect("animator");
+            let dur_ms = (duration_secs * 1000.0) as i64;
+            let _ = env.call_method(
+                &animator,
+                jni::jni_str!("translationXBy"),
+                jni::jni_sig!("(F)Landroid/view/ViewPropertyAnimator;"),
+                &[JValue::Float(dx as f32)],
+            );
+            let _ = env.call_method(
+                &animator,
+                jni::jni_str!("translationYBy"),
+                jni::jni_sig!("(F)Landroid/view/ViewPropertyAnimator;"),
+                &[JValue::Float(dy as f32)],
+            );
+            let _ = env.call_method(
+                &animator,
+                jni::jni_str!("setDuration"),
+                jni::jni_sig!("(J)Landroid/view/ViewPropertyAnimator;"),
+                &[JValue::Long(dur_ms)],
+            );
+            let _ = env.call_method(&animator, jni::jni_str!("start"), jni::jni_sig!("()V"), &[]);
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }
 
 /// Set a fixed width on a widget via LayoutParams.
 pub fn set_width(handle: i64, width: f64) {
     if let Some(view_ref) = get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(16);
-        let width_px = dp_to_px(&mut env, width as f32);
-        if let Ok(lp) = env.call_method(
-            view_ref.as_obj(),
-            "getLayoutParams",
-            "()Landroid/view/ViewGroup$LayoutParams;",
-            &[],
-        ) {
-            if let Ok(lp_obj) = lp.l() {
-                if !lp_obj.is_null() {
-                    let _ = env.set_field(&lp_obj, "width", "I", JValue::Int(width_px));
-                    // Clear weight so width is respected
-                    if env
-                        .is_instance_of(&lp_obj, "android/widget/LinearLayout$LayoutParams")
-                        .unwrap_or(false)
-                    {
-                        let _ = env.set_field(&lp_obj, "weight", "F", JValue::Float(0.0));
-                    }
-                    let _ = env.call_method(
-                        view_ref.as_obj(),
-                        "setLayoutParams",
-                        "(Landroid/view/ViewGroup$LayoutParams;)V",
-                        &[JValue::Object(&lp_obj)],
-                    );
-                } else {
-                    // No LayoutParams yet — create one
-                    let params = env.new_object(
-                        "android/widget/LinearLayout$LayoutParams",
-                        "(II)V",
-                        &[JValue::Int(width_px), JValue::Int(-2)], // -2 = WRAP_CONTENT
-                    );
-                    if let Ok(params) = params {
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 16);
+            let width_px = dp_to_px(env, width as f32);
+            if let Ok(lp) = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("getLayoutParams"),
+                jni::jni_sig!("()Landroid/view/ViewGroup$LayoutParams;"),
+                &[],
+            ) {
+                if let Ok(lp_obj) = lp.l() {
+                    if !lp_obj.is_null() {
+                        let _ = env.set_field(
+                            &lp_obj,
+                            jni::jni_str!("width"),
+                            jni::jni_sig!("I"),
+                            JValue::Int(width_px),
+                        );
+                        // Clear weight so width is respected
+                        if env
+                            .is_instance_of(
+                                &lp_obj,
+                                jni::jni_str!("android/widget/LinearLayout$LayoutParams"),
+                            )
+                            .unwrap_or(false)
+                        {
+                            let _ = env.set_field(
+                                &lp_obj,
+                                jni::jni_str!("weight"),
+                                jni::jni_sig!("F"),
+                                JValue::Float(0.0),
+                            );
+                        }
                         let _ = env.call_method(
                             view_ref.as_obj(),
-                            "setLayoutParams",
-                            "(Landroid/view/ViewGroup$LayoutParams;)V",
-                            &[JValue::Object(&params)],
+                            jni::jni_str!("setLayoutParams"),
+                            jni::jni_sig!("(Landroid/view/ViewGroup$LayoutParams;)V"),
+                            &[JValue::Object(&lp_obj)],
                         );
+                    } else {
+                        // No LayoutParams yet — create one
+                        let params = env.new_object(
+                            jni::jni_str!("android/widget/LinearLayout$LayoutParams"),
+                            jni::jni_sig!("(II)V"),
+                            &[JValue::Int(width_px), JValue::Int(-2)], // -2 = WRAP_CONTENT
+                        );
+                        if let Ok(params) = params {
+                            let _ = env.call_method(
+                                view_ref.as_obj(),
+                                jni::jni_str!("setLayoutParams"),
+                                jni::jni_sig!("(Landroid/view/ViewGroup$LayoutParams;)V"),
+                                &[JValue::Object(&params)],
+                            );
+                        }
                     }
                 }
             }
-        }
-        unsafe {
-            env.pop_local_frame(&JObject::null());
-        }
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }
 
 /// Set a fixed height on a widget via LayoutParams.
 pub fn set_height(handle: i64, height: f64) {
     if let Some(view_ref) = get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(16);
-        let height_px = dp_to_px(&mut env, height as f32);
-        if let Ok(lp) = env.call_method(
-            view_ref.as_obj(),
-            "getLayoutParams",
-            "()Landroid/view/ViewGroup$LayoutParams;",
-            &[],
-        ) {
-            if let Ok(lp_obj) = lp.l() {
-                if !lp_obj.is_null() {
-                    let _ = env.set_field(&lp_obj, "height", "I", JValue::Int(height_px));
-                    let _ = env.call_method(
-                        view_ref.as_obj(),
-                        "setLayoutParams",
-                        "(Landroid/view/ViewGroup$LayoutParams;)V",
-                        &[JValue::Object(&lp_obj)],
-                    );
-                } else {
-                    let params = env.new_object(
-                        "android/widget/LinearLayout$LayoutParams",
-                        "(II)V",
-                        &[JValue::Int(-2), JValue::Int(height_px)], // -2 = WRAP_CONTENT
-                    );
-                    if let Ok(params) = params {
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 16);
+            let height_px = dp_to_px(env, height as f32);
+            if let Ok(lp) = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("getLayoutParams"),
+                jni::jni_sig!("()Landroid/view/ViewGroup$LayoutParams;"),
+                &[],
+            ) {
+                if let Ok(lp_obj) = lp.l() {
+                    if !lp_obj.is_null() {
+                        let _ = env.set_field(
+                            &lp_obj,
+                            jni::jni_str!("height"),
+                            jni::jni_sig!("I"),
+                            JValue::Int(height_px),
+                        );
                         let _ = env.call_method(
                             view_ref.as_obj(),
-                            "setLayoutParams",
-                            "(Landroid/view/ViewGroup$LayoutParams;)V",
-                            &[JValue::Object(&params)],
+                            jni::jni_str!("setLayoutParams"),
+                            jni::jni_sig!("(Landroid/view/ViewGroup$LayoutParams;)V"),
+                            &[JValue::Object(&lp_obj)],
                         );
+                    } else {
+                        let params = env.new_object(
+                            jni::jni_str!("android/widget/LinearLayout$LayoutParams"),
+                            jni::jni_sig!("(II)V"),
+                            &[JValue::Int(-2), JValue::Int(height_px)], // -2 = WRAP_CONTENT
+                        );
+                        if let Ok(params) = params {
+                            let _ = env.call_method(
+                                view_ref.as_obj(),
+                                jni::jni_str!("setLayoutParams"),
+                                jni::jni_sig!("(Landroid/view/ViewGroup$LayoutParams;)V"),
+                                &[JValue::Object(&params)],
+                            );
+                        }
                     }
                 }
             }
-        }
-        unsafe {
-            env.pop_local_frame(&JObject::null());
-        }
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }
 
@@ -896,112 +1031,126 @@ pub fn remove_child(parent_handle: i64, child_handle: i64) {
     if let (Some(parent_ref), Some(child_ref)) =
         (get_widget(parent_handle), get_widget(child_handle))
     {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let _ = env.call_method(
-            parent_ref.as_obj(),
-            "removeView",
-            "(Landroid/view/View;)V",
-            &[JValue::Object(child_ref.as_obj())],
-        );
-        unsafe {
-            env.pop_local_frame(&JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let _ = env.call_method(
+                parent_ref.as_obj(),
+                jni::jni_str!("removeView"),
+                jni::jni_sig!("(Landroid/view/View;)V"),
+                &[JValue::Object(child_ref.as_obj())],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }
 
 /// Reorder a child widget within a parent ViewGroup by index.
 pub fn reorder_child(parent_handle: i64, from_index: i64, to_index: i64) {
     if let Some(parent_ref) = get_widget(parent_handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(16);
-        // Get child at from_index
-        let child_result = env.call_method(
-            parent_ref.as_obj(),
-            "getChildAt",
-            "(I)Landroid/view/View;",
-            &[JValue::Int(from_index as i32)],
-        );
-        if let Ok(child_val) = child_result {
-            if let Ok(child_obj) = child_val.l() {
-                if !child_obj.is_null() {
-                    // Remove and re-add at target index
-                    let _ = env.call_method(
-                        parent_ref.as_obj(),
-                        "removeViewAt",
-                        "(I)V",
-                        &[JValue::Int(from_index as i32)],
-                    );
-                    let _ = env.call_method(
-                        parent_ref.as_obj(),
-                        "addView",
-                        "(Landroid/view/View;I)V",
-                        &[JValue::Object(&child_obj), JValue::Int(to_index as i32)],
-                    );
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 16);
+            // Get child at from_index
+            let child_result = env.call_method(
+                parent_ref.as_obj(),
+                jni::jni_str!("getChildAt"),
+                jni::jni_sig!("(I)Landroid/view/View;"),
+                &[JValue::Int(from_index as i32)],
+            );
+            if let Ok(child_val) = child_result {
+                if let Ok(child_obj) = child_val.l() {
+                    if !child_obj.is_null() {
+                        // Remove and re-add at target index
+                        let _ = env.call_method(
+                            parent_ref.as_obj(),
+                            jni::jni_str!("removeViewAt"),
+                            jni::jni_sig!("(I)V"),
+                            &[JValue::Int(from_index as i32)],
+                        );
+                        let _ = env.call_method(
+                            parent_ref.as_obj(),
+                            jni::jni_str!("addView"),
+                            jni::jni_sig!("(Landroid/view/View;I)V"),
+                            &[JValue::Object(&child_obj), JValue::Int(to_index as i32)],
+                        );
+                    }
                 }
             }
-        }
-        unsafe {
-            env.pop_local_frame(&JObject::null());
-        }
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }
 
 /// Pin a child view's width to match its parent (MATCH_PARENT).
 pub fn match_parent_width(child_handle: i64) {
     if let Some(view_ref) = get_widget(child_handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(16);
-        if let Ok(lp) = env.call_method(
-            view_ref.as_obj(),
-            "getLayoutParams",
-            "()Landroid/view/ViewGroup$LayoutParams;",
-            &[],
-        ) {
-            if let Ok(lp_obj) = lp.l() {
-                if !lp_obj.is_null() {
-                    let _ = env.set_field(&lp_obj, "width", "I", JValue::Int(-1)); // MATCH_PARENT
-                    let _ = env.call_method(
-                        view_ref.as_obj(),
-                        "setLayoutParams",
-                        "(Landroid/view/ViewGroup$LayoutParams;)V",
-                        &[JValue::Object(&lp_obj)],
-                    );
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 16);
+            if let Ok(lp) = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("getLayoutParams"),
+                jni::jni_sig!("()Landroid/view/ViewGroup$LayoutParams;"),
+                &[],
+            ) {
+                if let Ok(lp_obj) = lp.l() {
+                    if !lp_obj.is_null() {
+                        let _ = env.set_field(
+                            &lp_obj,
+                            jni::jni_str!("width"),
+                            jni::jni_sig!("I"),
+                            JValue::Int(-1),
+                        ); // MATCH_PARENT
+                        let _ = env.call_method(
+                            view_ref.as_obj(),
+                            jni::jni_str!("setLayoutParams"),
+                            jni::jni_sig!("(Landroid/view/ViewGroup$LayoutParams;)V"),
+                            &[JValue::Object(&lp_obj)],
+                        );
+                    }
                 }
             }
-        }
-        unsafe {
-            env.pop_local_frame(&JObject::null());
-        }
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }
 
 /// Pin a child view's height to match its parent (MATCH_PARENT).
 pub fn match_parent_height(child_handle: i64) {
     if let Some(view_ref) = get_widget(child_handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(16);
-        if let Ok(lp) = env.call_method(
-            view_ref.as_obj(),
-            "getLayoutParams",
-            "()Landroid/view/ViewGroup$LayoutParams;",
-            &[],
-        ) {
-            if let Ok(lp_obj) = lp.l() {
-                if !lp_obj.is_null() {
-                    let _ = env.set_field(&lp_obj, "height", "I", JValue::Int(-1)); // MATCH_PARENT
-                    let _ = env.call_method(
-                        view_ref.as_obj(),
-                        "setLayoutParams",
-                        "(Landroid/view/ViewGroup$LayoutParams;)V",
-                        &[JValue::Object(&lp_obj)],
-                    );
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 16);
+            if let Ok(lp) = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("getLayoutParams"),
+                jni::jni_sig!("()Landroid/view/ViewGroup$LayoutParams;"),
+                &[],
+            ) {
+                if let Ok(lp_obj) = lp.l() {
+                    if !lp_obj.is_null() {
+                        let _ = env.set_field(
+                            &lp_obj,
+                            jni::jni_str!("height"),
+                            jni::jni_sig!("I"),
+                            JValue::Int(-1),
+                        ); // MATCH_PARENT
+                        let _ = env.call_method(
+                            view_ref.as_obj(),
+                            jni::jni_str!("setLayoutParams"),
+                            jni::jni_sig!("(Landroid/view/ViewGroup$LayoutParams;)V"),
+                            &[JValue::Object(&lp_obj)],
+                        );
+                    }
                 }
             }
-        }
-        unsafe {
-            env.pop_local_frame(&JObject::null());
-        }
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }
 
@@ -1014,155 +1163,175 @@ pub fn set_detaches_hidden_views(_handle: i64, _detaches: bool) {
 /// Set border color on a widget via GradientDrawable stroke.
 pub fn set_border_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
     if let Some(view_ref) = get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(16);
-        let color = argb_color(a, r, g, b);
-        // Try to reuse existing GradientDrawable
-        if let Ok(bg) = env.call_method(
-            view_ref.as_obj(),
-            "getBackground",
-            "()Landroid/graphics/drawable/Drawable;",
-            &[],
-        ) {
-            if let Ok(bg_obj) = bg.l() {
-                if !bg_obj.is_null() {
-                    if env
-                        .is_instance_of(&bg_obj, "android/graphics/drawable/GradientDrawable")
-                        .unwrap_or(false)
-                    {
-                        let _ = env.call_method(
-                            &bg_obj,
-                            "setStroke",
-                            "(II)V",
-                            &[JValue::Int(2), JValue::Int(color)],
-                        ); // 2px default width
-                        unsafe {
-                            env.pop_local_frame(&JObject::null());
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 16);
+            let color = argb_color(a, r, g, b);
+            // Try to reuse existing GradientDrawable
+            if let Ok(bg) = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("getBackground"),
+                jni::jni_sig!("()Landroid/graphics/drawable/Drawable;"),
+                &[],
+            ) {
+                if let Ok(bg_obj) = bg.l() {
+                    if !bg_obj.is_null() {
+                        if env
+                            .is_instance_of(
+                                &bg_obj,
+                                jni::jni_str!("android/graphics/drawable/GradientDrawable"),
+                            )
+                            .unwrap_or(false)
+                        {
+                            let _ = env.call_method(
+                                &bg_obj,
+                                jni::jni_str!("setStroke"),
+                                jni::jni_sig!("(II)V"),
+                                &[JValue::Int(2), JValue::Int(color)],
+                            ); // 2px default width
+                            unsafe {
+                                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+                            }
+                            return;
                         }
-                        return;
                     }
                 }
             }
-        }
-        // Create new GradientDrawable with border
-        let gd = env
-            .new_object("android/graphics/drawable/GradientDrawable", "()V", &[])
-            .expect("GradientDrawable");
-        let _ = env.call_method(&gd, "setColor", "(I)V", &[JValue::Int(0)]); // transparent fill
-        let _ = env.call_method(
-            &gd,
-            "setStroke",
-            "(II)V",
-            &[JValue::Int(2), JValue::Int(color)],
-        );
-        let _ = env.call_method(
-            view_ref.as_obj(),
-            "setBackground",
-            "(Landroid/graphics/drawable/Drawable;)V",
-            &[JValue::Object(&gd)],
-        );
-        unsafe {
-            env.pop_local_frame(&JObject::null());
-        }
+            // Create new GradientDrawable with border
+            let gd = env
+                .new_object(
+                    jni::jni_str!("android/graphics/drawable/GradientDrawable"),
+                    jni::jni_sig!("()V"),
+                    &[],
+                )
+                .expect("GradientDrawable");
+            let _ = env.call_method(
+                &gd,
+                jni::jni_str!("setColor"),
+                jni::jni_sig!("(I)V"),
+                &[JValue::Int(0)],
+            ); // transparent fill
+            let _ = env.call_method(
+                &gd,
+                jni::jni_str!("setStroke"),
+                jni::jni_sig!("(II)V"),
+                &[JValue::Int(2), JValue::Int(color)],
+            );
+            let _ = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("setBackground"),
+                jni::jni_sig!("(Landroid/graphics/drawable/Drawable;)V"),
+                &[JValue::Object(&gd)],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }
 
 /// Set border width on a widget via GradientDrawable stroke.
 pub fn set_border_width(handle: i64, width: f64) {
     if let Some(view_ref) = get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(16);
-        let width_px = dp_to_px(&mut env, width as f32);
-        if let Ok(bg) = env.call_method(
-            view_ref.as_obj(),
-            "getBackground",
-            "()Landroid/graphics/drawable/Drawable;",
-            &[],
-        ) {
-            if let Ok(bg_obj) = bg.l() {
-                if !bg_obj.is_null() {
-                    if env
-                        .is_instance_of(&bg_obj, "android/graphics/drawable/GradientDrawable")
-                        .unwrap_or(false)
-                    {
-                        // setStroke requires both width and color
-                        let _ = env.call_method(
-                            &bg_obj,
-                            "setStroke",
-                            "(II)V",
-                            &[JValue::Int(width_px), JValue::Int(0xFF000000u32 as i32)],
-                        ); // black default
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 16);
+            let width_px = dp_to_px(env, width as f32);
+            if let Ok(bg) = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("getBackground"),
+                jni::jni_sig!("()Landroid/graphics/drawable/Drawable;"),
+                &[],
+            ) {
+                if let Ok(bg_obj) = bg.l() {
+                    if !bg_obj.is_null() {
+                        if env
+                            .is_instance_of(
+                                &bg_obj,
+                                jni::jni_str!("android/graphics/drawable/GradientDrawable"),
+                            )
+                            .unwrap_or(false)
+                        {
+                            // setStroke requires both width and color
+                            let _ = env.call_method(
+                                &bg_obj,
+                                jni::jni_str!("setStroke"),
+                                jni::jni_sig!("(II)V"),
+                                &[JValue::Int(width_px), JValue::Int(0xFF000000u32 as i32)],
+                            ); // black default
+                        }
                     }
                 }
             }
-        }
-        unsafe {
-            env.pop_local_frame(&JObject::null());
-        }
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }
 
 /// Set edge insets (padding) on a widget.
 pub fn set_edge_insets(handle: i64, top: f64, left: f64, bottom: f64, right: f64) {
     if let Some(view_ref) = get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let t = dp_to_px(&mut env, top as f32);
-        let l = dp_to_px(&mut env, left as f32);
-        let b = dp_to_px(&mut env, bottom as f32);
-        let r = dp_to_px(&mut env, right as f32);
-        let _ = env.call_method(
-            view_ref.as_obj(),
-            "setPadding",
-            "(IIII)V",
-            &[
-                JValue::Int(l),
-                JValue::Int(t),
-                JValue::Int(r),
-                JValue::Int(b),
-            ],
-        );
-        unsafe {
-            env.pop_local_frame(&JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let t = dp_to_px(env, top as f32);
+            let l = dp_to_px(env, left as f32);
+            let b = dp_to_px(env, bottom as f32);
+            let r = dp_to_px(env, right as f32);
+            let _ = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("setPadding"),
+                jni::jni_sig!("(IIII)V"),
+                &[
+                    JValue::Int(l),
+                    JValue::Int(t),
+                    JValue::Int(r),
+                    JValue::Int(b),
+                ],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }
 
 /// Set view opacity (alpha) in [0.0, 1.0].
 pub fn set_opacity(handle: i64, alpha: f64) {
     if let Some(view_ref) = get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let _ = env.call_method(
-            view_ref.as_obj(),
-            "setAlpha",
-            "(F)V",
-            &[JValue::Float(alpha as f32)],
-        );
-        unsafe {
-            env.pop_local_frame(&JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let _ = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("setAlpha"),
+                jni::jni_sig!("(F)V"),
+                &[JValue::Float(alpha as f32)],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }
 
 /// Set on-click callback for any widget (via PerryBridge).
 pub fn set_on_click(handle: i64, callback: f64) {
     if let Some(view_ref) = get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let cb_key = crate::callback::register(callback);
-        let bridge_class =
-            jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-        let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-        let _ = env.call_static_method(
-            bridge_cls,
-            "setOnClickCallback",
-            "(Landroid/view/View;J)V",
-            &[JValue::Object(view_ref.as_obj()), JValue::Long(cb_key)],
-        );
-        unsafe {
-            env.pop_local_frame(&JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let cb_key = crate::callback::register(callback);
+            let bridge_class =
+                jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+            let bridge_cls: &jni::objects::JClass = &bridge_class;
+            let _ = env.call_static_method(
+                bridge_cls,
+                jni::jni_str!("setOnClickCallback"),
+                jni::jni_sig!("(Landroid/view/View;J)V"),
+                &[JValue::Object(view_ref.as_obj()), JValue::Long(cb_key)],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }
 
@@ -1171,75 +1340,81 @@ pub fn set_on_click(handle: i64, callback: f64) {
 /// A low hugging value means the view WANTS to expand (high weight).
 pub fn set_hugging(handle: i64, priority: f64) {
     if let Some(view_ref) = get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(16);
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 16);
 
-        // Determine parent orientation to set the correct axis
-        let parent_horizontal = (|| -> Option<bool> {
-            let parent = env
-                .call_method(
-                    view_ref.as_obj(),
-                    "getParent",
-                    "()Landroid/view/ViewParent;",
-                    &[],
-                )
-                .ok()?
-                .l()
-                .ok()?;
-            if parent.is_null() {
-                return None;
-            }
-            if !env
-                .is_instance_of(&parent, "android/widget/LinearLayout")
-                .unwrap_or(false)
-            {
-                return None;
-            }
-            let orient = env
-                .call_method(&parent, "getOrientation", "()I", &[])
-                .map(|v| v.i().unwrap_or(-1))
-                .unwrap_or(-1);
-            Some(orient == 0) // 0=HORIZONTAL
-        })()
-        .unwrap_or(false);
+            // Determine parent orientation to set the correct axis
+            let parent_horizontal = (|| -> Option<bool> {
+                let parent = env
+                    .call_method(
+                        view_ref.as_obj(),
+                        jni::jni_str!("getParent"),
+                        jni::jni_sig!("()Landroid/view/ViewParent;"),
+                        &[],
+                    )
+                    .ok()?
+                    .l()
+                    .ok()?;
+                if parent.is_null() {
+                    return None;
+                }
+                if !env
+                    .is_instance_of(&parent, jni::jni_str!("android/widget/LinearLayout"))
+                    .unwrap_or(false)
+                {
+                    return None;
+                }
+                let orient = env
+                    .call_method(
+                        &parent,
+                        jni::jni_str!("getOrientation"),
+                        jni::jni_sig!("()I"),
+                        &[],
+                    )
+                    .map(|v| v.i().unwrap_or(-1))
+                    .unwrap_or(-1);
+                Some(orient == 0) // 0=HORIZONTAL
+            })()
+            .unwrap_or(false);
 
-        // Map hugging priority to weight:
-        // low hugging (< 100) = high weight (expands), high hugging = compact (wrap content)
-        let expand = priority < 100.0;
-        let weight = if expand { 1.0f32 } else { 0.0f32 };
+            // Map hugging priority to weight:
+            // low hugging (< 100) = high weight (expands), high hugging = compact (wrap content)
+            let expand = priority < 100.0;
+            let weight = if expand { 1.0f32 } else { 0.0f32 };
 
-        let (w, h) = if parent_horizontal {
-            // HStack: weight distributes WIDTH; cross-axis (height) = MATCH_PARENT
-            if expand {
-                (0, -1)
+            let (w, h) = if parent_horizontal {
+                // HStack: weight distributes WIDTH; cross-axis (height) = MATCH_PARENT
+                if expand {
+                    (0, -1)
+                } else {
+                    (-2, -1)
+                } // width=0+weight or WRAP_CONTENT; height=MATCH_PARENT
             } else {
-                (-2, -1)
-            } // width=0+weight or WRAP_CONTENT; height=MATCH_PARENT
-        } else {
-            // VStack (default): weight distributes HEIGHT; cross-axis (width) = MATCH_PARENT
-            if expand {
-                (-1, 0)
-            } else {
-                (-1, -2)
-            } // width=MATCH_PARENT; height=0+weight or WRAP_CONTENT
-        };
+                // VStack (default): weight distributes HEIGHT; cross-axis (width) = MATCH_PARENT
+                if expand {
+                    (-1, 0)
+                } else {
+                    (-1, -2)
+                } // width=MATCH_PARENT; height=0+weight or WRAP_CONTENT
+            };
 
-        let params = env.new_object(
-            "android/widget/LinearLayout$LayoutParams",
-            "(IIF)V",
-            &[JValue::Int(w), JValue::Int(h), JValue::Float(weight)],
-        );
-        if let Ok(params) = params {
-            let _ = env.call_method(
-                view_ref.as_obj(),
-                "setLayoutParams",
-                "(Landroid/view/ViewGroup$LayoutParams;)V",
-                &[JValue::Object(&params)],
+            let params = env.new_object(
+                jni::jni_str!("android/widget/LinearLayout$LayoutParams"),
+                jni::jni_sig!("(IIF)V"),
+                &[JValue::Int(w), JValue::Int(h), JValue::Float(weight)],
             );
-        }
-        unsafe {
-            env.pop_local_frame(&JObject::null());
-        }
+            if let Ok(params) = params {
+                let _ = env.call_method(
+                    view_ref.as_obj(),
+                    jni::jni_str!("setLayoutParams"),
+                    jni::jni_sig!("(Landroid/view/ViewGroup$LayoutParams;)V"),
+                    &[JValue::Object(&params)],
+                );
+            }
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }
 
@@ -1252,12 +1427,17 @@ fn argb_color(a: f64, r: f64, g: f64, b: f64) -> i32 {
 }
 
 /// Convert dp to pixels via PerryBridge.
-pub fn dp_to_px(env: &mut jni::JNIEnv, dp: f32) -> i32 {
+pub fn dp_to_px(env: &mut jni::Env, dp: f32) -> i32 {
     let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
+        jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+    let bridge_cls: &jni::objects::JClass = &bridge_class;
     let result = env
-        .call_static_method(bridge_cls, "dpToPx", "(F)I", &[JValue::Float(dp)])
+        .call_static_method(
+            bridge_cls,
+            jni::jni_str!("dpToPx"),
+            jni::jni_sig!("(F)I"),
+            &[JValue::Float(dp)],
+        )
         .expect("Failed to convert dp to px");
     result.i().expect("dpToPx did not return int")
 }

--- a/crates/perry-ui-android/src/widgets/navstack.rs
+++ b/crates/perry-ui-android/src/widgets/navstack.rs
@@ -1,7 +1,7 @@
 //! NavigationStack — FrameLayout with page stack (show/hide)
 
 use crate::jni_bridge;
-use jni::objects::JValue;
+use jni::JValue;
 use std::cell::RefCell;
 use std::collections::HashMap;
 
@@ -17,39 +17,39 @@ thread_local! {
 
 pub fn create(title_ptr: *const u8, body_handle: i64) -> i64 {
     let _title = unsafe { str_from_header(title_ptr) };
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
 
-    let activity = super::get_activity(&mut env);
-    let frame_layout = env
-        .new_object(
-            "android/widget/FrameLayout",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("Failed to create FrameLayout");
+        let activity = super::get_activity(env);
+        let frame_layout = env
+            .new_object(
+                jni::jni_str!("android/widget/FrameLayout"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("Failed to create FrameLayout");
 
-    let global = env
-        .new_global_ref(frame_layout)
-        .expect("Failed to create global ref");
-    let handle = super::register_widget(global);
+        let global =
+            jni_bridge::new_global_ref(env, frame_layout).expect("Failed to create global ref");
+        let handle = super::register_widget(global);
 
-    // Add the initial page
-    super::add_child(handle, body_handle);
+        // Add the initial page
+        super::add_child(handle, body_handle);
 
-    NAV_STATES.with(|s| {
-        s.borrow_mut().insert(
-            handle,
-            NavState {
-                pages: vec![body_handle],
-            },
-        );
-    });
+        NAV_STATES.with(|s| {
+            s.borrow_mut().insert(
+                handle,
+                NavState {
+                    pages: vec![body_handle],
+                },
+            );
+        });
 
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
-    handle
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+        handle
+    })
 }
 
 pub fn push(handle: i64, title_ptr: *const u8, body_handle: i64) {

--- a/crates/perry-ui-android/src/widgets/picker.rs
+++ b/crates/perry-ui-android/src/widgets/picker.rs
@@ -2,7 +2,7 @@
 
 use crate::callback;
 use crate::jni_bridge;
-use jni::objects::JValue;
+use jni::JValue;
 use std::cell::RefCell;
 use std::collections::HashMap;
 
@@ -27,51 +27,50 @@ pub(crate) fn scan_android_picker_gc_roots(visitor: &mut perry_ffi::GcRootVisito
 
 pub fn create(label_ptr: *const u8, on_change: f64, _style: i64) -> i64 {
     let _label = unsafe { str_from_header(label_ptr) };
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
 
-    let activity = super::get_activity(&mut env);
-    let spinner = env
-        .new_object(
-            "android/widget/Spinner",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("Failed to create Spinner");
+        let activity = super::get_activity(env);
+        let spinner = env
+            .new_object(
+                jni::jni_str!("android/widget/Spinner"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("Failed to create Spinner");
 
-    // Set up selection callback via PerryBridge
-    if on_change != 0.0 {
-        let cb_key = callback::register(on_change);
-        let bridge_class =
-            jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-        let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-        let _ = env.call_static_method(
-            bridge_cls,
-            "setSpinnerCallback",
-            "(Landroid/widget/Spinner;J)V",
-            &[JValue::Object(&spinner), JValue::Long(cb_key)],
-        );
-    }
+        // Set up selection callback via PerryBridge
+        if on_change != 0.0 {
+            let cb_key = callback::register(on_change);
+            let bridge_class =
+                jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+            let bridge_cls: &jni::objects::JClass = &bridge_class;
+            let _ = env.call_static_method(
+                bridge_cls,
+                jni::jni_str!("setSpinnerCallback"),
+                jni::jni_sig!("(Landroid/widget/Spinner;J)V"),
+                &[JValue::Object(&spinner), JValue::Long(cb_key)],
+            );
+        }
 
-    let global = env
-        .new_global_ref(spinner)
-        .expect("Failed to create global ref");
-    let handle = super::register_widget(global);
+        let global = jni_bridge::new_global_ref(env, spinner).expect("Failed to create global ref");
+        let handle = super::register_widget(global);
 
-    PICKER_STATES.with(|s| {
-        s.borrow_mut().insert(
-            handle,
-            PickerState {
-                items: Vec::new(),
-                on_change,
-            },
-        );
-    });
+        PICKER_STATES.with(|s| {
+            s.borrow_mut().insert(
+                handle,
+                PickerState {
+                    items: Vec::new(),
+                    on_change,
+                },
+            );
+        });
 
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
-    handle
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+        handle
+    })
 }
 
 pub fn add_item(handle: i64, title_ptr: *const u8) {
@@ -87,87 +86,95 @@ pub fn add_item(handle: i64, title_ptr: *const u8) {
 
 pub fn set_selected(handle: i64, index: i64) {
     if let Some(view_ref) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let _ = env.call_method(
-            view_ref.as_obj(),
-            "setSelection",
-            "(I)V",
-            &[JValue::Int(index as i32)],
-        );
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let _ = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("setSelection"),
+                jni::jni_sig!("(I)V"),
+                &[JValue::Int(index as i32)],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+        })
     }
 }
 
 pub fn get_selected(handle: i64) -> i64 {
     if let Some(view_ref) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let result = env.call_method(view_ref.as_obj(), "getSelectedItemPosition", "()I", &[]);
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
-        if let Ok(jni::objects::JValueGen::Int(i)) = result {
-            return i as i64;
-        }
+        return jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let result = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("getSelectedItemPosition"),
+                jni::jni_sig!("()I"),
+                &[],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+            result.and_then(|value| value.i()).unwrap_or(-1) as i64
+        });
     }
     -1
 }
 
 fn refresh_adapter(handle: i64, items: &[String]) {
     if let Some(view_ref) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(32 + items.len() as i32);
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 32 + items.len() as i32);
 
-        let activity = super::get_activity(&mut env);
+            let activity = super::get_activity(env);
 
-        // Create String array
-        let str_class = env.find_class("java/lang/String").expect("String class");
-        let arr = env
-            .new_object_array(
-                items.len() as i32,
-                &str_class,
-                &jni::objects::JObject::null(),
-            )
-            .expect("Failed to create String array");
+            // Create String array
+            let str_class = env
+                .find_class(jni::jni_str!("java/lang/String"))
+                .expect("String class");
+            let arr = env
+                .new_object_array(
+                    items.len() as i32,
+                    &str_class,
+                    &jni::objects::JObject::null(),
+                )
+                .expect("Failed to create String array");
 
-        for (i, item) in items.iter().enumerate() {
-            let jstr = env.new_string(item).expect("Failed to create JNI string");
-            let _ = env.set_object_array_element(&arr, i as i32, &jstr);
-        }
+            for (i, item) in items.iter().enumerate() {
+                let jstr = env.new_string(item).expect("Failed to create JNI string");
+                let _ = arr.set_element(env, i, &jstr);
+            }
 
-        // Create ArrayAdapter(context, android.R.layout.simple_spinner_item, items)
-        let adapter = env
-            .new_object(
-                "android/widget/ArrayAdapter",
-                "(Landroid/content/Context;I[Ljava/lang/Object;)V",
-                &[
-                    JValue::Object(&activity),
-                    JValue::Int(0x01090008), // android.R.layout.simple_spinner_item
-                    JValue::Object(&arr),
-                ],
-            )
-            .expect("Failed to create ArrayAdapter");
+            // Create ArrayAdapter(context, android.R.layout.simple_spinner_item, items)
+            let adapter = env
+                .new_object(
+                    jni::jni_str!("android/widget/ArrayAdapter"),
+                    jni::jni_sig!("(Landroid/content/Context;I[Ljava/lang/Object;)V"),
+                    &[
+                        JValue::Object(&activity),
+                        JValue::Int(0x01090008), // android.R.layout.simple_spinner_item
+                        JValue::Object(&arr),
+                    ],
+                )
+                .expect("Failed to create ArrayAdapter");
 
-        // Set dropdown layout
-        let _ = env.call_method(
-            &adapter,
-            "setDropDownViewResource",
-            "(I)V",
-            &[JValue::Int(0x01090009)], // android.R.layout.simple_spinner_dropdown_item
-        );
+            // Set dropdown layout
+            let _ = env.call_method(
+                &adapter,
+                jni::jni_str!("setDropDownViewResource"),
+                jni::jni_sig!("(I)V"),
+                &[JValue::Int(0x01090009)], // android.R.layout.simple_spinner_dropdown_item
+            );
 
-        let _ = env.call_method(
-            view_ref.as_obj(),
-            "setAdapter",
-            "(Landroid/widget/SpinnerAdapter;)V",
-            &[JValue::Object(&adapter)],
-        );
+            let _ = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("setAdapter"),
+                jni::jni_sig!("(Landroid/widget/SpinnerAdapter;)V"),
+                &[JValue::Object(&adapter)],
+            );
 
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+        })
     }
 }

--- a/crates/perry-ui-android/src/widgets/progressview.rs
+++ b/crates/perry-ui-android/src/widgets/progressview.rs
@@ -1,78 +1,84 @@
 //! ProgressView — Android ProgressBar
 
 use crate::jni_bridge;
-use jni::objects::JValue;
+use jni::JValue;
 
 pub fn create() -> i64 {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
 
-    let activity = super::get_activity(&mut env);
+        let activity = super::get_activity(env);
 
-    // ProgressBar with horizontal style
-    // Use the constructor with style: android.R.attr.progressBarStyleHorizontal = 0x01010078
-    let progress_bar = env
-        .new_object(
-            "android/widget/ProgressBar",
-            "(Landroid/content/Context;Landroid/util/AttributeSet;II)V",
-            &[
-                JValue::Object(&activity),
-                JValue::Object(&jni::objects::JObject::null()),
-                JValue::Int(0),
-                JValue::Int(0x01010078), // android.R.attr.progressBarStyleHorizontal
-            ],
-        )
-        .expect("Failed to create ProgressBar");
+        // ProgressBar with horizontal style
+        // Use the constructor with style: android.R.attr.progressBarStyleHorizontal = 0x01010078
+        let progress_bar = env
+            .new_object(
+                jni::jni_str!("android/widget/ProgressBar"),
+                jni::jni_sig!("(Landroid/content/Context;Landroid/util/AttributeSet;II)V"),
+                &[
+                    JValue::Object(&activity),
+                    JValue::Object(&jni::objects::JObject::null()),
+                    JValue::Int(0),
+                    JValue::Int(0x01010078), // android.R.attr.progressBarStyleHorizontal
+                ],
+            )
+            .expect("Failed to create ProgressBar");
 
-    let _ = env.call_method(&progress_bar, "setMax", "(I)V", &[JValue::Int(1000)]);
-    let _ = env.call_method(
-        &progress_bar,
-        "setIndeterminate",
-        "(Z)V",
-        &[JValue::Bool(1)],
-    );
+        let _ = env.call_method(
+            &progress_bar,
+            jni::jni_str!("setMax"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(1000)],
+        );
+        let _ = env.call_method(
+            &progress_bar,
+            jni::jni_str!("setIndeterminate"),
+            jni::jni_sig!("(Z)V"),
+            &[JValue::Bool(true)],
+        );
 
-    let global = env
-        .new_global_ref(progress_bar)
-        .expect("Failed to create global ref");
-    let handle = super::register_widget(global);
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
-    handle
+        let global =
+            jni_bridge::new_global_ref(env, progress_bar).expect("Failed to create global ref");
+        let handle = super::register_widget(global);
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+        handle
+    })
 }
 
 pub fn set_value(handle: i64, value: f64) {
     if let Some(view_ref) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
 
-        if value < 0.0 {
-            // Indeterminate
-            let _ = env.call_method(
-                view_ref.as_obj(),
-                "setIndeterminate",
-                "(Z)V",
-                &[JValue::Bool(1)],
-            );
-        } else {
-            let _ = env.call_method(
-                view_ref.as_obj(),
-                "setIndeterminate",
-                "(Z)V",
-                &[JValue::Bool(0)],
-            );
-            let progress = (value * 1000.0) as i32;
-            let _ = env.call_method(
-                view_ref.as_obj(),
-                "setProgress",
-                "(I)V",
-                &[JValue::Int(progress)],
-            );
-        }
+            if value < 0.0 {
+                // Indeterminate
+                let _ = env.call_method(
+                    view_ref.as_obj(),
+                    jni::jni_str!("setIndeterminate"),
+                    jni::jni_sig!("(Z)V"),
+                    &[JValue::Bool(true)],
+                );
+            } else {
+                let _ = env.call_method(
+                    view_ref.as_obj(),
+                    jni::jni_str!("setIndeterminate"),
+                    jni::jni_sig!("(Z)V"),
+                    &[JValue::Bool(false)],
+                );
+                let progress = (value * 1000.0) as i32;
+                let _ = env.call_method(
+                    view_ref.as_obj(),
+                    jni::jni_str!("setProgress"),
+                    jni::jni_sig!("(I)V"),
+                    &[JValue::Int(progress)],
+                );
+            }
 
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+        })
     }
 }

--- a/crates/perry-ui-android/src/widgets/qrcode.rs
+++ b/crates/perry-ui-android/src/widgets/qrcode.rs
@@ -3,7 +3,7 @@
 //! A full QR code renderer (e.g. via ZXing or a Rust crate) can replace this later.
 
 use crate::jni_bridge;
-use jni::objects::JValue;
+use jni::JValue;
 
 use perry_ffi::copy_string_from_raw as str_from_header;
 
@@ -14,153 +14,163 @@ pub fn create(data_ptr: *const u8, size: f64) -> i64 {
     let data_str = unsafe { str_from_header(data_ptr) };
     let display_size = if size > 0.0 { size } else { 200.0 };
 
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
 
-    let activity = super::get_activity(&mut env);
+        let activity = super::get_activity(env);
 
-    // Create a TextView styled as a QR code placeholder
-    let text_view = env
-        .new_object(
-            "android/widget/TextView",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("Failed to create TextView for QR code");
+        // Create a TextView styled as a QR code placeholder
+        let text_view = env
+            .new_object(
+                jni::jni_str!("android/widget/TextView"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("Failed to create TextView for QR code");
 
-    // Set the data text
-    let display_text = if data_str.is_empty() { "QR" } else { &data_str };
-    let jstr = env.new_string(display_text).expect("QR text string");
-    let _ = env.call_method(
-        &text_view,
-        "setText",
-        "(Ljava/lang/CharSequence;)V",
-        &[JValue::Object(&jstr)],
-    );
+        // Set the data text
+        let display_text = if data_str.is_empty() { "QR" } else { &data_str };
+        let jstr = env.new_string(display_text).expect("QR text string");
+        let _ = env.call_method(
+            &text_view,
+            jni::jni_str!("setText"),
+            jni::jni_sig!("(Ljava/lang/CharSequence;)V"),
+            &[JValue::Object(&jstr)],
+        );
 
-    // Center text
-    let _ = env.call_method(&text_view, "setGravity", "(I)V", &[JValue::Int(0x11)]); // Gravity.CENTER
+        // Center text
+        let _ = env.call_method(
+            &text_view,
+            jni::jni_str!("setGravity"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(0x11)],
+        ); // Gravity.CENTER
 
-    // Monospace font for code-like appearance
-    let font_name = env.new_string("monospace").expect("font name");
-    let tf = env.call_static_method(
-        "android/graphics/Typeface",
-        "create",
-        "(Ljava/lang/String;I)Landroid/graphics/Typeface;",
-        &[JValue::Object(&font_name), JValue::Int(1)],
-    ); // BOLD=1
-    if let Ok(tf_val) = tf {
-        if let Ok(tf_obj) = tf_val.l() {
-            let _ = env.call_method(
-                &text_view,
-                "setTypeface",
-                "(Landroid/graphics/Typeface;)V",
-                &[JValue::Object(&tf_obj)],
-            );
+        // Monospace font for code-like appearance
+        let font_name = env.new_string("monospace").expect("font name");
+        let tf = env.call_static_method(
+            jni::jni_str!("android/graphics/Typeface"),
+            jni::jni_str!("create"),
+            jni::jni_sig!("(Ljava/lang/String;I)Landroid/graphics/Typeface;"),
+            &[JValue::Object(&font_name), JValue::Int(1)],
+        ); // BOLD=1
+        if let Ok(tf_val) = tf {
+            if let Ok(tf_obj) = tf_val.l() {
+                let _ = env.call_method(
+                    &text_view,
+                    jni::jni_str!("setTypeface"),
+                    jni::jni_sig!("(Landroid/graphics/Typeface;)V"),
+                    &[JValue::Object(&tf_obj)],
+                );
+            }
         }
-    }
 
-    // Small text size
-    let _ = env.call_method(
-        &text_view,
-        "setTextSize",
-        "(IF)V",
-        &[JValue::Int(2), JValue::Float(10.0)],
-    ); // COMPLEX_UNIT_SP=2
+        // Small text size
+        let _ = env.call_method(
+            &text_view,
+            jni::jni_str!("setTextSize"),
+            jni::jni_sig!("(IF)V"),
+            &[JValue::Int(2), JValue::Float(10.0)],
+        ); // COMPLEX_UNIT_SP=2
 
-    // Set a border-like background
-    let gd = env
-        .new_object("android/graphics/drawable/GradientDrawable", "()V", &[])
-        .expect("GradientDrawable");
-    let _ = env.call_method(
-        &gd,
-        "setColor",
-        "(I)V",
-        &[JValue::Int(0xFFFFFFFFu32 as i32)],
-    ); // White background
-    let _ = env.call_method(
-        &gd,
-        "setStroke",
-        "(II)V",
-        &[JValue::Int(2), JValue::Int(0xFF000000u32 as i32)],
-    ); // Black border
-    let corner_px = super::dp_to_px(&mut env, 4.0);
-    let _ = env.call_method(
-        &gd,
-        "setCornerRadius",
-        "(F)V",
-        &[JValue::Float(corner_px as f32)],
-    );
-    let _ = env.call_method(
-        &text_view,
-        "setBackground",
-        "(Landroid/graphics/drawable/Drawable;)V",
-        &[JValue::Object(&gd)],
-    );
+        // Set a border-like background
+        let gd = env
+            .new_object(
+                jni::jni_str!("android/graphics/drawable/GradientDrawable"),
+                jni::jni_sig!("()V"),
+                &[],
+            )
+            .expect("GradientDrawable");
+        let _ = env.call_method(
+            &gd,
+            jni::jni_str!("setColor"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(0xFFFFFFFFu32 as i32)],
+        ); // White background
+        let _ = env.call_method(
+            &gd,
+            jni::jni_str!("setStroke"),
+            jni::jni_sig!("(II)V"),
+            &[JValue::Int(2), JValue::Int(0xFF000000u32 as i32)],
+        ); // Black border
+        let corner_px = super::dp_to_px(env, 4.0);
+        let _ = env.call_method(
+            &gd,
+            jni::jni_str!("setCornerRadius"),
+            jni::jni_sig!("(F)V"),
+            &[JValue::Float(corner_px as f32)],
+        );
+        let _ = env.call_method(
+            &text_view,
+            jni::jni_str!("setBackground"),
+            jni::jni_sig!("(Landroid/graphics/drawable/Drawable;)V"),
+            &[JValue::Object(&gd)],
+        );
 
-    // Text color black
-    let _ = env.call_method(
-        &text_view,
-        "setTextColor",
-        "(I)V",
-        &[JValue::Int(0xFF000000u32 as i32)],
-    );
+        // Text color black
+        let _ = env.call_method(
+            &text_view,
+            jni::jni_str!("setTextColor"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(0xFF000000u32 as i32)],
+        );
 
-    // Set fixed size
-    let size_px = super::dp_to_px(&mut env, display_size as f32);
-    let params = env
-        .new_object(
-            "android/widget/LinearLayout$LayoutParams",
-            "(II)V",
-            &[JValue::Int(size_px), JValue::Int(size_px)],
-        )
-        .expect("LayoutParams");
-    let _ = env.call_method(
-        &text_view,
-        "setLayoutParams",
-        "(Landroid/view/ViewGroup$LayoutParams;)V",
-        &[JValue::Object(&params)],
-    );
+        // Set fixed size
+        let size_px = super::dp_to_px(env, display_size as f32);
+        let params = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout$LayoutParams"),
+                jni::jni_sig!("(II)V"),
+                &[JValue::Int(size_px), JValue::Int(size_px)],
+            )
+            .expect("LayoutParams");
+        let _ = env.call_method(
+            &text_view,
+            jni::jni_str!("setLayoutParams"),
+            jni::jni_sig!("(Landroid/view/ViewGroup$LayoutParams;)V"),
+            &[JValue::Object(&params)],
+        );
 
-    // Padding
-    let pad = super::dp_to_px(&mut env, 8.0);
-    let _ = env.call_method(
-        &text_view,
-        "setPadding",
-        "(IIII)V",
-        &[
-            JValue::Int(pad),
-            JValue::Int(pad),
-            JValue::Int(pad),
-            JValue::Int(pad),
-        ],
-    );
+        // Padding
+        let pad = super::dp_to_px(env, 8.0);
+        let _ = env.call_method(
+            &text_view,
+            jni::jni_str!("setPadding"),
+            jni::jni_sig!("(IIII)V"),
+            &[
+                JValue::Int(pad),
+                JValue::Int(pad),
+                JValue::Int(pad),
+                JValue::Int(pad),
+            ],
+        );
 
-    let global = env
-        .new_global_ref(text_view)
-        .expect("Failed to create global ref");
-    let handle = super::register_widget(global);
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
-    handle
+        let global =
+            jni_bridge::new_global_ref(env, text_view).expect("Failed to create global ref");
+        let handle = super::register_widget(global);
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+        handle
+    })
 }
 
 /// Update the QR code content of an existing widget.
 pub fn set_data(handle: i64, data_ptr: *const u8) {
     let data_str = unsafe { str_from_header(data_ptr) };
     if let Some(view_ref) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let jstr = env.new_string(data_str).expect("QR text string");
-        let _ = env.call_method(
-            view_ref.as_obj(),
-            "setText",
-            "(Ljava/lang/CharSequence;)V",
-            &[JValue::Object(&jstr)],
-        );
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let jstr = env.new_string(data_str).expect("QR text string");
+            let _ = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("setText"),
+                jni::jni_sig!("(Ljava/lang/CharSequence;)V"),
+                &[JValue::Object(&jstr)],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+        })
     }
 }

--- a/crates/perry-ui-android/src/widgets/rich_text.rs
+++ b/crates/perry-ui-android/src/widgets/rich_text.rs
@@ -12,7 +12,10 @@
 
 use crate::app::str_from_header;
 use crate::jni_bridge;
-use jni::objects::{JObject, JValue};
+use jni::objects::JObject;
+use jni::signature::RuntimeMethodSignature;
+use jni::strings::JNIString;
+use jni::JValue;
 
 extern "C" {
     fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
@@ -22,87 +25,97 @@ extern "C" {
 const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
 
 fn call_bridge_void(name: &str, sig: &str, args: &[JValue]) {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let _ = env.call_static_method(bridge_cls, name, sig, args);
-    if env.exception_check().unwrap_or(false) {
-        let _ = env.exception_describe();
-        let _ = env.exception_clear();
-    }
-    unsafe {
-        env.pop_local_frame(&JObject::null());
-    }
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let parsed_sig =
+            RuntimeMethodSignature::from_str(sig).expect("valid PerryBridge signature");
+        let _ = env.call_static_method(
+            bridge_cls,
+            JNIString::new(name),
+            parsed_sig.method_signature(),
+            args,
+        );
+        if env.exception_check() {
+            let _ = env.exception_describe();
+            let _ = env.exception_clear();
+        }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+        }
+    })
 }
 
 /// Create a rich-text EditText. Note that `width`/`height` here are layout
 /// hints; the actual LayoutParams are applied by the parent stack when this
 /// widget is added.
 pub fn create(width: f64, height: f64, on_change: f64) -> i64 {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(16);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 16);
 
-    let cb_key = if on_change != 0.0 {
-        crate::callback::register(on_change)
-    } else {
-        0
-    };
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let result = env.call_static_method(
-        bridge_cls,
-        "richTextCreate",
-        "(DDJ)Landroid/widget/EditText;",
-        &[
-            JValue::Double(width),
-            JValue::Double(height),
-            JValue::Long(cb_key),
-        ],
-    );
-    let handle = match result {
-        Ok(jv) => match jv.l() {
-            Ok(obj) if !obj.is_null() => {
-                let g = env.new_global_ref(obj).expect("global-ref RichText");
-                super::register_widget(g)
-            }
-            _ => 0,
-        },
-        Err(_) => {
-            if env.exception_check().unwrap_or(false) {
-                let _ = env.exception_describe();
-                let _ = env.exception_clear();
-            }
+        let cb_key = if on_change != 0.0 {
+            crate::callback::register(on_change)
+        } else {
             0
+        };
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let result = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("richTextCreate"),
+            jni::jni_sig!("(DDJ)Landroid/widget/EditText;"),
+            &[
+                JValue::Double(width),
+                JValue::Double(height),
+                JValue::Long(cb_key),
+            ],
+        );
+        let handle = match result {
+            Ok(jv) => match jv.l() {
+                Ok(obj) if !obj.is_null() => {
+                    let g = jni_bridge::new_global_ref(env, obj).expect("global-ref RichText");
+                    super::register_widget(g)
+                }
+                _ => 0,
+            },
+            Err(_) => {
+                if env.exception_check() {
+                    let _ = env.exception_describe();
+                    let _ = env.exception_clear();
+                }
+                0
+            }
+        };
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
         }
-    };
-    unsafe {
-        env.pop_local_frame(&JObject::null());
-    }
-    handle
+        handle
+    })
 }
 
 /// Replace the entire content with a plain string.
 pub fn set_string(handle: i64, text_ptr: *const u8) {
     let text = unsafe { str_from_header(text_ptr) };
     if let Some(view) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let jtext = env.new_string(text).expect("rich_text set_string text");
-        let bridge_class =
-            jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-        let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-        let _ = env.call_static_method(
-            bridge_cls,
-            "richTextSetString",
-            "(Landroid/widget/EditText;Ljava/lang/String;)V",
-            &[JValue::Object(view.as_obj()), JValue::Object(&jtext)],
-        );
-        unsafe {
-            env.pop_local_frame(&JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let jtext = env.new_string(text).expect("rich_text set_string text");
+            let bridge_class =
+                jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+            let bridge_cls: &jni::objects::JClass = &bridge_class;
+            let _ = env.call_static_method(
+                bridge_cls,
+                jni::jni_str!("richTextSetString"),
+                jni::jni_sig!("(Landroid/widget/EditText;Ljava/lang/String;)V"),
+                &[JValue::Object(view.as_obj()), JValue::Object(&jtext)],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+        })
     }
 }
 
@@ -111,40 +124,42 @@ pub fn get_string(handle: i64) -> f64 {
     let Some(view) = super::get_widget(handle) else {
         return f64::from_bits(TAG_UNDEFINED);
     };
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let result = env.call_static_method(
-        bridge_cls,
-        "richTextGetString",
-        "(Landroid/widget/EditText;)Ljava/lang/String;",
-        &[JValue::Object(view.as_obj())],
-    );
-    let text: Option<String> = match result {
-        Ok(jv) => match jv.l() {
-            Ok(obj) if !obj.is_null() => {
-                let jstr: jni::objects::JString = obj.into();
-                env.get_string(&jstr).map(|s| s.into()).ok()
-            }
-            _ => None,
-        },
-        Err(_) => None,
-    };
-    unsafe {
-        env.pop_local_frame(&JObject::null());
-    }
-    match text {
-        Some(s) => {
-            let bytes = s.as_bytes();
-            unsafe {
-                let p = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
-                js_nanbox_string(p as i64)
-            }
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let result = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("richTextGetString"),
+            jni::jni_sig!("(Landroid/widget/EditText;)Ljava/lang/String;"),
+            &[JValue::Object(view.as_obj())],
+        );
+        let text: Option<String> = match result {
+            Ok(jv) => match jv.l() {
+                Ok(obj) if !obj.is_null() => {
+                    let jstr: jni::objects::JString =
+                        unsafe { jni::objects::JString::from_raw(env, obj.into_raw()) };
+                    jstr.try_to_string(env).map(|s| s.into()).ok()
+                }
+                _ => None,
+            },
+            Err(_) => None,
+        };
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
         }
-        None => f64::from_bits(TAG_UNDEFINED),
-    }
+        match text {
+            Some(s) => {
+                let bytes = s.as_bytes();
+                unsafe {
+                    let p = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+                    js_nanbox_string(p as i64)
+                }
+            }
+            None => f64::from_bits(TAG_UNDEFINED),
+        }
+    })
 }
 
 /// Parse HTML via `Html.fromHtml(s, FROM_HTML_MODE_COMPACT)` and set it as
@@ -154,30 +169,31 @@ pub fn set_html(handle: i64, html_ptr: *const u8) -> i64 {
     let Some(view) = super::get_widget(handle) else {
         return 0;
     };
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
-    let jhtml = env.new_string(html).expect("rich_text html string");
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let _ = env.call_static_method(
-        bridge_cls,
-        "richTextSetHtml",
-        "(Landroid/widget/EditText;Ljava/lang/String;)V",
-        &[JValue::Object(view.as_obj()), JValue::Object(&jhtml)],
-    );
-    if env.exception_check().unwrap_or(false) {
-        let _ = env.exception_describe();
-        let _ = env.exception_clear();
-        unsafe {
-            env.pop_local_frame(&JObject::null());
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
+        let jhtml = env.new_string(html).expect("rich_text html string");
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("richTextSetHtml"),
+            jni::jni_sig!("(Landroid/widget/EditText;Ljava/lang/String;)V"),
+            &[JValue::Object(view.as_obj()), JValue::Object(&jhtml)],
+        );
+        if env.exception_check() {
+            let _ = env.exception_describe();
+            let _ = env.exception_clear();
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+            }
+            return 0;
         }
-        return 0;
-    }
-    unsafe {
-        env.pop_local_frame(&JObject::null());
-    }
-    1
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+        }
+        1
+    })
 }
 
 /// Serialize the current rich content as HTML via
@@ -187,40 +203,42 @@ pub fn get_html(handle: i64) -> f64 {
     let Some(view) = super::get_widget(handle) else {
         return f64::from_bits(TAG_UNDEFINED);
     };
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let result = env.call_static_method(
-        bridge_cls,
-        "richTextGetHtml",
-        "(Landroid/widget/EditText;)Ljava/lang/String;",
-        &[JValue::Object(view.as_obj())],
-    );
-    let html: Option<String> = match result {
-        Ok(jv) => match jv.l() {
-            Ok(obj) if !obj.is_null() => {
-                let jstr: jni::objects::JString = obj.into();
-                env.get_string(&jstr).map(|s| s.into()).ok()
-            }
-            _ => None,
-        },
-        Err(_) => None,
-    };
-    unsafe {
-        env.pop_local_frame(&JObject::null());
-    }
-    match html {
-        Some(s) => {
-            let bytes = s.as_bytes();
-            unsafe {
-                let p = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
-                js_nanbox_string(p as i64)
-            }
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let result = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("richTextGetHtml"),
+            jni::jni_sig!("(Landroid/widget/EditText;)Ljava/lang/String;"),
+            &[JValue::Object(view.as_obj())],
+        );
+        let html: Option<String> = match result {
+            Ok(jv) => match jv.l() {
+                Ok(obj) if !obj.is_null() => {
+                    let jstr: jni::objects::JString =
+                        unsafe { jni::objects::JString::from_raw(env, obj.into_raw()) };
+                    jstr.try_to_string(env).map(|s| s.into()).ok()
+                }
+                _ => None,
+            },
+            Err(_) => None,
+        };
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
         }
-        None => f64::from_bits(TAG_UNDEFINED),
-    }
+        match html {
+            Some(s) => {
+                let bytes = s.as_bytes();
+                unsafe {
+                    let p = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+                    js_nanbox_string(p as i64)
+                }
+            }
+            None => f64::from_bits(TAG_UNDEFINED),
+        }
+    })
 }
 
 pub fn toggle_bold(handle: i64) {

--- a/crates/perry-ui-android/src/widgets/rich_tooltip.rs
+++ b/crates/perry-ui-android/src/widgets/rich_tooltip.rs
@@ -9,7 +9,8 @@
 //! site in lib.rs.
 
 use crate::jni_bridge;
-use jni::objects::{JObject, JValue};
+use jni::objects::JObject;
+use jni::JValue;
 
 /// Attach a rich tooltip to `widget_handle` showing the subtree rooted at
 /// `content_handle`. The popup auto-dismisses on outside touch.
@@ -21,25 +22,26 @@ pub fn set_rich_tooltip(widget_handle: i64, content_handle: i64, _hover_delay_ms
         return;
     };
 
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let _ = env.call_static_method(
-        bridge_cls,
-        "setRichTooltip",
-        "(Landroid/view/View;Landroid/view/View;)V",
-        &[
-            JValue::Object(trigger.as_obj()),
-            JValue::Object(content.as_obj()),
-        ],
-    );
-    if env.exception_check().unwrap_or(false) {
-        let _ = env.exception_describe();
-        let _ = env.exception_clear();
-    }
-    unsafe {
-        env.pop_local_frame(&JObject::null());
-    }
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("setRichTooltip"),
+            jni::jni_sig!("(Landroid/view/View;Landroid/view/View;)V"),
+            &[
+                JValue::Object(trigger.as_obj()),
+                JValue::Object(content.as_obj()),
+            ],
+        );
+        if env.exception_check() {
+            let _ = env.exception_describe();
+            let _ = env.exception_clear();
+        }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+        }
+    })
 }

--- a/crates/perry-ui-android/src/widgets/scrollview.rs
+++ b/crates/perry-ui-android/src/widgets/scrollview.rs
@@ -1,6 +1,6 @@
 use crate::callback;
 use crate::jni_bridge;
-use jni::objects::JValue;
+use jni::JValue;
 use std::cell::RefCell;
 use std::collections::HashMap;
 
@@ -22,92 +22,96 @@ pub fn create() -> i64 {
             b"create: getting env\0".as_ptr(),
         );
     }
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
-    unsafe {
-        __android_log_print(
-            3,
-            b"PerryScrollView\0".as_ptr(),
-            b"create: got env, getting activity\0".as_ptr(),
-        );
-    }
-    let activity = super::get_activity(&mut env);
-    unsafe {
-        __android_log_print(
-            3,
-            b"PerryScrollView\0".as_ptr(),
-            b"create: got activity, creating ScrollView\0".as_ptr(),
-        );
-    }
-
-    let scroll_result = env.new_object(
-        "android/widget/ScrollView",
-        "(Landroid/content/Context;)V",
-        &[JValue::Object(&activity)],
-    );
-    let scroll = match scroll_result {
-        Ok(s) => {
-            unsafe {
-                __android_log_print(
-                    3,
-                    b"PerryScrollView\0".as_ptr(),
-                    b"create: ScrollView created OK\0".as_ptr(),
-                );
-            }
-            s
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
+        unsafe {
+            __android_log_print(
+                3,
+                b"PerryScrollView\0".as_ptr(),
+                b"create: got env, getting activity\0".as_ptr(),
+            );
         }
-        Err(e) => {
-            let msg = format!("Failed to create ScrollView: {:?}\0", e);
-            unsafe {
-                __android_log_print(
-                    6,
-                    b"PerryScrollView\0".as_ptr(),
-                    b"create: ERROR: %s\0".as_ptr(),
-                    msg.as_ptr(),
-                );
+        let activity = super::get_activity(env);
+        unsafe {
+            __android_log_print(
+                3,
+                b"PerryScrollView\0".as_ptr(),
+                b"create: got activity, creating ScrollView\0".as_ptr(),
+            );
+        }
+
+        let scroll_result = env.new_object(
+            jni::jni_str!("android/widget/ScrollView"),
+            jni::jni_sig!("(Landroid/content/Context;)V"),
+            &[JValue::Object(&activity)],
+        );
+        let scroll = match scroll_result {
+            Ok(s) => {
+                unsafe {
+                    __android_log_print(
+                        3,
+                        b"PerryScrollView\0".as_ptr(),
+                        b"create: ScrollView created OK\0".as_ptr(),
+                    );
+                }
+                s
             }
-            // Check if there's a pending JNI exception
-            if env.exception_check().unwrap_or(false) {
+            Err(e) => {
+                let msg = format!("Failed to create ScrollView: {:?}\0", e);
                 unsafe {
                     __android_log_print(
                         6,
                         b"PerryScrollView\0".as_ptr(),
-                        b"create: JNI exception pending, describing:\0".as_ptr(),
+                        b"create: ERROR: %s\0".as_ptr(),
+                        msg.as_ptr(),
                     );
                 }
-                let _ = env.exception_describe();
-                let _ = env.exception_clear();
+                // Check if there's a pending JNI exception
+                if env.exception_check() {
+                    unsafe {
+                        __android_log_print(
+                            6,
+                            b"PerryScrollView\0".as_ptr(),
+                            b"create: JNI exception pending, describing:\0".as_ptr(),
+                        );
+                    }
+                    let _ = env.exception_describe();
+                    let _ = env.exception_clear();
+                }
+                panic!("Failed to create ScrollView: {:?}", e);
             }
-            panic!("Failed to create ScrollView: {:?}", e);
+        };
+
+        // Fill viewport so content can expand
+        let _ = env.call_method(
+            &scroll,
+            jni::jni_str!("setFillViewport"),
+            jni::jni_sig!("(Z)V"),
+            &[JValue::Bool(true)],
+        );
+
+        // MATCH_PARENT for both dimensions
+        let params = env
+            .new_object(
+                jni::jni_str!("android/widget/FrameLayout$LayoutParams"),
+                jni::jni_sig!("(II)V"),
+                &[JValue::Int(-1), JValue::Int(-1)],
+            )
+            .expect("Failed to create LayoutParams");
+        let _ = env.call_method(
+            &scroll,
+            jni::jni_str!("setLayoutParams"),
+            jni::jni_sig!("(Landroid/view/ViewGroup$LayoutParams;)V"),
+            &[JValue::Object(&params)],
+        );
+
+        let global = jni_bridge::new_global_ref(env, scroll).expect("Failed to create global ref");
+        let handle = super::register_widget(global);
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
         }
-    };
-
-    // Fill viewport so content can expand
-    let _ = env.call_method(&scroll, "setFillViewport", "(Z)V", &[JValue::Bool(1)]);
-
-    // MATCH_PARENT for both dimensions
-    let params = env
-        .new_object(
-            "android/widget/FrameLayout$LayoutParams",
-            "(II)V",
-            &[JValue::Int(-1), JValue::Int(-1)],
-        )
-        .expect("Failed to create LayoutParams");
-    let _ = env.call_method(
-        &scroll,
-        "setLayoutParams",
-        "(Landroid/view/ViewGroup$LayoutParams;)V",
-        &[JValue::Object(&params)],
-    );
-
-    let global = env
-        .new_global_ref(scroll)
-        .expect("Failed to create global ref");
-    let handle = super::register_widget(global);
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
-    handle
+        handle
+    })
 }
 
 /// Set the content child of a ScrollView.
@@ -117,74 +121,92 @@ pub fn set_child(scroll_handle: i64, child_handle: i64) {
         super::get_widget(scroll_handle),
         super::get_widget(child_handle),
     ) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        // Remove existing children
-        let _ = env.call_method(scroll_ref.as_obj(), "removeAllViews", "()V", &[]);
-        // Add the new child
-        let _ = env.call_method(
-            scroll_ref.as_obj(),
-            "addView",
-            "(Landroid/view/View;)V",
-            &[JValue::Object(child_ref.as_obj())],
-        );
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            // Remove existing children
+            let _ = env.call_method(
+                scroll_ref.as_obj(),
+                jni::jni_str!("removeAllViews"),
+                jni::jni_sig!("()V"),
+                &[],
+            );
+            // Add the new child
+            let _ = env.call_method(
+                scroll_ref.as_obj(),
+                jni::jni_str!("addView"),
+                jni::jni_sig!("(Landroid/view/View;)V"),
+                &[JValue::Object(child_ref.as_obj())],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+        })
     }
 }
 
 /// Scroll so that the given child widget is visible.
 pub fn scroll_to(_scroll_handle: i64, child_handle: i64) {
     if let Some(child_ref) = super::get_widget(child_handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        // Get the child's top position and scroll its parent to it
-        let top = env
-            .call_method(child_ref.as_obj(), "getTop", "()I", &[])
-            .map(|v| v.i().unwrap_or(0))
-            .unwrap_or(0);
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            // Get the child's top position and scroll its parent to it
+            let top = env
+                .call_method(
+                    child_ref.as_obj(),
+                    jni::jni_str!("getTop"),
+                    jni::jni_sig!("()I"),
+                    &[],
+                )
+                .map(|v| v.i().unwrap_or(0))
+                .unwrap_or(0);
 
-        // Get the parent ScrollView
-        let parent = env.call_method(
-            child_ref.as_obj(),
-            "getParent",
-            "()Landroid/view/ViewParent;",
-            &[],
-        );
-        if let Ok(parent_val) = parent {
-            if let Ok(parent_obj) = parent_val.l() {
-                if !parent_obj.is_null() {
-                    let _ = env.call_method(
-                        &parent_obj,
-                        "smoothScrollTo",
-                        "(II)V",
-                        &[JValue::Int(0), JValue::Int(top)],
-                    );
+            // Get the parent ScrollView
+            let parent = env.call_method(
+                child_ref.as_obj(),
+                jni::jni_str!("getParent"),
+                jni::jni_sig!("()Landroid/view/ViewParent;"),
+                &[],
+            );
+            if let Ok(parent_val) = parent {
+                if let Ok(parent_obj) = parent_val.l() {
+                    if !parent_obj.is_null() {
+                        let _ = env.call_method(
+                            &parent_obj,
+                            jni::jni_str!("smoothScrollTo"),
+                            jni::jni_sig!("(II)V"),
+                            &[JValue::Int(0), JValue::Int(top)],
+                        );
+                    }
                 }
             }
-        }
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+        })
     }
 }
 
 /// Get the vertical scroll offset.
 pub fn get_offset(scroll_handle: i64) -> f64 {
     if let Some(scroll_ref) = super::get_widget(scroll_handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let result = env.call_method(scroll_ref.as_obj(), "getScrollY", "()I", &[]);
-        let offset = if let Ok(val) = result {
-            val.i().unwrap_or(0) as f64
-        } else {
-            0.0
-        };
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
-        return offset;
+        return jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let result = env.call_method(
+                scroll_ref.as_obj(),
+                jni::jni_str!("getScrollY"),
+                jni::jni_sig!("()I"),
+                &[],
+            );
+            let offset = if let Ok(val) = result {
+                val.i().unwrap_or(0) as f64
+            } else {
+                0.0
+            };
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+            offset
+        });
     }
     0.0
 }
@@ -215,42 +237,44 @@ pub fn set_scroll_end_callback(scroll_handle: i64, callback: f64, threshold_px: 
     };
     let cb_key = callback::register(callback);
 
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
 
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
 
-    let _ = env.call_static_method(
-        bridge_cls,
-        "setOnScrollEndCallback",
-        "(Landroid/view/View;JF)V",
-        &[
-            JValue::Object(scroll_ref.as_obj()),
-            JValue::Long(cb_key),
-            JValue::Float(threshold_px),
-        ],
-    );
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("setOnScrollEndCallback"),
+            jni::jni_sig!("(Landroid/view/View;JF)V"),
+            &[
+                JValue::Object(scroll_ref.as_obj()),
+                JValue::Long(cb_key),
+                JValue::Float(threshold_px),
+            ],
+        );
 
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }
 
 /// Set the vertical scroll offset.
 pub fn set_offset(scroll_handle: i64, offset: f64) {
     if let Some(scroll_ref) = super::get_widget(scroll_handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let _ = env.call_method(
-            scroll_ref.as_obj(),
-            "smoothScrollTo",
-            "(II)V",
-            &[JValue::Int(0), JValue::Int(offset as i32)],
-        );
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let _ = env.call_method(
+                scroll_ref.as_obj(),
+                jni::jni_str!("smoothScrollTo"),
+                jni::jni_sig!("(II)V"),
+                &[JValue::Int(0), JValue::Int(offset as i32)],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+        })
     }
 }

--- a/crates/perry-ui-android/src/widgets/securefield.rs
+++ b/crates/perry-ui-android/src/widgets/securefield.rs
@@ -2,65 +2,75 @@
 
 use crate::callback;
 use crate::jni_bridge;
-use jni::objects::JValue;
+use jni::JValue;
 
 use perry_ffi::copy_string_from_raw as str_from_header;
 
 pub fn create(placeholder_ptr: *const u8, on_change: f64) -> i64 {
     let placeholder = unsafe { str_from_header(placeholder_ptr) };
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
 
-    let activity = super::get_activity(&mut env);
-    let edit_text = env
-        .new_object(
-            "android/widget/EditText",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("Failed to create EditText");
+        let activity = super::get_activity(env);
+        let edit_text = env
+            .new_object(
+                jni::jni_str!("android/widget/EditText"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("Failed to create EditText");
 
-    // Set input type to password (TYPE_CLASS_TEXT | TYPE_TEXT_VARIATION_PASSWORD = 0x81)
-    let _ = env.call_method(&edit_text, "setInputType", "(I)V", &[JValue::Int(0x81)]);
-
-    // Set placeholder
-    let jstr = env
-        .new_string(placeholder)
-        .expect("Failed to create JNI string");
-    let _ = env.call_method(
-        &edit_text,
-        "setHint",
-        "(Ljava/lang/CharSequence;)V",
-        &[JValue::Object(&jstr)],
-    );
-
-    // Set single line
-    let _ = env.call_method(&edit_text, "setSingleLine", "(Z)V", &[JValue::Bool(1)]);
-
-    // Register change callback via PerryBridge
-    if on_change != 0.0 {
-        let cb_key = callback::register(on_change);
-        let bridge_class =
-            jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-        let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-        // Use the same JNI bridge entrypoint as textfield/textarea —
-        // PerryBridge.setTextChangedCallback. The stale `setTextWatcher`
-        // name didn't exist on the Kotlin side and aborted with
-        // NoSuchMethodError whenever a SecureField was constructed.
-        let _ = env.call_static_method(
-            bridge_cls,
-            "setTextChangedCallback",
-            "(Landroid/widget/EditText;J)V",
-            &[JValue::Object(&edit_text), JValue::Long(cb_key)],
+        // Set input type to password (TYPE_CLASS_TEXT | TYPE_TEXT_VARIATION_PASSWORD = 0x81)
+        let _ = env.call_method(
+            &edit_text,
+            jni::jni_str!("setInputType"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(0x81)],
         );
-    }
 
-    let global = env
-        .new_global_ref(edit_text)
-        .expect("Failed to create global ref");
-    let handle = super::register_widget(global);
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
-    handle
+        // Set placeholder
+        let jstr = env
+            .new_string(placeholder)
+            .expect("Failed to create JNI string");
+        let _ = env.call_method(
+            &edit_text,
+            jni::jni_str!("setHint"),
+            jni::jni_sig!("(Ljava/lang/CharSequence;)V"),
+            &[JValue::Object(&jstr)],
+        );
+
+        // Set single line
+        let _ = env.call_method(
+            &edit_text,
+            jni::jni_str!("setSingleLine"),
+            jni::jni_sig!("(Z)V"),
+            &[JValue::Bool(true)],
+        );
+
+        // Register change callback via PerryBridge
+        if on_change != 0.0 {
+            let cb_key = callback::register(on_change);
+            let bridge_class =
+                jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+            let bridge_cls: &jni::objects::JClass = &bridge_class;
+            // Use the same JNI bridge entrypoint as textfield/textarea —
+            // PerryBridge.setTextChangedCallback. The stale `setTextWatcher`
+            // name didn't exist on the Kotlin side and aborted with
+            // NoSuchMethodError whenever a SecureField was constructed.
+            let _ = env.call_static_method(
+                bridge_cls,
+                jni::jni_str!("setTextChangedCallback"),
+                jni::jni_sig!("(Landroid/widget/EditText;J)V"),
+                &[JValue::Object(&edit_text), JValue::Long(cb_key)],
+            );
+        }
+
+        let global =
+            jni_bridge::new_global_ref(env, edit_text).expect("Failed to create global ref");
+        let handle = super::register_widget(global);
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+        handle
+    })
 }

--- a/crates/perry-ui-android/src/widgets/slider.rs
+++ b/crates/perry-ui-android/src/widgets/slider.rs
@@ -1,98 +1,104 @@
 use crate::callback;
 use crate::jni_bridge;
-use jni::objects::JValue;
+use jni::JValue;
 
 /// Set the value of an existing SeekBar widget.
 pub fn set_value(handle: i64, value: f64) {
     if let Some(view_ref) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        // SeekBar uses integer progress; we scale based on the stored range.
-        // The range is set at creation: max = (max - min) * 100.
-        // So progress = (value - min) * 100.
-        // We store min in a tag via PerryBridge.
-        let bridge_class =
-            jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-        let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-        let _ = env.call_static_method(
-            bridge_cls,
-            "setSeekBarValue",
-            "(Landroid/widget/SeekBar;D)V",
-            &[JValue::Object(view_ref.as_obj()), JValue::Double(value)],
-        );
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            // SeekBar uses integer progress; we scale based on the stored range.
+            // The range is set at creation: max = (max - min) * 100.
+            // So progress = (value - min) * 100.
+            // We store min in a tag via PerryBridge.
+            let bridge_class =
+                jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+            let bridge_cls: &jni::objects::JClass = &bridge_class;
+            let _ = env.call_static_method(
+                bridge_cls,
+                jni::jni_str!("setSeekBarValue"),
+                jni::jni_sig!("(Landroid/widget/SeekBar;D)V"),
+                &[JValue::Object(view_ref.as_obj()), JValue::Double(value)],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+        })
     }
 }
 
 /// Create a SeekBar with min, max, initial values and onChange callback.
 pub fn create(min: f64, max: f64, initial: f64, on_change: f64) -> i64 {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
-    let activity = super::get_activity(&mut env);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
+        let activity = super::get_activity(env);
 
-    let seek_bar = env
-        .new_object(
-            "android/widget/SeekBar",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("Failed to create SeekBar");
+        let seek_bar = env
+            .new_object(
+                jni::jni_str!("android/widget/SeekBar"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("Failed to create SeekBar");
 
-    // SeekBar uses integer progress values.
-    // We use a scale factor of 100 for float precision.
-    // max = (max - min) * 100
-    let range = ((max - min) * 100.0) as i32;
-    let _ = env.call_method(&seek_bar, "setMax", "(I)V", &[JValue::Int(range)]);
+        // SeekBar uses integer progress values.
+        // We use a scale factor of 100 for float precision.
+        // max = (max - min) * 100
+        let range = ((max - min) * 100.0) as i32;
+        let _ = env.call_method(
+            &seek_bar,
+            jni::jni_str!("setMax"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(range)],
+        );
 
-    // Set initial progress
-    let initial_progress = ((initial - min) * 100.0) as i32;
-    let _ = env.call_method(
-        &seek_bar,
-        "setProgress",
-        "(I)V",
-        &[JValue::Int(initial_progress)],
-    );
+        // Set initial progress
+        let initial_progress = ((initial - min) * 100.0) as i32;
+        let _ = env.call_method(
+            &seek_bar,
+            jni::jni_str!("setProgress"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(initial_progress)],
+        );
 
-    // MATCH_PARENT width, WRAP_CONTENT height
-    let params = env
-        .new_object(
-            "android/widget/LinearLayout$LayoutParams",
-            "(II)V",
-            &[JValue::Int(-1), JValue::Int(-2)],
-        )
-        .expect("Failed to create LayoutParams");
-    let _ = env.call_method(
-        &seek_bar,
-        "setLayoutParams",
-        "(Landroid/view/ViewGroup$LayoutParams;)V",
-        &[JValue::Object(&params)],
-    );
+        // MATCH_PARENT width, WRAP_CONTENT height
+        let params = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout$LayoutParams"),
+                jni::jni_sig!("(II)V"),
+                &[JValue::Int(-1), JValue::Int(-2)],
+            )
+            .expect("Failed to create LayoutParams");
+        let _ = env.call_method(
+            &seek_bar,
+            jni::jni_str!("setLayoutParams"),
+            jni::jni_sig!("(Landroid/view/ViewGroup$LayoutParams;)V"),
+            &[JValue::Object(&params)],
+        );
 
-    // Register callback and set up OnSeekBarChangeListener via PerryBridge
-    let cb_key = callback::register(on_change);
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let _ = env.call_static_method(
-        bridge_cls,
-        "setSeekBarCallback",
-        "(Landroid/widget/SeekBar;JDD)V",
-        &[
-            JValue::Object(&seek_bar),
-            JValue::Long(cb_key),
-            JValue::Double(min),
-            JValue::Double(max),
-        ],
-    );
+        // Register callback and set up OnSeekBarChangeListener via PerryBridge
+        let cb_key = callback::register(on_change);
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("setSeekBarCallback"),
+            jni::jni_sig!("(Landroid/widget/SeekBar;JDD)V"),
+            &[
+                JValue::Object(&seek_bar),
+                JValue::Long(cb_key),
+                JValue::Double(min),
+                JValue::Double(max),
+            ],
+        );
 
-    let global = env
-        .new_global_ref(seek_bar)
-        .expect("Failed to create global ref");
-    let handle = super::register_widget(global);
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
-    handle
+        let global =
+            jni_bridge::new_global_ref(env, seek_bar).expect("Failed to create global ref");
+        let handle = super::register_widget(global);
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+        handle
+    })
 }

--- a/crates/perry-ui-android/src/widgets/spacer.rs
+++ b/crates/perry-ui-android/src/widgets/spacer.rs
@@ -1,42 +1,41 @@
 use crate::jni_bridge;
-use jni::objects::JValue;
+use jni::JValue;
 
 /// Create a flexible spacer (Space widget with weight=1 in LinearLayout).
 pub fn create() -> i64 {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
-    let activity = super::get_activity(&mut env);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
+        let activity = super::get_activity(env);
 
-    let space = env
-        .new_object(
-            "android/widget/Space",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("Failed to create Space");
+        let space = env
+            .new_object(
+                jni::jni_str!("android/widget/Space"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("Failed to create Space");
 
-    // Give it weight=1 so it expands to fill available space in a LinearLayout.
-    // LinearLayout.LayoutParams(0, 0, 1.0f) — width=0, height=0, weight=1
-    let params = env
-        .new_object(
-            "android/widget/LinearLayout$LayoutParams",
-            "(IIF)V",
-            &[JValue::Int(0), JValue::Int(0), JValue::Float(1.0)],
-        )
-        .expect("Failed to create LayoutParams");
-    let _ = env.call_method(
-        &space,
-        "setLayoutParams",
-        "(Landroid/view/ViewGroup$LayoutParams;)V",
-        &[JValue::Object(&params)],
-    );
+        // Give it weight=1 so it expands to fill available space in a LinearLayout.
+        // LinearLayout.LayoutParams(0, 0, 1.0f) — width=0, height=0, weight=1
+        let params = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout$LayoutParams"),
+                jni::jni_sig!("(IIF)V"),
+                &[JValue::Int(0), JValue::Int(0), JValue::Float(1.0)],
+            )
+            .expect("Failed to create LayoutParams");
+        let _ = env.call_method(
+            &space,
+            jni::jni_str!("setLayoutParams"),
+            jni::jni_sig!("(Landroid/view/ViewGroup$LayoutParams;)V"),
+            &[JValue::Object(&params)],
+        );
 
-    let global = env
-        .new_global_ref(space)
-        .expect("Failed to create global ref");
-    let handle = super::register_widget(global);
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
-    handle
+        let global = jni_bridge::new_global_ref(env, space).expect("Failed to create global ref");
+        let handle = super::register_widget(global);
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+        handle
+    })
 }

--- a/crates/perry-ui-android/src/widgets/tabbar.rs
+++ b/crates/perry-ui-android/src/widgets/tabbar.rs
@@ -1,6 +1,7 @@
 use crate::callback;
 use crate::jni_bridge;
-use jni::objects::{JObject, JValue};
+use jni::objects::JObject;
+use jni::JValue;
 use std::cell::RefCell;
 use std::collections::HashMap;
 
@@ -18,248 +19,265 @@ thread_local! {
 /// Create a tab bar (horizontal LinearLayout at the bottom).
 /// `on_select` is called with the tab index when a tab is tapped.
 pub fn create(on_select: f64) -> i64 {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
-    let activity = super::get_activity(&mut env);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
+        let activity = super::get_activity(env);
 
-    // Create a horizontal LinearLayout for tab buttons
-    let layout = env
-        .new_object(
-            "android/widget/LinearLayout",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("TabBar LinearLayout");
-    let _ = env.call_method(&layout, "setOrientation", "(I)V", &[JValue::Int(0)]);
-    let _ = env.call_method(
-        &layout,
-        "setBackgroundColor",
-        "(I)V",
-        &[JValue::Int(0xFFF8F8F8u32 as i32)],
-    );
-
-    // Create top divider line
-    let divider = env
-        .new_object(
-            "android/view/View",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("divider");
-    let _ = env.call_method(
-        &divider,
-        "setBackgroundColor",
-        "(I)V",
-        &[JValue::Int(0xFFE0E0E0u32 as i32)],
-    );
-    let dp1 = super::dp_to_px(&mut env, 1.0);
-    let dp = env
-        .new_object(
-            "android/widget/LinearLayout$LayoutParams",
-            "(II)V",
-            &[JValue::Int(-1), JValue::Int(dp1)],
-        )
-        .expect("dp");
-    let _ = env.call_method(
-        &divider,
-        "setLayoutParams",
-        "(Landroid/view/ViewGroup$LayoutParams;)V",
-        &[JValue::Object(&dp)],
-    );
-
-    // Wrapper: vertical layout with divider + tab row
-    let wrapper = env
-        .new_object(
-            "android/widget/LinearLayout",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("wrapper");
-    let _ = env.call_method(&wrapper, "setOrientation", "(I)V", &[JValue::Int(1)]);
-    let _ = env.call_method(
-        &wrapper,
-        "addView",
-        "(Landroid/view/View;)V",
-        &[JValue::Object(&divider)],
-    );
-    let _ = env.call_method(
-        &wrapper,
-        "addView",
-        "(Landroid/view/View;)V",
-        &[JValue::Object(&layout)],
-    );
-
-    let wp = env
-        .new_object(
-            "android/widget/LinearLayout$LayoutParams",
-            "(II)V",
-            &[JValue::Int(-1), JValue::Int(-2)],
-        )
-        .expect("wp");
-    let _ = env.call_method(
-        &wrapper,
-        "setLayoutParams",
-        "(Landroid/view/ViewGroup$LayoutParams;)V",
-        &[JValue::Object(&wp)],
-    );
-
-    let global = env.new_global_ref(wrapper).expect("TabBar ref");
-    let handle = super::register_widget(global);
-
-    let layout_global = env.new_global_ref(layout).expect("TabBar layout ref");
-    let layout_handle = super::register_widget(layout_global);
-
-    let cb_key = callback::register(on_select);
-
-    TABBAR_STATE.with(|s| {
-        s.borrow_mut().insert(
-            handle,
-            TabBarState {
-                tab_items: Vec::new(),
-                layout_handle,
-                callback_key: cb_key,
-                selected: 0,
-            },
+        // Create a horizontal LinearLayout for tab buttons
+        let layout = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("TabBar LinearLayout");
+        let _ = env.call_method(
+            &layout,
+            jni::jni_str!("setOrientation"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(0)],
         );
-    });
+        let _ = env.call_method(
+            &layout,
+            jni::jni_str!("setBackgroundColor"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(0xFFF8F8F8u32 as i32)],
+        );
 
-    unsafe {
-        env.pop_local_frame(&JObject::null());
-    }
-    handle
+        // Create top divider line
+        let divider = env
+            .new_object(
+                jni::jni_str!("android/view/View"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("divider");
+        let _ = env.call_method(
+            &divider,
+            jni::jni_str!("setBackgroundColor"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(0xFFE0E0E0u32 as i32)],
+        );
+        let dp1 = super::dp_to_px(env, 1.0);
+        let dp = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout$LayoutParams"),
+                jni::jni_sig!("(II)V"),
+                &[JValue::Int(-1), JValue::Int(dp1)],
+            )
+            .expect("dp");
+        let _ = env.call_method(
+            &divider,
+            jni::jni_str!("setLayoutParams"),
+            jni::jni_sig!("(Landroid/view/ViewGroup$LayoutParams;)V"),
+            &[JValue::Object(&dp)],
+        );
+
+        // Wrapper: vertical layout with divider + tab row
+        let wrapper = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("wrapper");
+        let _ = env.call_method(
+            &wrapper,
+            jni::jni_str!("setOrientation"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(1)],
+        );
+        let _ = env.call_method(
+            &wrapper,
+            jni::jni_str!("addView"),
+            jni::jni_sig!("(Landroid/view/View;)V"),
+            &[JValue::Object(&divider)],
+        );
+        let _ = env.call_method(
+            &wrapper,
+            jni::jni_str!("addView"),
+            jni::jni_sig!("(Landroid/view/View;)V"),
+            &[JValue::Object(&layout)],
+        );
+
+        let wp = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout$LayoutParams"),
+                jni::jni_sig!("(II)V"),
+                &[JValue::Int(-1), JValue::Int(-2)],
+            )
+            .expect("wp");
+        let _ = env.call_method(
+            &wrapper,
+            jni::jni_str!("setLayoutParams"),
+            jni::jni_sig!("(Landroid/view/ViewGroup$LayoutParams;)V"),
+            &[JValue::Object(&wp)],
+        );
+
+        let global = jni_bridge::new_global_ref(env, wrapper).expect("TabBar ref");
+        let handle = super::register_widget(global);
+
+        let layout_global = jni_bridge::new_global_ref(env, layout).expect("TabBar layout ref");
+        let layout_handle = super::register_widget(layout_global);
+
+        let cb_key = callback::register(on_select);
+
+        TABBAR_STATE.with(|s| {
+            s.borrow_mut().insert(
+                handle,
+                TabBarState {
+                    tab_items: Vec::new(),
+                    layout_handle,
+                    callback_key: cb_key,
+                    selected: 0,
+                },
+            );
+        });
+
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+        }
+        handle
+    })
 }
 
 /// Add a tab to the tab bar.
 pub fn add_tab(tabbar_handle: i64, label_ptr: *const u8) {
     let label = unsafe { crate::app::str_from_header(label_ptr) };
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
-    let activity = super::get_activity(&mut env);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
+        let activity = super::get_activity(env);
 
-    let (layout_handle, cb_key) = TABBAR_STATE.with(|s| {
-        let map = s.borrow();
-        let st = match map.get(&tabbar_handle) {
-            Some(st) => st,
-            None => return (0i64, 0i64),
-        };
-        (st.layout_handle, st.callback_key)
-    });
+        let (layout_handle, cb_key) = TABBAR_STATE.with(|s| {
+            let map = s.borrow();
+            let st = match map.get(&tabbar_handle) {
+                Some(st) => st,
+                None => return (0i64, 0i64),
+            };
+            (st.layout_handle, st.callback_key)
+        });
 
-    let layout_ref = match super::get_widget(layout_handle) {
-        Some(r) => r,
-        None => {
-            unsafe {
-                env.pop_local_frame(&JObject::null());
+        let layout_ref = match super::get_widget(layout_handle) {
+            Some(r) => r,
+            None => {
+                unsafe {
+                    let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+                }
+                return;
             }
-            return;
-        }
-    };
+        };
 
-    // Create TextView for the tab
-    let tv = env
-        .new_object(
-            "android/widget/TextView",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("Tab TV");
+        // Create TextView for the tab
+        let tv = env
+            .new_object(
+                jni::jni_str!("android/widget/TextView"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("Tab TV");
 
-    let jstr = env.new_string(&label).expect("tab label str");
-    let _ = env.call_method(
-        &tv,
-        "setText",
-        "(Ljava/lang/CharSequence;)V",
-        &[JValue::Object(&jstr)],
-    );
-    let _ = env.call_method(
-        &tv,
-        "setTextSize",
-        "(IF)V",
-        &[JValue::Int(2), JValue::Float(14.0)],
-    );
-    let _ = env.call_method(&tv, "setGravity", "(I)V", &[JValue::Int(17)]); // CENTER
+        let jstr = env.new_string(&label).expect("tab label str");
+        let _ = env.call_method(
+            &tv,
+            jni::jni_str!("setText"),
+            jni::jni_sig!("(Ljava/lang/CharSequence;)V"),
+            &[JValue::Object(&jstr)],
+        );
+        let _ = env.call_method(
+            &tv,
+            jni::jni_str!("setTextSize"),
+            jni::jni_sig!("(IF)V"),
+            &[JValue::Int(2), JValue::Float(14.0)],
+        );
+        let _ = env.call_method(
+            &tv,
+            jni::jni_str!("setGravity"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(17)],
+        ); // CENTER
 
-    let dp12 = super::dp_to_px(&mut env, 12.0);
-    let dp8 = super::dp_to_px(&mut env, 8.0);
-    let _ = env.call_method(
-        &tv,
-        "setPadding",
-        "(IIII)V",
-        &[
-            JValue::Int(dp12),
-            JValue::Int(dp8),
-            JValue::Int(dp12),
-            JValue::Int(dp8),
-        ],
-    );
-
-    // Equal weight layout params
-    let params = env
-        .new_object(
-            "android/widget/LinearLayout$LayoutParams",
-            "(IIF)V",
-            &[JValue::Int(0), JValue::Int(-2), JValue::Float(1.0)],
-        )
-        .expect("tab lp");
-    let _ = env.call_method(
-        &tv,
-        "setLayoutParams",
-        "(Landroid/view/ViewGroup$LayoutParams;)V",
-        &[JValue::Object(&params)],
-    );
-
-    // Add to layout
-    let _ = env.call_method(
-        layout_ref.as_obj(),
-        "addView",
-        "(Landroid/view/View;)V",
-        &[JValue::Object(&tv)],
-    );
-
-    let global = env.new_global_ref(tv).expect("tab ref");
-    let tab_handle = super::register_widget(global);
-
-    let tab_index = TABBAR_STATE.with(|s| {
-        let mut map = s.borrow_mut();
-        if let Some(state) = map.get_mut(&tabbar_handle) {
-            let idx = state.tab_items.len();
-            state.tab_items.push(tab_handle);
-            idx
-        } else {
-            0
-        }
-    });
-
-    // Set click handler via PerryBridge.setOnClickCallbackWithArg
-    if let Some(tab_ref) = super::get_widget(tab_handle) {
-        let bridge_class =
-            jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-        let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-        let _ = env.call_static_method(
-            bridge_cls,
-            "setOnClickCallbackWithArg",
-            "(Landroid/view/View;JD)V",
+        let dp12 = super::dp_to_px(env, 12.0);
+        let dp8 = super::dp_to_px(env, 8.0);
+        let _ = env.call_method(
+            &tv,
+            jni::jni_str!("setPadding"),
+            jni::jni_sig!("(IIII)V"),
             &[
-                JValue::Object(tab_ref.as_obj()),
-                JValue::Long(cb_key),
-                JValue::Double(tab_index as f64),
+                JValue::Int(dp12),
+                JValue::Int(dp8),
+                JValue::Int(dp12),
+                JValue::Int(dp8),
             ],
         );
-    }
 
-    // Initial color: gray (inactive)
-    if let Some(tab_ref) = super::get_widget(tab_handle) {
+        // Equal weight layout params
+        let params = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout$LayoutParams"),
+                jni::jni_sig!("(IIF)V"),
+                &[JValue::Int(0), JValue::Int(-2), JValue::Float(1.0)],
+            )
+            .expect("tab lp");
         let _ = env.call_method(
-            tab_ref.as_obj(),
-            "setTextColor",
-            "(I)V",
-            &[JValue::Int(0xFF6B7280u32 as i32)],
+            &tv,
+            jni::jni_str!("setLayoutParams"),
+            jni::jni_sig!("(Landroid/view/ViewGroup$LayoutParams;)V"),
+            &[JValue::Object(&params)],
         );
-    }
 
-    unsafe {
-        env.pop_local_frame(&JObject::null());
-    }
+        // Add to layout
+        let _ = env.call_method(
+            layout_ref.as_obj(),
+            jni::jni_str!("addView"),
+            jni::jni_sig!("(Landroid/view/View;)V"),
+            &[JValue::Object(&tv)],
+        );
+
+        let global = jni_bridge::new_global_ref(env, tv).expect("tab ref");
+        let tab_handle = super::register_widget(global);
+
+        let tab_index = TABBAR_STATE.with(|s| {
+            let mut map = s.borrow_mut();
+            if let Some(state) = map.get_mut(&tabbar_handle) {
+                let idx = state.tab_items.len();
+                state.tab_items.push(tab_handle);
+                idx
+            } else {
+                0
+            }
+        });
+
+        // Set click handler via PerryBridge.setOnClickCallbackWithArg
+        if let Some(tab_ref) = super::get_widget(tab_handle) {
+            let bridge_class =
+                jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+            let bridge_cls: &jni::objects::JClass = &bridge_class;
+            let _ = env.call_static_method(
+                bridge_cls,
+                jni::jni_str!("setOnClickCallbackWithArg"),
+                jni::jni_sig!("(Landroid/view/View;JD)V"),
+                &[
+                    JValue::Object(tab_ref.as_obj()),
+                    JValue::Long(cb_key),
+                    JValue::Double(tab_index as f64),
+                ],
+            );
+        }
+
+        // Initial color: gray (inactive)
+        if let Some(tab_ref) = super::get_widget(tab_handle) {
+            let _ = env.call_method(
+                tab_ref.as_obj(),
+                jni::jni_str!("setTextColor"),
+                jni::jni_sig!("(I)V"),
+                &[JValue::Int(0xFF6B7280u32 as i32)],
+            );
+        }
+
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+        }
+    })
 }
 
 /// Set the selected tab index, updating visual state.
@@ -268,28 +286,29 @@ pub fn set_selected(tabbar_handle: i64, index: i64) {
         let mut map = s.borrow_mut();
         if let Some(state) = map.get_mut(&tabbar_handle) {
             state.selected = index as usize;
-            let mut env = jni_bridge::get_env();
-            let _ = env.push_local_frame(16);
+            jni_bridge::with_env(|env| {
+                let _ = jni_bridge::push_local_frame(env, 16);
 
-            for (i, &item_handle) in state.tab_items.iter().enumerate() {
-                if let Some(item_ref) = super::get_widget(item_handle) {
-                    let color = if i == index as usize {
-                        0xFF2563EBu32 as i32 // Active: blue
-                    } else {
-                        0xFF6B7280u32 as i32 // Inactive: gray
-                    };
-                    let _ = env.call_method(
-                        item_ref.as_obj(),
-                        "setTextColor",
-                        "(I)V",
-                        &[JValue::Int(color)],
-                    );
+                for (i, &item_handle) in state.tab_items.iter().enumerate() {
+                    if let Some(item_ref) = super::get_widget(item_handle) {
+                        let color = if i == index as usize {
+                            0xFF2563EBu32 as i32 // Active: blue
+                        } else {
+                            0xFF6B7280u32 as i32 // Inactive: gray
+                        };
+                        let _ = env.call_method(
+                            item_ref.as_obj(),
+                            jni::jni_str!("setTextColor"),
+                            jni::jni_sig!("(I)V"),
+                            &[JValue::Int(color)],
+                        );
+                    }
                 }
-            }
 
-            unsafe {
-                env.pop_local_frame(&JObject::null());
-            }
+                unsafe {
+                    let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+                }
+            })
         }
     });
 }

--- a/crates/perry-ui-android/src/widgets/text.rs
+++ b/crates/perry-ui-android/src/widgets/text.rs
@@ -1,55 +1,57 @@
 use crate::app::str_from_header;
 use crate::jni_bridge;
-use jni::objects::{JObject, JValue};
+use jni::objects::JObject;
+use jni::JValue;
 
 /// Create a TextView. Returns widget handle.
 pub fn create(text_ptr: *const u8) -> i64 {
     let text = unsafe { str_from_header(text_ptr) };
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
 
-    let activity = super::get_activity(&mut env);
-    let text_view = env
-        .new_object(
-            "android/widget/TextView",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("Failed to create TextView");
+        let activity = super::get_activity(env);
+        let text_view = env
+            .new_object(
+                jni::jni_str!("android/widget/TextView"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("Failed to create TextView");
 
-    let jstr = env.new_string(text).expect("Failed to create JNI string");
-    let _ = env.call_method(
-        &text_view,
-        "setText",
-        "(Ljava/lang/CharSequence;)V",
-        &[JValue::Object(&jstr)],
-    );
+        let jstr = env.new_string(text).expect("Failed to create JNI string");
+        let _ = env.call_method(
+            &text_view,
+            jni::jni_str!("setText"),
+            jni::jni_sig!("(Ljava/lang/CharSequence;)V"),
+            &[JValue::Object(&jstr)],
+        );
 
-    let global = env
-        .new_global_ref(text_view)
-        .expect("Failed to create global ref");
-    let handle = super::register_widget(global);
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
-    handle
+        let global =
+            jni_bridge::new_global_ref(env, text_view).expect("Failed to create global ref");
+        let handle = super::register_widget(global);
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+        handle
+    })
 }
 
 /// Update the text of an existing TextView.
 pub fn set_text_str(handle: i64, text: &str) {
     if let Some(view_ref) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let jstr = env.new_string(text).expect("Failed to create JNI string");
-        let _ = env.call_method(
-            view_ref.as_obj(),
-            "setText",
-            "(Ljava/lang/CharSequence;)V",
-            &[JValue::Object(&jstr)],
-        );
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let jstr = env.new_string(text).expect("Failed to create JNI string");
+            let _ = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("setText"),
+                jni::jni_sig!("(Ljava/lang/CharSequence;)V"),
+                &[JValue::Object(&jstr)],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+        })
     }
 }
 
@@ -62,40 +64,42 @@ pub fn set_string(handle: i64, text_ptr: *const u8) {
 /// Set the text color of a TextView (RGBA 0.0-1.0).
 pub fn set_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
     if let Some(view_ref) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let ai = (a * 255.0) as i32;
-        let ri = (r * 255.0) as i32;
-        let gi = (g * 255.0) as i32;
-        let bi = (b * 255.0) as i32;
-        let color = (ai << 24) | (ri << 16) | (gi << 8) | bi;
-        let _ = env.call_method(
-            view_ref.as_obj(),
-            "setTextColor",
-            "(I)V",
-            &[JValue::Int(color)],
-        );
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let ai = (a * 255.0) as i32;
+            let ri = (r * 255.0) as i32;
+            let gi = (g * 255.0) as i32;
+            let bi = (b * 255.0) as i32;
+            let color = (ai << 24) | (ri << 16) | (gi << 8) | bi;
+            let _ = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("setTextColor"),
+                jni::jni_sig!("(I)V"),
+                &[JValue::Int(color)],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+        })
     }
 }
 
 /// Set the font size of a TextView (in sp, roughly equivalent to pt on iOS).
 pub fn set_font_size(handle: i64, size: f64) {
     if let Some(view_ref) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        // TypedValue.COMPLEX_UNIT_SP = 2
-        let _ = env.call_method(
-            view_ref.as_obj(),
-            "setTextSize",
-            "(IF)V",
-            &[JValue::Int(2), JValue::Float(size as f32)],
-        );
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            // TypedValue.COMPLEX_UNIT_SP = 2
+            let _ = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("setTextSize"),
+                jni::jni_sig!("(IF)V"),
+                &[JValue::Int(2), JValue::Float(size as f32)],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+        })
     }
 }
 
@@ -103,33 +107,34 @@ pub fn set_font_size(handle: i64, size: f64) {
 /// weight >= 1.0 means bold (Typeface.BOLD=1), otherwise normal (Typeface.NORMAL=0).
 pub fn set_font_weight(handle: i64, _size: f64, weight: f64) {
     if let Some(view_ref) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(16);
-        let style = if weight >= 0.5 { 1i32 } else { 0i32 }; // Typeface.BOLD=1, NORMAL=0
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 16);
+            let style = if weight >= 0.5 { 1i32 } else { 0i32 }; // Typeface.BOLD=1, NORMAL=0
 
-        // Create a Typeface with the default font family and desired style.
-        // Passing null Typeface to setTypeface corrupts the text content,
-        // so we must create a valid Typeface via Typeface.defaultFromStyle().
-        let typeface = env.call_static_method(
-            "android/graphics/Typeface",
-            "defaultFromStyle",
-            "(I)Landroid/graphics/Typeface;",
-            &[JValue::Int(style)],
-        );
-        if let Ok(tf_val) = typeface {
-            if let Ok(tf) = tf_val.l() {
-                let _ = env.call_method(
-                    view_ref.as_obj(),
-                    "setTypeface",
-                    "(Landroid/graphics/Typeface;)V",
-                    &[JValue::Object(&tf)],
-                );
+            // Create a Typeface with the default font family and desired style.
+            // Passing null Typeface to setTypeface corrupts the text content,
+            // so we must create a valid Typeface via Typeface.defaultFromStyle().
+            let typeface = env.call_static_method(
+                jni::jni_str!("android/graphics/Typeface"),
+                jni::jni_str!("defaultFromStyle"),
+                jni::jni_sig!("(I)Landroid/graphics/Typeface;"),
+                &[JValue::Int(style)],
+            );
+            if let Ok(tf_val) = typeface {
+                if let Ok(tf) = tf_val.l() {
+                    let _ = env.call_method(
+                        view_ref.as_obj(),
+                        jni::jni_str!("setTypeface"),
+                        jni::jni_sig!("(Landroid/graphics/Typeface;)V"),
+                        &[JValue::Object(&tf)],
+                    );
+                }
             }
-        }
 
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+        })
     }
 }
 
@@ -137,39 +142,40 @@ pub fn set_font_weight(handle: i64, _size: f64, weight: f64) {
 pub fn set_font_family(handle: i64, family_ptr: *const u8) {
     let family = unsafe { str_from_header(family_ptr) };
     if let Some(view_ref) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(16);
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 16);
 
-        let family_name = match family.as_str() {
-            "monospace" | "monospaced" => "monospace",
-            "system" | "default" => "sans-serif",
-            "serif" => "serif",
-            other => &other,
-        };
+            let family_name = match family.as_str() {
+                "monospace" | "monospaced" => "monospace",
+                "system" | "default" => "sans-serif",
+                "serif" => "serif",
+                other => &other,
+            };
 
-        let jfamily = env.new_string(family_name).expect("family string");
-        // Typeface.create(String, int) → Typeface
-        let typeface = env
-            .call_static_method(
-                "android/graphics/Typeface",
-                "create",
-                "(Ljava/lang/String;I)Landroid/graphics/Typeface;",
-                &[JValue::Object(&jfamily), JValue::Int(0)], // NORMAL=0
-            )
-            .expect("Typeface.create")
-            .l()
-            .expect("typeface");
+            let jfamily = env.new_string(family_name).expect("family string");
+            // Typeface.create(String, int) → Typeface
+            let typeface = env
+                .call_static_method(
+                    jni::jni_str!("android/graphics/Typeface"),
+                    jni::jni_str!("create"),
+                    jni::jni_sig!("(Ljava/lang/String;I)Landroid/graphics/Typeface;"),
+                    &[JValue::Object(&jfamily), JValue::Int(0)], // NORMAL=0
+                )
+                .expect("Typeface.create")
+                .l()
+                .expect("typeface");
 
-        let _ = env.call_method(
-            view_ref.as_obj(),
-            "setTypeface",
-            "(Landroid/graphics/Typeface;)V",
-            &[JValue::Object(&typeface)],
-        );
+            let _ = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("setTypeface"),
+                jni::jni_sig!("(Landroid/graphics/Typeface;)V"),
+                &[JValue::Object(&typeface)],
+            );
 
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+        })
     }
 }
 
@@ -177,53 +183,55 @@ pub fn set_font_family(handle: i64, family_ptr: *const u8) {
 /// max_width > 0: enable wrapping at that width. max_width <= 0: disable wrapping (single line).
 pub fn set_wraps(handle: i64, max_width: f64) {
     if let Some(view_ref) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(16);
-        if max_width > 0.0 {
-            // Enable wrapping
-            let _ = env.call_method(
-                view_ref.as_obj(),
-                "setSingleLine",
-                "(Z)V",
-                &[JValue::Bool(0)],
-            );
-            // Set max width in dp → px
-            let max_px = super::dp_to_px(&mut env, max_width as f32);
-            let _ = env.call_method(
-                view_ref.as_obj(),
-                "setMaxWidth",
-                "(I)V",
-                &[JValue::Int(max_px)],
-            );
-        } else {
-            // Disable wrapping
-            let _ = env.call_method(
-                view_ref.as_obj(),
-                "setSingleLine",
-                "(Z)V",
-                &[JValue::Bool(1)],
-            );
-        }
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 16);
+            if max_width > 0.0 {
+                // Enable wrapping
+                let _ = env.call_method(
+                    view_ref.as_obj(),
+                    jni::jni_str!("setSingleLine"),
+                    jni::jni_sig!("(Z)V"),
+                    &[JValue::Bool(false)],
+                );
+                // Set max width in dp → px
+                let max_px = super::dp_to_px(env, max_width as f32);
+                let _ = env.call_method(
+                    view_ref.as_obj(),
+                    jni::jni_str!("setMaxWidth"),
+                    jni::jni_sig!("(I)V"),
+                    &[JValue::Int(max_px)],
+                );
+            } else {
+                // Disable wrapping
+                let _ = env.call_method(
+                    view_ref.as_obj(),
+                    jni::jni_str!("setSingleLine"),
+                    jni::jni_sig!("(Z)V"),
+                    &[JValue::Bool(true)],
+                );
+            }
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+        })
     }
 }
 
 /// Set whether a TextView is selectable.
 pub fn set_selectable(handle: i64, selectable: bool) {
     if let Some(view_ref) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let _ = env.call_method(
-            view_ref.as_obj(),
-            "setTextIsSelectable",
-            "(Z)V",
-            &[JValue::Bool(selectable as u8)],
-        );
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let _ = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("setTextIsSelectable"),
+                jni::jni_sig!("(Z)V"),
+                &[JValue::Bool(selectable)],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+        })
     }
 }
 
@@ -235,29 +243,40 @@ pub fn set_selectable(handle: i64, selectable: bool) {
 /// view repaints with the new flags.
 pub fn set_decoration(handle: i64, decoration: i64) {
     if let Some(view_ref) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        if let Ok(paint_val) = env.call_method(
-            view_ref.as_obj(),
-            "getPaint",
-            "()Landroid/text/TextPaint;",
-            &[],
-        ) {
-            if let Ok(paint_obj) = paint_val.l() {
-                if !paint_obj.is_null() {
-                    let flag: i32 = match decoration {
-                        1 => 8,
-                        2 => 16,
-                        _ => 0,
-                    };
-                    let _ = env.call_method(&paint_obj, "setFlags", "(I)V", &[JValue::Int(flag)]);
-                    let _ = env.call_method(view_ref.as_obj(), "invalidate", "()V", &[]);
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            if let Ok(paint_val) = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("getPaint"),
+                jni::jni_sig!("()Landroid/text/TextPaint;"),
+                &[],
+            ) {
+                if let Ok(paint_obj) = paint_val.l() {
+                    if !paint_obj.is_null() {
+                        let flag: i32 = match decoration {
+                            1 => 8,
+                            2 => 16,
+                            _ => 0,
+                        };
+                        let _ = env.call_method(
+                            &paint_obj,
+                            jni::jni_str!("setFlags"),
+                            jni::jni_sig!("(I)V"),
+                            &[JValue::Int(flag)],
+                        );
+                        let _ = env.call_method(
+                            view_ref.as_obj(),
+                            jni::jni_str!("invalidate"),
+                            jni::jni_sig!("()V"),
+                            &[],
+                        );
+                    }
                 }
             }
-        }
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+        })
     }
 }
 
@@ -265,24 +284,30 @@ pub fn set_decoration(handle: i64, decoration: i64) {
 /// `lines = 0` is unlimited (passing Integer.MAX_VALUE to setMaxLines).
 pub fn set_number_of_lines(handle: i64, lines: i64) {
     if let Some(view_ref) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let n: i32 = if lines <= 0 {
-            i32::MAX
-        } else {
-            (lines as i32).max(1)
-        };
-        let _ = env.call_method(view_ref.as_obj(), "setMaxLines", "(I)V", &[JValue::Int(n)]);
-        // When a finite cap is set we also need an ellipsize mode so the
-        // tail of the last visible line gets "…" instead of just being
-        // clipped. Default to TruncateAt.END; users can override via
-        // `set_truncation_mode` afterwards.
-        if lines > 0 {
-            apply_ellipsize(&mut env, view_ref.as_obj(), 3 /* END */);
-        }
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let n: i32 = if lines <= 0 {
+                i32::MAX
+            } else {
+                (lines as i32).max(1)
+            };
+            let _ = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("setMaxLines"),
+                jni::jni_sig!("(I)V"),
+                &[JValue::Int(n)],
+            );
+            // When a finite cap is set we also need an ellipsize mode so the
+            // tail of the last visible line gets "…" instead of just being
+            // clipped. Default to TruncateAt.END; users can override via
+            // `set_truncation_mode` afterwards.
+            if lines > 0 {
+                apply_ellipsize(env, view_ref.as_obj(), 3 /* END */);
+            }
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+        })
     }
 }
 
@@ -290,12 +315,13 @@ pub fn set_number_of_lines(handle: i64, lines: i64) {
 /// ellipsize), 1=head, 2=middle, 3=tail.
 pub fn set_truncation_mode(handle: i64, mode: i64) {
     if let Some(view_ref) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        apply_ellipsize(&mut env, view_ref.as_obj(), mode);
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            apply_ellipsize(env, view_ref.as_obj(), mode);
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+        })
     }
 }
 
@@ -308,42 +334,43 @@ pub fn set_truncation_mode(handle: i64, mode: i64) {
 /// `setJustificationMode` (best-effort; API 26+).
 pub fn set_text_alignment(handle: i64, alignment: i64) {
     if let Some(view_ref) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        // Gravity flags: LEFT=3, RIGHT=5, CENTER_HORIZONTAL=1,
-        // START=0x00800003, CENTER_VERTICAL=16.
-        const CENTER_VERTICAL: i32 = 16;
-        let horiz: i32 = match alignment {
-            1 => 5,           // right
-            2 => 1,           // center horizontal
-            3 => 3,           // justified → left gravity (+ justification mode below)
-            4 => 0x0080_0003, // start (locale-natural)
-            _ => 3,           // left
-        };
-        let _ = env.call_method(
-            view_ref.as_obj(),
-            "setGravity",
-            "(I)V",
-            &[JValue::Int(horiz | CENTER_VERTICAL)],
-        );
-        if alignment == 3 {
-            // JUSTIFICATION_MODE_INTER_WORD = 1 (TextView, API 26+).
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            // Gravity flags: LEFT=3, RIGHT=5, CENTER_HORIZONTAL=1,
+            // START=0x00800003, CENTER_VERTICAL=16.
+            const CENTER_VERTICAL: i32 = 16;
+            let horiz: i32 = match alignment {
+                1 => 5,           // right
+                2 => 1,           // center horizontal
+                3 => 3,           // justified → left gravity (+ justification mode below)
+                4 => 0x0080_0003, // start (locale-natural)
+                _ => 3,           // left
+            };
             let _ = env.call_method(
                 view_ref.as_obj(),
-                "setJustificationMode",
-                "(I)V",
-                &[JValue::Int(1)],
+                jni::jni_str!("setGravity"),
+                jni::jni_sig!("(I)V"),
+                &[JValue::Int(horiz | CENTER_VERTICAL)],
             );
-        }
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+            if alignment == 3 {
+                // JUSTIFICATION_MODE_INTER_WORD = 1 (TextView, API 26+).
+                let _ = env.call_method(
+                    view_ref.as_obj(),
+                    jni::jni_str!("setJustificationMode"),
+                    jni::jni_sig!("(I)V"),
+                    &[JValue::Int(1)],
+                );
+            }
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+        })
     }
 }
 
 /// Resolve `mode` to the Android `TextUtils.TruncateAt` enum and call
 /// TextView.setEllipsize. `mode = 0` clears the ellipsize (null).
-fn apply_ellipsize(env: &mut jni::JNIEnv, view: &JObject, mode: i64) {
+fn apply_ellipsize(env: &mut jni::Env, view: &JObject, mode: i64) {
     // TextUtils.TruncateAt is an enum: START=1, MIDDLE=2, END=3, MARQUEE=4.
     // Public ordinal values: START=0, MIDDLE=1, END=2, MARQUEE=3 in the enum
     // class, but the values() array maps the public API names. We resolve
@@ -359,13 +386,13 @@ fn apply_ellipsize(env: &mut jni::JNIEnv, view: &JObject, mode: i64) {
         let null_obj = JObject::null();
         let _ = env.call_method(
             view,
-            "setEllipsize",
-            "(Landroid/text/TextUtils$TruncateAt;)V",
+            jni::jni_str!("setEllipsize"),
+            jni::jni_sig!("(Landroid/text/TextUtils$TruncateAt;)V"),
             &[JValue::Object(&null_obj)],
         );
         return;
     }
-    let enum_cls = match env.find_class("android/text/TextUtils$TruncateAt") {
+    let enum_cls = match env.find_class(jni::jni_str!("android/text/TextUtils$TruncateAt")) {
         Ok(c) => c,
         Err(_) => return,
     };
@@ -375,16 +402,16 @@ fn apply_ellipsize(env: &mut jni::JNIEnv, view: &JObject, mode: i64) {
     };
     let value = env.call_static_method(
         &enum_cls,
-        "valueOf",
-        "(Ljava/lang/String;)Landroid/text/TextUtils$TruncateAt;",
+        jni::jni_str!("valueOf"),
+        jni::jni_sig!("(Ljava/lang/String;)Landroid/text/TextUtils$TruncateAt;"),
         &[JValue::Object(&java_name)],
     );
     let Ok(v) = value else { return };
     let Ok(enum_obj) = v.l() else { return };
     let _ = env.call_method(
         view,
-        "setEllipsize",
-        "(Landroid/text/TextUtils$TruncateAt;)V",
+        jni::jni_str!("setEllipsize"),
+        jni::jni_sig!("(Landroid/text/TextUtils$TruncateAt;)V"),
         &[JValue::Object(&enum_obj)],
     );
 }

--- a/crates/perry-ui-android/src/widgets/textarea.rs
+++ b/crates/perry-ui-android/src/widgets/textarea.rs
@@ -1,77 +1,82 @@
 use crate::app::str_from_header;
 use crate::callback;
 use crate::jni_bridge;
-use jni::objects::JValue;
+use jni::JValue;
 
 /// Create a multi-line EditText (TextArea). Returns widget handle.
 pub fn create(placeholder_ptr: *const u8, on_change: f64) -> i64 {
     let placeholder = unsafe { str_from_header(placeholder_ptr) };
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
 
-    let activity = super::get_activity(&mut env);
-    let edit_text = env
-        .new_object(
-            "android/widget/EditText",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("Failed to create EditText");
+        let activity = super::get_activity(env);
+        let edit_text = env
+            .new_object(
+                jni::jni_str!("android/widget/EditText"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("Failed to create EditText");
 
-    // Set hint (placeholder)
-    let hint_str = env
-        .new_string(placeholder)
-        .expect("Failed to create JNI string");
-    let _ = env.call_method(
-        &edit_text,
-        "setHint",
-        "(Ljava/lang/CharSequence;)V",
-        &[JValue::Object(&hint_str)],
-    );
+        // Set hint (placeholder)
+        let hint_str = env
+            .new_string(placeholder)
+            .expect("Failed to create JNI string");
+        let _ = env.call_method(
+            &edit_text,
+            jni::jni_str!("setHint"),
+            jni::jni_sig!("(Ljava/lang/CharSequence;)V"),
+            &[JValue::Object(&hint_str)],
+        );
 
-    // Multi-line: do NOT call setSingleLine (default is multi-line)
-    // Set min lines and gravity to top-left for textarea behavior
-    let _ = env.call_method(&edit_text, "setMinLines", "(I)V", &[JValue::Int(4)]);
-    let _ = env.call_method(
-        &edit_text,
-        "setGravity",
-        "(I)V",
-        &[JValue::Int(0x30 | 0x03)], // TOP | LEFT
-    );
+        // Multi-line: do NOT call setSingleLine (default is multi-line)
+        // Set min lines and gravity to top-left for textarea behavior
+        let _ = env.call_method(
+            &edit_text,
+            jni::jni_str!("setMinLines"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(4)],
+        );
+        let _ = env.call_method(
+            &edit_text,
+            jni::jni_str!("setGravity"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(0x30 | 0x03)], // TOP | LEFT
+        );
 
-    // MATCH_PARENT width, WRAP_CONTENT height
-    let params = env
-        .new_object(
-            "android/widget/LinearLayout$LayoutParams",
-            "(II)V",
-            &[JValue::Int(-1), JValue::Int(-2)],
-        )
-        .expect("Failed to create LayoutParams");
-    let _ = env.call_method(
-        &edit_text,
-        "setLayoutParams",
-        "(Landroid/view/ViewGroup$LayoutParams;)V",
-        &[JValue::Object(&params)],
-    );
+        // MATCH_PARENT width, WRAP_CONTENT height
+        let params = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout$LayoutParams"),
+                jni::jni_sig!("(II)V"),
+                &[JValue::Int(-1), JValue::Int(-2)],
+            )
+            .expect("Failed to create LayoutParams");
+        let _ = env.call_method(
+            &edit_text,
+            jni::jni_str!("setLayoutParams"),
+            jni::jni_sig!("(Landroid/view/ViewGroup$LayoutParams;)V"),
+            &[JValue::Object(&params)],
+        );
 
-    // Register callback and set up TextWatcher via PerryBridge
-    let cb_key = callback::register(on_change);
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let _ = env.call_static_method(
-        bridge_cls,
-        "setTextChangedCallback",
-        "(Landroid/widget/EditText;J)V",
-        &[JValue::Object(&edit_text), JValue::Long(cb_key)],
-    );
+        // Register callback and set up TextWatcher via PerryBridge
+        let cb_key = callback::register(on_change);
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("setTextChangedCallback"),
+            jni::jni_sig!("(Landroid/widget/EditText;J)V"),
+            &[JValue::Object(&edit_text), JValue::Long(cb_key)],
+        );
 
-    let global = env
-        .new_global_ref(edit_text)
-        .expect("Failed to create global ref");
-    let handle = super::register_widget(global);
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
-    handle
+        let global =
+            jni_bridge::new_global_ref(env, edit_text).expect("Failed to create global ref");
+        let handle = super::register_widget(global);
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+        handle
+    })
 }

--- a/crates/perry-ui-android/src/widgets/textfield.rs
+++ b/crates/perry-ui-android/src/widgets/textfield.rs
@@ -1,83 +1,94 @@
 use crate::app::str_from_header;
 use crate::callback;
 use crate::jni_bridge;
-use jni::objects::JValue;
+use jni::JValue;
 
 /// Create an EditText with placeholder and onChange callback. Returns widget handle.
 pub fn create(placeholder_ptr: *const u8, on_change: f64) -> i64 {
     let placeholder = unsafe { str_from_header(placeholder_ptr) };
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
 
-    let activity = super::get_activity(&mut env);
-    let edit_text = env
-        .new_object(
-            "android/widget/EditText",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("Failed to create EditText");
+        let activity = super::get_activity(env);
+        let edit_text = env
+            .new_object(
+                jni::jni_str!("android/widget/EditText"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("Failed to create EditText");
 
-    // Set hint (placeholder)
-    let hint_str = env
-        .new_string(placeholder)
-        .expect("Failed to create JNI string");
-    let _ = env.call_method(
-        &edit_text,
-        "setHint",
-        "(Ljava/lang/CharSequence;)V",
-        &[JValue::Object(&hint_str)],
-    );
+        // Set hint (placeholder)
+        let hint_str = env
+            .new_string(placeholder)
+            .expect("Failed to create JNI string");
+        let _ = env.call_method(
+            &edit_text,
+            jni::jni_str!("setHint"),
+            jni::jni_sig!("(Ljava/lang/CharSequence;)V"),
+            &[JValue::Object(&hint_str)],
+        );
 
-    // Single line by default
-    let _ = env.call_method(&edit_text, "setSingleLine", "(Z)V", &[JValue::Bool(1)]);
+        // Single line by default
+        let _ = env.call_method(
+            &edit_text,
+            jni::jni_str!("setSingleLine"),
+            jni::jni_sig!("(Z)V"),
+            &[JValue::Bool(true)],
+        );
 
-    // MATCH_PARENT width, WRAP_CONTENT height
-    let params = env
-        .new_object(
-            "android/widget/LinearLayout$LayoutParams",
-            "(II)V",
-            &[JValue::Int(-1), JValue::Int(-2)],
-        )
-        .expect("Failed to create LayoutParams");
-    let _ = env.call_method(
-        &edit_text,
-        "setLayoutParams",
-        "(Landroid/view/ViewGroup$LayoutParams;)V",
-        &[JValue::Object(&params)],
-    );
+        // MATCH_PARENT width, WRAP_CONTENT height
+        let params = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout$LayoutParams"),
+                jni::jni_sig!("(II)V"),
+                &[JValue::Int(-1), JValue::Int(-2)],
+            )
+            .expect("Failed to create LayoutParams");
+        let _ = env.call_method(
+            &edit_text,
+            jni::jni_str!("setLayoutParams"),
+            jni::jni_sig!("(Landroid/view/ViewGroup$LayoutParams;)V"),
+            &[JValue::Object(&params)],
+        );
 
-    // Register callback and set up TextWatcher via PerryBridge
-    let cb_key = callback::register(on_change);
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let _ = env.call_static_method(
-        bridge_cls,
-        "setTextChangedCallback",
-        "(Landroid/widget/EditText;J)V",
-        &[JValue::Object(&edit_text), JValue::Long(cb_key)],
-    );
+        // Register callback and set up TextWatcher via PerryBridge
+        let cb_key = callback::register(on_change);
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("setTextChangedCallback"),
+            jni::jni_sig!("(Landroid/widget/EditText;J)V"),
+            &[JValue::Object(&edit_text), JValue::Long(cb_key)],
+        );
 
-    let global = env
-        .new_global_ref(edit_text)
-        .expect("Failed to create global ref");
-    let handle = super::register_widget(global);
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
-    handle
+        let global =
+            jni_bridge::new_global_ref(env, edit_text).expect("Failed to create global ref");
+        let handle = super::register_widget(global);
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+        handle
+    })
 }
 
 /// Focus an EditText (request focus).
 pub fn focus(handle: i64) {
     if let Some(view_ref) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let _ = env.call_method(view_ref.as_obj(), "requestFocus", "()Z", &[]);
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let _ = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("requestFocus"),
+                jni::jni_sig!("()Z"),
+                &[],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+        })
     }
 }
 
@@ -89,18 +100,19 @@ pub fn set_string_value(handle: i64, text_ptr: *const u8) {
 
 pub fn set_string_str(handle: i64, text: &str) {
     if let Some(view_ref) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let jstr = env.new_string(text).expect("Failed to create JNI string");
-        let _ = env.call_method(
-            view_ref.as_obj(),
-            "setText",
-            "(Ljava/lang/CharSequence;)V",
-            &[JValue::Object(&jstr)],
-        );
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let jstr = env.new_string(text).expect("Failed to create JNI string");
+            let _ = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("setText"),
+                jni::jni_sig!("(Ljava/lang/CharSequence;)V"),
+                &[JValue::Object(&jstr)],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+        })
     }
 }
 
@@ -111,42 +123,54 @@ extern "C" {
 /// Get the current text of an EditText. Returns a raw StringHeader pointer.
 pub fn get_string_value(handle: i64) -> *const u8 {
     if let Some(view_ref) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(16);
-        let text_result = env.call_method(
-            view_ref.as_obj(),
-            "getText",
-            "()Landroid/text/Editable;",
-            &[],
-        );
-        if let Ok(text_val) = text_result {
-            if let Ok(text_obj) = text_val.l() {
-                if !text_obj.is_null() {
-                    let jstr_result =
-                        env.call_method(&text_obj, "toString", "()Ljava/lang/String;", &[]);
-                    if let Ok(jstr_val) = jstr_result {
-                        if let Ok(jstr) = jstr_val.l() {
-                            if let Ok(rust_str) = env.get_string((&jstr).into()) {
-                                // Copy to owned String before pop_local_frame frees JNI refs.
-                                // JavaStr's Drop calls ReleaseStringUTFChars — if the jstring
-                                // local ref is already freed by pop_local_frame, JNI aborts.
-                                let owned: String = rust_str.into();
-                                let bytes = owned.as_bytes();
-                                let str_ptr = unsafe {
-                                    js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64)
+        let result = jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 16);
+            let text_result = env.call_method(
+                view_ref.as_obj(),
+                jni::jni_str!("getText"),
+                jni::jni_sig!("()Landroid/text/Editable;"),
+                &[],
+            );
+            if let Ok(text_val) = text_result {
+                if let Ok(text_obj) = text_val.l() {
+                    if !text_obj.is_null() {
+                        let jstr_result = env.call_method(
+                            &text_obj,
+                            jni::jni_str!("toString"),
+                            jni::jni_sig!("()Ljava/lang/String;"),
+                            &[],
+                        );
+                        if let Ok(jstr_val) = jstr_result {
+                            if let Ok(jstr) = jstr_val.l() {
+                                let jstr = unsafe {
+                                    jni::objects::JString::from_raw(env, jstr.into_raw())
                                 };
-                                unsafe {
-                                    env.pop_local_frame(&jni::objects::JObject::null());
+                                if let Ok(rust_str) = jstr.try_to_string(env) {
+                                    // Copy to owned String before pop_local_frame frees JNI refs.
+                                    let bytes = rust_str.as_bytes();
+                                    let str_ptr = unsafe {
+                                        js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64)
+                                    };
+                                    unsafe {
+                                        let _ = jni_bridge::pop_local_frame(
+                                            env,
+                                            &jni::objects::JObject::null(),
+                                        );
+                                    }
+                                    return Some(str_ptr);
                                 }
-                                return str_ptr;
                             }
                         }
                     }
                 }
             }
-        }
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+            None
+        });
+        if let Some(str_ptr) = result {
+            return str_ptr;
         }
     }
     unsafe { js_string_from_bytes(std::ptr::null(), 0) }
@@ -175,23 +199,24 @@ pub fn set_text_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
 /// Set a callback for when the user presses Enter/Done on the keyboard.
 pub fn set_on_submit(handle: i64, on_submit: f64) {
     if let Some(view_ref) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(16);
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 16);
 
-        let cb_key = crate::callback::register(on_submit);
-        let bridge_class =
-            jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-        let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-        // Use PerryBridge to set an OnEditorActionListener
-        let _ = env.call_static_method(
-            bridge_cls,
-            "setOnSubmitCallback",
-            "(Landroid/widget/EditText;J)V",
-            &[JValue::Object(view_ref.as_obj()), JValue::Long(cb_key)],
-        );
+            let cb_key = crate::callback::register(on_submit);
+            let bridge_class =
+                jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+            let bridge_cls: &jni::objects::JClass = &bridge_class;
+            // Use PerryBridge to set an OnEditorActionListener
+            let _ = env.call_static_method(
+                bridge_cls,
+                jni::jni_str!("setOnSubmitCallback"),
+                jni::jni_sig!("(Landroid/widget/EditText;J)V"),
+                &[JValue::Object(view_ref.as_obj()), JValue::Long(cb_key)],
+            );
 
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+        })
     }
 }

--- a/crates/perry-ui-android/src/widgets/toast.rs
+++ b/crates/perry-ui-android/src/widgets/toast.rs
@@ -18,7 +18,9 @@
 //! `PerryBridge.showToast(String)`, whose Kotlin implementation posts to
 //! the UI thread's `Handler(Looper.getMainLooper())`.
 
-use jni::objects::JValue;
+use jni::JValue;
+
+use crate::jni_bridge;
 
 /// Cross-platform handler entry point. Registered with
 /// `js_register_show_toast_handler` at app startup.
@@ -32,23 +34,24 @@ pub extern "C" fn show_toast_handler(msg_ptr: *const u8, msg_len: usize) {
         String::from_utf8_lossy(bytes).into_owned()
     };
 
-    let mut env = crate::jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
+    crate::jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
 
-    if let Ok(jstr) = env.new_string(&msg) {
-        let bridge_class = crate::jni_bridge::with_cache(|c| {
-            env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap()
-        });
-        let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-        let _ = env.call_static_method(
-            bridge_cls,
-            "showToast",
-            "(Ljava/lang/String;)V",
-            &[JValue::Object(&jstr)],
-        );
-    }
+        if let Ok(jstr) = env.new_string(&msg) {
+            let bridge_class = crate::jni_bridge::with_cache(|c| {
+                env.new_local_ref(&c.perry_bridge_class).unwrap()
+            });
+            let bridge_cls: &jni::objects::JClass = &bridge_class;
+            let _ = env.call_static_method(
+                bridge_cls,
+                jni::jni_str!("showToast"),
+                jni::jni_sig!("(Ljava/lang/String;)V"),
+                &[JValue::Object(&jstr)],
+            );
+        }
 
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }

--- a/crates/perry-ui-android/src/widgets/toggle.rs
+++ b/crates/perry-ui-android/src/widgets/toggle.rs
@@ -1,11 +1,11 @@
-use jni::objects::JValue;
+use jni::JValue;
 use std::cell::RefCell;
 use std::collections::HashMap;
 
 use crate::app::str_from_header;
 use crate::callback;
 use crate::jni_bridge;
-use jni::objects::GlobalRef;
+use crate::jni_bridge::GlobalRef;
 
 thread_local! {
     /// Maps widget handle (the HStack container) -> Switch GlobalRef,
@@ -17,17 +17,18 @@ thread_local! {
 pub fn set_state(handle: i64, on: i64) {
     TOGGLE_SWITCHES.with(|switches| {
         if let Some(switch_ref) = switches.borrow().get(&handle) {
-            let mut env = jni_bridge::get_env();
-            let _ = env.push_local_frame(8);
-            let _ = env.call_method(
-                switch_ref.as_obj(),
-                "setChecked",
-                "(Z)V",
-                &[JValue::Bool(if on != 0 { 1 } else { 0 })],
-            );
-            unsafe {
-                env.pop_local_frame(&jni::objects::JObject::null());
-            }
+            jni_bridge::with_env(|env| {
+                let _ = jni_bridge::push_local_frame(env, 8);
+                let _ = env.call_method(
+                    switch_ref.as_obj(),
+                    jni::jni_str!("setChecked"),
+                    jni::jni_sig!("(Z)V"),
+                    &[JValue::Bool(on != 0)],
+                );
+                unsafe {
+                    let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+                }
+            })
         }
     });
 }
@@ -36,77 +37,86 @@ pub fn set_state(handle: i64, on: i64) {
 /// Returns a widget handle for a LinearLayout(HORIZONTAL) containing the label and switch.
 pub fn create(label_ptr: *const u8, on_change: f64) -> i64 {
     let label = unsafe { str_from_header(label_ptr) };
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
 
-    let activity = super::get_activity(&mut env);
+        let activity = super::get_activity(env);
 
-    // Create the Switch widget
-    let switch = env
-        .new_object(
-            "android/widget/Switch",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("Failed to create Switch");
+        // Create the Switch widget
+        let switch = env
+            .new_object(
+                jni::jni_str!("android/widget/Switch"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("Failed to create Switch");
 
-    // Set label text on the Switch itself (Switch extends CompoundButton extends TextView)
-    let jstr = env.new_string(label).expect("Failed to create JNI string");
-    let _ = env.call_method(
-        &switch,
-        "setText",
-        "(Ljava/lang/CharSequence;)V",
-        &[JValue::Object(&jstr)],
-    );
+        // Set label text on the Switch itself (Switch extends CompoundButton extends TextView)
+        let jstr = env.new_string(label).expect("Failed to create JNI string");
+        let _ = env.call_method(
+            &switch,
+            jni::jni_str!("setText"),
+            jni::jni_sig!("(Ljava/lang/CharSequence;)V"),
+            &[JValue::Object(&jstr)],
+        );
 
-    // Register callback and set up OnCheckedChangeListener via PerryBridge
-    let cb_key = callback::register(on_change);
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let _ = env.call_static_method(
-        bridge_cls,
-        "setOnCheckedChangeCallback",
-        "(Landroid/widget/CompoundButton;J)V",
-        &[JValue::Object(&switch), JValue::Long(cb_key)],
-    );
+        // Register callback and set up OnCheckedChangeListener via PerryBridge
+        let cb_key = callback::register(on_change);
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("setOnCheckedChangeCallback"),
+            jni::jni_sig!("(Landroid/widget/CompoundButton;J)V"),
+            &[JValue::Object(&switch), JValue::Long(cb_key)],
+        );
 
-    // Create horizontal container (to match iOS pattern where toggle = label + switch)
-    let container = env
-        .new_object(
-            "android/widget/LinearLayout",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("Failed to create LinearLayout");
+        // Create horizontal container (to match iOS pattern where toggle = label + switch)
+        let container = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("Failed to create LinearLayout");
 
-    // HORIZONTAL = 0
-    let _ = env.call_method(&container, "setOrientation", "(I)V", &[JValue::Int(0)]);
-    // CENTER_VERTICAL = 16
-    let _ = env.call_method(&container, "setGravity", "(I)V", &[JValue::Int(16)]);
+        // HORIZONTAL = 0
+        let _ = env.call_method(
+            &container,
+            jni::jni_str!("setOrientation"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(0)],
+        );
+        // CENTER_VERTICAL = 16
+        let _ = env.call_method(
+            &container,
+            jni::jni_str!("setGravity"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(16)],
+        );
 
-    // Add the Switch (which already has the label text)
-    let _ = env.call_method(
-        &container,
-        "addView",
-        "(Landroid/view/View;)V",
-        &[JValue::Object(&switch)],
-    );
+        // Add the Switch (which already has the label text)
+        let _ = env.call_method(
+            &container,
+            jni::jni_str!("addView"),
+            jni::jni_sig!("(Landroid/view/View;)V"),
+            &[JValue::Object(&switch)],
+        );
 
-    let switch_global = env
-        .new_global_ref(&switch)
-        .expect("Failed to create global ref");
-    let container_global = env
-        .new_global_ref(container)
-        .expect("Failed to create global ref");
-    let handle = super::register_widget(container_global);
+        let switch_global =
+            jni_bridge::new_global_ref(env, &switch).expect("Failed to create global ref");
+        let container_global =
+            jni_bridge::new_global_ref(env, container).expect("Failed to create global ref");
+        let handle = super::register_widget(container_global);
 
-    TOGGLE_SWITCHES.with(|switches| {
-        switches.borrow_mut().insert(handle, switch_global);
-    });
+        TOGGLE_SWITCHES.with(|switches| {
+            switches.borrow_mut().insert(handle, switch_global);
+        });
 
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
-    handle
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+        handle
+    })
 }

--- a/crates/perry-ui-android/src/widgets/tree_view.rs
+++ b/crates/perry-ui-android/src/widgets/tree_view.rs
@@ -13,7 +13,8 @@
 use crate::app::str_from_header;
 use crate::callback;
 use crate::jni_bridge;
-use jni::objects::{JObject, JString, JValue};
+use jni::objects::{JObject, JString};
+use jni::JValue;
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 
@@ -86,52 +87,53 @@ pub fn create(root_node: i64, on_select: f64) -> i64 {
         0
     };
 
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let result = env.call_static_method(
-        bridge_cls,
-        "treeViewCreate",
-        "(J)Landroid/widget/ListView;",
-        &[JValue::Long(cb_key)],
-    );
-    let widget_handle = match result {
-        Ok(jv) => match jv.l() {
-            Ok(obj) if !obj.is_null() => {
-                let g = env.new_global_ref(obj).expect("global-ref TreeView");
-                super::register_widget(g)
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let result = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("treeViewCreate"),
+            jni::jni_sig!("(J)Landroid/widget/ListView;"),
+            &[JValue::Long(cb_key)],
+        );
+        let widget_handle = match result {
+            Ok(jv) => match jv.l() {
+                Ok(obj) if !obj.is_null() => {
+                    let g = jni_bridge::new_global_ref(env, obj).expect("global-ref TreeView");
+                    super::register_widget(g)
+                }
+                _ => 0,
+            },
+            Err(_) => {
+                if env.exception_check() {
+                    let _ = env.exception_describe();
+                    let _ = env.exception_clear();
+                }
+                0
             }
-            _ => 0,
-        },
-        Err(_) => {
-            if env.exception_check().unwrap_or(false) {
-                let _ = env.exception_describe();
-                let _ = env.exception_clear();
-            }
-            0
+        };
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
         }
-    };
-    unsafe {
-        env.pop_local_frame(&JObject::null());
-    }
 
-    if widget_handle != 0 {
-        TREE_VIEWS.with(|m| {
-            m.borrow_mut().insert(
-                widget_handle,
-                TreeViewState {
-                    root_node,
-                    expanded: HashSet::new(),
-                    callback_key: cb_key,
-                    selected_id: None,
-                },
-            );
-        });
-        refresh(widget_handle);
-    }
-    widget_handle
+        if widget_handle != 0 {
+            TREE_VIEWS.with(|m| {
+                m.borrow_mut().insert(
+                    widget_handle,
+                    TreeViewState {
+                        root_node,
+                        expanded: HashSet::new(),
+                        callback_key: cb_key,
+                        selected_id: None,
+                    },
+                );
+            });
+            refresh(widget_handle);
+        }
+        widget_handle
+    })
 }
 
 pub fn expand_all(widget_handle: i64) {
@@ -307,57 +309,62 @@ fn refresh(widget_handle: i64) {
         return;
     };
     let (rows, ids) = flatten_visible(widget_handle);
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(64);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 64);
 
-    let str_class = env.find_class("java/lang/String").expect("String class");
-    let rows_arr = env
-        .new_object_array(rows.len() as i32, &str_class, &JObject::null())
-        .expect("rows array");
-    for (i, row) in rows.iter().enumerate() {
-        let js = env.new_string(row).expect("row string");
-        let _ = env.set_object_array_element(&rows_arr, i as i32, &js);
-    }
-    let ids_arr = env
-        .new_object_array(ids.len() as i32, &str_class, &JObject::null())
-        .expect("ids array");
-    for (i, id) in ids.iter().enumerate() {
-        let js = env.new_string(id).expect("id string");
-        let _ = env.set_object_array_element(&ids_arr, i as i32, &js);
-    }
+        let str_class = env
+            .find_class(jni::jni_str!("java/lang/String"))
+            .expect("String class");
+        let rows_arr = env
+            .new_object_array(rows.len() as i32, &str_class, &JObject::null())
+            .expect("rows array");
+        for (i, row) in rows.iter().enumerate() {
+            let js = env.new_string(row).expect("row string");
+            let _ = rows_arr.set_element(env, i, &js);
+        }
+        let ids_arr = env
+            .new_object_array(ids.len() as i32, &str_class, &JObject::null())
+            .expect("ids array");
+        for (i, id) in ids.iter().enumerate() {
+            let js = env.new_string(id).expect("id string");
+            let _ = ids_arr.set_element(env, i, &js);
+        }
 
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let _ = env.call_static_method(
-        bridge_cls,
-        "treeViewRefresh",
-        "(JLandroid/widget/ListView;[Ljava/lang/String;[Ljava/lang/String;)V",
-        &[
-            JValue::Long(widget_handle),
-            JValue::Object(view.as_obj()),
-            JValue::Object(&rows_arr),
-            JValue::Object(&ids_arr),
-        ],
-    );
-    if env.exception_check().unwrap_or(false) {
-        let _ = env.exception_describe();
-        let _ = env.exception_clear();
-    }
-    unsafe {
-        env.pop_local_frame(&JObject::null());
-    }
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("treeViewRefresh"),
+            jni::jni_sig!("(JLandroid/widget/ListView;[Ljava/lang/String;[Ljava/lang/String;)V"),
+            &[
+                JValue::Long(widget_handle),
+                JValue::Object(view.as_obj()),
+                JValue::Object(&rows_arr),
+                JValue::Object(&ids_arr),
+            ],
+        );
+        if env.exception_check() {
+            let _ = env.exception_describe();
+            let _ = env.exception_clear();
+        }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+        }
+    })
 }
 
 /// JNI entry point: PerryBridge.nativeTreeRowTapped(long widgetHandle, String id).
 /// Runs on the UI thread (ListView OnItemClickListener).
 #[no_mangle]
 pub extern "C" fn Java_com_perry_app_PerryBridge_nativeTreeRowTapped(
-    mut env: jni::JNIEnv,
+    mut env: jni::EnvUnowned,
     _class: jni::objects::JClass,
     widget_handle: jni::sys::jlong,
     id: JString,
 ) {
-    let s: String = env.get_string(&id).map(|j| j.into()).unwrap_or_default();
-    handle_row_tap(widget_handle as i64, &s);
+    jni_bridge::with_unowned_env(&mut env, |env| {
+        let s = id.try_to_string(env).unwrap_or_default();
+        handle_row_tap(widget_handle as i64, &s);
+    });
 }

--- a/crates/perry-ui-android/src/widgets/vstack.rs
+++ b/crates/perry-ui-android/src/widgets/vstack.rs
@@ -1,132 +1,140 @@
 use crate::jni_bridge;
-use jni::objects::JValue;
+use jni::JValue;
 
 /// Create a LinearLayout with VERTICAL orientation.
 pub fn create(spacing: f64) -> i64 {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
-    let activity = super::get_activity(&mut env);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
+        let activity = super::get_activity(env);
 
-    let layout = env
-        .new_object(
-            "android/widget/LinearLayout",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("Failed to create LinearLayout");
+        let layout = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("Failed to create LinearLayout");
 
-    // VERTICAL = 1
-    let _ = env.call_method(&layout, "setOrientation", "(I)V", &[JValue::Int(1)]);
+        // VERTICAL = 1
+        let _ = env.call_method(
+            &layout,
+            jni::jni_str!("setOrientation"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(1)],
+        );
 
-    // Set spacing between children via a custom divider or padding approach.
-    // LinearLayout doesn't have a direct "spacing" API, but we can set
-    // showDividers + dividerPadding, or we handle spacing in add_child.
-    // For simplicity, store spacing and apply as margins on children via PerryBridge.
-    let spacing_px = super::dp_to_px(&mut env, spacing as f32);
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let _ = env.call_static_method(
-        bridge_cls,
-        "setLinearLayoutSpacing",
-        "(Landroid/widget/LinearLayout;I)V",
-        &[JValue::Object(&layout), JValue::Int(spacing_px)],
-    );
+        // Set spacing between children via a custom divider or padding approach.
+        // LinearLayout doesn't have a direct "spacing" API, but we can set
+        // showDividers + dividerPadding, or we handle spacing in add_child.
+        // For simplicity, store spacing and apply as margins on children via PerryBridge.
+        let spacing_px = super::dp_to_px(env, spacing as f32);
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("setLinearLayoutSpacing"),
+            jni::jni_sig!("(Landroid/widget/LinearLayout;I)V"),
+            &[JValue::Object(&layout), JValue::Int(spacing_px)],
+        );
 
-    // No default padding — matches macOS/iOS behavior (VStack has zero insets)
+        // No default padding — matches macOS/iOS behavior (VStack has zero insets)
 
-    // LayoutParams: MATCH_PARENT width, WRAP_CONTENT height
-    // Height defaults to WRAP_CONTENT so VStacks don't expand to fill parents.
-    // Use widgetMatchParentHeight() to opt-in to filling (e.g. root appBody).
-    let params = env
-        .new_object(
-            "android/widget/LinearLayout$LayoutParams",
-            "(II)V",
-            &[JValue::Int(-1), JValue::Int(-2)], // MATCH_PARENT width, WRAP_CONTENT height
-        )
-        .expect("Failed to create LayoutParams");
-    let _ = env.call_method(
-        &layout,
-        "setLayoutParams",
-        "(Landroid/view/ViewGroup$LayoutParams;)V",
-        &[JValue::Object(&params)],
-    );
+        // LayoutParams: MATCH_PARENT width, WRAP_CONTENT height
+        // Height defaults to WRAP_CONTENT so VStacks don't expand to fill parents.
+        // Use widgetMatchParentHeight() to opt-in to filling (e.g. root appBody).
+        let params = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout$LayoutParams"),
+                jni::jni_sig!("(II)V"),
+                &[JValue::Int(-1), JValue::Int(-2)], // MATCH_PARENT width, WRAP_CONTENT height
+            )
+            .expect("Failed to create LayoutParams");
+        let _ = env.call_method(
+            &layout,
+            jni::jni_str!("setLayoutParams"),
+            jni::jni_sig!("(Landroid/view/ViewGroup$LayoutParams;)V"),
+            &[JValue::Object(&params)],
+        );
 
-    let global = env
-        .new_global_ref(layout)
-        .expect("Failed to create global ref");
-    let handle = super::register_widget(global);
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
-    handle
+        let global = jni_bridge::new_global_ref(env, layout).expect("Failed to create global ref");
+        let handle = super::register_widget(global);
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+        handle
+    })
 }
 
 /// Create a LinearLayout with VERTICAL orientation and custom padding (insets).
 pub fn create_with_insets(spacing: f64, top: f64, left: f64, bottom: f64, right: f64) -> i64 {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
-    let activity = super::get_activity(&mut env);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
+        let activity = super::get_activity(env);
 
-    let layout = env
-        .new_object(
-            "android/widget/LinearLayout",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("Failed to create LinearLayout");
+        let layout = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("Failed to create LinearLayout");
 
-    // VERTICAL = 1
-    let _ = env.call_method(&layout, "setOrientation", "(I)V", &[JValue::Int(1)]);
+        // VERTICAL = 1
+        let _ = env.call_method(
+            &layout,
+            jni::jni_str!("setOrientation"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(1)],
+        );
 
-    let spacing_px = super::dp_to_px(&mut env, spacing as f32);
-    let bridge_class =
-        jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-    let bridge_cls: &jni::objects::JClass = (&bridge_class).into();
-    let _ = env.call_static_method(
-        bridge_cls,
-        "setLinearLayoutSpacing",
-        "(Landroid/widget/LinearLayout;I)V",
-        &[JValue::Object(&layout), JValue::Int(spacing_px)],
-    );
+        let spacing_px = super::dp_to_px(env, spacing as f32);
+        let bridge_class =
+            jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+        let bridge_cls: &jni::objects::JClass = &bridge_class;
+        let _ = env.call_static_method(
+            bridge_cls,
+            jni::jni_str!("setLinearLayoutSpacing"),
+            jni::jni_sig!("(Landroid/widget/LinearLayout;I)V"),
+            &[JValue::Object(&layout), JValue::Int(spacing_px)],
+        );
 
-    // Set custom padding (convert dp to px)
-    let top_px = super::dp_to_px(&mut env, top as f32);
-    let left_px = super::dp_to_px(&mut env, left as f32);
-    let bottom_px = super::dp_to_px(&mut env, bottom as f32);
-    let right_px = super::dp_to_px(&mut env, right as f32);
-    let _ = env.call_method(
-        &layout,
-        "setPadding",
-        "(IIII)V",
-        &[
-            JValue::Int(left_px),
-            JValue::Int(top_px),
-            JValue::Int(right_px),
-            JValue::Int(bottom_px),
-        ],
-    );
+        // Set custom padding (convert dp to px)
+        let top_px = super::dp_to_px(env, top as f32);
+        let left_px = super::dp_to_px(env, left as f32);
+        let bottom_px = super::dp_to_px(env, bottom as f32);
+        let right_px = super::dp_to_px(env, right as f32);
+        let _ = env.call_method(
+            &layout,
+            jni::jni_str!("setPadding"),
+            jni::jni_sig!("(IIII)V"),
+            &[
+                JValue::Int(left_px),
+                JValue::Int(top_px),
+                JValue::Int(right_px),
+                JValue::Int(bottom_px),
+            ],
+        );
 
-    let params = env
-        .new_object(
-            "android/widget/LinearLayout$LayoutParams",
-            "(II)V",
-            &[JValue::Int(-1), JValue::Int(-2)],
-        )
-        .expect("Failed to create LayoutParams");
-    let _ = env.call_method(
-        &layout,
-        "setLayoutParams",
-        "(Landroid/view/ViewGroup$LayoutParams;)V",
-        &[JValue::Object(&params)],
-    );
+        let params = env
+            .new_object(
+                jni::jni_str!("android/widget/LinearLayout$LayoutParams"),
+                jni::jni_sig!("(II)V"),
+                &[JValue::Int(-1), JValue::Int(-2)],
+            )
+            .expect("Failed to create LayoutParams");
+        let _ = env.call_method(
+            &layout,
+            jni::jni_str!("setLayoutParams"),
+            jni::jni_sig!("(Landroid/view/ViewGroup$LayoutParams;)V"),
+            &[JValue::Object(&params)],
+        );
 
-    let global = env
-        .new_global_ref(layout)
-        .expect("Failed to create global ref");
-    let handle = super::register_widget(global);
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
-    handle
+        let global = jni_bridge::new_global_ref(env, layout).expect("Failed to create global ref");
+        let handle = super::register_widget(global);
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+        handle
+    })
 }

--- a/crates/perry-ui-android/src/widgets/webview.rs
+++ b/crates/perry-ui-android/src/widgets/webview.rs
@@ -16,7 +16,8 @@
 //! contract as macOS / iOS / Windows.
 
 use crate::jni_bridge;
-use jni::objects::{GlobalRef, JValue};
+use crate::jni_bridge::GlobalRef;
+use jni::JValue;
 use std::cell::RefCell;
 use std::collections::HashMap;
 
@@ -73,83 +74,94 @@ pub fn create(url_ptr: *const u8, _width: f64, _height: f64, ephemeral_hint: f64
         // Mirrors set_ephemeral(1) but happens before any nav.
         wipe_process_storage();
     }
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
 
-    let activity = super::get_activity(&mut env);
-    let webview = match env.new_object(
-        "android/webkit/WebView",
-        "(Landroid/content/Context;)V",
-        &[JValue::Object(&activity)],
-    ) {
-        Ok(w) => w,
-        Err(_) => {
-            unsafe {
-                let _ = env.pop_local_frame(&jni::objects::JObject::null());
+        let activity = super::get_activity(env);
+        let webview = match env.new_object(
+            jni::jni_str!("android/webkit/WebView"),
+            jni::jni_sig!("(Landroid/content/Context;)V"),
+            &[JValue::Object(&activity)],
+        ) {
+            Ok(w) => w,
+            Err(_) => {
+                unsafe {
+                    let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+                }
+                return 0;
             }
-            return 0;
+        };
+
+        // Enable JavaScript so user OAuth pages can run; gated by getSettings().setJavaScriptEnabled(true).
+        if let Ok(settings) = env.call_method(
+            &webview,
+            jni::jni_str!("getSettings"),
+            jni::jni_sig!("()Landroid/webkit/WebSettings;"),
+            &[],
+        ) {
+            if let Ok(s) = settings.l() {
+                let _ = env.call_method(
+                    &s,
+                    jni::jni_str!("setJavaScriptEnabled"),
+                    jni::jni_sig!("(Z)V"),
+                    &[JValue::Bool(true)],
+                );
+                let _ = env.call_method(
+                    &s,
+                    jni::jni_str!("setDomStorageEnabled"),
+                    jni::jni_sig!("(Z)V"),
+                    &[JValue::Bool(true)],
+                );
+            }
         }
-    };
 
-    // Enable JavaScript so user OAuth pages can run; gated by getSettings().setJavaScriptEnabled(true).
-    if let Ok(settings) = env.call_method(
-        &webview,
-        "getSettings",
-        "()Landroid/webkit/WebSettings;",
-        &[],
-    ) {
-        if let Ok(s) = settings.l() {
-            let _ = env.call_method(&s, "setJavaScriptEnabled", "(Z)V", &[JValue::Bool(1)]);
-            let _ = env.call_method(&s, "setDomStorageEnabled", "(Z)V", &[JValue::Bool(1)]);
+        // Construct PerryWebViewClient(widgetHandle) — wires shouldOverrideUrlLoading
+        // / onPageFinished / onReceivedError back through PerryBridge to native.
+        // The handle isn't allocated until below; we register the WebView first
+        // and then attach the client. Use a placeholder of 0 here and rewire
+        // once we know the real handle.
+        // NOTE: this two-pass shape avoids a chicken-and-egg between handle
+        // allocation and client construction — see `attach_perry_client` below.
+
+        if !url.is_empty() {
+            if let Ok(jurl) = env.new_string(&url) {
+                let _ = env.call_method(
+                    &webview,
+                    jni::jni_str!("loadUrl"),
+                    jni::jni_sig!("(Ljava/lang/String;)V"),
+                    &[JValue::Object(&jurl)],
+                );
+            }
         }
-    }
 
-    // Construct PerryWebViewClient(widgetHandle) — wires shouldOverrideUrlLoading
-    // / onPageFinished / onReceivedError back through PerryBridge to native.
-    // The handle isn't allocated until below; we register the WebView first
-    // and then attach the client. Use a placeholder of 0 here and rewire
-    // once we know the real handle.
-    // NOTE: this two-pass shape avoids a chicken-and-egg between handle
-    // allocation and client construction — see `attach_perry_client` below.
+        let global_ref = match jni_bridge::new_global_ref(env, &webview) {
+            Ok(g) => g,
+            Err(_) => {
+                unsafe {
+                    let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+                }
+                return 0;
+            }
+        };
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
 
-    if !url.is_empty() {
-        if let Ok(jurl) = env.new_string(&url) {
-            let _ = env.call_method(
-                &webview,
-                "loadUrl",
-                "(Ljava/lang/String;)V",
-                &[JValue::Object(&jurl)],
+        let handle = super::register_widget(global_ref);
+        WEBVIEW_STATES.with(|s| {
+            s.borrow_mut().insert(
+                handle,
+                WebViewState {
+                    on_should_navigate: 0.0,
+                    on_loaded: 0.0,
+                    on_error: 0.0,
+                    allowed_domains: Vec::new(),
+                },
             );
-        }
-    }
-
-    let global_ref = match env.new_global_ref(&webview) {
-        Ok(g) => g,
-        Err(_) => {
-            unsafe {
-                let _ = env.pop_local_frame(&jni::objects::JObject::null());
-            }
-            return 0;
-        }
-    };
-    unsafe {
-        let _ = env.pop_local_frame(&jni::objects::JObject::null());
-    }
-
-    let handle = super::register_widget(global_ref);
-    WEBVIEW_STATES.with(|s| {
-        s.borrow_mut().insert(
-            handle,
-            WebViewState {
-                on_should_navigate: 0.0,
-                on_loaded: 0.0,
-                on_error: 0.0,
-                allowed_domains: Vec::new(),
-            },
-        );
-    });
-    attach_perry_client(handle);
-    handle
+        });
+        attach_perry_client(handle);
+        handle
+    })
 }
 
 fn attach_perry_client(handle: i64) {
@@ -157,23 +169,24 @@ fn attach_perry_client(handle: i64) {
         Some(v) => v,
         None => return,
     };
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
-    if let Ok(client) = env.new_object(
-        "com/perry/app/PerryWebViewClient",
-        "(J)V",
-        &[JValue::Long(handle)],
-    ) {
-        let _ = env.call_method(
-            &view,
-            "setWebViewClient",
-            "(Landroid/webkit/WebViewClient;)V",
-            &[JValue::Object(&client)],
-        );
-    }
-    unsafe {
-        let _ = env.pop_local_frame(&jni::objects::JObject::null());
-    }
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
+        if let Ok(client) = env.new_object(
+            jni::jni_str!("com/perry/app/PerryWebViewClient"),
+            jni::jni_sig!("(J)V"),
+            &[JValue::Long(handle)],
+        ) {
+            let _ = env.call_method(
+                view.as_obj(),
+                jni::jni_str!("setWebViewClient"),
+                jni::jni_sig!("(Landroid/webkit/WebViewClient;)V"),
+                &[JValue::Object(&client)],
+            );
+        }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }
 
 fn call_string_method(handle: i64, method: &str, sig: &str, jstr: &str) {
@@ -181,14 +194,22 @@ fn call_string_method(handle: i64, method: &str, sig: &str, jstr: &str) {
         Some(v) => v,
         None => return,
     };
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
-    if let Ok(s) = env.new_string(jstr) {
-        let _ = env.call_method(&view, method, sig, &[JValue::Object(&s)]);
-    }
-    unsafe {
-        let _ = env.pop_local_frame(&jni::objects::JObject::null());
-    }
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
+        if let Ok(s) = env.new_string(jstr) {
+            let parsed_sig = jni::signature::RuntimeMethodSignature::from_str(sig)
+                .expect("valid WebView method signature");
+            let _ = env.call_method(
+                view.as_obj(),
+                jni::strings::JNIString::new(method),
+                parsed_sig.method_signature(),
+                &[JValue::Object(&s)],
+            );
+        }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }
 
 fn call_void_method(handle: i64, method: &str) {
@@ -196,8 +217,14 @@ fn call_void_method(handle: i64, method: &str) {
         Some(v) => v,
         None => return,
     };
-    let mut env = jni_bridge::get_env();
-    let _ = env.call_method(&view, method, "()V", &[]);
+    jni_bridge::with_env(|env| {
+        let _ = env.call_method(
+            view.as_obj(),
+            jni::strings::JNIString::new(method),
+            jni::jni_sig!("()V"),
+            &[],
+        );
+    })
 }
 
 pub fn load_url(handle: i64, url_ptr: *const u8) {
@@ -225,20 +252,26 @@ pub fn can_go_back(handle: i64) -> i64 {
         Some(v) => v,
         None => return 0,
     };
-    let mut env = jni_bridge::get_env();
-    match env.call_method(&view, "canGoBack", "()Z", &[]) {
-        Ok(v) => match v.z() {
-            Ok(b) => {
-                if b {
-                    1
-                } else {
-                    0
+    jni_bridge::with_env(|env| {
+        match env.call_method(
+            view.as_obj(),
+            jni::jni_str!("canGoBack"),
+            jni::jni_sig!("()Z"),
+            &[],
+        ) {
+            Ok(v) => match v.z() {
+                Ok(b) => {
+                    if b {
+                        1
+                    } else {
+                        0
+                    }
                 }
-            }
+                Err(_) => 0,
+            },
             Err(_) => 0,
-        },
-        Err(_) => 0,
-    }
+        }
+    })
 }
 
 /// Fire `evaluateJavascript(js, PerryWebViewEvalCallback(callbackKey))`.
@@ -258,39 +291,40 @@ pub fn evaluate_js(handle: i64, js_ptr: *const u8, callback: f64) {
     EVAL_CALLBACKS.with(|m| {
         m.borrow_mut().insert(key, callback);
     });
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
-    if let Ok(jjs) = env.new_string(js) {
-        if let Ok(cb) = env.new_object(
-            "com/perry/app/PerryWebViewEvalCallback",
-            "(J)V",
-            &[JValue::Long(key)],
-        ) {
-            let _ = env.call_method(
-                &view,
-                "evaluateJavascript",
-                "(Ljava/lang/String;Landroid/webkit/ValueCallback;)V",
-                &[JValue::Object(&jjs), JValue::Object(&cb)],
-            );
-        } else {
-            // Fallback: stock evaluateJavascript with null callback — the
-            // JS still runs, but the user callback never fires. Drop the
-            // EVAL_CALLBACKS entry so it doesn't leak.
-            EVAL_CALLBACKS.with(|m| {
-                m.borrow_mut().remove(&key);
-            });
-            let null_cb = jni::objects::JObject::null();
-            let _ = env.call_method(
-                &view,
-                "evaluateJavascript",
-                "(Ljava/lang/String;Landroid/webkit/ValueCallback;)V",
-                &[JValue::Object(&jjs), JValue::Object(&null_cb)],
-            );
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
+        if let Ok(jjs) = env.new_string(js) {
+            if let Ok(cb) = env.new_object(
+                jni::jni_str!("com/perry/app/PerryWebViewEvalCallback"),
+                jni::jni_sig!("(J)V"),
+                &[JValue::Long(key)],
+            ) {
+                let _ = env.call_method(
+                    view.as_obj(),
+                    jni::jni_str!("evaluateJavascript"),
+                    jni::jni_sig!("(Ljava/lang/String;Landroid/webkit/ValueCallback;)V"),
+                    &[JValue::Object(&jjs), JValue::Object(&cb)],
+                );
+            } else {
+                // Fallback: stock evaluateJavascript with null callback — the
+                // JS still runs, but the user callback never fires. Drop the
+                // EVAL_CALLBACKS entry so it doesn't leak.
+                EVAL_CALLBACKS.with(|m| {
+                    m.borrow_mut().remove(&key);
+                });
+                let null_cb = jni::objects::JObject::null();
+                let _ = env.call_method(
+                    view.as_obj(),
+                    jni::jni_str!("evaluateJavascript"),
+                    jni::jni_sig!("(Ljava/lang/String;Landroid/webkit/ValueCallback;)V"),
+                    &[JValue::Object(&jjs), JValue::Object(&null_cb)],
+                );
+            }
         }
-    }
-    unsafe {
-        let _ = env.pop_local_frame(&jni::objects::JObject::null());
-    }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }
 
 // =============================================================================
@@ -315,81 +349,80 @@ fn next_eval_callback_key() -> i64 {
 
 #[no_mangle]
 pub extern "system" fn Java_com_perry_app_PerryBridge_nativeWebViewShouldNavigate(
-    mut env: jni::JNIEnv,
+    mut env: jni::EnvUnowned,
     _class: jni::objects::JClass,
     widget_handle: jni::sys::jlong,
     url: jni::objects::JString,
 ) -> jni::sys::jboolean {
-    let url_str: String = match env.get_string(&url) {
-        Ok(s) => s.into(),
-        Err(_) => return 1, // allow on read failure (open default)
-    };
+    jni_bridge::with_unowned_env(&mut env, |env| {
+        let url_str = match url.try_to_string(env) {
+            Ok(s) => s,
+            Err(_) => return true, // allow on read failure (open default)
+        };
 
-    let (on_should, allowed) = WEBVIEW_STATES.with(|s| {
-        s.borrow()
-            .get(&(widget_handle as i64))
-            .map(|st| (st.on_should_navigate, st.allowed_domains.clone()))
-            .unwrap_or((0.0, Vec::new()))
-    });
+        let (on_should, allowed) = WEBVIEW_STATES.with(|s| {
+            s.borrow()
+                .get(&(widget_handle as i64))
+                .map(|st| (st.on_should_navigate, st.allowed_domains.clone()))
+                .unwrap_or((0.0, Vec::new()))
+        });
 
-    // Allowlist gate.
-    if !allowed.is_empty() {
-        let host = host_of_url(&url_str);
-        if !host_in_allowlist(&host, &allowed) {
-            return 0; // cancel
+        // Allowlist gate.
+        if !allowed.is_empty() {
+            let host = host_of_url(&url_str);
+            if !host_in_allowlist(&host, &allowed) {
+                return false; // cancel
+            }
         }
-    }
 
-    if on_should == 0.0 {
-        return 1; // allow
-    }
-    let url_nb = nanbox_str(&url_str);
-    let closure_ptr = unsafe { js_nanbox_get_pointer(on_should) } as *const u8;
-    if closure_ptr.is_null() {
-        return 1;
-    }
-    let result_cell = StdCell::new(f64::from_bits(0x7FFC_0000_0000_0001));
-    let result_cell_ref = &result_cell;
-    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let r = unsafe { js_closure_call1(closure_ptr, url_nb) };
-        result_cell_ref.set(r);
-    }));
-    let result = result_cell.get();
-    let bits = result.to_bits();
-    let is_undefined = bits == 0x7FFC_0000_0000_0001;
-    let allow = is_undefined || unsafe { js_is_truthy(result) != 0 };
-    if allow {
-        1
-    } else {
-        0
-    }
+        if on_should == 0.0 {
+            return true; // allow
+        }
+        let url_nb = nanbox_str(&url_str);
+        let closure_ptr = unsafe { js_nanbox_get_pointer(on_should) } as *const u8;
+        if closure_ptr.is_null() {
+            return true;
+        }
+        let result_cell = StdCell::new(f64::from_bits(0x7FFC_0000_0000_0001));
+        let result_cell_ref = &result_cell;
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let r = unsafe { js_closure_call1(closure_ptr, url_nb) };
+            result_cell_ref.set(r);
+        }));
+        let result = result_cell.get();
+        let bits = result.to_bits();
+        let is_undefined = bits == 0x7FFC_0000_0000_0001;
+        is_undefined || unsafe { js_is_truthy(result) != 0 }
+    })
 }
 
 #[no_mangle]
 pub extern "system" fn Java_com_perry_app_PerryBridge_nativeWebViewLoaded(
-    mut env: jni::JNIEnv,
+    mut env: jni::EnvUnowned,
     _class: jni::objects::JClass,
     widget_handle: jni::sys::jlong,
     url: jni::objects::JString,
 ) {
-    let url_str: String = env.get_string(&url).map(|s| s.into()).unwrap_or_default();
-    let on_loaded = WEBVIEW_STATES.with(|s| {
-        s.borrow()
-            .get(&(widget_handle as i64))
-            .map(|st| st.on_loaded)
-            .unwrap_or(0.0)
+    jni_bridge::with_unowned_env(&mut env, |env| {
+        let url_str = url.try_to_string(env).unwrap_or_default();
+        let on_loaded = WEBVIEW_STATES.with(|s| {
+            s.borrow()
+                .get(&(widget_handle as i64))
+                .map(|st| st.on_loaded)
+                .unwrap_or(0.0)
+        });
+        if on_loaded == 0.0 {
+            return;
+        }
+        let closure_ptr = unsafe { js_nanbox_get_pointer(on_loaded) } as *const u8;
+        if closure_ptr.is_null() {
+            return;
+        }
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let nb = nanbox_str(&url_str);
+            unsafe { js_closure_call1(closure_ptr, nb) };
+        }));
     });
-    if on_loaded == 0.0 {
-        return;
-    }
-    let closure_ptr = unsafe { js_nanbox_get_pointer(on_loaded) } as *const u8;
-    if closure_ptr.is_null() {
-        return;
-    }
-    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let nb = nanbox_str(&url_str);
-        unsafe { js_closure_call1(closure_ptr, nb) };
-    }));
 }
 
 extern "C" {
@@ -398,70 +431,68 @@ extern "C" {
 
 #[no_mangle]
 pub extern "system" fn Java_com_perry_app_PerryBridge_nativeWebViewError(
-    mut env: jni::JNIEnv,
+    mut env: jni::EnvUnowned,
     _class: jni::objects::JClass,
     widget_handle: jni::sys::jlong,
     code: jni::sys::jlong,
     message: jni::objects::JString,
 ) {
-    let msg: String = env
-        .get_string(&message)
-        .map(|s| s.into())
-        .unwrap_or_default();
-    let on_error = WEBVIEW_STATES.with(|s| {
-        s.borrow()
-            .get(&(widget_handle as i64))
-            .map(|st| st.on_error)
-            .unwrap_or(0.0)
+    jni_bridge::with_unowned_env(&mut env, |env| {
+        let msg = message.try_to_string(env).unwrap_or_default();
+        let on_error = WEBVIEW_STATES.with(|s| {
+            s.borrow()
+                .get(&(widget_handle as i64))
+                .map(|st| st.on_error)
+                .unwrap_or(0.0)
+        });
+        if on_error == 0.0 {
+            return;
+        }
+        let closure_ptr = unsafe { js_nanbox_get_pointer(on_error) } as *const u8;
+        if closure_ptr.is_null() {
+            return;
+        }
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let msg_nb = nanbox_str(&msg);
+            unsafe { js_closure_call2(closure_ptr, code as f64, msg_nb) };
+        }));
     });
-    if on_error == 0.0 {
-        return;
-    }
-    let closure_ptr = unsafe { js_nanbox_get_pointer(on_error) } as *const u8;
-    if closure_ptr.is_null() {
-        return;
-    }
-    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let msg_nb = nanbox_str(&msg);
-        unsafe { js_closure_call2(closure_ptr, code as f64, msg_nb) };
-    }));
 }
 
 #[no_mangle]
 pub extern "system" fn Java_com_perry_app_PerryBridge_nativeWebViewEvalResult(
-    mut env: jni::JNIEnv,
+    mut env: jni::EnvUnowned,
     _class: jni::objects::JClass,
     callback_key: jni::sys::jlong,
     result: jni::objects::JString,
 ) {
-    let raw: String = env
-        .get_string(&result)
-        .map(|s| s.into())
-        .unwrap_or_default();
-    let callback = EVAL_CALLBACKS.with(|m| m.borrow_mut().remove(&(callback_key as i64)));
-    let callback = match callback {
-        Some(c) if c != 0.0 => c,
-        _ => return,
-    };
-    // Strip outer JSON quotes for plain string returns (matches the
-    // Windows / WKWebView ergonomic for `document.cookie`-style reads);
-    // `null` becomes empty.
-    let s = if raw == "null" {
-        String::new()
-    } else if raw.starts_with('"') && raw.ends_with('"') && raw.len() >= 2 {
-        let inner = &raw[1..raw.len() - 1];
-        inner.replace("\\\"", "\"").replace("\\\\", "\\")
-    } else {
-        raw
-    };
-    let closure_ptr = unsafe { js_nanbox_get_pointer(callback) } as *const u8;
-    if closure_ptr.is_null() {
-        return;
-    }
-    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let nb = nanbox_str(&s);
-        unsafe { js_closure_call1(closure_ptr, nb) };
-    }));
+    jni_bridge::with_unowned_env(&mut env, |env| {
+        let raw = result.try_to_string(env).unwrap_or_default();
+        let callback = EVAL_CALLBACKS.with(|m| m.borrow_mut().remove(&(callback_key as i64)));
+        let callback = match callback {
+            Some(c) if c != 0.0 => c,
+            _ => return,
+        };
+        // Strip outer JSON quotes for plain string returns (matches the
+        // Windows / WKWebView ergonomic for `document.cookie`-style reads);
+        // `null` becomes empty.
+        let s = if raw == "null" {
+            String::new()
+        } else if raw.starts_with('"') && raw.ends_with('"') && raw.len() >= 2 {
+            let inner = &raw[1..raw.len() - 1];
+            inner.replace("\\\"", "\"").replace("\\\\", "\\")
+        } else {
+            raw
+        };
+        let closure_ptr = unsafe { js_nanbox_get_pointer(callback) } as *const u8;
+        if closure_ptr.is_null() {
+            return;
+        }
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let nb = nanbox_str(&s);
+            unsafe { js_closure_call1(closure_ptr, nb) };
+        }));
+    });
 }
 
 fn host_of_url(s: &str) -> String {
@@ -489,30 +520,31 @@ fn host_in_allowlist(host: &str, allowlist: &[String]) -> bool {
 }
 
 pub fn clear_cookies(_handle: i64) {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
-    // CookieManager.getInstance().removeAllCookies(null) — process-wide.
-    if let Ok(mgr_class) = env.find_class("android/webkit/CookieManager") {
-        if let Ok(mgr) = env.call_static_method(
-            &mgr_class,
-            "getInstance",
-            "()Landroid/webkit/CookieManager;",
-            &[],
-        ) {
-            if let Ok(mgr_obj) = mgr.l() {
-                let null_cb = jni::objects::JObject::null();
-                let _ = env.call_method(
-                    &mgr_obj,
-                    "removeAllCookies",
-                    "(Landroid/webkit/ValueCallback;)V",
-                    &[JValue::Object(&null_cb)],
-                );
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
+        // CookieManager.getInstance().removeAllCookies(null) — process-wide.
+        if let Ok(mgr_class) = env.find_class(jni::jni_str!("android/webkit/CookieManager")) {
+            if let Ok(mgr) = env.call_static_method(
+                &mgr_class,
+                jni::jni_str!("getInstance"),
+                jni::jni_sig!("()Landroid/webkit/CookieManager;"),
+                &[],
+            ) {
+                if let Ok(mgr_obj) = mgr.l() {
+                    let null_cb = jni::objects::JObject::null();
+                    let _ = env.call_method(
+                        &mgr_obj,
+                        jni::jni_str!("removeAllCookies"),
+                        jni::jni_sig!("(Landroid/webkit/ValueCallback;)V"),
+                        &[JValue::Object(&null_cb)],
+                    );
+                }
             }
         }
-    }
-    unsafe {
-        let _ = env.pop_local_frame(&jni::objects::JObject::null());
-    }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }
 
 pub fn set_user_agent(handle: i64, ua_ptr: *const u8) {
@@ -521,25 +553,29 @@ pub fn set_user_agent(handle: i64, ua_ptr: *const u8) {
         Some(v) => v,
         None => return,
     };
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
-    if let Ok(settings) =
-        env.call_method(&view, "getSettings", "()Landroid/webkit/WebSettings;", &[])
-    {
-        if let Ok(s) = settings.l() {
-            if let Ok(jua) = env.new_string(ua) {
-                let _ = env.call_method(
-                    &s,
-                    "setUserAgentString",
-                    "(Ljava/lang/String;)V",
-                    &[JValue::Object(&jua)],
-                );
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
+        if let Ok(settings) = env.call_method(
+            view.as_obj(),
+            jni::jni_str!("getSettings"),
+            jni::jni_sig!("()Landroid/webkit/WebSettings;"),
+            &[],
+        ) {
+            if let Ok(s) = settings.l() {
+                if let Ok(jua) = env.new_string(ua) {
+                    let _ = env.call_method(
+                        &s,
+                        jni::jni_str!("setUserAgentString"),
+                        jni::jni_sig!("(Ljava/lang/String;)V"),
+                        &[JValue::Object(&jua)],
+                    );
+                }
             }
         }
-    }
-    unsafe {
-        let _ = env.pop_local_frame(&jni::objects::JObject::null());
-    }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }
 
 pub fn set_allowed_domains(handle: i64, domains_arr_handle: i64) {
@@ -555,7 +591,7 @@ pub fn set_allowed_domains(handle: i64, domains_arr_handle: i64) {
             let elem = js_array_get_element_f64(domains_arr_handle, i);
             let str_ptr = js_get_string_pointer_unified(elem);
             if !str_ptr.is_null() {
-                domains.push(unsafe { str_from_header(str_ptr) }.to_string());
+                domains.push(str_from_header(str_ptr).to_string());
             }
         }
     }
@@ -577,41 +613,47 @@ pub fn set_ephemeral(_handle: i64, ephemeral: i64) {
 /// truthy. Best-effort; errors are swallowed so a missing
 /// CookieManager / WebStorage class doesn't take down widget creation.
 fn wipe_process_storage() {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(8);
-    if let Ok(mgr_class) = env.find_class("android/webkit/CookieManager") {
-        if let Ok(mgr) = env.call_static_method(
-            &mgr_class,
-            "getInstance",
-            "()Landroid/webkit/CookieManager;",
-            &[],
-        ) {
-            if let Ok(mgr_obj) = mgr.l() {
-                let null_cb = jni::objects::JObject::null();
-                let _ = env.call_method(
-                    &mgr_obj,
-                    "removeAllCookies",
-                    "(Landroid/webkit/ValueCallback;)V",
-                    &[JValue::Object(&null_cb)],
-                );
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 8);
+        if let Ok(mgr_class) = env.find_class(jni::jni_str!("android/webkit/CookieManager")) {
+            if let Ok(mgr) = env.call_static_method(
+                &mgr_class,
+                jni::jni_str!("getInstance"),
+                jni::jni_sig!("()Landroid/webkit/CookieManager;"),
+                &[],
+            ) {
+                if let Ok(mgr_obj) = mgr.l() {
+                    let null_cb = jni::objects::JObject::null();
+                    let _ = env.call_method(
+                        &mgr_obj,
+                        jni::jni_str!("removeAllCookies"),
+                        jni::jni_sig!("(Landroid/webkit/ValueCallback;)V"),
+                        &[JValue::Object(&null_cb)],
+                    );
+                }
             }
         }
-    }
-    if let Ok(storage_class) = env.find_class("android/webkit/WebStorage") {
-        if let Ok(s) = env.call_static_method(
-            &storage_class,
-            "getInstance",
-            "()Landroid/webkit/WebStorage;",
-            &[],
-        ) {
-            if let Ok(storage) = s.l() {
-                let _ = env.call_method(&storage, "deleteAllData", "()V", &[]);
+        if let Ok(storage_class) = env.find_class(jni::jni_str!("android/webkit/WebStorage")) {
+            if let Ok(s) = env.call_static_method(
+                &storage_class,
+                jni::jni_str!("getInstance"),
+                jni::jni_sig!("()Landroid/webkit/WebStorage;"),
+                &[],
+            ) {
+                if let Ok(storage) = s.l() {
+                    let _ = env.call_method(
+                        &storage,
+                        jni::jni_str!("deleteAllData"),
+                        jni::jni_sig!("()V"),
+                        &[],
+                    );
+                }
             }
         }
-    }
-    unsafe {
-        let _ = env.pop_local_frame(&jni::objects::JObject::null());
-    }
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+    })
 }
 
 pub fn set_on_should_navigate(handle: i64, closure: f64) {

--- a/crates/perry-ui-android/src/widgets/wheel_picker.rs
+++ b/crates/perry-ui-android/src/widgets/wheel_picker.rs
@@ -1,7 +1,8 @@
 //! Native Android wheel picker backed by `android.widget.NumberPicker`.
 
 use crate::{callback, jni_bridge};
-use jni::objects::{JObject, JValue};
+use jni::objects::JObject;
+use jni::JValue;
 use std::cell::RefCell;
 use std::collections::HashMap;
 
@@ -12,41 +13,46 @@ thread_local! {
 use perry_ffi::copy_string_from_raw as str_from_header;
 
 pub fn create(on_change: f64) -> i64 {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(24);
-    let activity = super::get_activity(&mut env);
-    let picker = env
-        .new_object(
-            "android/widget/NumberPicker",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("Failed to create NumberPicker");
-    let _ = env.call_method(&picker, "setEnabled", "(Z)V", &[JValue::Bool(0)]);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 24);
+        let activity = super::get_activity(env);
+        let picker = env
+            .new_object(
+                jni::jni_str!("android/widget/NumberPicker"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("Failed to create NumberPicker");
+        let _ = env.call_method(
+            &picker,
+            jni::jni_str!("setEnabled"),
+            jni::jni_sig!("(Z)V"),
+            &[JValue::Bool(false)],
+        );
 
-    if on_change != 0.0 {
-        let callback_key = callback::register(on_change);
-        let bridge =
-            jni_bridge::with_cache(|c| env.new_local_ref(c.perry_bridge_class.as_obj()).unwrap());
-        let bridge_class: &jni::objects::JClass = (&bridge).into();
-        env.call_static_method(
-            bridge_class,
-            "setNumberPickerCallback",
-            "(Landroid/widget/NumberPicker;J)V",
-            &[JValue::Object(&picker), JValue::Long(callback_key)],
-        )
-        .expect("Failed to install NumberPicker callback");
-    }
+        if on_change != 0.0 {
+            let callback_key = callback::register(on_change);
+            let bridge =
+                jni_bridge::with_cache(|c| env.new_local_ref(&c.perry_bridge_class).unwrap());
+            let bridge_class: &jni::objects::JClass = &bridge;
+            env.call_static_method(
+                bridge_class,
+                jni::jni_str!("setNumberPickerCallback"),
+                jni::jni_sig!("(Landroid/widget/NumberPicker;J)V"),
+                &[JValue::Object(&picker), JValue::Long(callback_key)],
+            )
+            .expect("Failed to install NumberPicker callback");
+        }
 
-    let global = env
-        .new_global_ref(picker)
-        .expect("Failed to create NumberPicker global ref");
-    let handle = super::register_widget(global);
-    ITEMS.with(|m| m.borrow_mut().insert(handle, Vec::new()));
-    unsafe {
-        env.pop_local_frame(&JObject::null());
-    }
-    handle
+        let global = jni_bridge::new_global_ref(env, picker)
+            .expect("Failed to create NumberPicker global ref");
+        let handle = super::register_widget(global);
+        ITEMS.with(|m| m.borrow_mut().insert(handle, Vec::new()));
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+        }
+        handle
+    })
 }
 
 pub fn add_item(handle: i64, title_ptr: *const u8) {
@@ -68,49 +74,63 @@ fn refresh_items(handle: i64, items: &[String]) {
     let Some(view) = super::get_widget(handle) else {
         return;
     };
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(24 + items.len() as i32);
-    let string_class = env.find_class("java/lang/String").expect("String class");
-    let values = env
-        .new_object_array(items.len() as i32, &string_class, &JObject::null())
-        .expect("Failed to create NumberPicker values");
-    for (index, item) in items.iter().enumerate() {
-        let value = env.new_string(item).expect("Failed to create picker value");
-        env.set_object_array_element(&values, index as i32, &value)
-            .expect("Failed to store picker value");
-    }
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 24 + items.len() as i32);
+        let string_class = env
+            .find_class(jni::jni_str!("java/lang/String"))
+            .expect("String class");
+        let values = env
+            .new_object_array(items.len() as i32, &string_class, &JObject::null())
+            .expect("Failed to create NumberPicker values");
+        for (index, item) in items.iter().enumerate() {
+            let value = env.new_string(item).expect("Failed to create picker value");
+            values
+                .set_element(env, index, &value)
+                .expect("Failed to store picker value");
+        }
 
-    // NumberPicker requires clearing displayedValues before its range changes.
-    let null = JObject::null();
-    let _ = env.call_method(
-        view.as_obj(),
-        "setDisplayedValues",
-        "([Ljava/lang/String;)V",
-        &[JValue::Object(&null)],
-    );
-    let _ = env.call_method(view.as_obj(), "setMinValue", "(I)V", &[JValue::Int(0)]);
-    let _ = env.call_method(
-        view.as_obj(),
-        "setMaxValue",
-        "(I)V",
-        &[JValue::Int(items.len() as i32 - 1)],
-    );
-    let _ = env.call_method(
-        view.as_obj(),
-        "setDisplayedValues",
-        "([Ljava/lang/String;)V",
-        &[JValue::Object(&values)],
-    );
-    let _ = env.call_method(
-        view.as_obj(),
-        "setWrapSelectorWheel",
-        "(Z)V",
-        &[JValue::Bool((items.len() > 2) as u8)],
-    );
-    let _ = env.call_method(view.as_obj(), "setEnabled", "(Z)V", &[JValue::Bool(1)]);
-    unsafe {
-        env.pop_local_frame(&JObject::null());
-    }
+        // NumberPicker requires clearing displayedValues before its range changes.
+        let null = JObject::null();
+        let _ = env.call_method(
+            view.as_obj(),
+            jni::jni_str!("setDisplayedValues"),
+            jni::jni_sig!("([Ljava/lang/String;)V"),
+            &[JValue::Object(&null)],
+        );
+        let _ = env.call_method(
+            view.as_obj(),
+            jni::jni_str!("setMinValue"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(0)],
+        );
+        let _ = env.call_method(
+            view.as_obj(),
+            jni::jni_str!("setMaxValue"),
+            jni::jni_sig!("(I)V"),
+            &[JValue::Int(items.len() as i32 - 1)],
+        );
+        let _ = env.call_method(
+            view.as_obj(),
+            jni::jni_str!("setDisplayedValues"),
+            jni::jni_sig!("([Ljava/lang/String;)V"),
+            &[JValue::Object(&values)],
+        );
+        let _ = env.call_method(
+            view.as_obj(),
+            jni::jni_str!("setWrapSelectorWheel"),
+            jni::jni_sig!("(Z)V"),
+            &[JValue::Bool(items.len() > 2)],
+        );
+        let _ = env.call_method(
+            view.as_obj(),
+            jni::jni_str!("setEnabled"),
+            jni::jni_sig!("(Z)V"),
+            &[JValue::Bool(true)],
+        );
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &JObject::null());
+        }
+    })
 }
 
 pub fn set_selected(handle: i64, index: i64) {
@@ -123,13 +143,14 @@ pub fn set_selected(handle: i64, index: i64) {
         return;
     }
     if let Some(view) = super::get_widget(handle) {
-        let mut env = jni_bridge::get_env();
-        let _ = env.call_method(
-            view.as_obj(),
-            "setValue",
-            "(I)V",
-            &[JValue::Int(index as i32)],
-        );
+        jni_bridge::with_env(|env| {
+            let _ = env.call_method(
+                view.as_obj(),
+                jni::jni_str!("setValue"),
+                jni::jni_sig!("(I)V"),
+                &[JValue::Int(index as i32)],
+            );
+        })
     }
 }
 
@@ -145,9 +166,15 @@ pub fn get_selected(handle: i64) -> i64 {
     let Some(view) = super::get_widget(handle) else {
         return -1;
     };
-    let mut env = jni_bridge::get_env();
-    env.call_method(view.as_obj(), "getValue", "()I", &[])
+    jni_bridge::with_env(|env| {
+        env.call_method(
+            view.as_obj(),
+            jni::jni_str!("getValue"),
+            jni::jni_sig!("()I"),
+            &[],
+        )
         .and_then(|value| value.i())
         .map(i64::from)
         .unwrap_or(-1)
+    })
 }

--- a/crates/perry-ui-android/src/widgets/zstack.rs
+++ b/crates/perry-ui-android/src/widgets/zstack.rs
@@ -1,27 +1,27 @@
 //! ZStack — FrameLayout (overlapping children)
 
 use crate::jni_bridge;
-use jni::objects::JValue;
+use jni::JValue;
 
 pub fn create() -> i64 {
-    let mut env = jni_bridge::get_env();
-    let _ = env.push_local_frame(32);
+    jni_bridge::with_env(|env| {
+        let _ = jni_bridge::push_local_frame(env, 32);
 
-    let activity = super::get_activity(&mut env);
-    let frame_layout = env
-        .new_object(
-            "android/widget/FrameLayout",
-            "(Landroid/content/Context;)V",
-            &[JValue::Object(&activity)],
-        )
-        .expect("Failed to create FrameLayout");
+        let activity = super::get_activity(env);
+        let frame_layout = env
+            .new_object(
+                jni::jni_str!("android/widget/FrameLayout"),
+                jni::jni_sig!("(Landroid/content/Context;)V"),
+                &[JValue::Object(&activity)],
+            )
+            .expect("Failed to create FrameLayout");
 
-    let global = env
-        .new_global_ref(frame_layout)
-        .expect("Failed to create global ref");
-    let handle = super::register_widget(global);
-    unsafe {
-        env.pop_local_frame(&jni::objects::JObject::null());
-    }
-    handle
+        let global =
+            jni_bridge::new_global_ref(env, frame_layout).expect("Failed to create global ref");
+        let handle = super::register_widget(global);
+        unsafe {
+            let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+        }
+        handle
+    })
 }

--- a/crates/perry-ui-android/src/window.rs
+++ b/crates/perry-ui-android/src/window.rs
@@ -1,7 +1,8 @@
 //! Multi-window — Dialog-based windows on Android
 
 use crate::jni_bridge;
-use jni::objects::{GlobalRef, JValue};
+use crate::jni_bridge::GlobalRef;
+use jni::JValue;
 use std::cell::RefCell;
 use std::collections::HashMap;
 
@@ -9,8 +10,8 @@ use perry_ffi::copy_string_from_raw as str_from_header;
 
 struct WindowState {
     title: String,
-    width: f64,
-    height: f64,
+    _width: f64,
+    _height: f64,
     body_handle: Option<i64>,
     dialog_ref: Option<GlobalRef>,
 }
@@ -34,8 +35,8 @@ pub fn create(title_ptr: *const u8, width: f64, height: f64) -> i64 {
             id,
             WindowState {
                 title,
-                width,
-                height,
+                _width: width,
+                _height: height,
                 body_handle: None,
                 dialog_ref: None,
             },
@@ -65,53 +66,53 @@ pub fn show(window_handle: i64) {
 
     if let Some(body_handle) = body {
         if let Some(view_ref) = crate::widgets::get_widget(body_handle) {
-            let mut env = jni_bridge::get_env();
-            let _ = env.push_local_frame(32);
+            jni_bridge::with_env(|env| {
+                let _ = jni_bridge::push_local_frame(env, 32);
 
-            let activity = crate::widgets::get_activity(&mut env);
+                let activity = crate::widgets::get_activity(env);
 
-            let dialog = env
-                .new_object(
-                    "android/app/Dialog",
-                    "(Landroid/content/Context;)V",
-                    &[JValue::Object(&activity)],
-                )
-                .expect("Failed to create Dialog");
+                let dialog = env
+                    .new_object(
+                        jni::jni_str!("android/app/Dialog"),
+                        jni::jni_sig!("(Landroid/content/Context;)V"),
+                        &[JValue::Object(&activity)],
+                    )
+                    .expect("Failed to create Dialog");
 
-            // Set title
-            if !title.is_empty() {
-                let jtitle = env.new_string(&title).expect("Failed to create JNI string");
+                // Set title
+                if !title.is_empty() {
+                    let jtitle = env.new_string(&title).expect("Failed to create JNI string");
+                    let _ = env.call_method(
+                        &dialog,
+                        jni::jni_str!("setTitle"),
+                        jni::jni_sig!("(Ljava/lang/CharSequence;)V"),
+                        &[JValue::Object(&jtitle)],
+                    );
+                }
+
+                // Set content
                 let _ = env.call_method(
                     &dialog,
-                    "setTitle",
-                    "(Ljava/lang/CharSequence;)V",
-                    &[JValue::Object(&jtitle)],
+                    jni::jni_str!("setContentView"),
+                    jni::jni_sig!("(Landroid/view/View;)V"),
+                    &[JValue::Object(view_ref.as_obj())],
                 );
-            }
 
-            // Set content
-            let _ = env.call_method(
-                &dialog,
-                "setContentView",
-                "(Landroid/view/View;)V",
-                &[JValue::Object(view_ref.as_obj())],
-            );
+                let _ = env.call_method(&dialog, jni::jni_str!("show"), jni::jni_sig!("()V"), &[]);
 
-            let _ = env.call_method(&dialog, "show", "()V", &[]);
+                let global =
+                    jni_bridge::new_global_ref(env, dialog).expect("Failed to create global ref");
+                WINDOWS.with(|w| {
+                    let mut windows = w.borrow_mut();
+                    if let Some(state) = windows.get_mut(&window_handle) {
+                        state.dialog_ref = Some(global);
+                    }
+                });
 
-            let global = env
-                .new_global_ref(dialog)
-                .expect("Failed to create global ref");
-            WINDOWS.with(|w| {
-                let mut windows = w.borrow_mut();
-                if let Some(state) = windows.get_mut(&window_handle) {
-                    state.dialog_ref = Some(global);
+                unsafe {
+                    let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
                 }
-            });
-
-            unsafe {
-                env.pop_local_frame(&jni::objects::JObject::null());
-            }
+            })
         }
     }
 }
@@ -125,11 +126,17 @@ pub fn close(window_handle: i64) {
     });
 
     if let Some(dialog_ref) = dialog {
-        let mut env = jni_bridge::get_env();
-        let _ = env.push_local_frame(8);
-        let _ = env.call_method(dialog_ref.as_obj(), "dismiss", "()V", &[]);
-        unsafe {
-            env.pop_local_frame(&jni::objects::JObject::null());
-        }
+        jni_bridge::with_env(|env| {
+            let _ = jni_bridge::push_local_frame(env, 8);
+            let _ = env.call_method(
+                dialog_ref.as_obj(),
+                jni::jni_str!("dismiss"),
+                jni::jni_sig!("()V"),
+                &[],
+            );
+            unsafe {
+                let _ = jni_bridge::pop_local_frame(env, &jni::objects::JObject::null());
+            }
+        })
     }
 }


### PR DESCRIPTION
Lands dependabot's #9454 with the migration it was missing. The bump commit is dependabot's; the migration was done by a codex agent I ran with a working Android cross-check as its loop, and I verified the result independently.

**Why the bump alone couldn't merge:** jni 0.22 is a breaking release. Measured, not inferred — `main` passes the `aarch64-linux-android` cross-check in ~25s; the bump as filed fails with **1,601 errors** (`JValueGen` removed, `GlobalRef` now generic). And the break would have been silent: the crate is `#![cfg(target_os = "android")]` (host checks pass vacuously) and `build-cross` is `fail-fast: false`, so it would present as a missing Android UI bundle, not a red job.

**The migration**, per the agent's report and my audit: JValueGen/GlobalRef reshapes, `JObject::from_raw(env, raw)`, `JNI_OnLoad` over FFI-safe raw types, and compatibility `push/pop_local_frame` helpers over JNI v1.2's raw frame functions. Exported C/JNI ABI unchanged; no crate outside `perry-ui-android` touched.

**What I verified myself, not from the report:**
- **Frame discipline one-for-one:** `main` has 233 `pop_local_frame` / 202 `push_local_frame` lines in the crate; the migrated tree has 234/204 — exactly the two new helper definitions. An over-released JNI local is a device-only use-after-free, so this was the audit's focus.
- **Android cross-check exit 0, zero errors, zero perry-ui-android warnings** — re-run by me with the NDK recipe recorded on #9454.
- No baseline/allowlist/ratchet file in the diff; no other crate touched; fmt and file-size green.

**Stated limit:** runtime behaviour under ART is not verifiable off-device. The migration is compile-verified and structure-preserving; the first on-device exercise will be the real test, which is also true of every change to this crate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated Android integration to the latest JNI interface.
  - Improved management of Android runtime connections and temporary references.
  - Standardized handling of Java strings, method calls, signatures, and boolean values across Android features and widgets.
  - Preserved existing UI, media, networking, callback, and system behavior while improving compatibility with the updated Android bridge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->