### PR TITLE
test(9087): class toString reports source identity after #9465

### DIFF
--- a/crates/perry/tests/issue_9087_class_ref_add.rs
+++ b/crates/perry/tests/issue_9087_class_ref_add.rs
@@ -63,9 +63,17 @@ console.log(valued + 2);
     assert_eq!(
         String::from_utf8_lossy(&run.stdout),
         concat!(
-            "string function K() { [native code] }1\n",
-            "string 1function K() { [native code] }\n",
-            "string function K() { [native code] }01234567\n",
+            // #9465 made class name/toString/inspect report SOURCE IDENTITY,
+            // which is what node does — `String(class K {…})` is the class's
+            // source text, not `function K() { [native code] }`. Verified:
+            //   $ node -e 'class K { static m() { return 1; } }; \
+            //              console.log("string " + K + "1")'
+            //   string class K { static m() { return 1; } }1
+            // Perry reports the TypeScript source it compiled, so the type
+            // annotation is retained here.
+            "string class K { static m(): number { return 1; } }1\n",
+            "string 1class K { static m(): number { return 1; } }\n",
+            "string class K { static m(): number { return 1; } }01234567\n",
             "42\n"
         )
     );


### PR DESCRIPTION
`cargo-test-perry (2/8)` fails on `main`:

```
test class_refs_use_string_concatenation_for_dynamic_add ... FAILED
  left:  "string class K { static m(): number { return 1; } }1\n…"
  right: "string function K() { [native code] }1\n…"
```

**The code is right; the test expectation is stale.** `e86a2611cf` ("class name/toString/inspect report source identity", from #9465) deliberately changed `String(SomeClass)` from `function K() { [native code] }` to the class's source text — which is what node does:

```
$ node -e 'class K { static m() { return 1; } }; console.log("string " + K + "1")'
string class K { static m() { return 1; } }1
```

`issue_9087_class_ref_add.rs` was not updated alongside it. This updates the three affected lines to the new (more spec-correct) output, with the node verification recorded inline so the next reader does not have to re-derive it.

Perry reports the **TypeScript** source it compiled, so the `: number` annotation is retained in the expected string — that difference is noted in the comment.

Verified locally: `cargo test -p perry --test issue_9087_class_ref_add` → `1 passed; 0 failed`.

Blocking: `cargo-test-perry` is in `full-suite-gate`'s needs, so this stops any release cut.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected string conversion for declared classes used in dynamic concatenation.
  - Class values now stringify to their TypeScript source identity instead of a native-function representation.
  - Preserved existing numeric conversion behavior for `valueOf` cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->