### PR TITLE
test(9249): opt the blocked-store case into strict mode (#9426 semantics)

### DIFF
--- a/changelog.d/9481-9249-strict-mode-store.md
+++ b/changelog.d/9481-9249-strict-mode-store.md
@@ -1,0 +1,16 @@
+**test(9249): opt the blocked-store case into strict mode (#9426 semantics)**
+
+`reflect_define_property_non_writable_prototype_index_blocks_array_store`
+asserted a `TypeError` from a sloppy-mode script. #9426 made a rejected
+array-element write throw **only in strict mode** — which matches node:
+
+| | output |
+|---|---|
+| Perry, with `"use strict"` | `TypeError 1 P` |
+| Perry, as written (script) | `no error 1 P` |
+| `node --experimental-strip-types`, same `.ts` | `no error 1 P` |
+
+Perry and node agree exactly, so the code is right and the expectation was
+stale. The test's purpose — a non-writable inherited index BLOCKS the store —
+is still worth keeping, so it opts into strict mode rather than weakening the
+assertion to the sloppy no-op.

--- a/crates/perry/tests/issue_9249_array_prototype_define_property.rs
+++ b/crates/perry/tests/issue_9249_array_prototype_define_property.rs
@@ -111,7 +111,15 @@ console.log(hits, values.length, values[5]);
 #[test]
 fn reflect_define_property_non_writable_prototype_index_blocks_array_store() {
     compile_and_run(
-        r#"
+        r#""use strict";
+// #9426 made a rejected array-element write throw ONLY in strict mode, which
+// is what node does. This file is a bare .ts — the oracle
+// (`node --experimental-strip-types`) runs it as a SCRIPT, i.e. sloppy, where
+// the rejected store silently no-ops in node too:
+//   $ node --experimental-strip-types <this program without "use strict">
+//   no error 1 P
+// The point of this test is that a non-writable inherited index BLOCKS the
+// store, so it opts into strict mode rather than asserting the sloppy no-op.
 Reflect.defineProperty(Array.prototype, 11, {
   value: "P",
   writable: false,


### PR DESCRIPTION
`cargo-test-perry (4/8)` fails on `main`:

```
test reflect_define_property_non_writable_prototype_index_blocks_array_store ... FAILED
  left:  "no error 1 P"
  right: "TypeError 1 P"
```

**Perry is correct here; the expectation was stale.** `dcf1ec0fbc` (#9426) made a rejected array-element write throw **only in strict mode** — which is what node does.

Measured against the oracle this suite actually uses:

| | output |
|---|---|
| Perry, with `"use strict"` | `TypeError 1 P` |
| Perry, as written (script) | `no error 1 P` |
| `node --experimental-strip-types`, same `.ts` | `no error 1 P` |

Perry and node agree exactly. (I first compared against a `.mjs`, which node treats as a *module* — hence strict, hence a throw — and briefly mistook this for a regression. The `.ts` script form is the right comparison.)

The test's purpose — proving a non-writable inherited index **blocks** the store — is still worth keeping, so this opts the case into strict mode rather than weakening the assertion to the sloppy no-op. The node script-mode output is recorded inline so the next reader does not repeat my mistake.

Verified locally: `cargo test -p perry --test issue_9249_array_prototype_define_property` → **4 passed, 0 failed**.

Blocking: `cargo-test-perry` is in `full-suite-gate`'s needs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified strict-mode behavior for rejected array-element writes.
  * Documented why the relevant test explicitly enables strict mode.
  * Added notes explaining alignment with Node.js behavior in strict and sloppy modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->