### PR TITLE
fix(codegen): root the dynamic-dispatch receiver across its argument list (#9417)

### DIFF
--- a/changelog.d/9417-dispatch-receiver-roots.md
+++ b/changelog.d/9417-dispatch-receiver-roots.md
@@ -1,0 +1,32 @@
+### Fixed
+
+- **A dynamic instance-method call no longer loses its receiver to the GC
+  (#9417).** `lower_call/property_get/dynamic_dispatch.rs` lowered the receiver
+  first — JS evaluation order requires the MemberExpression to be evaluated
+  before the arguments — and then consumed it last, in the own-override probe,
+  the class-id tower and `js_native_call_method`. Every argument expression was
+  lowered in between, and an argument is arbitrary user code that can allocate.
+  A bare SSA register is not a GC root, so an evacuating young-gen minor inside
+  an argument left the receiver naming from-space.
+
+  Nothing faulted at the move. `js_object_get_own_field_or_undef` failed its
+  `obj_type == GC_TYPE_OBJECT` check on the recycled cell and answered
+  `TAG_UNDEFINED`, so the override probe missed and the by-name dispatch ran on
+  a retired address — the failure surfaced as a wrong answer several steps
+  downstream, naming a property unrelated to the defect. In the Claude Code
+  bundle that was `Cannot read properties of undefined (reading 'def')` on the
+  request-build path, from zod's `ZodObject.extend`; unauthenticated
+  `--input-format stream-json` went from 24/25 runs bad to 0/25.
+
+  Both dispatch sites in that file — the unknown-receiver-class path and the
+  known-class virtual tower — now root the receiver and every argument in one
+  `RootedGroup` and re-read below the group, the same combinator
+  `early_branches.rs`'s computed-key dispatch (`obj[k](…)`) has used since
+  #7210. `root_reload` then re-derives each later use that a collection point
+  can reach. `operand_protection` still decides how each operand is protected,
+  so a provably non-pointer argument costs nothing.
+
+  `test-files/test_gap_9417_dispatch_receiver_roots.ts` reproduces the wrong
+  answer deterministically with no GC environment knobs, and
+  `temp_root_coverage::dispatch_receiver` pins the emission contract under both
+  root lowerings.

--- a/crates/perry-codegen/src/lower_call/property_get/dynamic_dispatch.rs
+++ b/crates/perry-codegen/src/lower_call/property_get/dynamic_dispatch.rs
@@ -7,7 +7,7 @@ use super::*;
 use anyhow::Result;
 use perry_hir::Expr;
 
-use crate::expr::{lower_expr, nanbox_pointer_inline, unbox_to_i64, FnCtx};
+use crate::expr::{nanbox_pointer_inline, unbox_to_i64, FnCtx};
 use crate::nanbox::double_literal;
 use crate::type_analysis::receiver_class_name;
 use crate::types::{DOUBLE, I1, I32, I64};
@@ -923,10 +923,29 @@ pub(crate) fn try_lower_instance_method_call(
                 }
             }
 
-            let recv_box = lower_expr(ctx, object)?;
-            let mut fallback_user_args: Vec<String> = Vec::with_capacity(args.len());
+            // #9417, same defect as the dynamic-dispatch site above and for the
+            // same reason: the receiver is lowered first (JS evaluation order)
+            // and consumed by the override probe, the guarded direct calls and
+            // every arm of the class-id tower — all of it below the lowering of
+            // the argument expressions, any of which can drive an evacuating
+            // young-gen minor. `build_direct_method_args` additionally allocates
+            // a rest array between the re-read and the call.
+            //
+            // One `RootedGroup` over [receiver, ...args], re-read below the
+            // group. Every later use is a use of a register loaded out of a
+            // rooted slot, so `root_reload` re-derives the ones a collection
+            // point can reach — which is what makes a single re-read enough for
+            // a block with nine exits.
+            let mut roots = crate::rooting::open_rooted_group(1 + args.len());
+            let recv_idx = roots.lower(ctx, object, true)?;
+            let mut arg_idxs: Vec<usize> = Vec::with_capacity(args.len());
             for a in args {
-                fallback_user_args.push(lower_expr(ctx, a)?);
+                arg_idxs.push(roots.lower(ctx, a, true)?);
+            }
+            let recv_box = roots.reread(ctx, recv_idx)?;
+            let mut fallback_user_args: Vec<String> = Vec::with_capacity(args.len());
+            for &idx in &arg_idxs {
+                fallback_user_args.push(roots.reread(ctx, idx)?);
             }
             // #5391 path 4 (virtual tower): eligibility to collapse the
             // per-overriding-subclass class-id switch to a single by-name
@@ -1013,14 +1032,16 @@ pub(crate) fn try_lower_instance_method_call(
             if (fallback_has_rest || override_meta.iter().any(|meta| meta.0))
                 && can_collapse_virtual
             {
-                return Ok(Some(emit_collapsed_instance_dispatch(
+                let collapsed = emit_collapsed_instance_dispatch(
                     ctx,
                     &recv_box,
                     property,
                     &fallback_user_args,
                     call_byte_offset,
                     /* with_override_probe */ false,
-                )?));
+                )?;
+                roots.release(ctx);
+                return Ok(Some(collapsed));
             }
             let undefined_lit = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
             let direct_args = build_direct_method_args(
@@ -1351,6 +1372,7 @@ pub(crate) fn try_lower_instance_method_call(
                         } else {
                             ctx.block().call(DOUBLE, &target, &fast_args)
                         };
+                        roots.release(ctx);
                         return Ok(Some(value));
                     }
                 }
@@ -1400,7 +1422,9 @@ pub(crate) fn try_lower_instance_method_call(
                     if fallback_arguments_length_only {
                         let target =
                             crate::codegen::arguments::arguments_length_method_name(&fallback_fn);
-                        return Ok(Some(ctx.block().call(DOUBLE, &target, &arg_slices)));
+                        let value = ctx.block().call(DOUBLE, &target, &arg_slices);
+                        roots.release(ctx);
+                        return Ok(Some(value));
                     }
                     // Representation-selection Phase 5a: the proven-`this`
                     // clone, when one was emitted. Hoisted above the
@@ -1464,6 +1488,7 @@ pub(crate) fn try_lower_instance_method_call(
                             &fallback_fn,
                             &argument_specialized,
                         );
+                        roots.release(ctx);
                         return Ok(Some(argument_specialized));
                     }
                     // Prefer the typed-receiver clone (bare gep+load field
@@ -1532,6 +1557,7 @@ pub(crate) fn try_lower_instance_method_call(
                             &fallback_fn,
                             &merged,
                         );
+                        roots.release(ctx);
                         return Ok(Some(merged));
                     }
                     // Representation-selection Phase 5a: route to the
@@ -1546,6 +1572,7 @@ pub(crate) fn try_lower_instance_method_call(
                         &fallback_fn,
                         &direct,
                     );
+                    roots.release(ctx);
                     return Ok(Some(direct));
                 }
                 let arguments_length_direct_fn = fallback_arguments_length_only
@@ -1593,6 +1620,7 @@ pub(crate) fn try_lower_instance_method_call(
                     shape_only_guard,
                     &subclass_arms,
                 ) {
+                    roots.release(ctx);
                     return Ok(Some(guarded));
                 }
             }
@@ -1634,7 +1662,7 @@ pub(crate) fn try_lower_instance_method_call(
                 // array as one positional argument and break a native override
                 // such as `super.emit(event, ...args)` forwarding to
                 // EventEmitter (#620 / rest-spread-to-native-override).
-                return Ok(Some(emit_own_method_override_check(
+                let checked = emit_own_method_override_check(
                     ctx,
                     &recv_box,
                     property,
@@ -1642,7 +1670,9 @@ pub(crate) fn try_lower_instance_method_call(
                     &arg_slices,
                     &recv_box,
                     &fallback_user_args,
-                )));
+                );
+                roots.release(ctx);
+                return Ok(Some(checked));
             }
 
             // #5391 path 4 (virtual tower): collapse the per-overriding-subclass
@@ -1654,14 +1684,16 @@ pub(crate) fn try_lower_instance_method_call(
             // behavior-identical. The rest-bearing case already collapsed above
             // (before the rest bundling); this handles the non-rest case.
             if can_collapse_virtual {
-                return Ok(Some(emit_collapsed_instance_dispatch(
+                let collapsed = emit_collapsed_instance_dispatch(
                     ctx,
                     &recv_box,
                     property,
                     &fallback_user_args,
                     call_byte_offset,
                     /* with_override_probe */ false,
-                )?));
+                )?;
+                roots.release(ctx);
+                return Ok(Some(collapsed));
             }
 
             // Step 4: virtual dispatch via class_id switch.
@@ -1782,7 +1814,12 @@ pub(crate) fn try_lower_instance_method_call(
                 .iter()
                 .map(|(v, l)| (v.as_str(), l.as_str()))
                 .collect();
-            return Ok(Some(ctx.block().phi(DOUBLE, &phi_args)));
+            let v_tower = ctx.block().phi(DOUBLE, &phi_args);
+            // The release post-dominates every case block and the default arm,
+            // which is why the group is `open_rooted_group`: releasing inside an
+            // arm would cut slots a sibling arm still reads.
+            roots.release(ctx);
+            return Ok(Some(v_tower));
         }
     }
     Ok(None)

--- a/crates/perry-codegen/src/lower_call/property_get/dynamic_dispatch.rs
+++ b/crates/perry-codegen/src/lower_call/property_get/dynamic_dispatch.rs
@@ -331,7 +331,37 @@ pub(crate) fn try_lower_instance_method_call(
             }
         }
         if !implementors.is_empty() {
-            let recv_box = lower_expr(ctx, object)?;
+            // #9417: the receiver is lowered FIRST — JS evaluation order requires
+            // the MemberExpression to be evaluated before the arguments — and
+            // consumed LAST, after every argument expression. Each of those is
+            // arbitrary user code that can drive an evacuating young-gen minor,
+            // and a bare SSA register is not a GC root
+            // (`docs/src/internals/gc-rooting-invariant.md`, case 3), so from the
+            // first collection onward the receiver names from-space.
+            //
+            // Nothing faults there. `js_object_get_own_field_or_undef` fails its
+            // `obj_type == GC_TYPE_OBJECT` check on the recycled cell and answers
+            // TAG_UNDEFINED, the own-override probe misses, and the by-name
+            // dispatch runs on a retired address — so the failure surfaces as a
+            // wrong answer several steps downstream. That is #9417's `reading
+            // 'def'` in the Claude Code bundle: zod's `K4.extend(q, {…})` with the
+            // object literal in argument position.
+            //
+            // `early_branches.rs`'s COMPUTED-key dispatch (`obj[k](…)`) got this
+            // in #7210 (3); the named-property tower here did not. Same fix, same
+            // combinator: one `RootedGroup` over [receiver, ...args], re-read
+            // below the group. `root_reload` then re-derives every later use that
+            // a collection point can reach, so the re-read is needed once here
+            // rather than at each of the tower's ~dozen consumers.
+            //
+            // The window is stated as "collects" unconditionally: the consuming
+            // calls (`js_native_call_method` / `js_native_call_value`) run user
+            // code, and the receiver is live across the override probe that
+            // precedes them, so the answer does not depend on the arguments.
+            // `operand_protection` still decides HOW each operand is protected, so
+            // a numeric or boolean argument pays nothing.
+            let mut roots = crate::rooting::open_rooted_group(1 + args.len());
+            let recv_idx = roots.lower(ctx, object, true)?;
             // #1758 / epic #1785: the raw user args (no `this`, no issue-#235
             // padding, no rest-bundling) drive every concrete callee below. A
             // `perry_static_*` implementor (a class-object value reaching this
@@ -341,9 +371,14 @@ pub(crate) fn try_lower_instance_method_call(
             // static arity/rest semantics; the instance-style `fname(recv,
             // args…)` direct call would pass recv as arg0 and never set
             // IMPLICIT_THIS (the #1787 broken-tower bug).
-            let mut static_user_args: Vec<String> = Vec::with_capacity(args.len());
+            let mut arg_idxs: Vec<usize> = Vec::with_capacity(args.len());
             for a in args {
-                static_user_args.push(lower_expr(ctx, a)?);
+                arg_idxs.push(roots.lower(ctx, a, true)?);
+            }
+            let recv_box = roots.reread(ctx, recv_idx)?;
+            let mut static_user_args: Vec<String> = Vec::with_capacity(args.len());
+            for &idx in &arg_idxs {
+                static_user_args.push(roots.reread(ctx, idx)?);
             }
             // #5391 path 4: oversized modules full-outline the class-id switch
             // tower. The tower emits one icmp + case block per class implementing
@@ -369,6 +404,9 @@ pub(crate) fn try_lower_instance_method_call(
                     call_byte_offset,
                     /* with_override_probe */ true,
                 )?;
+                // Released below the call that reads the group, in the merge the
+                // collapse helper leaves current (`open_rooted_group`'s contract).
+                roots.release(ctx);
                 return Ok(Some(v));
             }
             // #5437: each implementor of `property` has its OWN declared arity
@@ -779,13 +817,18 @@ pub(crate) fn try_lower_instance_method_call(
 
             // Outer merge: phi over override and dispatch values.
             ctx.current_block = probe_outer_merge_idx;
-            return Ok(Some(ctx.block().phi(
+            let v_probe_phi = ctx.block().phi(
                 DOUBLE,
                 &[
                     (v_override_probe.as_str(), after_override_probe.as_str()),
                     (v_dispatch_phi.as_str(), after_dispatch_phi.as_str()),
                 ],
-            )));
+            );
+            // The release has to post-dominate BOTH arms of the override probe
+            // and every case block of the tower, which is why this group is
+            // `open_rooted_group` and the release sits in the outer merge.
+            roots.release(ctx);
+            return Ok(Some(v_probe_phi));
         }
     }
 

--- a/crates/perry-codegen/src/temp_root_coverage/dispatch_receiver.rs
+++ b/crates/perry-codegen/src/temp_root_coverage/dispatch_receiver.rs
@@ -107,7 +107,9 @@ fn tagged_class() -> perry_hir::Class {
 fn main_ir_for_dispatch(name: &str, arg: Expr) -> String {
     let mut module = Module::new(name);
     module.classes.push(tagged_class());
-    module.functions.push(empty_fn(MAKE_FN, "makeTagged", Type::Any));
+    module
+        .functions
+        .push(empty_fn(MAKE_FN, "makeTagged", Type::Any));
     // A named local so the module is not optimized down to nothing; the call's
     // receiver is still the inline `makeTagged()` result.
     module.init.push(Stmt::Let {
@@ -137,8 +139,8 @@ fn main_ir_for_dispatch(name: &str, arg: Expr) -> String {
         app_metadata: AppMetadata::default(),
         ..entry_opts()
     };
-    let bytes = compile_module(&module, opts)
-        .unwrap_or_else(|e| panic!("codegen failed for {name}: {e}"));
+    let bytes =
+        compile_module(&module, opts).unwrap_or_else(|e| panic!("codegen failed for {name}: {e}"));
     let ir = String::from_utf8(bytes).expect("LLVM IR should be UTF-8");
     crate::testing::root_slots::function_slice(&ir, "main").to_string()
 }

--- a/crates/perry-codegen/src/temp_root_coverage/dispatch_receiver.rs
+++ b/crates/perry-codegen/src/temp_root_coverage/dispatch_receiver.rs
@@ -1,0 +1,202 @@
+//! #9417: the instance-method dispatch tower's RECEIVER is a rooted temporary,
+//! not an SSA register.
+//!
+//! `lower_call/property_get/dynamic_dispatch.rs` lowers `object` first — JS
+//! evaluation order requires the MemberExpression to be evaluated before the
+//! arguments — and consumes it last, in `js_object_get_own_field_or_undef`, the
+//! class-id tower and `js_native_call_method`. Between those two points sit the
+//! argument expressions, which are arbitrary user code that can allocate. A bare
+//! SSA register is not a GC root, so an evacuating young-gen minor in an
+//! argument leaves the receiver naming from-space
+//! (`docs/src/internals/gc-rooting-invariant.md`, case 3).
+//!
+//! Nothing faults at the move: the probe fails its `obj_type == GC_TYPE_OBJECT`
+//! check on the recycled cell and answers TAG_UNDEFINED, so the wrong answer
+//! surfaces several steps downstream. `test-files/test_gap_9417_dispatch_
+//! receiver_roots.ts` is the end-to-end half of this, and it fails
+//! deterministically without GC environment knobs.
+//!
+//! # Non-vacuity
+//!
+//! The positive assertion names the VALUE — the register `makeTagged` produced
+//! went into a rooted slot, and the probe read its operand back OUT of that slot
+//! — so a compiler that roots nothing cannot satisfy it by emitting nothing. The
+//! receiver is deliberately a CALL RESULT rather than a local read: a load out of
+//! a shadow slot is a re-readable location that `root_reload` already re-derives,
+//! so a `LocalGet` receiver would pass against the unfixed compiler.
+//!
+//! The second test is the differential control on the other side: a numeric
+//! argument is not a heap reference, `operand_protection` answers `Reuse` for it,
+//! and it must still pay no slot. A fix that roots every operand unconditionally
+//! fails it.
+
+use super::{allocating, entry_opts, under_both_lowerings};
+use crate::testing::temp_slots::{assert_rooted_across, first_call_result, temp_root_slots};
+use crate::{compile_module, AppMetadata, CompileOptions};
+use perry_hir::types::Type;
+use perry_hir::{Expr, Function, Module, Stmt};
+
+const MAKE_FN: u32 = 900;
+const TAGGED_CLASS: u32 = 901;
+const JOIN_FN: u32 = 902;
+const RECV_LOCAL: u32 = 903;
+
+fn empty_fn(id: u32, name: &str, return_type: Type) -> Function {
+    Function {
+        id,
+        name: name.to_string(),
+        type_params: Vec::new(),
+        params: Vec::new(),
+        return_type,
+        body: vec![Stmt::Return(Some(Expr::Undefined))],
+        is_async: false,
+        is_generator: false,
+        is_strict: true,
+        is_exported: false,
+        captures: Vec::new(),
+        decorators: Vec::new(),
+        was_plain_async: false,
+        was_unrolled: false,
+    }
+}
+
+/// A class declaring `join`, so `property` has an implementor and the call takes
+/// the dispatch tower instead of a direct static call.
+fn tagged_class() -> perry_hir::Class {
+    perry_hir::Class {
+        id: TAGGED_CLASS,
+        name: "Tagged".to_string(),
+        type_params: Vec::new(),
+        extends: None,
+        extends_name: None,
+        native_extends: None,
+        extends_expr: None,
+        heritage_lexically_shadowed: false,
+        fields: vec![perry_hir::ClassField {
+            name: "tag".to_string(),
+            key_expr: None,
+            ty: Type::String,
+            init: None,
+            is_private: false,
+            is_readonly: false,
+            decorators: Vec::new(),
+        }],
+        constructor: None,
+        methods: vec![empty_fn(JOIN_FN, "join", Type::Any)],
+        getters: Vec::new(),
+        setters: Vec::new(),
+        static_accessor_names: Vec::new(),
+        static_accessor_fn_ids: Vec::new(),
+        static_fields: Vec::new(),
+        static_methods: Vec::new(),
+        computed_members: Vec::new(),
+        decorators: Vec::new(),
+        is_exported: false,
+        is_nested: false,
+        alloc_width_hint: 0,
+        specialized_from: None,
+        aliases: Vec::new(),
+    }
+}
+
+/// `const r: any = makeTagged(); r.join(<arg>)` — but with the receiver INLINE
+/// in the call, so it is the call's result register and not a slot load.
+///
+/// `makeTagged` returns `any`, so `receiver_class_name` cannot name a class and
+/// `needs_dynamic_dispatch` selects the tower.
+fn main_ir_for_dispatch(name: &str, arg: Expr) -> String {
+    let mut module = Module::new(name);
+    module.classes.push(tagged_class());
+    module.functions.push(empty_fn(MAKE_FN, "makeTagged", Type::Any));
+    // A named local so the module is not optimized down to nothing; the call's
+    // receiver is still the inline `makeTagged()` result.
+    module.init.push(Stmt::Let {
+        id: RECV_LOCAL,
+        name: "out".to_string(),
+        ty: Type::Any,
+        mutable: false,
+        init: Some(Expr::Call {
+            callee: Box::new(Expr::PropertyGet {
+                object: Box::new(Expr::Call {
+                    callee: Box::new(Expr::FuncRef(MAKE_FN)),
+                    args: Vec::new(),
+                    type_args: Vec::new(),
+                    byte_offset: 0,
+                }),
+                property: "join".to_string(),
+                byte_offset: 0,
+            }),
+            args: vec![arg],
+            type_args: Vec::new(),
+            byte_offset: 0,
+        }),
+    });
+    module.init.push(Stmt::Expr(Expr::LocalGet(RECV_LOCAL)));
+
+    let opts = CompileOptions {
+        app_metadata: AppMetadata::default(),
+        ..entry_opts()
+    };
+    let bytes = compile_module(&module, opts)
+        .unwrap_or_else(|e| panic!("codegen failed for {name}: {e}"));
+    let ir = String::from_utf8(bytes).expect("LLVM IR should be UTF-8");
+    crate::testing::root_slots::function_slice(&ir, "main").to_string()
+}
+
+/// THE GAP (#9417). The receiver is produced before the argument and consumed
+/// after it, so it must live in a rooted slot and the probe must read it back
+/// out of that slot.
+///
+/// Sabotage: reverting `dynamic_dispatch.rs` to `lower_expr(ctx, object)` +
+/// per-argument `lower_expr` fails this assertion with "is never stored into a
+/// rooted slot — it lives its whole life in an SSA register".
+#[test]
+fn a_dispatch_receiver_is_rooted_across_its_argument_list() {
+    under_both_lowerings(|lowering| {
+        let ir = main_ir_for_dispatch("dispatch_receiver_rooted.ts", allocating());
+        let producer = first_call_result(&ir, "perry_fn_dispatch_receiver_rooted_ts__makeTagged")
+            .unwrap_or_else(|| {
+                panic!(
+                    "{lowering}: no call to `makeTagged` in `main` — this test has no \
+                     subject:\n{ir}"
+                )
+            });
+        assert_rooted_across(
+            &ir,
+            &producer,
+            "js_object_get_own_field_or_undef",
+            &format!(
+                "{lowering}: #9417 — the dispatch receiver is live across the argument \
+                 list, which allocates"
+            ),
+        );
+    });
+}
+
+/// The control on the other side: a numeric argument is not a heap reference, so
+/// `operand_protection` answers `Reuse` and it costs no slot. Exactly one temp
+/// slot separates the two fixtures — the heap argument's.
+///
+/// Without this half, a lowering that roots every operand unconditionally would
+/// pass the test above and pay for it on every call in the program.
+#[test]
+fn a_numeric_dispatch_argument_still_pays_no_temp_slot() {
+    under_both_lowerings(|lowering| {
+        let heap = main_ir_for_dispatch("dispatch_receiver_heap_arg.ts", allocating());
+        let numeric = main_ir_for_dispatch("dispatch_receiver_numeric_arg.ts", Expr::Integer(7));
+        let heap_slots = temp_root_slots(&heap).len();
+        let numeric_slots = temp_root_slots(&numeric).len();
+        assert!(
+            heap_slots > 0,
+            "{lowering}: the heap-argument fixture must root something, or the \
+             comparison below is between two zeroes:\n{heap}"
+        );
+        assert_eq!(
+            numeric_slots,
+            heap_slots - 1,
+            "{lowering}: a numeric argument is provably not a heap reference and must \
+             pay no temp-root slot (heap fixture {heap_slots}, numeric fixture \
+             {numeric_slots})"
+        );
+    });
+}

--- a/crates/perry-codegen/src/temp_root_coverage/mod.rs
+++ b/crates/perry-codegen/src/temp_root_coverage/mod.rs
@@ -45,9 +45,10 @@ use perry_hir::{Expr, Module, ModuleInitKind, Stmt};
 
 mod builtin_ctor;
 mod call_callee;
+mod dispatch_receiver;
 mod operands;
 
-fn entry_opts() -> CompileOptions {
+pub(crate) fn entry_opts() -> CompileOptions {
     CompileOptions {
         target: None,
         is_entry_module: true,

--- a/test-files/test_gap_9417_dispatch_receiver_roots.ts
+++ b/test-files/test_gap_9417_dispatch_receiver_roots.ts
@@ -1,18 +1,31 @@
-// #9417: the dynamic instance-method dispatch tower lowered the RECEIVER into a
-// bare SSA register, then lowered every ARGUMENT expression — arbitrary user
-// code that allocates — and only then consumed the receiver. An evacuating
-// young-gen minor inside the argument moves the receiver and the register keeps
-// the pre-collection address.
+// #9417: the dynamic instance-method dispatch tower held the RECEIVER in a bare
+// SSA register across the lowering of every ARGUMENT expression.
+//
+// `lower_call/property_get/dynamic_dispatch.rs` lowered `object` first (JS
+// evaluation order requires that), then lowered each argument — arbitrary user
+// code that allocates — and only then consumed the receiver in
+// `js_object_get_own_field_or_undef` / `js_native_call_method` /
+// `js_implicit_this_set`. An evacuating young-gen minor inside an argument moves
+// the receiver, and the register keeps the pre-collection address.
 //
 // Nothing faults at the move: `js_object_get_own_field_or_undef` fails its
 // `obj_type == GC_TYPE_OBJECT` check on the recycled cell and answers
-// TAG_UNDEFINED, so the override probe misses and the by-name dispatch runs on a
-// retired address. The observable is a wrong answer, several steps downstream.
+// TAG_UNDEFINED, so the own-override probe misses and the by-name dispatch runs
+// on a retired address. The observable is a wrong answer several steps
+// downstream — which is why #9417 presented as `reading 'def'` on a property
+// nowhere near the defect.
 //
-// The receiver must NOT be a plain local read: a load out of a shadow slot is
-// re-derived by `root_reload.rs`. It has to be a value with no re-readable
-// location — a call result — which is exactly what cc's site is
-// (`js_native_call_value` -> spill -> object-literal ctor -> reload).
+// TWO THINGS THIS FIXTURE NEEDS, AND BOTH ARE LOAD-BEARING:
+//
+// 1. The receiver must NOT be a plain local read. A load out of a shadow slot is
+//    a re-readable location, so `root_reload.rs` re-derives it below the
+//    collection point and the shape is already correct. It has to be a value
+//    with no such location — a call result — which is exactly cc's site
+//    (`js_native_call_value` -> spill -> object-literal ctor -> reload).
+// 2. The argument must allocate past the 16 MiB nursery cap
+//    (`SCAVENGE_NURSERY_CAP_DEFAULT_MB`) with cells that ESCAPE. A
+//    scalar-replaced object literal never reaches the arena, and a churn that
+//    allocates nothing is a test that cannot fail.
 
 class Tagged {
   tag: string;
@@ -24,8 +37,8 @@ class Tagged {
   }
 }
 
-// A second implementor keeps the dispatch tower from collapsing to a single
-// static callee, which is what `needs_dynamic_dispatch` selects on.
+// A second implementor of `join` keeps the call on the dispatch tower rather
+// than a single static callee.
 class OtherTagged {
   tag: string;
   constructor(tag: string) {
@@ -37,51 +50,55 @@ class OtherTagged {
 }
 
 // Returns `any`, so the receiver's class is not statically known and the call
-// goes through the dynamic instance-method dispatch tower.
+// takes the dynamic instance-method dispatch path.
 function makeTagged(k: number): any {
   return new Tagged("t" + k);
 }
 
-// Allocates enough to drive at least one evacuating young-gen minor while the
-// receiver is live only in a register.
 function churn(n: number): string {
-  let out = "";
+  let out = "x";
+  let keep: any[] = [];
   for (let i = 0; i < n; i++) {
-    const cell = { a: i, b: i + 1, c: i + 2 };
-    if (cell.a === n - 1) {
-      out = "" + cell.c;
+    const cell = { a: i, b: i + 1, c: i + 2, d: i + 3 };
+    keep.push(cell);
+    if (keep.length >= 1024) {
+      out = "" + keep[0].c;
+      keep = [];
     }
   }
   return out;
 }
 
 function main(): void {
+  // THE GAP. The receiver is the result of `makeTagged(k)`; the argument
+  // `churn(...)` collects while it is live only in a register.
   let bad = 0;
-  let firstBad = "";
-  for (let k = 0; k < 60; k++) {
+  let firstKind = "";
+  for (let k = 0; k < 8; k++) {
     const expect = "t" + k + "|";
-    let got = "";
+    let got: any = "";
     try {
-      got = makeTagged(k).join(churn(4000));
+      got = makeTagged(k).join(churn(500000));
     } catch (e) {
-      got = "threw:" + (e as Error).message;
+      got = "threw";
     }
-    if (got.indexOf(expect) !== 0) {
+    const ok = typeof got === "string" && got.indexOf(expect) === 0;
+    if (!ok) {
       bad++;
-      if (firstBad === "") {
-        firstBad = got;
+      if (firstKind === "") {
+        firstKind = typeof got === "string" ? "wrong-string" : typeof got;
       }
     }
   }
-  // Keep `OtherTagged` reachable so it is registered as an implementor.
-  const keep: any = new OtherTagged("x");
-  if (keep.join("y") !== "other|y") {
-    console.log("control broken");
-  }
   console.log("dispatch-receiver bad=" + bad);
-  if (bad > 0) {
-    console.log("first bad: " + firstBad);
-  }
+  console.log("first bad kind=" + firstKind);
+
+  // CONTRACT, NOT A GAP: the same dispatch with a non-collecting argument must
+  // keep working. This half has never failed — it is here so a fix that
+  // over-roots or mis-orders the group is caught, not because it demonstrates
+  // the defect.
+  const keep: any = new OtherTagged("x");
+  console.log("control=" + keep.join("y"));
 }
 
 main();

--- a/test-files/test_gap_9417_dispatch_receiver_roots.ts
+++ b/test-files/test_gap_9417_dispatch_receiver_roots.ts
@@ -1,0 +1,87 @@
+// #9417: the dynamic instance-method dispatch tower lowered the RECEIVER into a
+// bare SSA register, then lowered every ARGUMENT expression — arbitrary user
+// code that allocates — and only then consumed the receiver. An evacuating
+// young-gen minor inside the argument moves the receiver and the register keeps
+// the pre-collection address.
+//
+// Nothing faults at the move: `js_object_get_own_field_or_undef` fails its
+// `obj_type == GC_TYPE_OBJECT` check on the recycled cell and answers
+// TAG_UNDEFINED, so the override probe misses and the by-name dispatch runs on a
+// retired address. The observable is a wrong answer, several steps downstream.
+//
+// The receiver must NOT be a plain local read: a load out of a shadow slot is
+// re-derived by `root_reload.rs`. It has to be a value with no re-readable
+// location — a call result — which is exactly what cc's site is
+// (`js_native_call_value` -> spill -> object-literal ctor -> reload).
+
+class Tagged {
+  tag: string;
+  constructor(tag: string) {
+    this.tag = tag;
+  }
+  join(other: string): string {
+    return this.tag + "|" + other;
+  }
+}
+
+// A second implementor keeps the dispatch tower from collapsing to a single
+// static callee, which is what `needs_dynamic_dispatch` selects on.
+class OtherTagged {
+  tag: string;
+  constructor(tag: string) {
+    this.tag = tag;
+  }
+  join(other: string): string {
+    return "other|" + other;
+  }
+}
+
+// Returns `any`, so the receiver's class is not statically known and the call
+// goes through the dynamic instance-method dispatch tower.
+function makeTagged(k: number): any {
+  return new Tagged("t" + k);
+}
+
+// Allocates enough to drive at least one evacuating young-gen minor while the
+// receiver is live only in a register.
+function churn(n: number): string {
+  let out = "";
+  for (let i = 0; i < n; i++) {
+    const cell = { a: i, b: i + 1, c: i + 2 };
+    if (cell.a === n - 1) {
+      out = "" + cell.c;
+    }
+  }
+  return out;
+}
+
+function main(): void {
+  let bad = 0;
+  let firstBad = "";
+  for (let k = 0; k < 60; k++) {
+    const expect = "t" + k + "|";
+    let got = "";
+    try {
+      got = makeTagged(k).join(churn(4000));
+    } catch (e) {
+      got = "threw:" + (e as Error).message;
+    }
+    if (got.indexOf(expect) !== 0) {
+      bad++;
+      if (firstBad === "") {
+        firstBad = got;
+      }
+    }
+  }
+  // Keep `OtherTagged` reachable so it is registered as an implementor.
+  const keep: any = new OtherTagged("x");
+  if (keep.join("y") !== "other|y") {
+    console.log("control broken");
+  }
+  console.log("dispatch-receiver bad=" + bad);
+  if (bad > 0) {
+    console.log("first bad: " + firstBad);
+  }
+}
+
+main();


### PR DESCRIPTION
The residual root cause of #9417 — the claude-code `Cannot read properties of undefined (reading 'def')` divergence. **cc-level result: 49/62 bad runs before, 0/74 after**, all 74 reaching node's `Not logged in`.

## The issue's diagnosis was right about the mechanism, wrong about the site

The posted diagnosis said `perry_closure_cli_2_1_112_js__57014` "contains zero `js_shadow_slot_bind` calls, so `collect_pointer_typed_locals` returned empty." **That premise is a vacuity trap the codebase itself documents** (`native_root_coverage/mod.rs`'s module doc): under the shipping native-roots lowering, `lower_precise_roots_to_native_stack` *deletes* every bind and retypes the alloca to `ptr addrspace(1)` — zero binds is what a correctly-rooted function looks like. Only **3** of 141,217 cc `.text` functions carry any binds (the shadow-frame-spilled giants).

Read the truth from the stack map instead (a `.perry_gcmap` decoder is part of the kept artifacts): the function **is** in the map — 54 records, roots at five slots — but the receiver's slot `rsp+128` is in **no record** at the allocating pc. And the value in that slot is not a local at all: it is the result of a `js_native_call_value` — an **expression temporary**. `collect_pointer_typed_locals` only slots params, `Let` bindings and catch params; temporaries belong to `rooting/temp_root.rs`. `pointer_locals.rs` and `closure.rs:612` are correct code.

## Real root cause

`crates/perry-codegen/src/lower_call/property_get/dynamic_dispatch.rs`, two sites — the unknown-receiver-class dispatch and the known-class virtual tower:

```rust
let recv_box = lower_expr(ctx, object)?;                       // receiver first (JS order)
for a in args { static_user_args.push(lower_expr(ctx, a)?); }  // user code; allocates
… js_object_get_own_field_or_undef(recv_box, …)                // consumed last
```

No `RootedGroup`. This is `gc-rooting-invariant.md` **case 3** ("method receiver across the argument list"), fixed for *computed*-key dispatch in #7210(3) and never for named-property dispatch. An evacuating minor between the receiver's production and its use hands the probe a retired from-space address; the probe's `obj_type` check fails on the recycled cell and answers `undefined` **silently**, so the crash surfaces steps later on an unrelated property — which is exactly how it masqueraded as an auth-path data bug (zod's `ZodObject.extend` reading `q._zod.def` on the request-build path).

**Blast radius, measured on the cc binary: 14,002 distinct functions — 9.9% of 141,217 — contain at least one call through the unrooted lowering.** Systemic, not one bad shape.

## Fix and soundness

One `open_rooted_group` over `[receiver, ...args]` at both sites, values re-read below the group; `root_reload` re-derives every later use a collection point can reach (verified in the emitted tower arms: `load ptr addrspace(1), ptr %r39`). Releases sit in the merge blocks that post-dominate every arm.

**No "skip rooting when X" reasoning.** The window states `collects = true` unconditionally — the consuming calls run user code. `operand_protection` still routes provably-non-pointer operands to `Reuse`, so numeric arguments pay nothing. The available narrowing (per-operand truthful windows) would need `js_object_get_own_field_or_undef` / `js_object_get_class_id` certified in `gc_call_effects` — broader than a soundness fix should carry; the conservative path is taken and the narrowing left as follow-up.

**Stack-map proof in the fixed binary:** `__57014`'s receiver slot is now listed as a root at the probe pc and re-read from that slot after it.

## Verification

**Gap test, deterministic, no GC knobs** — `test-files/test_gap_9417_dispatch_receiver_roots.ts`. Two load-bearing repro properties: the receiver must be a *call result* (a `LocalGet` is re-derived by `root_reload` anyway), and the argument must allocate past the 16 MiB nursery with *escaping* cells. On unfixed main, 5/5 identical: `dispatch-receiver bad=8`. Node and fixed: `bad=0`, 5/5 — and clean 3/3 at `PERRY_GC_SCAVENGE_NURSERY_MB=1`.

**Codegen coverage tests, sabotage-verified:** reverting `dynamic_dispatch.rs` alone fails both with *"takes [%r2 …], none of which was re-read from %r1 between the store and the call"*.

| check | result |
|---|---|
| perry-runtime lib (`--test-threads=1`) | **2942 / 0** |
| perry-codegen lib | **1385 / 0** |
| gap suite (627) | **622 pass, 5 fail — exactly the snapshot's 5**, 0 compile-fail, 0 crash, `GAP_RC=0` |
| cc unauthenticated stream-json | base **49/62 BAD** → fixed **0/74 BAD**; at `NURSERY_MB=1` base emits empty output 12/12, fixed is 12/12 correct |

## Cost (same-SHA A/B)

`.text` +1.39% (232.68 → 235.92 MB), `.perry_gcmap` +6.03%. Microbenchmarks interleaved 6×: non-pointer argument **0%**; call-result receiver **0%**; the one paying shape is local-receiver + heap-allocating argument at **+0.6 ns/call** — the conservative window on a loop that is nothing but the dispatch. The per-operand narrowing above recovers this if it ever matters.

Closes #9417 (the runtime-side sibling defect found during diagnosis already landed as #9444; the ~20-site sweep of that shape is #9445).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dynamic instance-method calls that could fail when argument evaluation triggered memory collection.
  * Preserved the method receiver reliably while evaluating complex or memory-intensive arguments.
  * Improved stability for calls involving dynamically typed objects and allocating operations.

* **Tests**
  * Added regression coverage for receiver preservation during dynamic dispatch.
  * Added scenarios covering both memory-allocating and non-allocating arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->