### PR TITLE
fix: the event loop looks before it sleeps (#9441); async fs writes are actually async, so process.exit() abandons them (#9442)

### DIFF
--- a/changelog.d/9441-idle-exit-latency.md
+++ b/changelog.d/9441-idle-exit-latency.md
@@ -1,0 +1,56 @@
+### Fixed
+
+- **A finished program no longer lingers about a second before exiting.**
+  The generated event loop's body ended in an unconditional
+  `js_wait_for_event()`, which parks for up to `IDLE_CAP_MS` (1 s) when no timer
+  deadline is nearer. That park happened even on the iteration that CONSUMED
+  the last event source — the drain that fired the final timer, or dispatched
+  stdin's `'end'` — so the loop header discovered "nothing left to do" a full
+  second after the answer was already known. On the reporting machine a program
+  whose only work was a 20 ms `setTimeout` took 1082 ms (min of 5) against
+  node's 132 ms, while the same binary exits in 45 ms when `process.exit(0)`
+  runs in the first tick. It is pure user-visible latency, and it lands after
+  the useful work is done — the part a user actually waits on.
+
+  Lowering the constant is not the fix, and neither is a new wake. Every
+  off-main producer in the runtime already calls `js_notify_main_thread` when
+  its source goes away — the stdin reader's EOF path, the child-process and pty
+  reactors, dgram, signals, the bun-FFI callback bridge — so the removals left
+  unserved are precisely the ones the MAIN thread performed itself, inside the
+  very body iteration that then parks. For those a wake is not an available
+  shape: the main thread is the pump. It has to look before it sleeps.
+
+  So the loop now looks. The body hands off to a new `event_loop.body_check`
+  block that re-asks the same liveness question the header asks, and only the
+  live answer reaches the park; the dead answer goes straight back to the
+  header, which exits. Asking in codegen rather than inside `js_wait_for_event`
+  is what makes the question EXACT: `js_cron_timer_has_pending` is a stdlib
+  symbol perry-runtime's own archive does not define, so a runtime-side
+  predicate would have had to omit cron — and would then spin on a cron-only
+  program instead of parking. Here the predicate is literally the header's, by
+  construction: both call one `emit_event_loop_liveness`, so the two cannot
+  drift.
+
+  Affected files:
+
+  - `crates/perry-codegen/src/codegen/entry.rs` — `emit_event_loop_liveness`
+    (extracted from the header's inline sequence, no arm changed), the
+    `event_loop.body_check` re-check, and `event_loop.body_wait`, which still
+    holds the park for a loop that does have live work.
+
+  Validation: `test-files/test_gap_9441_idle_exit_latency.ts`, byte-compared
+  against node 26.5.1. Each role's wall clock is compared against a role that
+  exits in its first tick, so process spawn and runtime init cancel out, and
+  the minimum of three samples is taken so a scheduling spike cannot decide the
+  verdict. On unfixed `origin/main` the `timer-idle` and `stdin-end` arms both
+  report `false`; node reports `true` for all four. `refed-timer` is the
+  anti-regression arm — a live 300 ms timer must still hold the loop open — and
+  `test_gap_9416_stdin_only_loop_liveness` covers the same ground for stdin.
+
+  The mechanism is pinned structurally rather than on a stopwatch by
+  `event_loop_body_rechecks_liveness_before_parking` in
+  `crates/perry-codegen/src/codegen/entry/tests.rs`: the body must not contain
+  `js_wait_for_event`, the re-check must consult every arm the header consults,
+  and `event_loop.body_wait` must still park. Confirmed to fail against
+  `origin/main`'s `entry.rs` ("the body must hand off to the liveness re-check,
+  not park unconditionally") and pass with the fix.

--- a/changelog.d/9442-process-exit-abandons-async-fs.md
+++ b/changelog.d/9442-process-exit-abandons-async-fs.md
@@ -1,0 +1,60 @@
+### Fixed
+
+- **`process.exit()` no longer completes async fs work that Node abandons.**
+  Five fire-and-forget `fs.promises.appendFile` calls followed by
+  `process.exit(0)` in the same tick landed five records where Node lands zero.
+  This is a divergence in the opposite direction from the usual truncation
+  report: perry wrote data the program had deliberately walked away from, so an
+  error path that exits on purpose could leave partially-written or duplicate
+  state committed behind it.
+
+  The scope question the issue asks has a clear answer, and it is not the
+  expected one: **perry's exit path drains nothing.** `js_process_exit` runs the
+  exit sequence and calls `libc::_exit`; a pending `setTimeout`, a queued
+  `net.Socket` write and a pending microtask are all dropped there exactly as
+  Node drops them. What diverged is upstream of the exit: perry's *async* fs
+  write entry points did the write SYNCHRONOUSLY inside the call and returned an
+  already-settled promise (or a deferred callback over an already-committed
+  write). There was no in-flight work left to abandon, so `process.exit()`
+  "worked" for the wrong reason.
+
+  The four entry points now park the operation on a zero-delay callback timer —
+  the mechanism `fs::stream`'s `schedule_drain` already uses — instead of
+  performing it inline. That buys three properties at once, none of them newly
+  invented: the timer queue GC-roots the closure and its captured path / data /
+  options / sink values; a pending callback timer is a live event source, so a
+  program that ends by draining its loop still lands every record and an
+  `await` on the returned promise still resolves; and `process.exit()`
+  terminates through `libc::_exit` without ticking the timer queues, so the
+  parked write is dropped the way Node drops it.
+
+  Argument validation that throws still runs on the calling turn, so a bad path
+  or a bad options object raises where it did before rather than turning into
+  an uncaught exception inside a timer.
+
+  Affected files:
+
+  - `crates/perry-runtime/src/fs/deferred.rs` (new) — the parked operation and
+    its four schedulers.
+  - `crates/perry-runtime/src/fs/mod.rs` — module registration.
+  - `crates/perry-runtime/src/fs/callbacks.rs` — `fs.writeFile(…, cb)` and
+    `fs.appendFile(…, cb)` park instead of writing inline.
+  - `crates/perry-runtime/src/node_submodules/fs_promises.rs` —
+    `fs.promises.writeFile` / `fs.promises.appendFile` return a PENDING promise.
+
+  Validation: `test-files/test_gap_9442_process_exit_abandons_async_fs.ts` and
+  its CommonJS half `…_cjs.cts`, byte-compared against node 26.5.1. Eight roles:
+  the reported promise repro, the callback form, `writeFile`, a pending timer,
+  and four controls that keep a fix from over-abandoning — a synchronous write,
+  an *awaited* write that genuinely completed before the exit, a program that
+  ends naturally with no `process.exit()` at all (which must still land all five
+  records, and is also what pins the #9441 idle-exit fix), and a
+  `process.on("exit")` listener whose own synchronous write must still land.
+  On unfixed `origin/main` the first three roles report 5, 5 and 1 records
+  against Node's 0, 0 and 0, and the `exit-listener` role reports 4 against
+  Node's 1; all four controls already matched and still match.
+
+  The `exit-listener` role also answers the question the issue raises about the
+  neighbouring known divergence: the `exit` event and the abandoned work do not
+  share a root. The listener already fires on an explicit exit (#9403) and its
+  synchronous write lands in both engines; only the pending async writes differ.

--- a/crates/perry-codegen/src/codegen/entry.rs
+++ b/crates/perry-codegen/src/codegen/entry.rs
@@ -199,6 +199,50 @@ fn collect_entry_env_literals(hir: &HirModule) -> Vec<(String, String)> {
 /// `hir.script_global_functions` list is already deduped (last declaration
 /// wins) and excludes nested closures / object-literal methods, which must
 /// not pollute the global object.
+/// #9441 — emit the event loop's "is any source still live?" test into the
+/// current block and return the i32 disjunction.
+///
+/// Emitted TWICE per loop: once in `event_loop.check_pending`, which decides
+/// whether to run the body, and once in `event_loop.body_check`, which decides
+/// whether the body's park is worth taking. It is one function so the two
+/// cannot drift — an arm added to the header but not to the post-body check
+/// would silently restore the second of idle latency this exists to remove.
+fn emit_event_loop_liveness(ctx: &mut FnCtx<'_>, needs_stdlib: bool) -> String {
+    let has_timers = ctx.block().call(I32, "js_timer_has_pending", &[]);
+    let has_callbacks = ctx.block().call(I32, "js_callback_timer_has_pending", &[]);
+    let has_intervals = ctx.block().call(I32, "js_interval_timer_has_pending", &[]);
+    // Cron jobs (node-cron schedule() / npm cron's CronJob). Guarded on
+    // `needs_stdlib` like `js_stdlib_init_dispatch` — the runtime-only link
+    // doesn't carry the cron symbols (and a cron import always pulls stdlib
+    // in). With stdlib linked the symbol always resolves: perry-ext-cron or
+    // the bundled scheduler provide the real queue; perry-stdlib exports a
+    // 0-returning stub otherwise. Without this gate (and the tick in
+    // loop_body) a program whose only live work is a running cron job exits
+    // immediately and scheduled callbacks never fire.
+    let has_cron = if needs_stdlib {
+        ctx.block().call(I32, "js_cron_timer_has_pending", &[])
+    } else {
+        "0".to_string()
+    };
+    let has_stdlib = ctx.block().call(I32, "js_stdlib_has_active_handles", &[]);
+    let has_ffi_callbacks = ctx
+        .block()
+        .call(I32, "js_bun_ffi_has_active_threadsafe_callbacks", &[]);
+    // #591: TASK_QUEUE may carry a pending `.then` continuation that was
+    // queued by `js_run_stdlib_pump`'s resolution path in the SAME body
+    // iteration that already drained the inflight counter and
+    // PENDING_RESOLUTIONS to zero. Without this gate, the header check would
+    // flip to "exit" before the next body's microtask drain ran the
+    // continuation.
+    let has_microtasks = ctx.block().call(I32, "js_microtasks_pending", &[]);
+    let any1 = ctx.block().or(I32, &has_timers, &has_callbacks);
+    let any2 = ctx.block().or(I32, &has_intervals, &has_stdlib);
+    let any2 = ctx.block().or(I32, &any2, &has_ffi_callbacks);
+    let any3 = ctx.block().or(I32, &any1, &any2);
+    let any4 = ctx.block().or(I32, &any3, &has_cron);
+    ctx.block().or(I32, &any4, &has_microtasks)
+}
+
 fn emit_script_global_function_decls(ctx: &mut FnCtx<'_>, hir: &HirModule) {
     for (name, fid) in &hir.script_global_functions {
         if ctx.block().is_terminated() {
@@ -1183,11 +1227,17 @@ pub(super) fn compile_module_entry(
                 let pending_idx = ctx.new_block("event_loop.check_pending");
                 let host_ret_idx = ctx.new_block("event_loop.host_return");
                 let body_idx = ctx.new_block("event_loop.body");
+                // #9441: the post-body liveness re-check and the park it
+                // guards. See the comment on `body_check` below.
+                let body_check_idx = ctx.new_block("event_loop.body_check");
+                let body_wait_idx = ctx.new_block("event_loop.body_wait");
                 let exit_idx = ctx.new_block("event_loop.exit");
                 let header_label = ctx.block_label(header_idx);
                 let pending_label = ctx.block_label(pending_idx);
                 let host_ret_label = ctx.block_label(host_ret_idx);
                 let body_label = ctx.block_label(body_idx);
+                let body_check_label = ctx.block_label(body_check_idx);
+                let body_wait_label = ctx.block_label(body_wait_idx);
                 let exit_label = ctx.block_label(exit_idx);
 
                 // Initial event-loop flush (4 rounds) before entering the
@@ -1238,44 +1288,7 @@ pub(super) fn compile_module_entry(
 
                 // check_pending: is there any reason to keep running?
                 ctx.current_block = pending_idx;
-                let has_timers = ctx.block().call(I32, "js_timer_has_pending", &[]);
-                let has_callbacks = ctx.block().call(I32, "js_callback_timer_has_pending", &[]);
-                let has_intervals = ctx.block().call(I32, "js_interval_timer_has_pending", &[]);
-                // Cron jobs (node-cron schedule() / npm cron's CronJob).
-                // Guarded on `needs_stdlib` like js_stdlib_init_dispatch
-                // above — the runtime-only link doesn't carry the cron
-                // symbols (and a cron import always pulls stdlib in).
-                // With stdlib linked the symbol always resolves:
-                // perry-ext-cron or the bundled scheduler provide the
-                // real queue; perry-stdlib exports a 0-returning stub
-                // otherwise. Without this gate (and the tick in
-                // loop_body below) a program whose only live work is a
-                // running cron job exits immediately and scheduled
-                // callbacks never fire — the CRON_TIMERS machinery
-                // existed but nothing in the generated event loop drove
-                // it.
-                let has_cron = if cross_module.needs_stdlib {
-                    ctx.block().call(I32, "js_cron_timer_has_pending", &[])
-                } else {
-                    "0".to_string()
-                };
-                let has_stdlib = ctx.block().call(I32, "js_stdlib_has_active_handles", &[]);
-                let has_ffi_callbacks =
-                    ctx.block()
-                        .call(I32, "js_bun_ffi_has_active_threadsafe_callbacks", &[]);
-                // #591: TASK_QUEUE may carry a pending `.then` continuation
-                // that was queued by `js_run_stdlib_pump`'s resolution path
-                // in the SAME body iteration that already drained the inflight
-                // counter and PENDING_RESOLUTIONS to zero. Without this gate,
-                // the header check would flip to "exit" before the next body's
-                // microtask drain ran the continuation.
-                let has_microtasks = ctx.block().call(I32, "js_microtasks_pending", &[]);
-                let any1 = ctx.block().or(I32, &has_timers, &has_callbacks);
-                let any2 = ctx.block().or(I32, &has_intervals, &has_stdlib);
-                let any2 = ctx.block().or(I32, &any2, &has_ffi_callbacks);
-                let any3 = ctx.block().or(I32, &any1, &any2);
-                let any4 = ctx.block().or(I32, &any3, &has_cron);
-                let any = ctx.block().or(I32, &any4, &has_microtasks);
+                let any = emit_event_loop_liveness(&mut ctx, cross_module.needs_stdlib);
                 let cmp = ctx.block().icmp_ne(I32, &any, &zero);
                 ctx.block().cond_br(&cmp, &body_label, &exit_label);
 
@@ -1290,10 +1303,55 @@ pub(super) fn compile_module_entry(
                     let _ = ctx.block().call(I32, "js_cron_timer_tick", &[]);
                 }
                 ctx.block().call_void("js_run_stdlib_pump", &[]);
+                ctx.block().br(&body_check_label);
+
+                // #9441 — body_check: ask the liveness question AGAIN, now that
+                // the body has run.
+                //
+                // The body's last act used to be an unconditional
+                // `js_wait_for_event`, which parks for up to `IDLE_CAP_MS`
+                // (1 s) when no timer deadline is nearer. That park happened
+                // even on the iteration that CONSUMED the last event source —
+                // the drain that fired the final timer, or dispatched stdin's
+                // `'end'` — so the header discovered "nothing left to do" a
+                // second after the answer was already known. A program whose
+                // only work was a 20 ms `setTimeout` measured 1082 ms against
+                // node's 132 ms; the same binary exits in 45 ms when
+                // `process.exit(0)` runs in the first tick.
+                //
+                // No wake can shorten that sleep, which is why the fix is a
+                // look and not a notify. Every off-main producer in the runtime
+                // already notifies when its source goes away (the stdin
+                // reader's EOF path, the child-process and pty reactors, dgram,
+                // signals), so the removals left unserved are exactly the ones
+                // the MAIN thread performed itself — inside the very iteration
+                // that then parks. For those a wake is not an available shape:
+                // the main thread is the pump. It has to look before it sleeps.
+                //
+                // Asking here rather than inside `js_wait_for_event` is what
+                // makes the question EXACT: `has_cron` is a stdlib symbol the
+                // runtime cannot call (perry-runtime's archive does not define
+                // it), so a runtime-side predicate would have had to omit cron
+                // and would then spin on a cron-only program instead of
+                // parking. Here the predicate is literally the header's, by
+                // construction.
+                //
+                // Branching to the header rather than to the exit block keeps
+                // the host-driven return (`js_event_loop_host_driven`) and the
+                // exit epilogue on exactly one path each; the header re-runs a
+                // cheap predicate and leaves.
+                ctx.current_block = body_check_idx;
+                let still_live = emit_event_loop_liveness(&mut ctx, cross_module.needs_stdlib);
+                let still_live_cmp = ctx.block().icmp_ne(I32, &still_live, &zero);
+                ctx.block()
+                    .cond_br(&still_live_cmp, &body_wait_label, &header_label);
+
+                // body_wait: something is still live, so park until it moves.
                 // Issue #84: condvar-backed wait. Returns immediately when
                 // a tokio worker (net/ws/http/fetch/redis/spawn) notifies
                 // after pushing to its queue; otherwise blocks until the
                 // next timer/interval deadline or a 1 s safety cap.
+                ctx.current_block = body_wait_idx;
                 ctx.block().call_void("js_wait_for_event", &[]);
                 ctx.block().br(&header_label);
 

--- a/crates/perry-codegen/src/codegen/entry/tests.rs
+++ b/crates/perry-codegen/src/codegen/entry/tests.rs
@@ -282,6 +282,85 @@ fn event_loop_microtask_pump_is_the_single_timer_phase_owner() {
     }
 }
 
+/// #9441: the body's park must be guarded by a re-check of the SAME liveness
+/// question the header asks, so the iteration that consumed the last event
+/// source does not sleep on an answer already known.
+///
+/// This is the mechanism assertion. On unfixed `origin/main` the body ended in
+/// an unconditional `call void @js_wait_for_event()` and the ~1 s idle tail was
+/// visible only on a stopwatch; here it is structural.
+#[test]
+fn event_loop_body_rechecks_liveness_before_parking() {
+    let ir = emitted_ir("executable");
+
+    let body_start = ir
+        .find("\nevent_loop.body.")
+        .map(|offset| offset + 1)
+        .unwrap_or_else(|| panic!("missing event-loop body block in emitted IR:\n{ir}"));
+    let body_len = ir[body_start..]
+        .find("\nevent_loop.")
+        .expect("the body block should be followed by another event_loop block");
+    let body_block = &ir[body_start..body_start + body_len];
+    assert!(
+        !body_block.contains("js_wait_for_event"),
+        "the body must hand off to the liveness re-check, not park unconditionally\n{body_block}"
+    );
+    assert!(
+        body_block.contains("br label %event_loop.body_check"),
+        "the body must branch to the post-body liveness re-check\n{body_block}"
+    );
+
+    let check_start = ir
+        .find("\nevent_loop.body_check.")
+        .map(|offset| offset + 1)
+        .unwrap_or_else(|| panic!("missing event_loop.body_check block:\n{ir}"));
+    let check_len = ir[check_start..]
+        .find("\nevent_loop.")
+        .expect("body_check should be followed by another event_loop block");
+    let check_block = &ir[check_start..check_start + check_len];
+
+    // Every arm the header consults must be re-asked here, or a source the
+    // re-check cannot see would make the loop spin instead of park.
+    for arm in [
+        "js_timer_has_pending",
+        "js_callback_timer_has_pending",
+        "js_interval_timer_has_pending",
+        "js_stdlib_has_active_handles",
+        "js_bun_ffi_has_active_threadsafe_callbacks",
+        "js_microtasks_pending",
+    ] {
+        assert!(
+            check_block.contains(arm),
+            "the post-body re-check must consult {arm} exactly as the header does\n{check_block}"
+        );
+    }
+    assert!(
+        check_block.contains("br i1 ") && check_block.contains("%event_loop.body_wait"),
+        "the re-check must branch to the park only when something is still live\n{check_block}"
+    );
+    assert!(
+        check_block.contains("%event_loop.header"),
+        "the re-check must skip the park and go straight back to the header when \
+         nothing is live\n{check_block}"
+    );
+
+    // The park itself still exists — the fix removes the park on a DEAD loop,
+    // not the park on a live one, and deleting it would spin every waiting
+    // program at 100 % CPU.
+    let wait_start = ir
+        .find("\nevent_loop.body_wait.")
+        .map(|offset| offset + 1)
+        .unwrap_or_else(|| panic!("missing event_loop.body_wait block:\n{ir}"));
+    let wait_len = ir[wait_start..]
+        .find("\nevent_loop.")
+        .expect("body_wait should be followed by another event_loop block");
+    let wait_block = &ir[wait_start..wait_start + wait_len];
+    assert!(
+        wait_block.contains("call void @js_wait_for_event()"),
+        "a loop with live work must still park\n{wait_block}"
+    );
+}
+
 #[test]
 fn dylib_entry_does_not_release_process_owned_collection_storage() {
     let ir = emitted_ir("dylib");

--- a/crates/perry-runtime/src/fs/callbacks.rs
+++ b/crates/perry-runtime/src/fs/callbacks.rs
@@ -156,7 +156,8 @@ pub(crate) unsafe fn call_cb_err1(callback: *const ClosureHeader, err_val: f64) 
     defer_fs_callback(callback, &[err_val]);
 }
 
-/// `fs.writeFile(path, data, callback)` — sync write + immediate callback.
+/// `fs.writeFile(path, data, callback)` — the write is parked on a later
+/// event-loop turn (#9442), then the callback is delivered.
 #[no_mangle]
 pub extern "C" fn js_fs_write_file_callback(
     path_value: f64,
@@ -177,16 +178,15 @@ pub extern "C" fn js_fs_write_file_callback(
             return f64::from_bits(TAG_UNDEFINED);
         }
     }
-    unsafe {
-        match write_file_path_or_fd_result(path_value, content_value, options) {
-            Ok(()) => call_cb0(cb),
-            Err(err_val) => call_cb_err1(cb, err_val),
-        }
-    }
+    // #9442: park the write instead of performing it here. Node hands
+    // `writeFile` to the thread pool and returns; a `process.exit()` in the
+    // same tick abandons it, and perry must abandon it too.
+    defer_write_file_callback(path_value, content_value, options, cb);
     f64::from_bits(TAG_UNDEFINED)
 }
 
-/// `fs.appendFile(path, data, callback)` — sync append + immediate callback.
+/// `fs.appendFile(path, data, callback)` — the append is parked on a later
+/// event-loop turn (#9442), then the callback is delivered.
 #[no_mangle]
 pub extern "C" fn js_fs_append_file_callback(
     path_value: f64,
@@ -207,8 +207,10 @@ pub extern "C" fn js_fs_append_file_callback(
             return f64::from_bits(TAG_UNDEFINED);
         }
     }
-    let _ = js_fs_append_file_sync_options(path_value, content_value, options);
-    call_cb0(cb);
+    // #9442: park the write instead of performing it here. Node hands
+    // `appendFile` to the thread pool and returns; a `process.exit()` in the
+    // same tick abandons it, and perry must abandon it too.
+    defer_append_file_callback(path_value, content_value, options, cb);
     f64::from_bits(TAG_UNDEFINED)
 }
 

--- a/crates/perry-runtime/src/fs/deferred.rs
+++ b/crates/perry-runtime/src/fs/deferred.rs
@@ -1,0 +1,243 @@
+//! #9442 — deferred async fs writes.
+//!
+//! Node's `fs.writeFile` / `fs.appendFile` — both the callback form and the
+//! `fs/promises` form — hand the work to the libuv thread pool and return.
+//! Nothing has touched the file when the call returns, and `process.exit()`
+//! does not drain that pool: an exit in the same tick abandons the write.
+//!
+//! Perry did the write SYNCHRONOUSLY inside the call and returned an
+//! already-settled promise (or a deferred callback over an already-committed
+//! write). There was no in-flight work left for `process.exit()` to abandon, so
+//! five fire-and-forget `appendFile` calls followed by `process.exit(0)` landed
+//! five records where Node lands none — perry committed state a program had
+//! deliberately walked away from.
+//!
+//! The fix keeps the work synchronous but moves it OFF the calling turn: the
+//! operation is parked on a zero-delay callback timer, the same mechanism
+//! `fs::stream`'s `schedule_drain` uses. That buys three properties at once,
+//! all of them already load-bearing elsewhere in the runtime, none of them
+//! newly invented here:
+//!
+//!   * the timer queue GC-roots the closure and therefore its captured path /
+//!     data / options / sink values, so they survive the turn;
+//!   * a pending callback timer is a live event source
+//!     (`js_callback_timer_has_pending`), so a program that ends by draining
+//!     its loop still lands every record, and an `await` on the returned
+//!     promise still resolves;
+//!   * `process.exit()` terminates through `libc::_exit` without ticking the
+//!     timer queues, so the parked write is dropped exactly as Node drops it.
+//!
+//! Argument validation that THROWS stays on the calling turn (see the
+//! `validate::*` calls in the schedulers below), so a bad path or a bad options
+//! object still raises where it did before rather than turning into an uncaught
+//! exception inside a timer.
+
+use crate::closure::{
+    js_closure_alloc, js_closure_get_capture_f64, js_closure_set_capture_f64, ClosureHeader,
+};
+
+use super::validate;
+
+const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
+
+/// Capture layout for the parked operation. Slot 4 holds `Mode`.
+const CAP_PATH: u32 = 0;
+const CAP_DATA: u32 = 1;
+const CAP_OPTIONS: u32 = 2;
+const CAP_SINK: u32 = 3;
+const CAP_MODE: u32 = 4;
+const CAPTURE_COUNT: u32 = 5;
+
+const MODE_APPEND_PROMISE: f64 = 0.0;
+const MODE_WRITE_PROMISE: f64 = 1.0;
+const MODE_APPEND_CALLBACK: f64 = 2.0;
+const MODE_WRITE_CALLBACK: f64 = 3.0;
+
+fn undefined() -> f64 {
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+/// Park `perform_deferred_fs_write` on the next event-loop turn with the
+/// operation's five captured values.
+///
+/// The JS values are rooted across the closure allocation. `js_closure_alloc`
+/// is a GC allocation, and under the default copied-minor scavenge a raw
+/// NaN-boxed `f64` copy held only in a Rust local names from-space the moment
+/// one runs — the same shape as the bare-pointer-across-allocation class the
+/// moving collector made live. The closure itself needs no handle here:
+/// `js_set_timeout_callback` roots it for exactly this reason (see
+/// `schedule_callback_timer`'s own `RuntimeHandleScope`).
+fn park(path: f64, data: f64, options: f64, sink: f64, mode: f64) {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let path_handle = scope.root_nanbox_f64(path);
+    let data_handle = scope.root_nanbox_f64(data);
+    let options_handle = scope.root_nanbox_f64(options);
+    let sink_handle = scope.root_nanbox_f64(sink);
+    let closure = js_closure_alloc(perform_deferred_fs_write as *const u8, CAPTURE_COUNT);
+    js_closure_set_capture_f64(closure, CAP_PATH, path_handle.get_nanbox_f64());
+    js_closure_set_capture_f64(closure, CAP_DATA, data_handle.get_nanbox_f64());
+    js_closure_set_capture_f64(closure, CAP_OPTIONS, options_handle.get_nanbox_f64());
+    js_closure_set_capture_f64(closure, CAP_SINK, sink_handle.get_nanbox_f64());
+    js_closure_set_capture_f64(closure, CAP_MODE, mode);
+    // Zero delay: the operation runs on the next turn of whichever loop is
+    // driving — the generated event loop, or the poll loop an `await` spins.
+    // A pending callback timer is a live event source, so a program that ends
+    // by draining its loop still performs it; `process.exit()` never ticks the
+    // timer queues, so an exit in the same tick drops it, as Node does.
+    let _ = crate::timer::js_set_timeout_callback(closure as i64, 0.0);
+}
+
+/// Park a promise-form operation and hand back its PENDING promise.
+///
+/// Every JS value here is held across two allocations (`js_promise_new` and,
+/// inside `park`, the closure plus the timer's async-resource init), so the
+/// returned promise is re-read from its handle rather than from the local that
+/// created it.
+fn park_promise(path: f64, data: f64, options: f64, mode: f64) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let path_handle = scope.root_nanbox_f64(path);
+    let data_handle = scope.root_nanbox_f64(data);
+    let options_handle = scope.root_nanbox_f64(options);
+    let promise = crate::promise::js_promise_new();
+    let promise_handle = scope
+        .root_nanbox_f64(f64::from_bits(
+            crate::value::JSValue::pointer(promise as *const u8).bits(),
+        ));
+    park(
+        path_handle.get_nanbox_f64(),
+        data_handle.get_nanbox_f64(),
+        options_handle.get_nanbox_f64(),
+        promise_handle.get_nanbox_f64(),
+        mode,
+    );
+    promise_handle.get_nanbox_f64()
+}
+
+/// `fs.promises.appendFile(path, data[, options])`.
+pub(crate) fn defer_append_file_promise(path: f64, data: f64, options: f64) -> f64 {
+    validate::validate_path_or_fd("path", path, "write");
+    validate::validate_string_or_object_options("options", options);
+    park_promise(path, data, options, MODE_APPEND_PROMISE)
+}
+
+/// `fs.promises.writeFile(path, data[, options])`.
+pub(crate) fn defer_write_file_promise(path: f64, data: f64, options: f64) -> f64 {
+    validate::validate_path_or_fd("path", path, "write");
+    validate::validate_string_or_object_options("options", options);
+    park_promise(path, data, options, MODE_WRITE_PROMISE)
+}
+
+/// `fs.appendFile(path, data[, options], cb)`.
+pub(crate) fn defer_append_file_callback(
+    path: f64,
+    data: f64,
+    options: f64,
+    callback: *const ClosureHeader,
+) {
+    validate::validate_path_or_fd("path", path, "write");
+    validate::validate_string_or_object_options("options", options);
+    park(
+        path,
+        data,
+        options,
+        callback_sink_value(callback),
+        MODE_APPEND_CALLBACK,
+    );
+}
+
+/// `fs.writeFile(path, data[, options], cb)`.
+pub(crate) fn defer_write_file_callback(
+    path: f64,
+    data: f64,
+    options: f64,
+    callback: *const ClosureHeader,
+) {
+    validate::validate_path_or_fd("path", path, "write");
+    validate::validate_string_or_object_options("options", options);
+    park(
+        path,
+        data,
+        options,
+        callback_sink_value(callback),
+        MODE_WRITE_CALLBACK,
+    );
+}
+
+fn callback_sink_value(callback: *const ClosureHeader) -> f64 {
+    if callback.is_null() {
+        undefined()
+    } else {
+        f64::from_bits(crate::value::JSValue::pointer(callback as *const u8).bits())
+    }
+}
+
+fn callback_from_sink(sink: f64) -> *const ClosureHeader {
+    super::extract_closure_ptr(sink)
+}
+
+/// The parked operation. Runs on a later event-loop turn; never on the turn
+/// that scheduled it, which is the whole point.
+extern "C" fn perform_deferred_fs_write(closure: *const ClosureHeader) -> f64 {
+    let mode = js_closure_get_capture_f64(closure, CAP_MODE);
+    // The operation allocates (error values, decoded strings), so the captured
+    // JS values are read through handles rather than held raw across it — the
+    // sink especially, which is used AFTER the operation returns.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let path_handle = scope.root_nanbox_f64(js_closure_get_capture_f64(closure, CAP_PATH));
+    let data_handle = scope.root_nanbox_f64(js_closure_get_capture_f64(closure, CAP_DATA));
+    let options_handle = scope.root_nanbox_f64(js_closure_get_capture_f64(closure, CAP_OPTIONS));
+    let sink_handle = scope.root_nanbox_f64(js_closure_get_capture_f64(closure, CAP_SINK));
+
+    // A throw from inside a timer callback would terminate the process; every
+    // path that used to throw synchronously has already run on the calling
+    // turn, so anything caught here is routed to the operation's own sink.
+    let outcome = crate::exception::catch_js_throw(|| {
+        let path = path_handle.get_nanbox_f64();
+        let data = data_handle.get_nanbox_f64();
+        let options = options_handle.get_nanbox_f64();
+        let result = if mode == MODE_APPEND_PROMISE || mode == MODE_APPEND_CALLBACK {
+            // Matches the pre-#9442 behaviour of both append entry points: the
+            // sync helper's 0/1 status was discarded, so an I/O failure settles
+            // as success. Deferral must not quietly change that contract.
+            let _ = super::js_fs_append_file_sync_options(path, data, options);
+            Ok(())
+        } else {
+            unsafe { super::write_file_path_or_fd_result(path, data, options) }
+        };
+        match result {
+            Ok(()) => undefined(),
+            Err(err) => err,
+        }
+    });
+
+    let error_value = match outcome {
+        Ok(value) => {
+            if crate::value::JSValue::from_bits(value.to_bits()).is_undefined() {
+                None
+            } else {
+                Some(value)
+            }
+        }
+        Err(thrown) => Some(thrown),
+    };
+
+    let sink = sink_handle.get_nanbox_f64();
+    if mode == MODE_APPEND_PROMISE || mode == MODE_WRITE_PROMISE {
+        let promise = crate::value::js_nanbox_get_pointer(sink) as *mut crate::promise::Promise;
+        if !promise.is_null() {
+            match error_value {
+                None => crate::promise::js_promise_resolve(promise, undefined()),
+                Some(err) => crate::promise::js_promise_reject(promise, err),
+            }
+        }
+    } else {
+        let callback = callback_from_sink(sink);
+        if !callback.is_null() {
+            match error_value {
+                None => super::callbacks::call_cb0(callback),
+                Some(err) => unsafe { super::callbacks::call_cb_err1(callback, err) },
+            }
+        }
+    }
+    undefined()
+}

--- a/crates/perry-runtime/src/fs/mod.rs
+++ b/crates/perry-runtime/src/fs/mod.rs
@@ -18,6 +18,11 @@ use crate::value::{POINTER_MASK, POINTER_TAG};
 
 mod callbacks;
 pub use callbacks::*;
+// #9442: the async write entry points park their work on a later event-loop
+// turn instead of doing it inline, so `process.exit()` abandons it the way
+// Node's does.
+mod deferred;
+pub(crate) use deferred::*;
 mod stream;
 pub use stream::*;
 mod filehandle;

--- a/crates/perry-runtime/src/node_submodules/fs_promises.rs
+++ b/crates/perry-runtime/src/node_submodules/fs_promises.rs
@@ -143,12 +143,11 @@ pub(crate) extern "C" fn thunk_fs_promises_writeFile(
     data: f64,
     options: f64,
 ) -> f64 {
-    match catch_fs_promises_throw(|| {
-        match unsafe { crate::fs::write_file_path_or_fd_result(path, data, options) } {
-            Ok(()) => crate::fs::promise_undefined_fs(),
-            Err(err) => crate::fs::promise_rejected_fs(err),
-        }
-    }) {
+    // #9442: return a PENDING promise and park the write on a later turn, the
+    // way Node returns before the thread pool has touched the file. Argument
+    // validation that throws still runs here, so a bad path or options object
+    // rejects exactly as it did before.
+    match catch_fs_promises_throw(|| crate::fs::defer_write_file_promise(path, data, options)) {
         Ok(promise) => promise,
         Err(err) => crate::fs::promise_rejected_fs(err),
     }
@@ -161,9 +160,13 @@ pub(crate) extern "C" fn thunk_fs_promises_appendFile(
     data: f64,
     options: f64,
 ) -> f64 {
-    promise_from_sync_undefined(|| {
-        let _ = crate::fs::js_fs_append_file_sync_options(path, data, options);
-    })
+    // #9442: see `thunk_fs_promises_writeFile`. Five of these followed by
+    // `process.exit(0)` in the same tick is the issue's repro; Node lands zero
+    // records because none of the five has run yet.
+    match catch_fs_promises_throw(|| crate::fs::defer_append_file_promise(path, data, options)) {
+        Ok(promise) => promise,
+        Err(err) => crate::fs::promise_rejected_fs(err),
+    }
 }
 
 pub(crate) extern "C" fn thunk_fs_promises_chmod(

--- a/test-files/test_gap_9441_idle_exit_latency.ts
+++ b/test-files/test_gap_9441_idle_exit_latency.ts
@@ -1,0 +1,116 @@
+// #9441: a program that has finished its work must not linger.
+//
+// `IDLE_CAP_MS = 1000` in crates/perry-runtime/src/event_pump.rs is the wait
+// budget `js_wait_for_event` uses when no timer deadline is nearer. The
+// generated event loop parks on it at the END of every body iteration —
+// INCLUDING the iteration that consumed the last event source. Nothing can wake
+// that park, because the state it is waiting for a change in has already
+// changed: the answer is known and the pump is asleep on it. The next loop
+// header therefore discovers "nothing left to do" a full second late, and that
+// second is pure user-visible latency on every short-lived program.
+//
+// This fixture measures the tail rather than asserting an absolute duration,
+// because the machine it runs on is shared: each role's wall clock is compared
+// against a `baseline` role that exits in its first tick, so process spawn,
+// dynamic linking and runtime init cancel out and only the idle tail is left.
+// Three samples are taken of each and the MINIMUM is compared, so a scheduling
+// spike inflates a sample without changing the verdict. The 400 ms threshold
+// sits between the ~1000 ms structural tail and the ~20 ms a healthy exit costs
+// — wide enough that it is not a benchmark, narrow enough that it cannot pass
+// with the park still in place.
+//
+// Measured on the reporting machine, `origin/main` @1659211e7c, min of 5 runs
+// under load ~105: baseline 45 ms, timer-idle 1082 ms, stdin-end likewise past
+// the budget, promise-idle 38 ms. Node: baseline 110 ms, timer-idle 132 ms.
+//
+// `refed-timer` is the anti-regression arm: a program with a live 300 ms timer
+// must NOT exit early. A fix that simply stopped parking, or that widened the
+// "nothing is live" test until it swallowed a pending timer, reports here — and
+// test_gap_9416_stdin_only_loop_liveness covers the same ground for stdin.
+import { spawn } from "node:child_process";
+
+const ROLE_ENV = "PERRY_9441_ROLE";
+const SAMPLES = 3;
+// The tail is ~1000 ms structurally and ~20 ms once the park is skipped.
+const TAIL_BUDGET_MS = 400;
+// `refed-timer` holds a 300 ms timer; allow generous slack under load.
+const REFED_MIN_MS = 200;
+const WATCHDOG_MS = 8000;
+
+const role = process.env[ROLE_ENV] ?? "";
+
+if (role === "baseline") {
+  // Exits in its first tick: the cost of spawn + init and nothing else.
+  process.exit(0);
+} else if (role === "timer-idle") {
+  // One short timer, then the loop is empty. The park that follows the firing
+  // iteration is the bug.
+  setTimeout(() => {}, 20);
+} else if (role === "promise-idle") {
+  // CONTROL, not a witness: this shape was already fast before the fix
+  // (measured 38 ms against the timer arm's 1082 ms), because the pump's
+  // NOTIFIED fast path returns without ever computing a budget when a promise
+  // resolution flipped the flag. It is here so a fix that reorganises the wait
+  // cannot make the ALREADY-fast path slow while making the slow one fast.
+  void Promise.resolve().then(() => {});
+} else if (role === "stdin-end") {
+  // The reported probe: a stdin reader whose pipe is closed immediately. The
+  // last source goes away when `'end'` is dispatched, on the main thread, in
+  // the same iteration that then parks.
+  const stream: any = process.stdin;
+  stream.once("end", () => {});
+  stream.resume();
+} else if (role === "refed-timer") {
+  // ANTI-REGRESSION: a live 300 ms timer must still hold the loop open.
+  setTimeout(() => {}, 300);
+} else {
+  const childArgs = [...process.execArgv, ...process.argv.slice(1)];
+
+  const runOnce = (name: string, closeStdin: boolean) =>
+    new Promise<number>((resolve) => {
+      const started = Date.now();
+      const child = spawn(process.execPath, childArgs, {
+        env: { ...process.env, [ROLE_ENV]: name },
+        stdio: [closeStdin ? "pipe" : "ignore", "inherit", "inherit"],
+      });
+      let settled = false;
+      const watchdog = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        child.kill("SIGKILL");
+        resolve(WATCHDOG_MS);
+      }, WATCHDOG_MS);
+      child.on("exit", () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(watchdog);
+        resolve(Date.now() - started);
+      });
+      if (closeStdin) {
+        child.stdin!.end();
+      }
+    });
+
+  const best = async (name: string, closeStdin = false) => {
+    let min = Number.POSITIVE_INFINITY;
+    for (let i = 0; i < SAMPLES; i++) {
+      const ms = await runOnce(name, closeStdin);
+      if (ms < min) min = ms;
+    }
+    return min;
+  };
+
+  (async () => {
+    const baseline = await best("baseline");
+    const timerIdle = await best("timer-idle");
+    const promiseIdle = await best("promise-idle");
+    const stdinEnd = await best("stdin-end", true);
+    const refed = await best("refed-timer");
+
+    console.log("timer-idle tail under budget:", timerIdle - baseline < TAIL_BUDGET_MS);
+    console.log("promise-idle tail under budget:", promiseIdle - baseline < TAIL_BUDGET_MS);
+    console.log("stdin-end tail under budget:", stdinEnd - baseline < TAIL_BUDGET_MS);
+    console.log("refed-timer held the loop open:", refed - baseline >= REFED_MIN_MS);
+    console.log("done");
+  })();
+}

--- a/test-files/test_gap_9442_process_exit_abandons_async_fs.ts
+++ b/test-files/test_gap_9442_process_exit_abandons_async_fs.ts
@@ -1,0 +1,147 @@
+// #9442: `process.exit()` must terminate WITHOUT completing async fs work that
+// has not run yet — Node's exit does not drain the libuv work queue, so five
+// fire-and-forget `fs.promises.appendFile` calls followed by `process.exit(0)`
+// in the same tick land ZERO records on disk.
+//
+// Perry landed five. The root cause is not that perry's exit path drains a
+// queue (it does not — `js_process_exit` runs the exit sequence and calls
+// `libc::_exit`): it is that perry's *async* fs write entry points did the
+// write SYNCHRONOUSLY inside the call and returned an already-settled promise
+// (or invoked the callback immediately). There was no in-flight work left to
+// abandon, so `process.exit()` "worked" for the wrong reason and committed
+// state the program had deliberately walked away from.
+//
+// Every role writes only to its own file and prints nothing; the PARENT reports
+// what survived, so the transcript is independent of child stdout ordering.
+//
+// The two controls are what keep the fix from over-abandoning:
+//   * `awaited-control`   — a write that genuinely completed before the exit
+//                           MUST still be on disk.
+//   * `natural-control`   — a program that ends by draining its event loop
+//                           (no `process.exit()` at all) MUST still land every
+//                           record. This is also the arm that pins #9441: the
+//                           idle-exit fix makes the pump notice emptiness
+//                           sooner and must not cut the drain short.
+//
+// `exit-listener` answers the question the issue asks about the neighbouring
+// known divergence: the `exit` event and the abandoned work do NOT share a
+// root. The listener fires on an explicit exit (#9403) and its own synchronous
+// write lands, while the pending async writes are still dropped.
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { spawn } from "node:child_process";
+
+const ROLE_ENV = "PERRY_9442_ROLE";
+const FILE_ENV = "PERRY_9442_FILE";
+const WATCHDOG_MS = 5000;
+
+const role = process.env[ROLE_ENV] ?? "";
+const target = process.env[FILE_ENV] ?? "";
+
+function fireAndForgetPromises(n: number): void {
+  for (let i = 0; i < n; i++) {
+    // Deliberately un-awaited: the promise is discarded on purpose.
+    void fs.promises.appendFile(target, "line " + i + "\n");
+  }
+}
+
+if (role === "promise-exit") {
+  // The reported repro.
+  fireAndForgetPromises(5);
+  process.exit(0);
+} else if (role === "callback-exit") {
+  // The callback form of the same operation.
+  for (let i = 0; i < 5; i++) {
+    fs.appendFile(target, "cb " + i + "\n", () => {});
+  }
+  process.exit(0);
+} else if (role === "writefile-exit") {
+  // `writeFile` shares the entry point family with `appendFile`.
+  void fs.promises.writeFile(target, "written\n");
+  process.exit(0);
+} else if (role === "timer-exit") {
+  // A pending timer is abandoned by `process.exit()` in both engines; this arm
+  // exists so a fix that starts draining the loop at exit reports here.
+  setTimeout(() => {
+    fs.appendFileSync(target, "timer\n");
+  }, 0);
+  process.exit(0);
+} else if (role === "sync-control") {
+  // CONTROL: a synchronous write is already committed and must survive.
+  fs.appendFileSync(target, "sync\n");
+  process.exit(0);
+} else if (role === "awaited-control") {
+  // CONTROL: an awaited write genuinely completed before the exit. A fix that
+  // abandons this is worse than the bug.
+  (async () => {
+    await fs.promises.appendFile(target, "awaited\n");
+    process.exit(0);
+  })();
+} else if (role === "natural-control") {
+  // CONTROL: no `process.exit()` at all. The event loop drains and every
+  // record must land, exactly as in Node.
+  fireAndForgetPromises(5);
+} else if (role === "exit-listener") {
+  // The `exit` event fires on an explicit exit and its synchronous work lands;
+  // the pending async writes are still abandoned.
+  process.on("exit", () => {
+    fs.appendFileSync(target, "exit-listener\n");
+  });
+  fireAndForgetPromises(3);
+  process.exit(0);
+} else {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "perry9442-"));
+  const childArgs = [...process.execArgv, ...process.argv.slice(1)];
+
+  const runRole = (name: string) =>
+    new Promise<void>((resolve) => {
+      const file = path.join(tmpDir, name + ".txt");
+      const child = spawn(process.execPath, childArgs, {
+        env: { ...process.env, [ROLE_ENV]: name, [FILE_ENV]: file },
+        stdio: ["ignore", "inherit", "inherit"],
+      });
+      let settled = false;
+      // Record COUNT only, with a missing file counted as zero. Whether Node's
+      // thread pool won the race to `open(2)` before `_exit` — leaving an empty
+      // file behind rather than none — is a scheduling artifact, not a
+      // semantic; the question this fixture asks is the issue's own, "how many
+      // records did the abandoned program commit". Contents are sorted because
+      // Node's pool completes concurrent appends in an arbitrary order.
+      const report = (code: number | null | string) => {
+        const lines = fs.existsSync(file)
+          ? fs.readFileSync(file, "utf8").split("\n").filter((l) => l.length > 0)
+          : [];
+        console.log(name + " exit=" + code + " records=" + lines.length);
+        if (lines.length > 0) {
+          console.log("  " + name + ": " + JSON.stringify(lines.slice().sort().join("|")));
+        }
+        resolve();
+      };
+      const watchdog = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        child.kill("SIGKILL");
+        report("WATCHDOG");
+      }, WATCHDOG_MS);
+      child.on("exit", (code) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(watchdog);
+        report(code);
+      });
+    });
+
+  (async () => {
+    await runRole("promise-exit");
+    await runRole("callback-exit");
+    await runRole("writefile-exit");
+    await runRole("timer-exit");
+    await runRole("sync-control");
+    await runRole("awaited-control");
+    await runRole("natural-control");
+    await runRole("exit-listener");
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    console.log("done");
+  })();
+}

--- a/test-files/test_gap_9442_process_exit_abandons_async_fs_cjs.cts
+++ b/test-files/test_gap_9442_process_exit_abandons_async_fs_cjs.cts
@@ -1,0 +1,79 @@
+// #9442, CommonJS half. `process.exit()` must abandon async fs work that has
+// not run yet in a `.cts` module too — the fix lives in the runtime's fs entry
+// points, not in the ESM lowering, and this fixture is what proves that rather
+// than assuming it. See test_gap_9442_process_exit_abandons_async_fs.ts for the
+// full role set and the reasoning; this one keeps the repro plus the two
+// controls that stop a fix from over-abandoning.
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawn } = require("node:child_process");
+
+const ROLE_ENV = "PERRY_9442_CJS_ROLE";
+const FILE_ENV = "PERRY_9442_CJS_FILE";
+const WATCHDOG_MS = 5000;
+
+const role = process.env[ROLE_ENV] || "";
+const target = process.env[FILE_ENV] || "";
+
+if (role === "promise-exit") {
+  for (let i = 0; i < 5; i++) {
+    void fs.promises.appendFile(target, "line " + i + "\n");
+  }
+  process.exit(0);
+} else if (role === "callback-exit") {
+  for (let i = 0; i < 5; i++) {
+    fs.appendFile(target, "cb " + i + "\n", () => {});
+  }
+  process.exit(0);
+} else if (role === "awaited-control") {
+  (async () => {
+    await fs.promises.appendFile(target, "awaited\n");
+    process.exit(0);
+  })();
+} else if (role === "natural-control") {
+  for (let i = 0; i < 5; i++) {
+    void fs.promises.appendFile(target, "line " + i + "\n");
+  }
+} else {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "perry9442c-"));
+  const childArgs = [...process.execArgv, ...process.argv.slice(1)];
+
+  const runRole = (name) =>
+    new Promise((resolve) => {
+      const file = path.join(tmpDir, name + ".txt");
+      const child = spawn(process.execPath, childArgs, {
+        env: Object.assign({}, process.env, { [ROLE_ENV]: name, [FILE_ENV]: file }),
+        stdio: ["ignore", "inherit", "inherit"],
+      });
+      let settled = false;
+      const report = (code) => {
+        const lines = fs.existsSync(file)
+          ? fs.readFileSync(file, "utf8").split("\n").filter((l) => l.length > 0)
+          : [];
+        console.log(name + " exit=" + code + " records=" + lines.length);
+        resolve();
+      };
+      const watchdog = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        child.kill("SIGKILL");
+        report("WATCHDOG");
+      }, WATCHDOG_MS);
+      child.on("exit", (code) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(watchdog);
+        report(code);
+      });
+    });
+
+  (async () => {
+    await runRole("promise-exit");
+    await runRole("callback-exit");
+    await runRole("awaited-control");
+    await runRole("natural-control");
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    console.log("done");
+  })();
+}


### PR DESCRIPTION
Two event-loop lifecycle fixes, separate commits, one lane because their fixes could have fought each other — the shared pin is the `natural-control` fixture arm (no `process.exit()`), which lands all 5 records in node, in perry before, and in perry after both changes.

## #9441 — the ~1s idle tail (`388e1f0e29`)

**Root cause: not the constant, and not a missing wake.** The generated event loop's body ended in an *unconditional* `js_wait_for_event()`, which parks up to `IDLE_CAP_MS` (1000 ms) — **even on the iteration that consumed the last event source**. Every off-main producer already calls `js_notify_main_thread` when its source disappears; the removals left unserved are exactly the ones the main thread performed *itself*, inside the iteration that then parks. For those a wake is not an available shape — the main thread **is** the pump. It has to look before it sleeps.

**Fix in codegen, not the runtime, for a reason established by trying the other way first**: a runtime-side predicate cannot see `js_cron_timer_has_pending` (a stdlib symbol perry-runtime's archive does not define — `nm` says `U`, never `T`), so it would have had to omit cron and would then *spin* on a cron-only program. In codegen the re-check is literally the header's own liveness question: the body hands off to `event_loop.body_check`, only the live answer reaches the park, and both sites share one `emit_event_loop_liveness` so they cannot drift.

**Verification is mechanism-first, not a stopwatch** (this box runs at load 30–105): `event_loop_body_rechecks_liveness_before_parking` asserts the body contains no `js_wait_for_event`, the re-check consults every header arm, and the park still exists — and it **fails against origin/main's `entry.rs`**. The fixture asserts under-budget booleans; the wall numbers, min/median of 5:

| role | main | fixed | node |
|---|---|---|---|
| timer-idle (20 ms timer, then idle) | **1082/1089** | **55/62** | 132/134 |
| refed-timer 300 ms (anti-regression) | 1353/1366 | 335/344 | — |
| promise-idle (control — already fast via NOTIFIED) | 38/41 | 33/35 | — |

`test_gap_9416_stdin_only_loop_liveness` still passes.

## #9442 — `process.exit()` vs in-flight async fs (`7742e6408c`)

**The scope answer is the finding: perry's exit path drains nothing.** `js_process_exit` ends in `libc::_exit`; pending timers, queued socket writes and microtasks are dropped exactly as node drops them. What diverged was upstream — **`fs.promises.{writeFile,appendFile}` and the callback forms did the write synchronously** and returned an already-settled promise. There was nothing in flight to abandon.

Fix: the four entry points park the operation on a zero-delay callback timer — the mechanism `fs::stream`'s `schedule_drain` already uses. That buys three properties at once: the timer queue GC-roots the closure; a pending callback timer is a live event source (natural drain still lands every record, `await` still resolves); `_exit` never ticks timer queues. Throwing validation stays on the calling turn; values held across the allocations are rooted via `RuntimeHandleScope`.

Before-diff (node vs unfixed main):
```
-promise-exit  records=0     +records=5
-callback-exit records=0     +records=5
-writefile-exit records=0    +records=1
```
ESM and `.cts` fixtures both byte-identical to node after (same md5, 3/3). Controls that must not move — `timer-exit`, `sync-control`, `awaited-control`, `natural-control` — matched before and still match.

**`process.on('exit')` does not share a root — established, not assumed**: the fixture's `exit-listener` role shows the listener already fires on explicit exit (#9403) and its synchronous write lands in both engines; only the pending async writes differed.

## Suites

- perry-runtime lib (`--release`, single-thread): **2974 passed, 0 failed**
- codegen entry tests: 25/0
- Targeted slice (exit/timer/stdin/process/stream/fs), before → after: 65 pass / **7 parity_fail** → **75 pass / 0 parity_fail** (the 7 are exactly the new fixtures across overlapping filters). Spot-checked on the fixed build: `test_gap_9421_async_output_flush`, `test_gap_zlib_fs_assert_*`, `test_gap_node_fs`, `test_gap_9416_*` — all pass.
- The full 1400+ suite was **not** run; stated rather than implied.

## Same family, deliberately not fixed here (filed separately)

`fs.createWriteStream` has the identical #9442 divergence — measured: `ws.write(...); process.exit(0)` → node `exists=false`, perry writes the bytes. Perry opens the fd eagerly at construction and writes inline; deferring the *open* cascades into `fd == None` error paths, `end()`, and `'finish'` ordering — materially larger than the four entry points. `child.stdin.write` is likewise synchronous to the pipe. Both in the follow-up issue, with the fixture arm deliberately absent rather than left failing.

Closes #9441. Closes #9442.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced exit delays after the event loop processes its final pending work.
  - Asynchronous filesystem writes now remain pending until a later event-loop turn, so writes not awaited before `process.exit()` are abandoned as expected.
  - Preserved synchronous validation, awaited writes, natural event-loop completion, and synchronous exit-listener writes.

- **Tests**
  - Added coverage for idle-exit latency and asynchronous filesystem behavior across promise, callback, CommonJS, and natural-exit scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->