### PR TITLE
fix(runtime): the hole-leak family — Set/Map raw reads, pop, typeof/String, param guards, console.table; util.format %s/%o policy (#9462, #9463)

### DIFF
--- a/changelog.d/9462-hole-leak-family.md
+++ b/changelog.d/9462-hole-leak-family.md
@@ -1,0 +1,97 @@
+### Fixed
+
+- **The hole-leak family: perry's internal empty-slot sentinel stopped escaping
+  into user-visible values.** `TAG_HOLE`'s bit pattern *is* a NaN, so any value
+  ladder that falls through to "must be a regular number" turns a hole into
+  `NaN` / `"number"`. Two producers were handing raw sentinels to user code, and
+  four consumers had no arm for one.
+
+  **Leak source 1 — `js_array_get_f64`'s Set/Map arm.** Perry deliberately
+  exposes a `Set`/`Map`'s live elements through the same array-like indexed
+  dispatch its `length` uses (`js_array_length` on a `Set` answers `size`), but
+  that arm indexed the raw element buffer directly and bounded the read by the
+  LIVE count while raw slots run `0..used`. After any `.delete()` it therefore
+  returned the TOMBSTONE — with none of the hole translation the plain-array arm
+  performs — *and* stopped short of the live tail:
+  `typeof s[0] === "number"`, `String(s[0]) === "NaN"`, `` `${s[0]}` === "NaN" ``.
+  It now reads through `js_set_value_at` / `js_map_entry_key_at`, the
+  live-index accessors the collections' own walkers already use, which compact
+  when `used != size` so raw index == live index again.
+
+  **Leak source 2 — `Array.prototype.pop`.** Found while checking which
+  downstream symptoms survived the first fix. The dense fast path explicitly
+  DECLINES on a hole and falls through to the generic arm, which returned the
+  raw slot: `[1, ,].pop()`, `new Array(3).pop()` and `delete a[a.length - 1]`
+  then `pop()` all produced a value that was `typeof "number"`, stringified
+  `"NaN"`, and compared `!== undefined`. That is the same shape #536 already
+  fixed once in this very function for the empty-array case. The element READ
+  arm translates the sentinel; the element REMOVE arm now does too.
+
+  With both sources closed, a sweep of every other hole-consuming path found no
+  remaining user-reachable producer: destructuring, rest, spread, `at`, `slice`,
+  `concat`, `flat`, `shift`, `splice`, `find`/`findLast`, `map`, `filter`,
+  `indexOf`, `includes`, `join`, `sort`, `reduce`, `forEach`, `for-of`, `in`,
+  `Object.values`/`entries`/`assign`, object spread, `JSON.stringify`,
+  `Array.from`, `structuredClone`, `with`/`toSorted`/`toReversed`/`toSpliced`,
+  `copyWithin`, `reverse`, `fill`, and the `entries`/`values` iterators all
+  already translate.
+
+  **Consumer ladders**, kept as defence in depth against the next producer and
+  pinned by unit tests rather than a fixture, since nothing user-facing reaches
+  them any more:
+
+  - `crates/perry-runtime/src/builtins/arithmetic.rs` — `classify_value_typeof`
+    had no hole arm, so `typeof` answered `"number"`.
+  - `crates/perry-runtime/src/value/to_string.rs` — `js_jsvalue_to_string`
+    rendered a hole `"NaN"`. `String(x)`, `` `${x}` `` and `x.toString()` all
+    funnel through this one helper.
+
+  **`console.table`, two independent mechanisms:**
+
+  - Hole cells printed `NaN`, and a cell-only fix would still not have matched
+    node: node derives the columns from the UNION of each row's OWN keys
+    (`Object.keys(row)`), and a hole is not an own key. `console.table([[1, , 3]])`
+    has columns `0` and `2` — the hole's whole column is absent. The header
+    derivation now computes that union, and a slot a row does not own renders as
+    an empty cell exactly like a short row's missing tail. Column ORDER matches
+    node's too: its column map is keyed by index strings, which `Object.keys`
+    returns in numeric order however the rows contributed them, so
+    `[[1, , 3], [4, 5, 6]]` is `0 1 2` and not `0 2 1`.
+  - `delete o.a; console.table(o)` printed `b | NaN`. `object_key_names`
+    compacted the tombstoned key out of a `Vec` **without keeping each key's slot
+    index**, and the fields were then read back by the compacted position — so
+    every key after a deleted one read its predecessor's slot. `format_object_as_json`
+    and both `console.rs` option decoders iterate `0..key_count` and `continue`
+    on a non-string key for exactly this reason; `table.rs` was the outlier and
+    now keeps the index. This also restored the nested-row case
+    (`delete o.r1; console.table(o)` had collapsed to a single `Values` column).
+
+  **A silent deopt from the same shape:** `param_type_guard.rs`'s `OP_MAP` /
+  `OP_SET` arms walked `0..size` over raw slots. A tombstone read as a real
+  entry matches no descriptor node, so a legitimate `Map<string, number>`
+  parameter lost its specialized clone after any `.delete()` — and the live
+  entries past `size` went unchecked. Both arms now walk `0..used`, skip
+  tombstones, and require the walk to have seen exactly `size` live entries.
+  `OP_ARRAY`/`OP_TUPLE` still *reject* a hole: there it is an element, here it
+  is bookkeeping.
+
+  Affected files:
+
+  - `crates/perry-runtime/src/array/indexing.rs`
+  - `crates/perry-runtime/src/array/push_pop.rs`
+  - `crates/perry-runtime/src/builtins/arithmetic.rs`
+  - `crates/perry-runtime/src/value/to_string.rs`
+  - `crates/perry-runtime/src/builtins/table.rs`
+  - `crates/perry-runtime/src/param_type_guard.rs`
+
+  Validation: `test-files/test_gap_9462_hole_leak_family.ts`, byte-compared
+  against node 26.5.1 — 61 of its 128 stdout lines diverge on unfixed
+  `origin/main`, and none after. The guard's accept/deopt verdict is not
+  observable from TypeScript (it only chooses which clone runs), so it is
+  asserted directly in `param_type_guard.rs`
+  (`a_tombstoned_entry_does_not_deopt_a_collection_parameter`: a clean Map
+  accepts, a Map with a deleted key still accepts, and a lie in the entry past
+  the old `size` bound still deopts — the last is what proves the live tail is
+  really walked). `array/collection_tag_tests.rs` asserts the leak source on the
+  helper itself, comparing against `js_array_length`'s live count rather than
+  merely "not a hole". `perry-runtime --lib`: 2980 passed, 0 failed.

--- a/changelog.d/9462-hole-leak-family.md
+++ b/changelog.d/9462-hole-leak-family.md
@@ -85,7 +85,7 @@
   - `crates/perry-runtime/src/param_type_guard.rs`
 
   Validation: `test-files/test_gap_9462_hole_leak_family.ts`, byte-compared
-  against node 26.5.1 — 61 of its 128 stdout lines diverge on unfixed
+  against node 26.5.1 — 52 of its 128 stdout lines diverge on unfixed
   `origin/main`, and none after. The guard's accept/deopt verdict is not
   observable from TypeScript (it only chooses which clone runs), so it is
   asserted directly in `param_type_guard.rs`

--- a/changelog.d/9463-util-format-s-o-policy.md
+++ b/changelog.d/9463-util-format-s-o-policy.md
@@ -1,0 +1,64 @@
+### Fixed
+
+- **`util.format("%s", …)` now inspects an object that has no user
+  `toString`,** matching node. Perry applied `String(value)` unconditionally, so
+  `%s` on `[1, , 3]` gave `1,,3` where node gives `[ 1, <1 empty item>, 3 ]`, and
+  `%s` on any object gave `[object Object]`. Node's rule (`hasBuiltInToString` in
+  `lib/internal/util/inspect.js`) is: a number or bigint formats numerically, a
+  non-object goes through `String()`, and an object goes through `String()` only
+  when its `toString` is USER-defined — otherwise it is inspected with
+  `{ depth: 0 }`, which is why a nested object collapses to `[Object]` rather
+  than being walked.
+
+  The discriminator is the subtle part, and "resolves to a callable `toString`"
+  is **not** it: perry installs `Object.prototype.toString` as a real,
+  discoverable closure (`install_proto_method`), so every ordinary object
+  resolves one and a callable test answers "user-defined" for `{ a: 1 }`. The
+  implemented test compares the resolved closure's `func_ptr` against the
+  built-in thunk — exactly node's built-in question, and it stays right for
+  `obj.toString = Object.prototype.toString`, which node also inspects. Arrays,
+  Maps and Sets carry no user `toString` in this model and always inspect.
+
+- **`util.format("%o", …)` now carries the `showHidden` surface for arrays.**
+  `%o` is `util.inspect(value, { showHidden: true, depth: 4 })`, and an array's
+  own `length` is a non-enumerable property, so node prints `[length]: N` after
+  the elements of every array at every depth — including nested ones
+  (`{ a: [ 1, 2, [length]: 2 ] }`) and the empty array, where `%o` is
+  `[ [length]: 0 ]` while `%O` is a bare `[]`. Perry omitted it entirely. The
+  `showHidden` plumbing already existed and already produced node's `[hidden]: 9`
+  bracket form for non-enumerable object properties; only the array tail was
+  missing.
+
+  Node's `groupArrayElements` column layout stops applying once a non-index
+  entry is appended — measured: `%o` on `[1 … 12]` stays on ONE line where the
+  same array under `%O` breaks into right-aligned columns — so the tail's
+  layout uses the single-line form whenever it fits the break length.
+
+  Affected files:
+
+  - `crates/perry-runtime/src/builtins/formatting/util_format.rs` — the `%s`
+    policy and its built-in-`toString` test.
+  - `crates/perry-runtime/src/builtins/formatting/value_repr.rs` — the
+    `[length]` entry and its layout.
+  - `crates/perry-runtime/src/builtins/formatting.rs` — both array walks (the
+    top-level one and the `format_jsvalue_for_json` twin that renders an array
+    reached as an object FIELD) emit the tail under `showHidden`.
+
+  `%O` is untouched and pinned as a control throughout, as is `%s` on every
+  primitive and on the two objects that DO define their own `toString`.
+
+  Validation: `test-files/test_gap_9463_util_format_s_o_policy.ts`, byte-compared
+  against node 26.5.1 — 20 of its 58 lines diverge on unfixed `origin/main`, none
+  after. `util_format.rs` also unit-tests the `%s` predicate directly over
+  primitives, an array, a Map, a Set, a plain object (must inspect) and an object
+  with an own non-builtin `toString` (must not) — the pair that fails in one
+  direction or the other if the built-in-thunk comparison is replaced by a bare
+  callable test.
+
+  Measured but deliberately NOT changed, each a separate pre-existing divergence
+  called out in the fixture header: `%s` on a BigInt (node's `formatBigInt` keeps
+  the `n` suffix, perry prints `5`); `%s` on a Date (node inspects to the ISO
+  form) or an Error (node prints the stack), neither of which is an ordinary
+  object in perry's model; `%s` on a class (#9468); and `%o` on an object nested
+  four deep, where node's `compact: 3` rule breaks the line and perry keeps it on
+  one.

--- a/changelog.d/9463-util-format-s-o-policy.md
+++ b/changelog.d/9463-util-format-s-o-policy.md
@@ -48,7 +48,7 @@
   primitive and on the two objects that DO define their own `toString`.
 
   Validation: `test-files/test_gap_9463_util_format_s_o_policy.ts`, byte-compared
-  against node 26.5.1 — 20 of its 58 lines diverge on unfixed `origin/main`, none
+  against node 26.5.1 — 23 of its 60 lines diverge on unfixed `origin/main`, none
   after. `util_format.rs` also unit-tests the `%s` predicate directly over
   primitives, an array, a Map, a Set, a plain object (must inspect) and an object
   with an own non-builtin `toString` (must not) — the pair that fails in one

--- a/crates/perry-runtime/src/array/collection_tag_tests.rs
+++ b/crates/perry-runtime/src/array/collection_tag_tests.rs
@@ -454,3 +454,69 @@ fn a_plain_array_foreach_iterates_without_probing_the_collection_registries() {
          collection_foreach_reroute and this is what fails"
     );
 }
+
+/// #9462: the Set/Map arm of `js_array_get_f64` used to index the raw element
+/// buffer directly, bounded by the LIVE count `size` while raw slots run
+/// `0..used`. After a `.delete()` it therefore handed the caller the TOMBSTONE
+/// — a bare `TAG_HOLE`, with none of the translation the plain-array arm
+/// performs — and never reached the live element sitting past it.
+///
+/// `js_array_length` on a Set answers `size`, so the paired contract is that
+/// indices `0..size` enumerate the LIVE elements. That is what is asserted
+/// here: not merely "not a hole", but the right element at the right index.
+#[test]
+fn a_tombstoned_collection_never_hands_a_hole_to_an_indexed_read() {
+    let (_map, _set) = arm_both_registries();
+
+    let set = js_set_alloc(4);
+    for value in [1.0, 2.0, 3.0] {
+        js_set_add(set, value);
+    }
+    crate::set::js_set_delete(set, 1.0);
+    let set_receiver = set as *const ArrayHeader;
+    assert_eq!(
+        js_array_length(set_receiver),
+        2,
+        "`length` reports live size"
+    );
+    for (index, expected) in [(0u32, 2.0), (1, 3.0)] {
+        let got = js_array_get_f64(set_receiver, index);
+        assert_ne!(
+            got.to_bits(),
+            crate::value::TAG_HOLE,
+            "set[{index}] must never be the raw hole sentinel"
+        );
+        assert_eq!(got, expected, "set[{index}] must be the live element");
+    }
+    assert_eq!(
+        js_array_get_f64(set_receiver, 2).to_bits(),
+        crate::value::TAG_UNDEFINED,
+        "past the live size the read is undefined, not a hole"
+    );
+
+    let map = js_map_alloc(4);
+    for (key, value) in [(1.0, 10.0), (2.0, 20.0), (3.0, 30.0)] {
+        js_map_set(map, key, value);
+    }
+    crate::map::js_map_delete(map, 1.0);
+    let map_receiver = map as *const ArrayHeader;
+    assert_eq!(
+        js_array_length(map_receiver),
+        2,
+        "`length` reports live size"
+    );
+    for (index, expected) in [(0u32, 2.0), (1, 3.0)] {
+        let got = js_array_get_f64(map_receiver, index);
+        assert_ne!(
+            got.to_bits(),
+            crate::value::TAG_HOLE,
+            "map[{index}] must never be the raw hole sentinel"
+        );
+        assert_eq!(got, expected, "map[{index}] must be the live entry key");
+    }
+    assert_eq!(
+        js_array_get_f64(map_receiver, 2).to_bits(),
+        crate::value::TAG_UNDEFINED,
+        "past the live size the read is undefined, not a hole"
+    );
+}

--- a/crates/perry-runtime/src/array/indexing.rs
+++ b/crates/perry-runtime/src/array/indexing.rs
@@ -448,7 +448,6 @@ pub extern "C" fn js_array_numeric_get_f64_unboxed(arr: *mut ArrayHeader, index:
 /// Get an element from an array by index (returns f64)
 #[no_mangle]
 pub extern "C" fn js_array_get_f64(arr: *const ArrayHeader, index: u32) -> f64 {
-    const TAG_UNDEFINED_F64: f64 = f64::from_bits(0x7FFC_0000_0000_0001u64);
     #[cfg(test)]
     ELEMENT_ACCESSOR_CALLS.with(|c| c.set(c.get().wrapping_add(1)));
 
@@ -517,26 +516,21 @@ pub extern "C" fn js_array_get_f64(arr: *const ArrayHeader, index: u32) -> f64 {
     // ask; the registry remains the liveness/layout proof.
     let receiver_tag = array_receiver_gc_tag(raw_ptr);
     if receiver_tag.0 == crate::gc::GC_TYPE_SET && crate::set::is_registered_set(raw_ptr as usize) {
-        let set = raw_ptr as *const crate::set::SetHeader;
-        unsafe {
-            let size = (*set).size;
-            if index >= size {
-                return TAG_UNDEFINED_F64;
-            }
-            let elements = (*set).elements as *const f64;
-            return std::ptr::read(elements.add(index as usize));
-        }
+        // #9462: go through the collection's own live-index accessor instead of
+        // indexing the raw element buffer. Raw slots run `0..used` while `size`
+        // is the LIVE count, so after any `.delete()` this arm returned the
+        // TOMBSTONE itself — a bare `TAG_HOLE` with none of the translation the
+        // plain-array arm below performs (`typeof s[0]` said "number",
+        // `String(s[0])` said "NaN") — and its `0..size` bound also stopped
+        // short of the live tail. `js_set_value_at` compacts when
+        // `used != size`, after which raw index == live index again; it is the
+        // same accessor `console.table` and the Set iterators already use.
+        return crate::set::js_set_value_at(raw_ptr as *const crate::set::SetHeader, index);
     }
     if receiver_tag.0 == crate::gc::GC_TYPE_MAP && crate::map::is_registered_map(raw_ptr as usize) {
-        let map = raw_ptr as *const crate::map::MapHeader;
-        unsafe {
-            let size = (*map).size;
-            if index >= size {
-                return TAG_UNDEFINED_F64;
-            }
-            let entries = (*map).entries as *const f64;
-            return std::ptr::read(entries.add(index as usize * 2));
-        }
+        // Same defect, same fix. This arm exposes the entry KEY at a raw pair
+        // index; `js_map_entry_key_at` is its live-index twin.
+        return crate::map::js_map_entry_key_at(raw_ptr as *const crate::map::MapHeader, index);
     }
 
     // A %TypedArray% receiver reaching the generic element read (an untyped

--- a/crates/perry-runtime/src/array/push_pop.rs
+++ b/crates/perry-runtime/src/array/push_pop.rs
@@ -1157,6 +1157,18 @@ pub extern "C" fn js_array_pop_f64(arr: *mut ArrayHeader) -> f64 {
             let elements_ptr = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
             let value = *elements_ptr.add(new_length as usize);
             (*arr).length = new_length;
+            // #9462: the popped slot can be a HOLE — `[1, ,].pop()`,
+            // `new Array(3).pop()`, `delete a[a.length - 1]` then pop. The
+            // dense fast path above explicitly DECLINES on `TAG_HOLE` and
+            // lands here, where the raw slot was returned untranslated; the
+            // sentinel's bits are a NaN, so `typeof v` was "number",
+            // `String(v)` was "NaN" and `v !== undefined` — the same shape as
+            // #536's bare-NaN empty pop, which this exact function was already
+            // fixed for once. The element READ arm of `js_array_get_f64`
+            // translates the sentinel; so must the element REMOVE arm.
+            if value.to_bits() == crate::value::TAG_HOLE {
+                return TAG_UNDEFINED_F64;
+            }
             return value;
         }
 

--- a/crates/perry-runtime/src/builtins/arithmetic.rs
+++ b/crates/perry-runtime/src/builtins/arithmetic.rs
@@ -689,7 +689,12 @@ enum ValueTypeofTag {
 fn classify_value_typeof(value: f64) -> ValueTypeofTag {
     let jsval = JSValue::from_bits(value.to_bits());
 
-    if jsval.is_undefined() {
+    if jsval.is_undefined() || jsval.bits() == crate::value::TAG_HOLE {
+        // #9462: `TAG_HOLE` is the internal empty-slot sentinel, and its bit
+        // pattern IS a NaN — without this arm it fell all the way through to
+        // the "regular f64 number" tail and `typeof` answered "number". User
+        // code only ever observes an unset slot as `undefined`, which is also
+        // what node reports.
         ValueTypeofTag::Undefined
     } else if jsval.is_null() {
         // typeof null === "object" in JavaScript
@@ -953,6 +958,30 @@ mod rel_numeric_fastpath_tests {
         assert!(!is_true(js_rel_gt(-0.0, 0.0)));
         assert!(is_true(js_rel_le(-0.0, 0.0)));
         assert!(is_true(js_rel_ge(-0.0, 0.0)));
+    }
+
+    /// #9462: `TAG_HOLE` is a NaN bit pattern, so without its own arm it fell
+    /// through every tag test to the "regular f64 number" tail and `typeof`
+    /// answered "number". User code only ever observes an unset slot as
+    /// `undefined`. This arm is defence in depth once the leak source in
+    /// `js_array_get_f64` is fixed — it is what keeps the NEXT producer of a
+    /// stray hole from re-opening the same symptom.
+    #[test]
+    fn an_array_hole_is_typeof_undefined() {
+        let hole = f64::from_bits(crate::value::TAG_HOLE);
+        assert_eq!(
+            js_value_typeof_tag(hole),
+            js_value_typeof_tag(f64::from_bits(crate::value::TAG_UNDEFINED)),
+            "a hole classifies exactly as undefined"
+        );
+        // Controls: a real NaN is still a number, and so is an ordinary double.
+        assert_ne!(js_value_typeof_tag(f64::NAN), js_value_typeof_tag(hole));
+        assert_eq!(js_value_typeof_tag(f64::NAN), js_value_typeof_tag(1.5));
+        // TDZ shares the 0x7FFC singleton namespace and must not be swept up.
+        assert_ne!(
+            js_value_typeof_tag(f64::from_bits(crate::value::TAG_TDZ)),
+            js_value_typeof_tag(hole)
+        );
     }
 
     #[test]

--- a/crates/perry-runtime/src/builtins/formatting.rs
+++ b/crates/perry-runtime/src/builtins/formatting.rs
@@ -971,7 +971,15 @@ pub(crate) fn format_jsvalue(value: f64, depth: usize) -> String {
                     let maybe_arr = ptr;
                     let length = (*maybe_arr).length as usize;
                     if length == 0 {
-                        return inspect_finish_circular(ptr as usize, "[]".to_string());
+                        // #9463: under `showHidden` even an empty array carries
+                        // its own non-enumerable `length` — node's `%o` on `[]`
+                        // is `[ [length]: 0 ]`, not `[]`.
+                        let empty = if inspect_show_hidden() {
+                            "[ [length]: 0 ]".to_string()
+                        } else {
+                            "[]".to_string()
+                        };
+                        return inspect_finish_circular(ptr as usize, empty);
                     }
                     let data_ptr = (maybe_arr as *const u8)
                         .add(std::mem::size_of::<crate::array::ArrayHeader>())
@@ -981,18 +989,27 @@ pub(crate) fn format_jsvalue(value: f64, depth: usize) -> String {
                     // `new Array(3)` as `[ NaN, NaN, NaN ]`. Runs of holes are
                     // ONE entry (`<N empty items>`), which is also why the
                     // layout below counts entries rather than slots.
-                    let parts = value_repr::array_entries_with_holes(data_ptr, length, |elem| {
-                        let elem_jsval = JSValue::from_bits(elem.to_bits());
-                        // Quote string elements like Node's util.inspect: 'hello'
-                        if elem_jsval.is_any_string() {
-                            let s = format_jsvalue(elem, depth + 1);
-                            return value_repr::ArrayEntry::new(format!("'{}'", s), false);
-                        }
-                        let rendered = format_jsvalue(elem, depth + 1);
-                        let numeric = value_repr::entry_is_numeric(elem, &rendered);
-                        value_repr::ArrayEntry::new(rendered, numeric)
-                    });
-                    let body_str = value_repr::render_array_body(&parts, inspect_compact_enabled());
+                    let mut parts =
+                        value_repr::array_entries_with_holes(data_ptr, length, |elem| {
+                            let elem_jsval = JSValue::from_bits(elem.to_bits());
+                            // Quote string elements like Node's util.inspect: 'hello'
+                            if elem_jsval.is_any_string() {
+                                let s = format_jsvalue(elem, depth + 1);
+                                return value_repr::ArrayEntry::new(format!("'{}'", s), false);
+                            }
+                            let rendered = format_jsvalue(elem, depth + 1);
+                            let numeric = value_repr::entry_is_numeric(elem, &rendered);
+                            value_repr::ArrayEntry::new(rendered, numeric)
+                        });
+                    let body_str = if inspect_show_hidden() {
+                        // #9463: `%o` is `util.inspect(v, { showHidden: true,
+                        // depth: 4 })`; the array's own `length` is part of that
+                        // surface.
+                        parts.push(value_repr::hidden_length_entry(length));
+                        value_repr::render_array_body_with_hidden(&parts)
+                    } else {
+                        value_repr::render_array_body(&parts, inspect_compact_enabled())
+                    };
                     inspect_finish_circular(ptr as usize, body_str)
                 } else if gc_type == crate::gc::GC_TYPE_OBJECT {
                     // Object — check for keys_array. Cycle check FIRST so the
@@ -1679,13 +1696,19 @@ fn format_jsvalue_for_json(value: f64, depth: usize) -> String {
                         // array reached as an object FIELD, so without it
                         // `{ h: new Array(3) }` still said
                         // `{ h: [ NaN, NaN, NaN ] }`.
-                        let parts =
+                        let mut parts =
                             value_repr::array_entries_with_holes(data_ptr, length, |elem| {
                                 value_repr::ArrayEntry::new(
                                     format_jsvalue_for_json(elem, depth + 1),
                                     false,
                                 )
                             });
+                        // #9463: the `showHidden` tail belongs on nested arrays
+                        // too — node's `%o` on `{ a: [1, 2] }` is
+                        // `{ a: [ 1, 2, [length]: 2 ] }`.
+                        if inspect_show_hidden() {
+                            parts.push(value_repr::hidden_length_entry(length));
+                        }
                         // Node formats empty arrays as `[]` and non-empty
                         // arrays with a space inside the brackets:
                         // `[ 1, 2, 3 ]`. Match byte-for-byte.

--- a/crates/perry-runtime/src/builtins/formatting/util_format.rs
+++ b/crates/perry-runtime/src/builtins/formatting/util_format.rs
@@ -118,6 +118,86 @@ unsafe fn util_format_json_object_has_cycle(ptr: *const u8, stack: &mut Vec<usiz
 /// unquoted (the `console.log(str)` bare-string behavior), so calling it
 /// directly for `%o`/`%O` diverged from Node, which routes the value
 /// through `util.inspect` (strings quoted at every depth).
+/// Node's `%s` rule for objects (`lib/internal/util/inspect.js`): a value that
+/// is not an object goes through `String(value)`, and an object does too —
+/// *unless* its `toString` is a built-in one, in which case node INSPECTS it
+/// with `{ depth: 0 }`. `hasBuiltInToString` is the check node uses; the
+/// practical reading is "an object with no USER-defined `toString` inspects",
+/// which is why `util.format("%s", [1, , 3])` is `[ 1, <1 empty item>, 3 ]` and
+/// not `1,,3` (#9463).
+///
+/// Perry's object model has no discoverable `Object.prototype.toString`
+/// (documented in `js_jsvalue_to_string`), so "the name resolves to a callable
+/// through the prototype chain" IS "user-defined" here — an object literal's
+/// own `toString`, or one declared on a user class's prototype. Arrays, Maps
+/// and Sets carry no reachable `toString` in this model and always inspect.
+///
+/// Deliberately NOT included, each a separate pre-existing divergence: a Date
+/// (node inspects to the ISO form, perry keeps the `toString` calendar form),
+/// an Error (node's `%s` prints the stack) and a class ref (#9468 /
+/// `value/to_string.rs:1042`). Those are not `GC_TYPE_OBJECT` and keep the
+/// `String()` route.
+unsafe fn util_format_s_inspects(val: f64) -> bool {
+    let jv = crate::value::JSValue::from_bits(val.to_bits());
+    if !jv.is_pointer() {
+        return false;
+    }
+    let addr = jv.as_pointer::<u8>() as usize;
+    if crate::value::addr_class::is_handle_band(addr)
+        || crate::symbol::is_registered_symbol(addr)
+        || crate::buffer::is_registered_buffer(addr)
+        || crate::typedarray::lookup_typed_array_kind(addr).is_some()
+    {
+        return false;
+    }
+    // `try_read_gc_header` is the audited classifier: it rejects the handle
+    // bands and anything that is not a real managed header, so no hand-rolled
+    // address floor is needed (and the addr-class ratchet forbids one).
+    let Some(header) = crate::value::addr_class::try_read_gc_header(addr) else {
+        return false;
+    };
+    match header.obj_type {
+        crate::gc::GC_TYPE_ARRAY | crate::gc::GC_TYPE_MAP | crate::gc::GC_TYPE_SET => true,
+        crate::gc::GC_TYPE_OBJECT => !object_has_a_user_to_string(val),
+        _ => false,
+    }
+}
+
+/// `Get(value, "toString")` without invoking it, then node's
+/// `hasBuiltInToString` question: is what came back a USER function, or a
+/// built-in?
+///
+/// "Resolves to a callable" is NOT the discriminator, which is the trap here:
+/// perry installs `Object.prototype.toString` as a real, discoverable closure
+/// (`install_proto_method`), so EVERY ordinary object resolves one and a
+/// callable test alone answers "user-defined" for `{ a: 1 }`. The
+/// discriminator is WHICH closure — comparing the resolved `func_ptr` against
+/// the built-in thunk is exactly node's built-in test, and it stays right for
+/// `obj.toString = Object.prototype.toString`, which node also inspects.
+///
+/// The lookup walks the prototype chain, so a user class's `toString` counts
+/// (`String(new WithToString())` resolves through this same helper today).
+/// Rooted across the key allocation: `js_string_from_bytes` can collect and
+/// move the receiver.
+unsafe fn object_has_a_user_to_string(val: f64) -> bool {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let receiver = scope.root_nanbox_f64(val);
+    let key = crate::string::js_string_from_bytes(b"toString".as_ptr(), 8);
+    let obj = (receiver.get_nanbox_f64().to_bits() & crate::value::POINTER_MASK)
+        as *const crate::object::ObjectHeader;
+    let method = crate::object::js_object_get_field_by_name_f64(obj, key);
+    let bits = method.to_bits();
+    if (bits & 0xFFFF_0000_0000_0000) != crate::value::POINTER_TAG {
+        return false;
+    }
+    let addr = (bits & crate::value::POINTER_MASK) as usize;
+    if !crate::closure::is_closure_ptr(addr) {
+        return false;
+    }
+    let closure = addr as *const crate::closure::ClosureHeader;
+    (*closure).func_ptr != crate::object::object_prototype_to_string_thunk as *const u8
+}
+
 fn inspect_format_arg(val: f64) -> String {
     let jv = crate::value::JSValue::from_bits(val.to_bits());
     if jv.is_any_string() {
@@ -236,7 +316,15 @@ pub extern "C" fn js_util_format(arr_ptr: *const crate::array::ArrayHeader) -> f
             let jv = JSValue::from_bits(val.to_bits());
             match spec {
                 b's' => {
-                    out.push_str(&jsvalue_as_owned_string(val));
+                    if util_format_s_inspects(val) {
+                        // Node: `inspect(value, { …opts, depth: 0,
+                        // colors: false, compact: 3 })` — note depth 0, so a
+                        // nested object collapses to `[Object]` (#9463).
+                        let _depth_guard = InspectDepthLimitGuard::new(0);
+                        out.push_str(&format_jsvalue(val, 0));
+                    } else {
+                        out.push_str(&jsvalue_as_owned_string(val));
+                    }
                 }
                 b'd' => {
                     // Node's `%d` uses Number(value), except BigInt keeps the
@@ -455,4 +543,77 @@ fn inspect_bool_option(options: f64, default_options: f64, name: &str) -> Option
     unsafe { crate::builtins::console::decode_dir_bool_option(options, name) }.or_else(|| unsafe {
         crate::builtins::console::decode_dir_bool_option(default_options, name)
     })
+}
+
+#[cfg(test)]
+mod s_placeholder_policy_tests {
+    use super::*;
+
+    fn boxed(ptr: *mut crate::object::ObjectHeader) -> f64 {
+        crate::value::js_nanbox_pointer(ptr as i64)
+    }
+
+    /// #9463: which values `%s` inspects instead of `String()`-coercing.
+    #[test]
+    fn only_objects_without_a_user_to_string_inspect() {
+        let _global = crate::gc::global_side_table_test_lock();
+        unsafe {
+            // Primitives never inspect.
+            assert!(!util_format_s_inspects(42.0));
+            assert!(!util_format_s_inspects(f64::from_bits(
+                crate::value::TAG_UNDEFINED
+            )));
+            assert!(!util_format_s_inspects(f64::from_bits(
+                crate::value::TAG_NULL
+            )));
+
+            let array = crate::array::js_array_alloc(2);
+            let array = crate::array::js_array_push_f64(array, 1.0);
+            assert!(util_format_s_inspects(crate::value::js_nanbox_pointer(
+                array as i64
+            )));
+
+            let map = crate::map::js_map_alloc(2);
+            crate::map::js_map_set(map, 1.0, 2.0);
+            assert!(util_format_s_inspects(crate::value::js_nanbox_pointer(
+                map as i64
+            )));
+
+            let set = crate::set::js_set_alloc(2);
+            crate::set::js_set_add(set, 1.0);
+            assert!(util_format_s_inspects(crate::value::js_nanbox_pointer(
+                set as i64
+            )));
+
+            // A plain object's `toString` resolves to the built-in
+            // `Object.prototype.toString` closure, which is what makes the
+            // "resolves to a callable" test wrong — node inspects this.
+            let plain = crate::object::js_object_alloc(0, 1);
+            let key = crate::string::js_string_from_bytes(b"a".as_ptr(), 1);
+            crate::object::js_object_set_field_by_name(plain, key, 1.0);
+            assert!(
+                util_format_s_inspects(boxed(plain)),
+                "a plain object must inspect"
+            );
+
+            // …and an OWN `toString` closure flips it back to `String(value)`.
+            // This is the pair that fails if the built-in thunk comparison is
+            // replaced by a bare callable test in either direction.
+            let custom = crate::object::js_object_alloc(0, 1);
+            let to_string_key = crate::string::js_string_from_bytes(b"toString".as_ptr(), 8);
+            let user_fn = crate::closure::js_closure_alloc(
+                crate::object::object_prototype_value_of_thunk as *const u8,
+                0,
+            );
+            crate::object::js_object_set_field_by_name(
+                custom,
+                to_string_key,
+                crate::value::js_nanbox_pointer(user_fn as i64),
+            );
+            assert!(
+                !util_format_s_inspects(boxed(custom)),
+                "an own non-builtin `toString` must keep String(value)"
+            );
+        }
+    }
 }

--- a/crates/perry-runtime/src/builtins/formatting/value_repr.rs
+++ b/crates/perry-runtime/src/builtins/formatting/value_repr.rs
@@ -179,6 +179,31 @@ pub(crate) fn entry_is_numeric(elem: f64, rendered: &str) -> bool {
     jv.is_number()
 }
 
+/// Node's `showHidden` tail for an array body. An array's own `length` is a
+/// non-enumerable property, so `util.inspect(a, { showHidden: true })` — which
+/// is exactly what `%o` is — prints it after the elements as `[length]: N`, on
+/// EVERY array and at every depth (#9463, measured against node 26.5.1:
+/// `util.format("%o", [1,2,3])` → `[ 1, 2, 3, [length]: 3 ]`, and `%o` on `[]`
+/// → `[ [length]: 0 ]` where `%O` gives a bare `[]`).
+pub(crate) fn hidden_length_entry(length: usize) -> ArrayEntry {
+    ArrayEntry::new(format!("[length]: {}", length), false)
+}
+
+/// Lay out an array body that carries the `showHidden` tail.
+///
+/// Node's `groupArrayElements` column layout stops applying once a non-index
+/// entry is appended — measured: `%o` on `[1..12]` stays on ONE line where the
+/// same array under `%O` breaks into right-aligned columns — so the single-line
+/// form is used whenever it fits inside the break length.
+pub(crate) fn render_array_body_with_hidden(parts: &[ArrayEntry]) -> String {
+    let texts: Vec<&str> = parts.iter().map(|p| p.text.as_str()).collect();
+    let inner = texts.join(", ");
+    if inner.len() + 4 <= 76 {
+        return format!("[ {} ]", inner);
+    }
+    join_rows(texts.iter().map(|text| (*text).to_string()))
+}
+
 /// Lay out rendered entries as Node's `util.inspect` array body.
 ///
 /// The single-line / multi-line decision counts ENTRIES, not array slots:
@@ -325,6 +350,35 @@ mod tests {
         assert_eq!(parts.len(), 1);
         // Seven SLOTS but one ENTRY, so Node keeps it on one line.
         assert_eq!(render_array_body(&parts, true), "[ <7 empty items> ]");
+    }
+
+    /// #9463: `%o` is `util.inspect(v, { showHidden: true, depth: 4 })`, and an
+    /// array's own `length` is a non-enumerable property node prints after the
+    /// elements. Measured against node 26.5.1.
+    #[test]
+    fn the_show_hidden_tail_is_nodes_length_entry() {
+        let parts = vec![entry("1", true), entry("2", true), hidden_length_entry(2)];
+        assert_eq!(
+            render_array_body_with_hidden(&parts),
+            "[ 1, 2, [length]: 2 ]"
+        );
+        // An empty array still carries it: node's `%o` on `[]` is
+        // `[ [length]: 0 ]` where `%O` is a bare `[]`.
+        assert_eq!(
+            render_array_body_with_hidden(&[hidden_length_entry(0)]),
+            "[ [length]: 0 ]"
+        );
+        // The tail is not numeric, so it never joins the right-aligned column
+        // layout — and node's grouping stops applying once it is present, which
+        // is why more than six entries still print on one line.
+        let many: Vec<ArrayEntry> = (1..=8)
+            .map(|n: u32| ArrayEntry::new(n.to_string(), true))
+            .chain(std::iter::once(hidden_length_entry(8)))
+            .collect();
+        assert_eq!(
+            render_array_body_with_hidden(&many),
+            "[ 1, 2, 3, 4, 5, 6, 7, 8, [length]: 8 ]"
+        );
     }
 
     #[test]

--- a/crates/perry-runtime/src/builtins/table.rs
+++ b/crates/perry-runtime/src/builtins/table.rs
@@ -207,6 +207,24 @@ fn render_table(headers: &[String], rows: &[Vec<String>]) {
 
 /// Read all keys from an object's keys_array as Strings.
 unsafe fn object_key_names(obj_ptr: *const crate::object::ObjectHeader) -> Vec<String> {
+    object_key_entries(obj_ptr)
+        .into_iter()
+        .map(|(_, name)| name)
+        .collect()
+}
+
+/// Own string keys of `obj_ptr`, each paired with the SLOT index it occupies in
+/// the object's field storage.
+///
+/// #9462: the slot index is the load-bearing half. A tombstoned key (`delete
+/// o.a` — default-on since #9331) leaves a non-string in the keys array, and
+/// dropping it from a `Vec` renumbers every later key. Reading the fields back
+/// by the COMPACTED position then reads the tombstone itself, so
+/// `console.table({a:1,b:2})` after `delete o.a` printed `b | NaN`.
+/// `format_object_as_json` and both `console.rs` option decoders already
+/// iterate `0..key_count` and `continue` on a non-string key for exactly this
+/// reason; this is that same walk, with the index kept.
+unsafe fn object_key_entries(obj_ptr: *const crate::object::ObjectHeader) -> Vec<(u32, String)> {
     let keys_array = crate::object::object_keys_array(obj_ptr);
     if keys_array.is_null() {
         return Vec::new();
@@ -216,7 +234,7 @@ unsafe fn object_key_names(obj_ptr: *const crate::object::ObjectHeader) -> Vec<S
     for i in 0..count {
         let key_val = crate::array::js_array_get(keys_array, i as u32);
         if let Some(s) = read_string_from_jsvalue(key_val) {
-            keys.push(s);
+            keys.push((i as u32, s));
         }
     }
     keys
@@ -416,10 +434,39 @@ pub extern "C" fn js_console_table_with_properties(value: f64, properties: f64) 
                     }
                 }
 
+                // #9462: node derives the columns from the UNION of each
+                // row's OWN keys (`Object.keys(row)`), and a hole is not an own
+                // key — so `console.table([[1, , 3]])` prints columns `0` and
+                // `2`, never three columns with a `NaN` in the middle. A cell-
+                // only fix cannot match node; the header derivation needs the
+                // same treatment. Ascending order is node's too: its column map
+                // is keyed by index strings, which `Object.keys` returns in
+                // numeric order however the rows contributed them
+                // (`[[1, , 3], [4, 5, 6]]` → `0 1 2`, not `0 2 1`).
+                let mut present = vec![false; max_len];
+                for i in 0..length {
+                    let elem = *data_ptr.add(i);
+                    if get_gc_type(elem) != crate::gc::GC_TYPE_ARRAY {
+                        continue;
+                    }
+                    let sub = JSValue::from_bits(elem.to_bits())
+                        .as_pointer::<crate::array::ArrayHeader>();
+                    let sub_len = ((*sub).length as usize).min(max_len);
+                    let sub_data = (sub as *const u8)
+                        .add(std::mem::size_of::<crate::array::ArrayHeader>())
+                        as *const f64;
+                    for (j, slot) in present.iter_mut().enumerate().take(sub_len) {
+                        if (*sub_data.add(j)).to_bits() != crate::value::TAG_HOLE {
+                            *slot = true;
+                        }
+                    }
+                }
+                let columns: Vec<usize> = (0..max_len).filter(|j| present[*j]).collect();
+
                 let include_values_col = !all_arrays;
-                let mut headers: Vec<String> = Vec::with_capacity(2 + max_len);
+                let mut headers: Vec<String> = Vec::with_capacity(2 + columns.len());
                 headers.push("(index)".to_string());
-                for j in 0..max_len {
+                for j in &columns {
                     headers.push(j.to_string());
                 }
                 if include_values_col {
@@ -438,19 +485,23 @@ pub extern "C" fn js_console_table_with_properties(value: f64, properties: f64) 
                         let sub_data = (sub as *const u8)
                             .add(std::mem::size_of::<crate::array::ArrayHeader>())
                             as *const f64;
-                        for j in 0..max_len {
-                            if j < sub_len {
-                                let v = *sub_data.add(j);
-                                row.push(format_table_cell(v));
-                            } else {
+                        for &j in &columns {
+                            // A slot this row does not own renders as an empty
+                            // cell, exactly like a short row's missing tail —
+                            // never as the hole sentinel's `NaN` (#9462).
+                            let empty = j >= sub_len
+                                || (*sub_data.add(j)).to_bits() == crate::value::TAG_HOLE;
+                            if empty {
                                 row.push("".to_string());
+                            } else {
+                                row.push(format_table_cell(*sub_data.add(j)));
                             }
                         }
                         if include_values_col {
                             row.push("".to_string());
                         }
                     } else {
-                        for _ in 0..max_len {
+                        for _ in &columns {
                             row.push("".to_string());
                         }
                         row.push(format_table_cell(elem));
@@ -477,7 +528,7 @@ pub extern "C" fn js_console_table_with_properties(value: f64, properties: f64) 
         } else if gc_type == crate::gc::GC_TYPE_OBJECT {
             // Single object: rows are property name → "Values" column.
             let obj_ptr = jsval.as_pointer::<crate::object::ObjectHeader>();
-            let keys = object_key_names(obj_ptr);
+            let keys = object_key_entries(obj_ptr);
             if keys.is_empty() {
                 return;
             }
@@ -485,8 +536,8 @@ pub extern "C" fn js_console_table_with_properties(value: f64, properties: f64) 
             // columns, e.g. console.table({ a: { a: 1, b: 2 } }).
             let mut nested_keys: Vec<String> = Vec::new();
             let mut all_nested = true;
-            for i in 0..keys.len() {
-                let v = crate::object::js_object_get_field_f64(obj_ptr, i as u32);
+            for (slot, _) in &keys {
+                let v = crate::object::js_object_get_field_f64(obj_ptr, *slot);
                 if get_gc_type(v) == crate::gc::GC_TYPE_OBJECT {
                     let vp =
                         JSValue::from_bits(v.to_bits()).as_pointer::<crate::object::ObjectHeader>();
@@ -507,8 +558,8 @@ pub extern "C" fn js_console_table_with_properties(value: f64, properties: f64) 
                     headers.push("Values".to_string());
                 }
                 let mut rows: Vec<Vec<String>> = Vec::with_capacity(keys.len());
-                for (i, key) in keys.iter().enumerate() {
-                    let v = crate::object::js_object_get_field_f64(obj_ptr, i as u32);
+                for (slot, key) in &keys {
+                    let v = crate::object::js_object_get_field_f64(obj_ptr, *slot);
                     let mut row = vec![key.clone()];
                     if get_gc_type(v) == crate::gc::GC_TYPE_OBJECT {
                         let vp = JSValue::from_bits(v.to_bits())
@@ -541,9 +592,10 @@ pub extern "C" fn js_console_table_with_properties(value: f64, properties: f64) 
             }
             let headers = vec!["(index)".to_string(), "Values".to_string()];
             let mut rows: Vec<Vec<String>> = Vec::with_capacity(keys.len());
-            for (i, key) in keys.iter().enumerate() {
-                // Read the value by field index (matches keys_array order).
-                let v = crate::object::js_object_get_field_f64(obj_ptr, i as u32);
+            for (slot, key) in &keys {
+                // Read the value by the key's OWN slot index — never by its
+                // position in the compacted name list (#9462).
+                let v = crate::object::js_object_get_field_f64(obj_ptr, *slot);
                 rows.push(vec![key.clone(), format_table_cell(v)]);
             }
             render_table(&headers, &rows);

--- a/crates/perry-runtime/src/param_type_guard.rs
+++ b/crates/perry-runtime/src/param_type_guard.rs
@@ -313,7 +313,14 @@ impl GuardState<'_> {
         Some((object, address, live_slots))
     }
 
-    unsafe fn plain_map(&self, value: JSValue) -> Option<(*const crate::map::MapHeader, usize)> {
+    /// Returns `(header, live_count, used_extent)`. #9462: raw entry indices
+    /// run `0..used`; `size` is the LIVE count and `used - size` counts the
+    /// tombstones a `.delete()` left behind. A walk needs BOTH — the bound is
+    /// `used`, the accept still has to describe `size` live entries.
+    unsafe fn plain_map(
+        &self,
+        value: JSValue,
+    ) -> Option<(*const crate::map::MapHeader, usize, usize)> {
         if !value.is_pointer() {
             return None;
         }
@@ -330,13 +337,23 @@ impl GuardState<'_> {
         let map = address as *const crate::map::MapHeader;
         let size = (*map).size as usize;
         let capacity = (*map).capacity as usize;
-        if size > capacity || size > MAX_CONTAINER_LEN || (size != 0 && (*map).entries.is_null()) {
+        let used = (*map).used as usize;
+        if size > capacity
+            || used > capacity
+            || used < size
+            || used > MAX_CONTAINER_LEN
+            || (used != 0 && (*map).entries.is_null())
+        {
             return None;
         }
-        Some((map, size))
+        Some((map, size, used))
     }
 
-    unsafe fn plain_set(&self, value: JSValue) -> Option<(*const crate::set::SetHeader, usize)> {
+    /// Returns `(header, live_count, used_extent)` — see [`Self::plain_map`].
+    unsafe fn plain_set(
+        &self,
+        value: JSValue,
+    ) -> Option<(*const crate::set::SetHeader, usize, usize)> {
         if !value.is_pointer() {
             return None;
         }
@@ -353,10 +370,16 @@ impl GuardState<'_> {
         let set = address as *const crate::set::SetHeader;
         let size = (*set).size as usize;
         let capacity = (*set).capacity as usize;
-        if size > capacity || size > MAX_CONTAINER_LEN || (size != 0 && (*set).elements.is_null()) {
+        let used = (*set).used as usize;
+        if size > capacity
+            || used > capacity
+            || used < size
+            || used > MAX_CONTAINER_LEN
+            || (used != 0 && (*set).elements.is_null())
+        {
             return None;
         }
-        Some((set, size))
+        Some((set, size, used))
     }
 
     /// Resolve and validate the object's `keys_array` ONCE per object (#8202).
@@ -649,15 +672,27 @@ impl GuardState<'_> {
                 {
                     return false;
                 }
-                let Some((map, size)) = self.plain_map(value) else {
+                let Some((map, size, used)) = self.plain_map(value) else {
                     return false;
                 };
                 if track && self.seen_or_insert(map as usize, node_id) {
                     return true;
                 }
                 let entries = (*map).entries as *const f64;
-                for index in 0..size {
+                // #9462: walk raw entries `0..used` and SKIP tombstones, the way
+                // the Map iterators do. Bounding by `size` read a tombstoned
+                // entry as if it were real — a `TAG_HOLE` key matches no
+                // descriptor node — so a legitimate `Map<string, number>`
+                // parameter silently lost its specialized clone after any
+                // `.delete()`, while the live entries past `size` went
+                // unchecked. `OP_ARRAY`/`OP_TUPLE` *reject* a hole because
+                // there it is an element; here it is bookkeeping.
+                let mut live = 0usize;
+                for index in 0..used {
                     let key = JSValue::from_bits(std::ptr::read(entries.add(index * 2)).to_bits());
+                    if key.bits() == TAG_HOLE {
+                        continue;
+                    }
                     let value =
                         JSValue::from_bits(std::ptr::read(entries.add(index * 2 + 1)).to_bits());
                     if !self.matches(key, key_node, depth + 1)
@@ -665,8 +700,12 @@ impl GuardState<'_> {
                     {
                         return false;
                     }
+                    live += 1;
                 }
-                true
+                // The walk must have seen exactly the live count; anything else
+                // means the header's bookkeeping disagrees with its buffer, and
+                // the guard fails closed onto the generic function.
+                live == size
             }
             OP_SET => {
                 let Some(child) = read_u32(node, 1) else {
@@ -675,20 +714,26 @@ impl GuardState<'_> {
                 if node.len() != 5 || self.descriptor.node(child).is_none() {
                     return false;
                 }
-                let Some((set, size)) = self.plain_set(value) else {
+                let Some((set, size, used)) = self.plain_set(value) else {
                     return false;
                 };
                 if track && self.seen_or_insert(set as usize, node_id) {
                     return true;
                 }
                 let elements = (*set).elements as *const f64;
-                for index in 0..size {
+                // #9462: same `used`-bounded, tombstone-skipping walk as OP_MAP.
+                let mut live = 0usize;
+                for index in 0..used {
                     let element = JSValue::from_bits(std::ptr::read(elements.add(index)).to_bits());
+                    if element.bits() == TAG_HOLE {
+                        continue;
+                    }
                     if !self.matches(element, child, depth + 1) {
                         return false;
                     }
+                    live += 1;
                 }
-                true
+                live == size
             }
             _ => false,
         }
@@ -1046,5 +1091,87 @@ mod tests {
         assert_eq!(guard(set_value, &set_descriptor), 1);
         crate::set::js_set_add(set, 7.0);
         assert_eq!(guard(set_value, &set_descriptor), 0);
+    }
+
+    /// #9462: a tombstone must not deopt a legitimate collection parameter.
+    ///
+    /// This IS the guard's own accept/deopt observable — the verdict
+    /// `js_param_type_guard` hands the specialized clone — not a timing proxy.
+    /// Raw entry indices run `0..used` while `size` is the live count, so the
+    /// old `0..size` walk read the hole `.delete()` left as if it were a real
+    /// entry (no descriptor node matches `TAG_HOLE`, so: deopt) AND never
+    /// reached the live entry sitting past it.
+    #[test]
+    fn a_tombstoned_entry_does_not_deopt_a_collection_parameter() {
+        let _global = crate::gc::global_side_table_test_lock();
+
+        let map_descriptor = descriptor(
+            0,
+            &[
+                &[OP_MAP, 1, 0, 0, 0, 2, 0, 0, 0],
+                &[OP_STRING],
+                &[OP_NUMBER],
+            ],
+        );
+        let map = crate::map::js_map_alloc(4);
+        for (name, value) in [(&b"a"[..], 1.0), (&b"b"[..], 2.0), (&b"c"[..], 3.0)] {
+            let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+            crate::map::js_map_set(map, crate::value::js_nanbox_string(key as i64), value);
+        }
+        let map_value = JSValue::from_bits(crate::value::js_nanbox_pointer(map as i64).to_bits());
+        assert_eq!(
+            guard(map_value, &map_descriptor),
+            1,
+            "a clean Map validates"
+        );
+
+        let doomed = crate::string::js_string_from_bytes(b"a".as_ptr(), 1);
+        assert_eq!(
+            crate::map::js_map_delete(map, crate::value::js_nanbox_string(doomed as i64)),
+            1,
+        );
+        assert_eq!(
+            guard(map_value, &map_descriptor),
+            1,
+            "a deleted key must not cost the specialized clone"
+        );
+
+        // …and the entry PAST the tombstone is genuinely validated, not merely
+        // skipped: `c` sits at raw index 2, beyond the live `size` of 2.
+        let liar = crate::string::js_string_from_bytes(b"c".as_ptr(), 1);
+        crate::map::js_map_set(
+            map,
+            crate::value::js_nanbox_string(liar as i64),
+            crate::value::js_nanbox_string(liar as i64),
+        );
+        assert_eq!(
+            guard(map_value, &map_descriptor),
+            0,
+            "the live tail past `size` is still type-checked"
+        );
+
+        let set_descriptor = descriptor(0, &[&[OP_SET, 1, 0, 0, 0], &[OP_NUMBER]]);
+        let set = crate::set::js_set_alloc(4);
+        for value in [1.0, 2.0, 3.0] {
+            crate::set::js_set_add(set, value);
+        }
+        let set_value = JSValue::from_bits(crate::value::js_nanbox_pointer(set as i64).to_bits());
+        assert_eq!(
+            guard(set_value, &set_descriptor),
+            1,
+            "a clean Set validates"
+        );
+        assert_eq!(crate::set::js_set_delete(set, 1.0), 1);
+        assert_eq!(
+            guard(set_value, &set_descriptor),
+            1,
+            "a deleted element must not cost the specialized clone"
+        );
+        crate::set::js_set_add(set, f64::from_bits(TAG_TRUE));
+        assert_eq!(
+            guard(set_value, &set_descriptor),
+            0,
+            "and a genuinely wrong element still deopts"
+        );
     }
 }

--- a/crates/perry-runtime/src/value/tests.rs
+++ b/crates/perry-runtime/src/value/tests.rs
@@ -227,3 +227,23 @@ fn test_jsvalue_equals_distinct_box_allocated_registered_symbols() {
 
     assert_eq!(js_jsvalue_equals(left, right), 0);
 }
+
+/// #9462: a hole reaching a string coercion rendered as `"NaN"` — the sentinel's
+/// bits are a NaN and the ladder's tail is `js_number_to_string`. Node prints
+/// `"undefined"` for `String(a[i])` on an empty slot, and template
+/// interpolation and `x.toString()` funnel through this same helper.
+#[test]
+fn an_array_hole_stringifies_as_undefined() {
+    fn text(value: f64) -> String {
+        let ptr = crate::value::js_jsvalue_to_string(value);
+        assert!(!ptr.is_null());
+        unsafe { crate::object::has_own_helpers::str_from_string_header(ptr) }
+            .expect("a rendered string is UTF-8")
+            .to_string()
+    }
+    assert_eq!(text(f64::from_bits(TAG_HOLE)), "undefined");
+    // Controls: a real NaN still prints NaN, and undefined is unchanged.
+    assert_eq!(text(f64::NAN), "NaN");
+    assert_eq!(text(f64::from_bits(TAG_UNDEFINED)), "undefined");
+    assert_eq!(text(f64::from_bits(TAG_NULL)), "null");
+}

--- a/crates/perry-runtime/src/value/to_string.rs
+++ b/crates/perry-runtime/src/value/to_string.rs
@@ -1029,7 +1029,12 @@ pub extern "C" fn js_jsvalue_to_string(value: f64) -> *mut crate::string::String
         // a correctness-preserving compatibility shim for the many
         // call sites that currently expect a heap pointer.
         crate::string::js_string_materialize_to_heap(value)
-    } else if jsval.is_undefined() {
+    } else if jsval.is_undefined() || jsval.bits() == crate::value::TAG_HOLE {
+        // #9462: an empty-slot sentinel that reached a string coercion. Its
+        // bits are a NaN, so the numeric tail below rendered it "NaN"; node
+        // prints "undefined" for `String(a[i])` on an empty slot. Template
+        // interpolation and `x.toString()` both funnel through here, so this
+        // one arm covers all three spellings.
         crate::string::js_string_from_bytes(b"undefined".as_ptr(), 9)
     } else if jsval.is_null() {
         crate::string::js_string_from_bytes(b"null".as_ptr(), 4)

--- a/test-files/test_gap_9462_hole_leak_family.ts
+++ b/test-files/test_gap_9462_hole_leak_family.ts
@@ -1,0 +1,217 @@
+// #9462 — the hole-leak family: perry's internal empty-slot sentinel
+// (`TAG_HOLE`) escaping into user-visible values, plus the value-decoding
+// ladders that had no arm for it. Byte-compared against
+// `node --experimental-strip-types`.
+//
+// `TAG_HOLE`'s bit pattern IS a NaN, so any ladder that falls through to
+// "must be a regular number" turns a hole into `NaN` / `"number"`:
+//
+//   1. LEAK SOURCE — `js_array_get_f64`'s Set/Map arm read the raw element
+//      buffer with no hole translation (the plain-array arm has it) and bounded
+//      the read by the LIVE count `size` while raw slots run `0..used`. After
+//      any `.delete()` it therefore handed back the tombstone itself.
+//   2. `classify_value_typeof` had no hole arm: `typeof` said `"number"`.
+//   3. `js_jsvalue_to_string` had none either: `String(hole)` was `"NaN"`, and
+//      template interpolation routes through the same helper.
+//   4. `console.table` rendered hole cells as `NaN` — and node omits the hole's
+//      whole COLUMN, so the header derivation needed the same treatment.
+//   5. `console.table` on an object with a deleted key printed `b | NaN`:
+//      the key list was compacted without keeping each key's slot index, and
+//      the fields were then read back by the compacted position.
+//
+// A note on why the Set/Map rows below are phrased as an invariant rather than
+// printed raw: perry deliberately exposes a Set/Map's live elements through the
+// same array-like indexed dispatch its `length` uses (`js_array_length` on a
+// Set answers `size`), while in node a Set is simply not indexable. `view[0]`
+// therefore differs by design and is not a parity question. What both must
+// agree on is that no INTERNAL sentinel ever reaches user code — which is
+// exactly what unfixed main violated, three ways at once.
+
+// Reports `clean` in node for every value below (a Set is not indexable, so
+// every read is `undefined`), and on unfixed perry main reported
+// `SENTINEL-ESCAPED` — `typeof` "number", `String()` "NaN", `${}` "NaN".
+function report(label: string, v: unknown): void {
+  const escaped =
+    (typeof v === "number" && Number.isNaN(v)) ||
+    String(v) === "NaN" ||
+    `${v}` === "NaN";
+  console.log(label, escaped ? "SENTINEL-ESCAPED" : "clean");
+}
+
+// --- 1. the leak source: Set/Map tombstones ---
+
+const liveSet = new Set<number>([1, 2, 3]);
+liveSet.delete(1);
+const setView = liveSet as unknown as number[];
+report("set-tombstone-slot0", setView[0]);
+report("set-tombstone-slot1", setView[1]);
+report("set-tombstone-past-end", setView[5]);
+
+const anySet: any = new Set<number>([10, 20, 30]);
+anySet.delete(10);
+report("set-tombstone-any", anySet[0]);
+
+const liveMap = new Map<string, number>([["a", 1], ["b", 2]]);
+liveMap.delete("a");
+const mapView = liveMap as unknown as number[];
+report("map-tombstone-slot0", mapView[0]);
+
+const anyMap: any = new Map<string, number>([["x", 1], ["y", 2]]);
+anyMap.delete("x");
+report("map-tombstone-any", anyMap[0]);
+
+// Through a typed parameter, so the read takes the specialized array lane.
+function readAt(a: number[], i: number): unknown {
+  return a[i];
+}
+const paramSet = new Set<number>([7, 8, 9]);
+paramSet.delete(7);
+report("set-tombstone-param", readAt(paramSet as unknown as number[], 0));
+
+// --- 2. the second leak source, found while checking which downstream
+//        symptoms survived the first: `Array.prototype.pop` ---
+// The dense fast path DECLINES on a hole and falls through to the generic
+// arm, which returned the raw slot. `[1, ,].pop()` therefore answered
+// `typeof "number"`, `String()` `"NaN"`, and `!== undefined` — the exact
+// shape #536 already fixed once in this same function for the empty-array
+// case. Every hole flavour reaches it. This is the only user-reachable
+// producer left after the Set/Map arm was fixed (swept: destructuring, rest,
+// spread, at, slice, concat, flat, shift, splice, find/findLast, map, filter,
+// indexOf, includes, join, sort, reduce, forEach, for-of, `in`,
+// Object.values/entries/assign, object spread, JSON.stringify, Array.from,
+// structuredClone, with/toSorted/toReversed/toSpliced, copyWithin, reverse,
+// fill, entries/values iterators — all already translate).
+
+const poppedTrailing = [1, ,].pop();
+console.log("pop-typeof", typeof poppedTrailing);
+console.log("pop-string", String(poppedTrailing));
+console.log("pop-template", `${poppedTrailing}`);
+console.log("pop-eq-undefined", poppedTrailing === undefined);
+console.log("pop-is-nan", Number.isNaN(poppedTrailing as unknown as number));
+console.log("pop-inspect", poppedTrailing);
+console.log("pop-sized", String(new Array(3).pop()));
+console.log("pop-sized-typeof", typeof new Array(1).pop());
+const popDeleted = [1, 2, 3];
+delete popDeleted[2];
+const poppedDeleted = popDeleted.pop();
+console.log("pop-deleted", String(poppedDeleted), typeof poppedDeleted);
+console.log("pop-empty", String(([] as number[]).pop()));
+console.log("pop-normal", String([1, 2].pop()));
+
+// --- 3. array-hole producers: typeof / String / template ---
+// These already answered `undefined` before the fix (the plain-array arm of
+// `js_array_get_f64` translates the sentinel) and must not move.
+
+const literalHoles = [1, , 3];
+console.log("literal-typeof", typeof literalHoles[1]);
+console.log("literal-string", String(literalHoles[1]));
+console.log("literal-template", `${literalHoles[1]}`);
+console.log("literal-value", literalHoles[1]);
+
+const sized = new Array(3);
+console.log("new-array-typeof", typeof sized[0]);
+console.log("new-array-string", String(sized[0]));
+console.log("new-array-template", `${sized[0]}`);
+console.log("new-array-inspect", sized);
+
+const deleted: any = { a: 1, b: 2 };
+delete deleted.a;
+console.log("delete-typeof", typeof deleted.a);
+console.log("delete-string", String(deleted.a));
+console.log("delete-template", `${deleted.a}`);
+console.log("delete-inspect", deleted);
+console.log("delete-keys", Object.keys(deleted).join(","));
+
+const deletedElement = [1, 2, 3];
+delete deletedElement[1];
+console.log("delete-element-typeof", typeof deletedElement[1]);
+console.log("delete-element-string", String(deletedElement[1]));
+console.log("delete-element-inspect", deletedElement);
+
+// --- 4. console.table on holey rows ---
+// Node derives the columns from the UNION of each row's OWN keys, and a hole
+// is not an own key: `[[1, , 3]]` has columns `0` and `2`, never a middle
+// column holding `NaN`.
+
+console.log("-- table holey row");
+console.table([[1, , 3]]);
+console.log("-- table hole in one of two rows");
+console.table([[1, 2, 3], [4, , 6]]);
+console.log("-- table all-hole row");
+console.table([new Array(3)]);
+console.log("-- table hole column order");
+console.table([[1, , 3], [4, 5, 6]]);
+console.log("-- table mixed primitive + holey row");
+console.table([1, [2, , 4]]);
+console.log("-- table sparse assignment");
+const sparse = new Array(3);
+sparse[1] = 5;
+console.table([sparse]);
+console.log("-- table holey primitives");
+console.table([1, , 3]);
+
+// --- 5. console.table on tombstoned objects ---
+
+console.log("-- table deleted first key");
+const rowObject: any = { a: 1, b: 2 };
+delete rowObject.a;
+console.table(rowObject);
+console.log("-- table deleted middle key");
+const threeKeys: any = { a: 1, b: 2, c: 3 };
+delete threeKeys.b;
+console.table(threeKeys);
+console.log("-- table deleted nested row");
+const nestedRows: any = { r1: { x: 1, y: 2 }, r2: { x: 3, y: 4 } };
+delete nestedRows.r1;
+console.table(nestedRows);
+console.log("-- table row array with deleted key");
+const partialRow: any = { a: 1, b: 2 };
+delete partialRow.a;
+console.table([partialRow, { a: 9, b: 8 }]);
+
+// --- 6. collection tombstones through console.table ---
+console.log("-- table set after delete");
+const tableSet = new Set([1, 2, 3]);
+tableSet.delete(1);
+console.table(tableSet);
+console.log("-- table map after delete");
+const tableMap = new Map<string, number>([["a", 1], ["b", 2]]);
+tableMap.delete("a");
+console.table(tableMap);
+
+// --- 7. the Map-parameter guard ---
+// The guard's own accept/deopt verdict is not observable from TypeScript — it
+// only decides whether a specialized clone runs — so it is asserted directly in
+// `param_type_guard.rs`'s unit tests
+// (`a_tombstoned_entry_does_not_deopt_a_collection_parameter`). What belongs
+// here is the behavioural pin: the RESULT must be identical whichever clone is
+// chosen, before and after a `.delete()`.
+function sumMap(m: Map<string, number>): number {
+  let total = 0;
+  for (const v of m.values()) {
+    total += v;
+  }
+  return total;
+}
+function joinSet(s: Set<number>): string {
+  const out: number[] = [];
+  for (const v of s) {
+    out.push(v);
+  }
+  return out.join(",");
+}
+const guardedMap = new Map<string, number>([["a", 1], ["b", 2], ["c", 3]]);
+console.log("map-param-before-delete", sumMap(guardedMap));
+guardedMap.delete("a");
+console.log("map-param-after-delete", sumMap(guardedMap));
+console.log("map-param-size", guardedMap.size);
+const guardedSet = new Set<number>([1, 2, 3]);
+console.log("set-param-before-delete", joinSet(guardedSet));
+guardedSet.delete(1);
+console.log("set-param-after-delete", joinSet(guardedSet));
+
+// --- 8. inspect controls (#9461 must not move) ---
+console.log("inspect-set-after-delete", liveSet);
+console.log("inspect-map-after-delete", liveMap);
+console.log("inspect-holes", [1, , 3]);
+console.log("inspect-new-array", new Array(3));

--- a/test-files/test_gap_9463_util_format_s_o_policy.ts
+++ b/test-files/test_gap_9463_util_format_s_o_policy.ts
@@ -1,0 +1,121 @@
+// #9463 — two `util.format` policy gaps, byte-compared against
+// `node --experimental-strip-types`.
+//
+//   1. `%s` on an object applied `String(value)` unconditionally. Node applies
+//      it only when the value has a USER-defined `toString`; an object whose
+//      `toString` is a built-in one is INSPECTED instead, with `{ depth: 0 }`.
+//      So `%s` on `[1, , 3]` is `[ 1, <1 empty item>, 3 ]`, not `1,,3`, and a
+//      nested object collapses to `[Object]` rather than being walked.
+//   2. `%o` is `util.inspect(value, { showHidden: true, depth: 4 })`. An
+//      array's own `length` is a non-enumerable property, so node prints
+//      `[length]: N` after the elements of every array, at every depth — even
+//      for `[]`, where `%o` is `[ [length]: 0 ]` while `%O` is `[]`.
+//
+// The `%O` rows are controls: `%O` is the default-options inspect and none of
+// them may move. So are the `%s`-on-a-primitive rows, and the two objects that
+// DO define their own `toString` — those must keep using it.
+//
+// Deliberately NOT covered, each a separate pre-existing divergence measured
+// while building this and reported alongside it:
+//   - `%s` on a BigInt: node's `formatBigInt` keeps the `n` suffix (`5n`),
+//     perry prints `5`.
+//   - `%s` on a Date (node inspects to the ISO form) or an Error (node prints
+//     the stack): neither is an ordinary object in perry's model.
+//   - `%s` / `String()` on a class: `#9468` / `value/to_string.rs:1042`.
+//   - `%o` on an object nested four deep, where node's `compact: 3` rule breaks
+//     the line and perry keeps it on one; and on arrays long enough for node's
+//     `groupArrayElements` column layout.
+
+import util from "node:util";
+
+class WithToString {
+  toString(): string {
+    return "CUSTOM-TO-STRING";
+  }
+}
+class PlainInstance {
+  v = 1;
+}
+
+const show = (label: string, value: string): void =>
+  console.log(label, JSON.stringify(value));
+
+// --- 1. %s on objects: inspect, not String() ---
+show("s-array", util.format("%s", [1, 2, 3]));
+show("s-array-holes", util.format("%s", [1, , 3]));
+show("s-array-sized", util.format("%s", new Array(3)));
+show("s-array-nested", util.format("%s", [[1, 2], [3]]));
+show("s-object", util.format("%s", { a: 1, b: "x" }));
+show("s-object-nested", util.format("%s", { a: { b: { c: 1 } } }));
+show("s-object-empty", util.format("%s", {}));
+show("s-class-instance", util.format("%s", new PlainInstance()));
+show("s-map", util.format("%s", new Map<string, number>([["a", 1]])));
+show("s-set", util.format("%s", new Set([1, 2])));
+
+// The control: a user `toString` still wins, own or inherited from a class.
+show("s-literal-tostring", util.format("%s", { toString: () => "LITERAL" }));
+show("s-method-tostring", util.format("%s", { toString() { return "METHOD"; } }));
+show("s-class-tostring", util.format("%s", new WithToString()));
+
+// The other control: `%s` on a primitive is untouched.
+show("s-null", util.format("%s", null));
+show("s-undefined", util.format("%s", undefined));
+show("s-number", util.format("%s", 42));
+show("s-float", util.format("%s", 1.5));
+show("s-string", util.format("%s", "hi"));
+show("s-boolean", util.format("%s", true));
+show("s-symbol", util.format("%s", Symbol("q")));
+show("s-regexp", util.format("%s", /ab/g));
+show("s-function", util.format("%s", function foo() {}));
+show("s-two-args", util.format("%s and %s", [1, 2], "tail"));
+
+// console.log routes its format string through the same helper.
+console.log("%s <- console-s", [1, , 3]);
+console.log("%s <- console-s-obj", { a: 1 });
+
+// --- 2. %o carries the showHidden surface ---
+show("o-array", util.format("%o", [1, 2, 3]));
+show("o-array-holes", util.format("%o", [1, , 3]));
+show("o-array-empty", util.format("%o", []));
+show("o-array-sized", util.format("%o", new Array(3)));
+show("o-array-nested", util.format("%o", [[1, 2], [3]]));
+show("o-array-in-object", util.format("%o", { a: [1, 2] }));
+show("o-array-strings", util.format("%o", ["a", "b"]));
+show("o-object", util.format("%o", { a: 1 }));
+show("o-object-hidden", util.format(
+  "%o",
+  Object.defineProperty({ a: 1 }, "hidden", { value: 9, enumerable: false }),
+));
+show("o-object-getter", util.format("%o", { get g() { return 1; }, n: 2 }));
+show("o-class-instance", util.format("%o", new PlainInstance()));
+show("o-map", util.format("%o", new Map<string, number>([["a", 1]])));
+show("o-set", util.format("%o", new Set([1, 2])));
+show("o-string", util.format("%o", "hi"));
+show("o-number", util.format("%o", 7));
+show("o-null", util.format("%o", null));
+show("o-undefined", util.format("%o", undefined));
+console.log("%o <- console-o", [1, 2, 3]);
+
+// --- 3. %O controls: none of these may move ---
+show("O-array", util.format("%O", [1, 2, 3]));
+show("O-array-holes", util.format("%O", [1, , 3]));
+show("O-array-empty", util.format("%O", []));
+show("O-array-sized", util.format("%O", new Array(3)));
+show("O-array-nested", util.format("%O", [[1, 2], [3]]));
+show("O-array-in-object", util.format("%O", { a: [1, 2] }));
+show("O-object", util.format("%O", { a: 1 }));
+show("O-object-hidden", util.format(
+  "%O",
+  Object.defineProperty({ a: 1 }, "hidden", { value: 9, enumerable: false }),
+));
+show("O-object-getter", util.format("%O", { get g() { return 1; }, n: 2 }));
+show("O-class-instance", util.format("%O", new PlainInstance()));
+show("O-map", util.format("%O", new Map<string, number>([["a", 1]])));
+show("O-set", util.format("%O", new Set([1, 2])));
+console.log("%O <- console-O", [1, 2, 3]);
+
+// --- 4. util.inspect controls: showHidden reaches it the same way ---
+show("inspect-default", util.inspect([1, 2, 3]));
+show("inspect-hidden", util.inspect([1, 2, 3], { showHidden: true }));
+show("inspect-hidden-empty", util.inspect([], { showHidden: true }));
+show("inspect-hidden-object", util.inspect({ a: 1 }, { showHidden: true }));


### PR DESCRIPTION
Five commits: the leak sources first, then downstream, then the format policy — so each later commit could be tested against the question "is this still reachable?"

## #9462 — the hole-leak family

**Leak source 1 — `js_array_get_f64`'s Set/Map arm** had two superimposed defects: raw element reads with no hole translation, *and* a `size` bound over slots that run `0..used` — after any `.delete()` it returned the tombstone itself and never reached the live tail. **The fix already existed in the tree**: `js_set_value_at` / `js_map_entry_key_at` compact when `used != size` and are what the collections' own walkers use. Compaction (not translate-in-place) is forced by the paired contract — `js_array_length` on a Set answers `size`, so translating would have put `undefined` mid-walk of a length-bounded loop.

**Leak source 2, found by sweeping rather than assuming — `Array.prototype.pop`** (`push_pop.rs:1157`): the dense fast path declines on `TAG_HOLE` and fell through to a generic arm returning the raw slot. `[1,,].pop()`, `new Array(3).pop()`, and `delete a[last]; a.pop()` all yielded a value with `typeof "number"`, `String()` `"NaN"`, `!== undefined`. Same shape #536 fixed once before in this function. Found by building a stage-1-only binary and sweeping ~60 hole-consuming shapes for what stayed reachable.

**`classify_value_typeof` and `js_jsvalue_to_string`** gained `TAG_HOLE` arms. Both *were* still reachable after leak source 1 (via `pop` — demonstrated on the stage-1 binary), and after leak source 2 the 60-shape sweep found no remaining user-reachable producer — so they are **defence in depth, pinned by unit tests rather than a `.ts` fixture**, and the PR says so instead of pretending a fixture could reach them.

**`param_type_guard.rs` `OP_MAP`/`OP_SET`**: independent of the leak sources (raw entry reads). The `size` bound meant a tombstone matched no descriptor → a legitimate `Map<string,number>` parameter silently lost its specialized clone after any `.delete()`, *and* live entries past `size` went unchecked. Now walks `0..used`, skips tombstones, requires exactly `size` live entries. Asserted via the guard's own verdict: clean accepts → deleted-key still accepts → **a lie in the entry past the old bound still deopts** — the arm that proves the tail is really walked.

**`console.table`, both mechanisms**, against node's *measured* surface: columns are the union of each row's own keys in **ascending index order** (`[[1,,3]]` → columns `0`,`2`; the hole's column is omitted entirely), and `object_key_names` now preserves slot indices like its three sibling sites instead of compacting — which also un-collapsed the nested-row case from a bare `Values` column.

## #9463 — util.format policy

**`%s`**: node inspects (depth 0) unless the object has a *user* `toString`. **The discriminator is a trap in perry**: `Object.prototype.toString` is installed as a real discoverable closure, so "resolves to a callable" answers "user-defined" for `{a:1}` — the first implementation did exactly that and left every plain object on `String()`, caught by a unit test. The shipped test compares the resolved closure's `func_ptr` against `object_prototype_to_string_thunk`.

**`%o`**: node's measured `showHidden` surface for arrays is `[length]: N` after the elements at every depth (`[]` → `[ [length]: 0 ]`); non-enumerables, getters and symbol keys already matched. Also measured and matched: the column-grouping layout stops applying once the tail is appended.

## Verification

- Fixtures byte-compared to node 26.5.1, demonstrated failing on an unfixed `origin/main` binary with compiler-matched archives: **52/128 lines diverged** (#9462), **23/60** (#9463); zero after. #9461's inspect fixture byte-identical on stdout *and* stderr.
- `cargo test --release -p perry-runtime --lib -- --test-threads=1`: **2980 passed, 0 failed** (5 new).
- Targeted parity slice both sides (163 console/format/table/inspect/map/set/array fixtures + 78 node-suite console/util fixtures), run as a direct compile+diff harness because the official runner completed 0 tests in 25 min at load ~180: before 147/8/8 → after **148/7/8**, node-suite 76/2/0 unchanged; pairwise byte-diff shows the only changed outputs are the new fixture (intended) and one `console.time` millisecond value. **Full suite not run** — stated, not implied.
- All 12 lint gates exit 0; fmt clean; clippy clean in every changed hunk.

## Reproduced, deliberately not fixed (documented in fixture headers + changelog)

`%s` on BigInt (node `"5n"`, perry `"5"`), on Date (node inspects to ISO) and on Error (node prints the stack); `%o` at depth ≥4 (`compact: 3` line-breaking) and node's column grouping on long arrays (pre-existing). `String(SomeClass)` untouched — #9468's territory.

No version bump — several branches are landing concurrently; that is the merge-time step.

Closes #9462. Closes #9463.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed empty array slots appearing as `NaN` or `number`; they now behave as `undefined`.
  - Corrected `Set` and `Map` indexed reads after entries are deleted.
  - Fixed `Array.prototype.pop()` to return `undefined` for empty slots.
  - Improved `console.table` output for deleted entries and sparse arrays.
  - Updated `util.format` to better match Node.js behavior for `%s` and `%o`.
  - Array inspection with hidden details now includes the `[length]` entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->