### PR TITLE
fix(fs): appendFile must report failure, not resolve; writeFileSync must throw; mode must reach open(2) (#9421)

### DIFF
--- a/changelog.d/9421-append-file-promise-reject.md
+++ b/changelog.d/9421-append-file-promise-reject.md
@@ -50,8 +50,18 @@ replays the session-writer shape; on unfixed `main` it prints `resolved`,
 `no-throw` and `writer-file: MISSING` where Node prints `ENOENT` and the two
 records.
 
-**Found while fixing, NOT fixed here:** the `mode` option is ignored on both
-append paths. `appendFile(p, data, { mode: 0o600 })` and the `appendFileSync`
-form open `0666 & ~umask`, so a freshly created file lands `0644` where Node
-lands `0600` — the claude-code transcript is world-readable under Perry.
-`writeFile` and `mkdir` honour their `mode`; only append does not.
+**Found while fixing:** `fs.writeFileSync` swallowed its errors the same way,
+and the `mode` option was dropped on every create path — so the transcript
+this issue is about was also landing `0644` instead of the `0600` the writer
+asks for. Both are fixed in this PR; see
+`changelog.d/9421-write-file-sync-throws.md`.
+
+**Found while fixing, NOT fixed here** (separate lanes, filed on their own):
+`process.stdin` delivers one `data` event per *line* rather than in 64 KiB
+chunks — 1 MB of short lines is 200,000 events and 2.10 s against Node's 16
+events and 0.04 s, and claude-code loses a non-deterministic tail of a piped
+prompt as a result (394 KB–612 KB of 1 MB across four runs). And
+`stream.setEncoding("utf8")` does not decode: fed bytes `0x00..0xFF` it yields
+158 code units with raw `U+0080..U+00FF` where Node yields 256 with 128
+`U+FFFD`, which puts invalid UTF-8 into the transcript and makes those lines
+unparseable JSON. Neither is touched by this PR.

--- a/changelog.d/9421-append-file-promise-reject.md
+++ b/changelog.d/9421-append-file-promise-reject.md
@@ -1,0 +1,57 @@
+**A failed `appendFile` is now reported instead of being reported as a
+success** — `fs/promises.appendFile` rejects, `fs.appendFileSync` throws, and
+`fs.appendFile(path, data, cb)` calls back with the error, all carrying Node's
+`code` / `errno` / `syscall` / `path`.
+
+```js
+await appendFile("/no/such/dir/f.txt", "x");  // was: RESOLVED   now: rejects ENOENT
+appendFileSync("/no/such/dir/f.txt", "x");    // was: no throw   now: throws ENOENT
+```
+
+All three surfaces called `js_fs_append_file_sync_options`, which reports
+failure by *returning `0`* rather than by throwing, and all three dropped that
+status on the floor (`let _ = …`). Every append that failed — missing parent
+directory, `EACCES`, `EISDIR`, a closed fd — looked like it had worked. The
+op now goes through `js_fs_append_file_result`, which returns a Node-shaped fs
+error value the way `write_file_path_or_fd_result` already did for
+`writeFile`, so each surface renders it in its own idiom.
+
+**This is #9421's missing transcript records.** `claude --bare -p hi` wrote 1
+record where Node wrote 5, deterministically. Nothing was wrong with the
+session writer or its flush timer — the writer's own recovery arm is
+
+```js
+try { await appendFile(p, chunk, { mode: 0o600 }) }
+catch { await mkdir(dirname(p), { recursive: true, mode: 0o700 })
+        await appendFile(p, chunk, { mode: 0o600 }) }
+```
+
+and it is *the only thing that ever creates* `~/.claude/projects/<slug>/`.
+Under Perry the first append resolved, the `catch` never ran, the directory
+was never created, and every queued record was discarded — with no error at
+any layer, because the one function that knew about the failure had returned
+it as a number nobody read. The single surviving record, `last-prompt`, is
+written through `openSync(path, "ax", mode)` + `appendFileSync(fd, …)`;
+`openSync` throws correctly, so that path took its recovery branch and made
+the directory a few hundred microseconds *after* the drain had already given
+up.
+
+**Why only `--bare`.** Without it, auto-memory materialises
+`~/.claude/projects/<sanitized-cwd>/memory/` about 47 ms before the first
+transcript flush, which creates the transcript directory as a side effect; the
+first append then succeeds and all 7 records land. `--bare` skips auto-memory
+(along with hooks, LSP, plugin sync, attribution, background prefetches and
+`CLAUDE.md` discovery), so nothing else made the directory and the bug became
+reachable. The flag did not change the write path — it removed the accident
+that was hiding it.
+
+`test_gap_9421_append_file_promise_reject` covers the three surfaces and
+replays the session-writer shape; on unfixed `main` it prints `resolved`,
+`no-throw` and `writer-file: MISSING` where Node prints `ENOENT` and the two
+records.
+
+**Found while fixing, NOT fixed here:** the `mode` option is ignored on both
+append paths. `appendFile(p, data, { mode: 0o600 })` and the `appendFileSync`
+form open `0666 & ~umask`, so a freshly created file lands `0644` where Node
+lands `0600` — the claude-code transcript is world-readable under Perry.
+`writeFile` and `mkdir` honour their `mode`; only append does not.

--- a/changelog.d/9421-write-file-sync-throws.md
+++ b/changelog.d/9421-write-file-sync-throws.md
@@ -1,0 +1,44 @@
+**`fs.writeFileSync` now throws when the write fails, and `mode` is honoured
+on every write and append that creates a file.** Same defect class as the
+`appendFile` swallow in this PR, found while fixing it.
+
+```js
+writeFileSync("/no/such/dir/f", "x")      // was: returned  now: throws ENOENT
+writeFileSync(p, 42)                      // was: wrote     now: ERR_INVALID_ARG_TYPE
+writeFileSync(p, "414243", "hex")         // was: wrote "414243"  now: writes "ABC"
+writeFileSync(p, "x", { mode: 0o600 })    // was: 0644     now: 0600
+```
+
+`writeFileSync` carried a **private copy** of the write op inside
+`js_fs_write_file_sync_options` that reported failure by returning `0`, and
+every caller — the codegen lowering, the namespace/computed dispatch entry —
+discarded it. The promise and callback forms were never affected: both already
+ran `write_file_path_or_fd_result`, which returns a Node-shaped fs error.
+The sync form now runs that same core, so the three agree.
+
+**The private copy diverged in more than error reporting.** It read its payload
+with `bytes_from_value` rather than `consume_write_file_input`, which is where
+`writeFile`'s argument validation and its `encoding` option live. So
+`writeFileSync` also accepted values Node rejects (`42`, `{}`, `null` — all
+`ERR_INVALID_ARG_TYPE`) and ignored `encoding` entirely, writing the six
+characters `414243` where Node writes the three bytes `ABC`. Deleting the copy
+fixes all three at once; that is the argument for routing through the shared
+core rather than bolting a status check onto the duplicate.
+
+**`mode` was dropped on the create path.** `open_file_for_write_flag` never
+passed it to `open(2)`, so every file Perry created landed `0666 & ~umask`
+regardless of the request — including claude-code's session transcript, which
+asks for `0600` and got `0644`: **world-readable.** The mode now reaches
+`open(2)`, which also gives Node's create-only rule for free (an existing file
+keeps its permissions; the fixture pins that by chmod-ing a file and rewriting
+it with a mode). Three call sites, all in the write/append family.
+`writeFile`, `writeFileSync`, `appendFile` and `appendFileSync` were each
+verified against Node.
+
+`test_gap_9421_write_file_sync_throws` covers the three sync call shapes
+(named import, namespace, computed), the promise and callback forms as
+controls, argument validation, `encoding` as both a bare string and an options
+field, `flag: "a"`, and `mode` on all four surfaces. On unfixed `main` it
+diverges from Node on 14 lines; with the fix it is byte-identical.
+`test_gap_9421_append_file_promise_reject` gains a `writer-mode` assertion on
+the transcript it reconstructs.

--- a/crates/perry-runtime/src/fs/callbacks.rs
+++ b/crates/perry-runtime/src/fs/callbacks.rs
@@ -207,8 +207,12 @@ pub extern "C" fn js_fs_append_file_callback(
             return f64::from_bits(TAG_UNDEFINED);
         }
     }
-    let _ = js_fs_append_file_sync_options(path_value, content_value, options);
-    call_cb0(cb);
+    unsafe {
+        match js_fs_append_file_result(path_value, content_value, options) {
+            Ok(()) => call_cb0(cb),
+            Err(err_val) => call_cb_err1(cb, err_val),
+        }
+    }
     f64::from_bits(TAG_UNDEFINED)
 }
 

--- a/crates/perry-runtime/src/fs/mod.rs
+++ b/crates/perry-runtime/src/fs/mod.rs
@@ -572,8 +572,8 @@ pub extern "C" fn js_fs_write_file_sync_options(
     }
 }
 
-/// Append content to a file synchronously
-/// Returns 1 on success, 0 on failure
+/// Append content to a file synchronously.
+/// Returns 1 on success and throws a Node-shaped fs error on failure (#9421).
 /// Accepts NaN-boxed string values
 #[no_mangle]
 pub extern "C" fn js_fs_append_file_sync(path_value: f64, content_value: f64) -> i32 {
@@ -584,45 +584,75 @@ pub extern "C" fn js_fs_append_file_sync(path_value: f64, content_value: f64) ->
     )
 }
 
+/// Shared `appendFile` op. Returns a Node-shaped fs error value
+/// (`code` / `errno` / `syscall` / `path`) instead of a bare status, so the
+/// sync FFI can throw it, the callback form can pass it as `err`, and
+/// `fs/promises.appendFile` can reject with it.
+///
+/// #9421: every one of those three surfaces used to read a `0`/`1` status
+/// that the callers dropped on the floor, so a failing append was reported
+/// as a *success*. The visible cost was in claude-code: its session writer is
+///
+/// ```js
+/// try { await appendFile(p, chunk) }
+/// catch { await mkdir(dirname(p), { recursive: true }); await appendFile(p, chunk) }
+/// ```
+///
+/// and it relies on the first append rejecting with ENOENT to learn that the
+/// transcript directory does not exist yet. Under Perry the promise resolved,
+/// the recovery arm never ran, and every queued transcript record was
+/// silently discarded.
+pub(crate) unsafe fn js_fs_append_file_result(
+    path_value: f64,
+    content_value: f64,
+    options_value: f64,
+) -> Result<(), f64> {
+    validate::validate_path_or_fd("path", path_value, "write");
+    validate::validate_string_or_object_options("options", options_value);
+
+    if let Some(fd) = numeric_fd_value(path_value) {
+        let content_bytes = bytes_from_value(content_value);
+        return FD_REGISTRY.with(|r| {
+            let mut reg = r.borrow_mut();
+            let Some(file) = reg.get_mut(&fd) else {
+                return Err(validate::build_ebadf_error_value("write"));
+            };
+            if let Err(err) = file.seek(SeekFrom::End(0)) {
+                return Err(build_fs_error_value_no_path(&err, "write"));
+            }
+            file.write_all(&content_bytes)
+                .map_err(|err| build_fs_error_value_no_path(&err, "write"))
+        });
+    }
+
+    let path_str = match decode_path_value(path_value) {
+        Some(s) => s,
+        None => validate::throw_invalid_path_arg("path", path_value),
+    };
+
+    let content_bytes = bytes_from_value(content_value);
+
+    let flag = file_options_flag(options_value, "a");
+    let mut file = match open_file_for_write_flag(&path_str, &flag) {
+        Ok(file) => file,
+        Err(err) => return Err(build_fs_error_value(&err, "open", &path_str)),
+    };
+    file.write_all(&content_bytes)
+        .map_err(|err| build_fs_error_value(&err, "write", &path_str))
+}
+
+/// Append content to a file synchronously.
+/// Returns 1 on success and throws a Node-shaped fs error on failure (#9421).
 #[no_mangle]
 pub extern "C" fn js_fs_append_file_sync_options(
     path_value: f64,
     content_value: f64,
     options_value: f64,
 ) -> i32 {
-    validate::validate_path_or_fd("path", path_value, "write");
-    validate::validate_string_or_object_options("options", options_value);
     unsafe {
-        if let Some(fd) = numeric_fd_value(path_value) {
-            let content_bytes = bytes_from_value(content_value);
-            return FD_REGISTRY.with(|r| {
-                let mut reg = r.borrow_mut();
-                let Some(file) = reg.get_mut(&fd) else {
-                    return 0;
-                };
-                let _ = file.seek(SeekFrom::End(0));
-                if file.write_all(&content_bytes).is_ok() {
-                    1
-                } else {
-                    0
-                }
-            });
-        }
-
-        let path_str = match decode_path_value(path_value) {
-            Some(s) => s,
-            None => return 0,
-        };
-
-        let content_bytes = bytes_from_value(content_value);
-
-        let flag = file_options_flag(options_value, "a");
-        match open_file_for_write_flag(&path_str, &flag) {
-            Ok(mut file) => match file.write_all(&content_bytes) {
-                Ok(_) => 1,
-                Err(_) => 0,
-            },
-            Err(_) => 0,
+        match js_fs_append_file_result(path_value, content_value, options_value) {
+            Ok(()) => 1,
+            Err(err) => crate::exception::js_throw(err),
         }
     }
 }

--- a/crates/perry-runtime/src/fs/mod.rs
+++ b/crates/perry-runtime/src/fs/mod.rs
@@ -527,47 +527,27 @@ fn read_file_bytes_with_options(path_value: f64, options_value: f64) -> Option<V
     }
 }
 
+/// Write content to a file synchronously.
+/// Returns 1 on success and throws a Node-shaped fs error on failure (#9421).
+///
+/// This now runs the same `write_file_path_or_fd_result` core the callback and
+/// promise forms have always used. The private copy it replaces reported
+/// failure by returning `0` -- which every caller discarded -- and, because it
+/// read the payload with `bytes_from_value` rather than
+/// `consume_write_file_input`, it also skipped the argument validation and
+/// ignored the `encoding` option: `writeFileSync(p, "414243", "hex")` wrote the
+/// six literal digits, and `writeFileSync(p, 42)` wrote something instead of
+/// throwing `ERR_INVALID_ARG_TYPE`.
 #[no_mangle]
 pub extern "C" fn js_fs_write_file_sync_options(
     path_value: f64,
     content_value: f64,
     options_value: f64,
 ) -> i32 {
-    validate::validate_path_or_fd("path", path_value, "write");
-    validate::validate_string_or_object_options("options", options_value);
     unsafe {
-        if let Some(fd) = numeric_fd_value(path_value) {
-            let content_bytes = bytes_from_value(content_value);
-            return FD_REGISTRY.with(|r| {
-                let mut reg = r.borrow_mut();
-                let Some(file) = reg.get_mut(&fd) else {
-                    return 0;
-                };
-                if file.write_all(&content_bytes).is_ok() {
-                    1
-                } else {
-                    0
-                }
-            });
-        }
-
-        let path_str = match decode_path_value(path_value) {
-            Some(s) => s,
-            None => return 0,
-        };
-
-        let content_bytes = bytes_from_value(content_value);
-
-        let flag = file_options_flag(options_value, "w");
-        match open_file_for_write_flag(&path_str, &flag) {
-            Ok(mut file) => {
-                if file.write_all(&content_bytes).is_ok() {
-                    1
-                } else {
-                    0
-                }
-            }
-            Err(_) => 0,
+        match write_file_path_or_fd_result(path_value, content_value, options_value) {
+            Ok(()) => 1,
+            Err(err) => crate::exception::js_throw(err),
         }
     }
 }
@@ -633,7 +613,8 @@ pub(crate) unsafe fn js_fs_append_file_result(
     let content_bytes = bytes_from_value(content_value);
 
     let flag = file_options_flag(options_value, "a");
-    let mut file = match open_file_for_write_flag(&path_str, &flag) {
+    let mode = write_mode_from_options(options_value);
+    let mut file = match open_file_for_write_flag(&path_str, &flag, mode) {
         Ok(file) => file,
         Err(err) => return Err(build_fs_error_value(&err, "open", &path_str)),
     };
@@ -717,6 +698,31 @@ fn mkdir_mode_from_options(options_value: f64) -> Option<u32> {
             if let Some(s) = options_string_field(options_value, b"mode") {
                 return parse_mode_string(&s);
             }
+        }
+    }
+    None
+}
+
+/// `mode` for a `writeFile` / `appendFile` options argument.
+///
+/// Unlike `mkdir`, a bare string option here is the ENCODING, not the mode, so
+/// only an options *object* can carry `mode`. Returned as the `open(2)` mode:
+/// it applies when the file is created and is ignored for an existing one,
+/// which is exactly what Node does. #9421.
+fn write_mode_from_options(options_value: f64) -> Option<u32> {
+    unsafe {
+        let mode = options_field_value(options_value, b"mode")?;
+        let bits = mode.bits();
+        let mode_value = crate::value::JSValue::from_bits(bits);
+        if mode_value.is_int32() {
+            return Some(mode_value.as_int32() as u32);
+        }
+        let v = f64::from_bits(bits);
+        if mode_value.is_number() && v.is_finite() {
+            return Some(v as u32);
+        }
+        if let Some(s) = options_string_field(options_value, b"mode") {
+            return parse_mode_string(&s);
         }
     }
     None
@@ -1249,9 +1255,23 @@ fn file_options_flag(options_value: f64, default_flag: &str) -> String {
     }
 }
 
-fn open_file_for_write_flag(path: &str, flag: &str) -> std::io::Result<fs::File> {
+fn open_file_for_write_flag(
+    path: &str,
+    flag: &str,
+    mode: Option<u32>,
+) -> std::io::Result<fs::File> {
     use std::fs::OpenOptions;
     let mut opts = OpenOptions::new();
+    // #9421: `{ mode }` was dropped, so every file Perry created landed
+    // `0666 & ~umask` where Node honours the request. `OpenOptions::mode` is
+    // the `open(2)` mode argument: consulted only when the file is created.
+    #[cfg(unix)]
+    if let Some(mode) = mode {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(mode & 0o7777);
+    }
+    #[cfg(not(unix))]
+    let _ = mode;
     match flag {
         "a" | "a+" => {
             opts.create(true).append(true);

--- a/crates/perry-runtime/src/fs/stream/write_file_input.rs
+++ b/crates/perry-runtime/src/fs/stream/write_file_input.rs
@@ -399,7 +399,8 @@ pub(crate) unsafe fn write_file_path_or_fd_result(
         None => validate::throw_invalid_path_arg("path", path_value),
     };
     let flag = file_options_flag(options, "w");
-    let mut file = match open_file_for_write_flag(&path, &flag) {
+    let mode = write_mode_from_options(options);
+    let mut file = match open_file_for_write_flag(&path, &flag, mode) {
         Ok(file) => file,
         Err(err) => return Err(build_fs_error_value(&err, "open", &path)),
     };

--- a/crates/perry-runtime/src/node_submodules/fs_promises.rs
+++ b/crates/perry-runtime/src/node_submodules/fs_promises.rs
@@ -161,8 +161,12 @@ pub(crate) extern "C" fn thunk_fs_promises_appendFile(
     data: f64,
     options: f64,
 ) -> f64 {
-    promise_from_sync_undefined(|| {
-        let _ = crate::fs::js_fs_append_file_sync_options(path, data, options);
+    // #9421: must REJECT when the append fails. It used to call the
+    // status-returning sync helper and drop the status, so a failed append
+    // resolved and callers that recover in `catch` (claude-code creates the
+    // missing transcript directory there) never ran their recovery.
+    promise_from_result_undefined(|| unsafe {
+        crate::fs::js_fs_append_file_result(path, data, options)
     })
 }
 

--- a/test-files/test_gap_9421_append_file_promise_reject.ts
+++ b/test-files/test_gap_9421_append_file_promise_reject.ts
@@ -25,6 +25,10 @@
 // Pre-fix Perry prints `resolved` / `no-throw` / `no-err` on the first three
 // probes and `writer-file: MISSING`. Node -- and fixed Perry -- print
 // `ENOENT` three times and the writer's two records.
+//
+// The `writer-mode` line pins the second half of the same defect: the `mode`
+// the writer passes was dropped on the create path, so the transcript landed
+// `0644` where Node makes it `0600`.
 
 import { appendFile, mkdir, readFile } from "node:fs/promises";
 import {
@@ -33,6 +37,7 @@ import {
   openSync,
   closeSync,
   rmSync,
+  statSync,
   appendFile as appendFileCb,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -89,6 +94,9 @@ async function main(): Promise<void> {
     const lines = text.split("\n").filter((l) => l.length > 0);
     console.log("writer-records: " + lines.length);
     for (const l of lines) console.log("writer-line: " + l);
+    // The writer asks for 0o600; a transcript is private. Perry used to drop
+    // the mode and create it 0666 & ~umask, i.e. world-readable.
+    console.log("writer-mode: " + (statSync(target).mode & 0o777).toString(8));
   } catch (e) {
     console.log("writer-file: MISSING (" + code(e) + ")");
   }

--- a/test-files/test_gap_9421_append_file_promise_reject.ts
+++ b/test-files/test_gap_9421_append_file_promise_reject.ts
@@ -1,0 +1,108 @@
+// #9421: `fs/promises.appendFile` must REJECT when the append fails.
+//
+// Perry routed the promise form through the status-returning sync helper
+// (`js_fs_append_file_sync_options`, `0` = failure) and then dropped the
+// status with `let _ = ...`, so the returned Promise ALWAYS resolved. The
+// same helper backed `fs.appendFileSync` (silently did nothing instead of
+// throwing) and `fs.appendFile(path, data, cb)` (called back with no error).
+//
+// The cost was invisible until a caller used the rejection as CONTROL FLOW.
+// The claude-code session writer does exactly that:
+//
+//     async appendToFile(p, chunk) {
+//       try { await appendFile(p, chunk, { mode: 0o600 }) }
+//       catch { await mkdir(dirname(p), { recursive: true, mode: 0o700 })
+//               await appendFile(p, chunk, { mode: 0o600 }) }
+//     }
+//
+// The transcript directory `~/.claude/projects/<slug>/` is created lazily --
+// by this very catch. Under Perry the first append "succeeded", the recovery
+// arm never ran, no directory was ever created, and every queued transcript
+// record was discarded with no error anywhere. `claude --bare -p hi` wrote 1
+// record where Node wrote 5; the survivor was the one record written through
+// `openSync` + `appendFileSync(fd, ...)`, which does throw.
+//
+// Pre-fix Perry prints `resolved` / `no-throw` / `no-err` on the first three
+// probes and `writer-file: MISSING`. Node -- and fixed Perry -- print
+// `ENOENT` three times and the writer's two records.
+
+import { appendFile, mkdir, readFile } from "node:fs/promises";
+import {
+  appendFileSync,
+  mkdtempSync,
+  openSync,
+  closeSync,
+  rmSync,
+  appendFile as appendFileCb,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+
+const root = mkdtempSync(join(tmpdir(), "perry9421-"));
+const missing = join(root, "nodir", "out.jsonl");
+
+function code(e: unknown): string {
+  const c = (e as { code?: string } | null)?.code;
+  return typeof c === "string" ? c : "NO-CODE";
+}
+
+async function main(): Promise<void> {
+  // 1. promise form
+  try {
+    await appendFile(missing, "x\n", { mode: 0o600 });
+    console.log("promises.appendFile: resolved");
+  } catch (e) {
+    console.log("promises.appendFile: " + code(e));
+  }
+
+  // 2. sync form
+  try {
+    appendFileSync(missing, "x\n", { mode: 0o600 });
+    console.log("appendFileSync: no-throw");
+  } catch (e) {
+    console.log("appendFileSync: " + code(e));
+  }
+
+  // 3. callback form
+  await new Promise<void>((resolve) => {
+    appendFileCb(missing, "x\n", (err) => {
+      console.log("appendFile(cb): " + (err ? code(err) : "no-err"));
+      resolve();
+    });
+  });
+
+  // 4. The session-writer shape: the catch is the only thing that ever
+  //    creates the directory.
+  const target = join(root, "projects", "session.jsonl");
+  async function appendToFile(p: string, chunk: string): Promise<void> {
+    try {
+      await appendFile(p, chunk, { mode: 0o600 });
+    } catch {
+      await mkdir(dirname(p), { recursive: true, mode: 0o700 });
+      await appendFile(p, chunk, { mode: 0o600 });
+    }
+  }
+  await appendToFile(target, '{"type":"queue-operation"}\n');
+  await appendToFile(target, '{"type":"user"}\n');
+  try {
+    const text = await readFile(target, "utf8");
+    const lines = text.split("\n").filter((l) => l.length > 0);
+    console.log("writer-records: " + lines.length);
+    for (const l of lines) console.log("writer-line: " + l);
+  } catch (e) {
+    console.log("writer-file: MISSING (" + code(e) + ")");
+  }
+
+  // 5. The happy paths still work: fresh file, grow it, then append via an fd.
+  const good = join(root, "good.txt");
+  await appendFile(good, "one\n");
+  await appendFile(good, "two\n");
+  const fd = openSync(good, "a");
+  appendFileSync(fd, "three\n");
+  closeSync(fd);
+  console.log("good: " + JSON.stringify(await readFile(good, "utf8")));
+
+  rmSync(root, { recursive: true, force: true });
+}
+
+main();

--- a/test-files/test_gap_9421_write_file_sync_throws.ts
+++ b/test-files/test_gap_9421_write_file_sync_throws.ts
@@ -1,0 +1,126 @@
+// #9421 (sibling of the `appendFile` swallow): `fs.writeFileSync` must throw.
+//
+// `writeFileSync` had its own private copy of the write op inside
+// `js_fs_write_file_sync_options`, which reported failure by RETURNING `0`.
+// Every caller -- the codegen lowering, the namespace/computed dispatch entry
+// -- discarded that status, so a failed write was reported as a success. The
+// promise and callback forms were already correct: both run
+// `write_file_path_or_fd_result`, which returns a Node-shaped fs error. The
+// sync form now runs that same core, so all three agree.
+//
+// Routing it through the shared core fixes three divergences at once, because
+// the private copy read its payload with `bytes_from_value` instead of
+// `consume_write_file_input`:
+//
+//   * a failing write returned instead of throwing;
+//   * `writeFileSync(p, 42)` wrote something instead of throwing
+//     ERR_INVALID_ARG_TYPE;
+//   * the `encoding` option was ignored -- `writeFileSync(p, "414243", "hex")`
+//     wrote the six literal digits rather than the three bytes "ABC".
+//
+// The `mode` option is covered too: it was dropped on the create path, so
+// every file Perry made landed `0666 & ~umask` where Node honours the request
+// (`{ mode: 0o600 }` gave `0644`). It now reaches `open(2)`, which means it
+// applies on create and is ignored for an existing file -- Node's rule, pinned
+// below by chmod-ing a file and rewriting it with a mode.
+//
+// This test is umask-sensitive by construction: the assertions use 0o600
+// (unaffected by the usual 0o022) and a plain-default probe, so it reads the
+// same under any umask that does not strip owner bits.
+
+import * as fs from "node:fs";
+import { writeFileSync, mkdtempSync, rmSync, existsSync, statSync, chmodSync } from "node:fs";
+import { writeFile as writeFileP, appendFile as appendFileP } from "node:fs/promises";
+import { writeFile as writeFileCb } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const root = mkdtempSync(join(tmpdir(), "perry9421w-"));
+const missing = join(root, "nodir", "out.txt");
+
+function code(e: unknown): string {
+  const c = (e as { code?: string } | null)?.code;
+  return typeof c === "string" ? c : "NO-CODE";
+}
+function probe(name: string, fn: () => void): void {
+  try {
+    fn();
+    console.log(name + ": no-throw");
+  } catch (e) {
+    console.log(name + ": " + code(e));
+  }
+}
+function mode(p: string): string {
+  return (statSync(p).mode & 0o777).toString(8);
+}
+
+async function main(): Promise<void> {
+  // 1. a failing write must throw, in every call shape the lowering can take
+  probe("sync/named", () => writeFileSync(missing, "x"));
+  probe("sync/namespace", () => fs.writeFileSync(missing, "x"));
+  const dyn = fs as unknown as Record<string, (...a: unknown[]) => unknown>;
+  probe("sync/computed", () => dyn["writeFileSync"](missing, "x"));
+  console.log("sync/created=" + existsSync(missing));
+
+  // 2. the promise and callback forms already agreed; pin them as controls
+  try {
+    await writeFileP(missing, "x");
+    console.log("promise: resolved");
+  } catch (e) {
+    console.log("promise: " + code(e));
+  }
+  await new Promise<void>((r) => {
+    writeFileCb(missing, "x", (err) => {
+      console.log("callback: " + (err ? code(err) : "no-err"));
+      r();
+    });
+  });
+
+  // 3. argument validation reached only through the shared core
+  const p = join(root, "d.bin");
+  probe("data/string", () => writeFileSync(p, "abc"));
+  console.log("  size=" + statSync(p).size);
+  probe("data/buffer", () => writeFileSync(p, Buffer.from([1, 2, 3, 4])));
+  console.log("  size=" + statSync(p).size);
+  probe("data/u8", () => writeFileSync(p, new Uint8Array([1, 2, 3])));
+  console.log("  size=" + statSync(p).size);
+  probe("data/u32", () => writeFileSync(p, new Uint32Array([1, 2])));
+  console.log("  size=" + statSync(p).size);
+  probe("data/dataview", () => writeFileSync(p, new DataView(new ArrayBuffer(5))));
+  console.log("  size=" + statSync(p).size);
+  probe("data/number", () => writeFileSync(p, 42 as unknown as string));
+  probe("data/object", () => writeFileSync(p, { a: 1 } as unknown as string));
+  probe("data/null", () => writeFileSync(p, null as unknown as string));
+
+  // 4. the encoding option, as a bare string and inside the options object
+  probe("enc/hex", () => writeFileSync(p, "414243", "hex"));
+  console.log("  hex-read=" + fs.readFileSync(p, "utf8"));
+  probe("enc/obj", () => writeFileSync(p, "QUJD", { encoding: "base64" }));
+  console.log("  b64-read=" + fs.readFileSync(p, "utf8"));
+
+  // 5. the flag option still selects append
+  probe("flag/a", () => writeFileSync(p, "-tail", { flag: "a" }));
+  console.log("  after-append=" + fs.readFileSync(p, "utf8"));
+
+  // 6. mode on the create path, all four surfaces
+  const m1 = join(root, "m1.txt");
+  writeFileSync(m1, "x", { mode: 0o600 });
+  console.log("mode/writeFileSync=" + mode(m1));
+  const m2 = join(root, "m2.txt");
+  await writeFileP(m2, "x", { mode: 0o600 });
+  console.log("mode/promises.writeFile=" + mode(m2));
+  const m3 = join(root, "m3.txt");
+  await appendFileP(m3, "x", { mode: 0o600 });
+  console.log("mode/promises.appendFile=" + mode(m3));
+  const m4 = join(root, "m4.txt");
+  fs.appendFileSync(m4, "x", { mode: 0o600 });
+  console.log("mode/appendFileSync=" + mode(m4));
+
+  // mode applies on CREATE only: an existing file keeps its permissions
+  chmodSync(m1, 0o644);
+  writeFileSync(m1, "y", { mode: 0o600 });
+  console.log("mode/existing-file-kept=" + mode(m1));
+
+  rmSync(root, { recursive: true, force: true });
+}
+main();


### PR DESCRIPTION
Solves #9421 — cc session transcripts written incompletely (1 record vs node's 5 under `--bare -p hi`).

## Root cause: the error was swallowed, and an accident masked it

The async-queue records **were** enqueued and the drain **did** run. Its single `appendFile` failed with `ENOENT` — and perry resolved the promise anyway. `js_fs_append_file_sync_options` reported failure by returning `0`, and all three callers discarded it with `let _ = …`: the promise form always resolved, the sync form never threw, the callback form passed no error.

That mattered because the bundle's recovery arm

```js
try { await appendFile(p, chunk, {mode:0o600}) }
catch { await mkdir(dirname(p), {recursive:true}); await appendFile(p, chunk, {mode:0o600}) }
```

is **the only code that ever creates `~/.claude/projects/<slug>/`** — and with the error swallowed it never ran. Node hits the identical ENOENT and recovers. Proven by strace alignment: perry's failed `openat` is followed by *no syscalls at all*; node's is followed by `mkdir`×3 and a successful retry. `last-prompt` survived because it goes through `openSync(path, "ax")`, which throws correctly.

**The `--bare` gate was never in the write path.** Non-bare cc creates `~/.claude/projects/<slug>/memory/` (the auto-memory default) 47 ms before the first flush, creating the transcript directory *as a side effect* and masking the bug. `--bare` skips auto-memory — the flag removed the accident, not the code path.

## Commit 1 — `appendFile` reports failure

New `js_fs_append_file_result → Result<(), f64>` returning a node-shaped fs error (`code`/`errno`/`syscall`/`path`), mirroring the existing `write_file_path_or_fd_result`. Sync throws it, callback passes it as `err`, promise rejects.

| shape | node | before | after |
|---|---|---|---|
| `--bare -p hi` ×5, records | 5 | 1,1,1,1,1 | **5,5,5,5,5** |
| record types/order | `queue-operation ×2, user, assistant, last-prompt` | `last-prompt` only | **identical** |
| `-p hi` ×5 (control) | 7 | 7 | 7 |

## Commit 2 — the `writeFileSync` sibling, and `mode`

The promise and callback forms were probed and are **not** broken — both already run `write_file_path_or_fd_result`. Only the sync form was, because it carried a **private copy** of the write op — and the copy had diverged in more than error reporting. Deleting it in favour of the shared `consume_write_file_input` path fixed three divergences at once:

| | before | node |
|---|---|---|
| `writeFileSync("/no/such/dir/f","x")` | returned, wrote nothing | throws `ENOENT` |
| `writeFileSync(p, 42)` / `{}` / `null` | wrote garbage | `ERR_INVALID_ARG_TYPE` |
| `writeFileSync(p,"414243","hex")` | wrote `414243` | writes `ABC` |

**`mode` now reaches `open(2)`.** `open_file_for_write_flag` has exactly 3 call sites, all in this family; an `Option<u32>` flows to `OpenOptions::mode`, which also buys node's create-only semantics for free (an existing file keeps its permissions — pinned in the fixture). The real-world consequence:

```
claude-code transcript file mode, --bare -p hi:
  node   0o600
  perry  0o644   ← world-readable session transcript
  fixed  0o600
```

## Verification

- `test_gap_9421_append_file_promise_reject.ts` — on unfixed main: `resolved` / `no-throw` / `writer-file: MISSING`; after: **byte-identical to node**, including the `writer-mode` assertion. Standalone — no bundle required.
- `test_gap_9421_write_file_sync_throws.ts` — all three sync call shapes (named/namespace/computed — all were broken), promise+callback controls, argument validation, `encoding` both spellings, `flag:"a"`, `mode` ×4 — **14 diff lines on unfixed main, byte-identical after**.
- `cargo test --release -p perry-runtime --lib -- --test-threads=1`: **2957 passed, 0 failed**.
- **cc recompiled and re-verified after commit 2** (writeFileSync now throws where cc used to get a silent no-op): `--bare -p hi` ×5 → 5,5,5,5,5; `-p hi` ×5 → 7,7,7,7,7. Regression sweep across all six stdin/transcript stress cases, commit-1 binary vs commit-2 binary: identical exit codes, HOME-tree entries and record counts — no behaviour change beyond the intended throw.

## Explicitly out of scope, filed separately

The stress suite's other two transcript-shaped cases are **different bugs**, split by input-shape A/B during this investigation: #9489 (`process.stdin` emits one `data` event per line — 200k events for 1 MB, cc truncates piped prompts to a random prefix) and #9490 (`setEncoding("utf8")` passes raw `0x80–0xFF` through and loses data — transcript JSONL unparseable). Neither is touched here.

Closes #9421.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File-writing and appending APIs now report failures consistently across promise, synchronous, and callback usage.
  * Synchronous writes now throw appropriate filesystem errors instead of silently failing.
  * Invalid data arguments are rejected with clear errors.
  * Encoding options correctly convert string data before writing.
  * Newly created files now honor the requested permission mode.
* **Tests**
  * Added coverage for write and append failures, validation, encodings, append behavior, file modes, and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->