### PR TITLE
test: actually apply the #9482 ignore (dropped from #9483)

### DIFF
--- a/crates/perry/tests/versioned_indexed_loop_callback_deopt.rs
+++ b/crates/perry/tests/versioned_indexed_loop_callback_deopt.rs
@@ -93,6 +93,12 @@ fn llvm_function_body(ir: &str, symbol: &str) -> String {
 }
 
 #[test]
+#[ignore = "#9482: aborts on LINUX only — `panic in a function that cannot unwind` \
+           inside the force_evacuation=false GC fixture. Consistent on ubuntu-latest \
+           (never observed green there); passes 3/3 on macOS at the same pin, so the \
+           macOS result proves nothing about Linux. Test file is byte-identical to the \
+           2026-08-31 pin, but it never executed in that tier, so its age is UNKNOWN — \
+           deferred to unblock a release, not shown to be pre-existing. See #9482."]
 fn cold_callback_arms_resume_once_at_the_next_index() {
     let dir = tempfile::tempdir().expect("tempdir");
     let entry = dir.path().join("main.ts");


### PR DESCRIPTION
#9483 was supposed to mark `cold_callback_arms_resume_once_at_the_next_index` as `#[ignore]`, but its merge commit `b1c02b22ca` contains **only the changelog fragment** — the attribute itself never landed:

```
b1c02b22ca  test: ignore the Linux-only GC deopt abort (#9482) (#9483)
  changelog.d/PENDING9482-ignore-linux-deopt.md | 14 +++
  1 file changed
```

My error, not a merge bug: the edit was still uncommitted when I ran `git stash` to switch branches, so the stash swallowed it and I committed only the changelog. This applies the attribute the fragment already describes.

Rationale is unchanged and stated in the `#[ignore]` text itself — the test aborts on `ubuntu-latest` with `panic in a function that cannot unwind` in the `force_evacuation=false` GC fixture, is consistent there (never observed green), passes 3/3 on macOS at the same pin, and its **age is unknown** because it never executed in the Aug-31 tier. Deferred to unblock a release, not shown to be pre-existing. See #9482.

Compiles clean (`cargo check -p perry --test versioned_indexed_loop_callback_deopt`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Marked a regression test as ignored on Linux.
  * Retained callback deoptimization and forced-evacuation coverage on supported platforms.
  * Documented the related issue for tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->