### PR TITLE
fix: createWriteStream, child.stdin.write and console.clear stop committing what process.exit() abandons in Node (#9493)

### DIFF
--- a/changelog.d/9493-deferred-stream-writes.md
+++ b/changelog.d/9493-deferred-stream-writes.md
@@ -1,0 +1,83 @@
+### Fixed
+
+- **`fs.createWriteStream` and `child.stdin.write()` no longer commit bytes
+  that `process.exit()` abandons in Node; `console.clear()` survives an
+  explicit exit.** Follow-up to #9442 (PR #9492), which fixed the four
+  `fs.{promises.,}{writeFile,appendFile}` entry points; the same divergence
+  class remained in three places, each measured against Node 26.5.1.
+
+  **`fs.createWriteStream`** opened the fd at construction and every
+  `write()` did `seek`+`write_all` inline, so `ws.write("a\nb\nc\n");
+  process.exit(0)` left a 6-byte file where Node leaves *no file*. Node opens
+  on a later turn (`_construct` → `fs.open` on the thread pool) and each
+  write is a pool request. The stream now runs on successive event-loop
+  turns — the #9442 mechanism (a zero-delay callback timer, GC-rooted, a live
+  event source, never ticked by `_exit`): the open (then `'open'`, `'ready'`),
+  the queued writes (then `'drain'` when a `write()` returned `false`, the
+  completed writes' callbacks, the `end()` callback and `'finish'`), then
+  the close (`'close'`). `write()` answers the back-pressure question from
+  the queued length as Node does; `fd` stays `null` and `pending` true until
+  the open; an open failure delivers a node-shaped error (`.code`,
+  `.syscall`, `.path`) to every pending callback, then `'error'`, then
+  `'close'`. Path validation still throws on the calling turn. A supplied fd
+  skips the open and emits no `'open'`/`'ready'` — the previous synchronous
+  replay of those events on `.on()` is now confined to read streams, which
+  still open eagerly.
+
+  **`child.stdin.write()`** did a blocking `write_all` into the pipe: it
+  parked the main thread on a full pipe until the child read (a language
+  server that stops reading hung the program), always returned `true`, never
+  emitted `'drain'`, and at `process.exit()` committed every byte where Node
+  commits only what the pipe accepts synchronously. It is now libuv's
+  try-write: the bytes the pipe takes right now land on the calling turn
+  (so a handshake-sized write — what the MCP stdio client sends — is committed
+  exactly as before, exit or not); the remainder goes to a per-child drain
+  thread and is reported back through the reactor's event queue, which fires
+  `'drain'` and then the queued callbacks in Node's order and performs the
+  close an `end()` left pending, so a child never sees EOF ahead of data it
+  was sent. The return value is `writableLength < writableHighWaterMark`
+  (64 KiB, Node's default for the stdin socket); `writableLength`,
+  `writableHighWaterMark` and `writableNeedDrain` are maintained on the
+  stream. Windows keeps the blocking write (no `O_NONBLOCK` on pipe handles).
+
+  **`console.clear()`** wrote its fragment into Rust's line-buffered stdout;
+  with no newline behind it, `process.exit()` — which terminates through
+  `_exit` — swallowed it. It now writes Node's exact bytes
+  (`cursorTo(0, 0)` + `clearScreenDown()`, `\x1b[1;1H\x1b[0J`, only when
+  stdout is a TTY and `TERM` is not `dumb`) and flushes, as Node's synchronous
+  TTY write does.
+
+  **`fs.Utf8Stream` at exit — measured negative, no change.** The issue
+  suspected buffered data was lost on explicit exit "that node does not
+  have". Node 26.5.1 has no exit flush either: a chunk held back by
+  `minLength` is lost on an explicit exit *and* on a natural one; only
+  `end()`, `flush()`/`flushSync()`, or crossing `minLength` commits it.
+  Perry already matched. The fixture pins the oracle so a later "flush on
+  exit" cannot land as a parity improvement.
+
+  Affected files:
+
+  - `crates/perry-runtime/src/fs/stream.rs` — the pending-write queue and
+    the open/drain/close turns; `fs/fd_ops.rs` — a string-flag open helper.
+  - `crates/perry-runtime/src/child_process/{reactor,emitter,builder}.rs` —
+    `CpStdin` (try-write, drain thread, `StdinWritten` completion event).
+  - `crates/perry-runtime/src/builtins/console.rs` — `js_console_clear`.
+
+  Validation, byte-compared against node 26.5.1, each failing on the
+  unfixed tree (`fix/exit-lifecycle`, the #9492 tip) and passing after:
+
+  - `test-files/test_gap_9493_write_stream_process_exit.ts` — exit in the
+    same tick (no file), exit from `'open'` (file, no bytes), a supplied fd,
+    natural drain, exit from `'finish'`, a sync control, and three printing
+    roles pinning event order, the supplied-fd shape, and the open-error
+    cascade.
+  - `test-files/test_gap_9493_child_stdin_backpressure.ts` — small write +
+    exit (lands), 4 MiB write + exit (pipe-capacity prefix only), the same
+    with `end()`, natural drain (all of it), the `write() === false` →
+    `'drain'` → callbacks sequence, and the small-write callback control.
+  - `test-files/test_gap_9493_console_clear_tty.ts` — under a pty (python
+    `pty.spawn`; `script(1)` needs a tty on its own stdin): exit right after
+    `clear`, a preceding `console.log`, natural exit, `TERM=dumb`, and piped
+    stdout.
+  - `test-files/test_gap_9493_utf8_stream_exit_no_flush.ts` — the measured
+    negative, with `end()`, `flushSync()`-in-`'exit'` and full-buffer controls.

--- a/crates/perry-runtime/src/builtins/console.rs
+++ b/crates/perry-runtime/src/builtins/console.rs
@@ -1444,17 +1444,26 @@ fn emit_console_trace_stack() {
 
 // === console.clear ===
 //
-// Best-effort: emit ANSI clear sequence on stdout — but ONLY when stdout
-// is an actual TTY. When stdout is piped or redirected to a file, Node
-// makes `console.clear()` a no-op (no escape sequence written), so emitting
-// it unconditionally would diff against Node by injecting `\x1b[2J\x1b[H`
-// into captured output.
+// Node (`lib/internal/console/constructor.js`): only when stdout is a TTY and
+// `TERM` is not `dumb`, `cursorTo(0, 0)` then `clearScreenDown()` — the bytes
+// `\x1b[1;1H\x1b[0J`. When stdout is piped or redirected it is a no-op, so
+// emitting anything there would diff against Node in captured output.
+//
+// #9493: the fragment has no newline, so it sat in Rust's line-buffered
+// stdout, and `process.exit()` — which terminates through `_exit` without
+// flushing — swallowed it. Node's TTY writes are synchronous, so it flushes
+// here. The old sequence (`\x1b[2J\x1b[H`) also differed from Node's.
 
 #[no_mangle]
 pub extern "C" fn js_console_clear() {
-    use std::io::IsTerminal as _;
-    if std::io::stdout().is_terminal() {
-        print!("\x1b[2J\x1b[H");
+    use std::io::{IsTerminal as _, Write as _};
+    let term_is_dumb = std::env::var_os("TERM").is_some_and(|term| term == "dumb");
+    if std::io::stdout().is_terminal() && !term_is_dumb {
+        // The crate's `print!` (the #9402 error-dropping writer), then an
+        // explicit flush: nothing else would ever flush a newline-less
+        // fragment before `_exit`.
+        print!("\x1b[1;1H\x1b[0J");
+        let _ = std::io::stdout().flush();
     }
 }
 

--- a/crates/perry-runtime/src/child_process/builder.rs
+++ b/crates/perry-runtime/src/child_process/builder.rs
@@ -174,6 +174,14 @@ pub(crate) fn cp_build_writable() -> f64 {
     cp_set_field(val, b"readable", TAG_FALSE_F64);
     cp_set_field(val, b"writable", TAG_TRUE_F64);
     cp_set_field(val, b"destroyed", TAG_FALSE_F64);
+    // #9493: the back-pressure observables `stdin.write()` maintains.
+    cp_set_field(val, b"writableLength", 0.0);
+    cp_set_field(
+        val,
+        b"writableHighWaterMark",
+        reactor::CP_STDIN_HIGH_WATER_MARK as f64,
+    );
+    cp_set_field(val, b"writableNeedDrain", TAG_FALSE_F64);
     val
 }
 

--- a/crates/perry-runtime/src/child_process/emitter.rs
+++ b/crates/perry-runtime/src/child_process/emitter.rs
@@ -322,8 +322,13 @@ pub(crate) extern "C" fn cp_stream_callback_thunk(closure: *const ClosureHeader)
 /// `NodeSink.fromWritable` waits for this callback before sending the next LSP
 /// frame, so dropping it stalls long-running language servers.
 ///
-/// Returns `true`: writes are synchronously drained into the OS pipe, so there
-/// is no buffered high-water mark that could require a later `drain` event.
+/// #9493: libuv's try-write. The bytes the pipe accepts now are committed
+/// synchronously; the remainder is queued behind a drain thread instead of
+/// parking the main thread, the return value is Node's `writableLength <
+/// writableHighWaterMark`, and a `false` is followed by `'drain'` (the MCP
+/// stdio client waits on exactly that pair). The callback of a queued write
+/// fires once its bytes are written; a fully-committed write's callback is
+/// deferred to the next turn as before.
 pub(crate) extern "C" fn cp_method_stdin_write(
     closure: *const ClosureHeader,
     chunk: f64,
@@ -331,14 +336,36 @@ pub(crate) extern "C" fn cp_method_stdin_write(
     arg3: f64,
 ) -> f64 {
     let this = cp_this(closure);
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let callback = cp_stream_callback(arg2, arg3).map(|cb| scope.root_nanbox_f64(cb));
+    let mut result = TAG_TRUE_F64;
+    let mut callback_queued = false;
     if let Some(handle) = cp_handle_of(this) {
         let bytes = cp_value_to_bytes(chunk);
-        reactor::cp_live_stdin_write(handle, &bytes);
+        let callback_bits = callback.as_ref().map(|cb| cb.get_nanbox_f64().to_bits());
+        if let Some(outcome) = reactor::cp_live_stdin_write(handle, &bytes, callback_bits) {
+            callback_queued = outcome.callback_queued;
+            if !outcome.below_high_water_mark {
+                result = TAG_FALSE_F64;
+            }
+            cp_set_field(this, b"writableLength", outcome.writable_length as f64);
+            cp_set_field(
+                this,
+                b"writableNeedDrain",
+                if outcome.below_high_water_mark {
+                    TAG_FALSE_F64
+                } else {
+                    TAG_TRUE_F64
+                },
+            );
+        }
     }
-    if let Some(callback) = cp_stream_callback(arg2, arg3) {
-        cp_defer_stream_callback(callback);
+    if !callback_queued {
+        if let Some(callback) = callback {
+            cp_defer_stream_callback(callback.get_nanbox_f64());
+        }
     }
-    TAG_TRUE_F64
+    result
 }
 
 /// `child.send(message[, sendHandle][, options][, callback])` — serialize
@@ -485,6 +512,11 @@ pub(crate) extern "C" fn cp_method_stdin_end(
     arg3: f64,
 ) -> f64 {
     let this = cp_this(closure);
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let callback = cp_stream_callback(arg2, arg3)
+        .or_else(|| (!crate::fs::extract_closure_ptr(chunk).is_null()).then_some(chunk))
+        .map(|cb| scope.root_nanbox_f64(cb));
+    let mut close_pending_on = None;
     if let Some(handle) = cp_handle_of(this) {
         // Optional final data chunk. Skip `undefined`, the `0.0` arg-padding
         // sentinel, and a callback argument (`end(cb)`).
@@ -495,16 +527,24 @@ pub(crate) extern "C" fn cp_method_stdin_end(
         {
             let bytes = cp_value_to_bytes(chunk);
             if !bytes.is_empty() {
-                reactor::cp_live_stdin_write(handle, &bytes);
+                let _ = reactor::cp_live_stdin_write(handle, &bytes, None);
             }
         }
-        reactor::cp_live_stdin_close(handle);
+        // #9493: with bytes still queued behind the pipe, the close — and the
+        // callback — wait for the drain thread, so the child never sees EOF
+        // ahead of data it was sent.
+        if !reactor::cp_live_stdin_close(handle) {
+            close_pending_on = Some(handle);
+        }
     }
     cp_set_field(this, b"writable", TAG_FALSE_F64);
-    if let Some(callback) = cp_stream_callback(arg2, arg3)
-        .or_else(|| (!crate::fs::extract_closure_ptr(chunk).is_null()).then_some(chunk))
-    {
-        cp_defer_stream_callback(callback);
+    if let Some(callback) = callback {
+        let queued = close_pending_on.is_some_and(|handle| {
+            reactor::cp_live_stdin_queue_callback(handle, callback.get_nanbox_f64().to_bits())
+        });
+        if !queued {
+            cp_defer_stream_callback(callback.get_nanbox_f64());
+        }
     }
     this
 }

--- a/crates/perry-runtime/src/child_process/reactor.rs
+++ b/crates/perry-runtime/src/child_process/reactor.rs
@@ -49,6 +49,176 @@ type CpReader = Box<dyn Read + Send>;
 type CpWriter = Box<dyn Write + Send>;
 type CpWaiter = Box<dyn FnOnce() -> (Option<i32>, Option<i32>) + Send>;
 
+/// Node's default `writableHighWaterMark` for a child's stdin socket.
+pub(super) const CP_STDIN_HIGH_WATER_MARK: usize = 64 * 1024;
+
+/// #9493: the writable side of a live child's stdin.
+///
+/// `stdin.write()` used to `write_all` inline: it parked the main thread on a
+/// full pipe until the child read (an LSP that stops reading hangs the
+/// program), always returned `true`, never emitted `'drain'`, and committed
+/// every byte before a `process.exit()` in the same tick. Node — libuv's
+/// `uv_try_write` — commits what the pipe accepts right now, queues the
+/// remainder for the loop, and judges the return value against the queued
+/// length. This is that shape: the synchronous try-write is on the main
+/// thread (bytes below pipe capacity land exactly as they did, including at
+/// `process.exit()`), the remainder goes to a drain thread, and completion
+/// (callbacks, `'drain'`, the deferred close for `end()`) is reported back
+/// through the event queue like every other child event.
+struct CpStdin {
+    /// Owns the pipe end; dropping it is the EOF the child sees.
+    writer: CpWriter,
+    /// Raw descriptor the drain thread dups. Unix only.
+    #[cfg(unix)]
+    fd: i32,
+    /// Bytes handed to the drain thread and not yet reported written —
+    /// `writableLength`.
+    queued: usize,
+    /// A `write()` returned `false` and no `'drain'` has fired since.
+    need_drain: bool,
+    /// `end()` ran while bytes were queued: close once they are written.
+    end_pending: bool,
+    /// Write/end callbacks that fire, in order, once the queue drains
+    /// (NaN-boxed closures; rooted by `cp_reactor_scan_roots_mut`).
+    callbacks: Vec<u64>,
+    /// Sender to the lazily-started drain thread.
+    #[cfg(unix)]
+    tx: Option<std::sync::mpsc::Sender<Vec<u8>>>,
+}
+
+impl CpStdin {
+    #[cfg(unix)]
+    fn new(writer: CpWriter, fd: i32) -> Self {
+        // `O_NONBLOCK` is a property of this open file description alone —
+        // the child's read end is a separate description — so the try-write
+        // reports `WouldBlock` instead of parking the main thread.
+        unsafe {
+            let flags = libc::fcntl(fd, libc::F_GETFL);
+            if flags >= 0 {
+                let _ = libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
+            }
+        }
+        Self {
+            writer,
+            fd,
+            queued: 0,
+            need_drain: false,
+            end_pending: false,
+            callbacks: Vec::new(),
+            tx: None,
+        }
+    }
+
+    #[cfg(not(unix))]
+    fn new(writer: CpWriter) -> Self {
+        Self {
+            writer,
+            queued: 0,
+            need_drain: false,
+            end_pending: false,
+            callbacks: Vec::new(),
+        }
+    }
+
+    /// libuv's `uv__try_write`: write until the pipe would block. Returns how
+    /// many bytes were committed. A broken pipe counts the whole chunk as
+    /// consumed — `SIGPIPE` is ignored process-wide (#9402), the reader is
+    /// gone, and there is nobody left to deliver to.
+    fn try_write(&mut self, bytes: &[u8]) -> usize {
+        let mut offset = 0;
+        while offset < bytes.len() {
+            match self.writer.write(&bytes[offset..]) {
+                Ok(0) => break,
+                Ok(n) => offset += n,
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => break,
+                Err(err) if err.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(_) => return bytes.len(),
+            }
+        }
+        offset
+    }
+
+    #[cfg(unix)]
+    fn enqueue(&mut self, handle: u64, bytes: Vec<u8>) {
+        if self.tx.is_none() {
+            let (tx, rx) = std::sync::mpsc::channel();
+            cp_spawn_stdin_drain(handle, self.fd, rx);
+            self.tx = Some(tx);
+        }
+        if let Some(tx) = &self.tx {
+            let _ = tx.send(bytes);
+        }
+    }
+
+    #[cfg(not(unix))]
+    fn enqueue(&mut self, handle: u64, bytes: Vec<u8>) {
+        // Blocking pipe handles: a short `write` only means an error, so the
+        // remainder is written inline as before and reported at once.
+        let _ = self.writer.write_all(&bytes);
+        cp_push_event(CpEvent::StdinWritten {
+            handle,
+            len: bytes.len(),
+            broken: false,
+        });
+    }
+}
+
+/// Drain thread for the bytes the pipe would not take synchronously. It
+/// owns a `dup` of the descriptor, so the registry's writer can be dropped
+/// (`end()`, child close, teardown) without pulling the fd out from under
+/// an in-flight write; the dup closes when the channel ends, which is what
+/// finally delivers EOF after an `end()` on a backed-up pipe.
+#[cfg(unix)]
+fn cp_spawn_stdin_drain(handle: u64, fd: i32, rx: std::sync::mpsc::Receiver<Vec<u8>>) {
+    let dup = unsafe { libc::dup(fd) };
+    std::thread::spawn(move || {
+        let mut broken = dup < 0;
+        for chunk in rx {
+            let mut offset = 0;
+            while !broken && offset < chunk.len() {
+                let n = unsafe {
+                    libc::write(
+                        dup,
+                        chunk[offset..].as_ptr() as *const libc::c_void,
+                        chunk.len() - offset,
+                    )
+                };
+                if n >= 0 {
+                    offset += n as usize;
+                    continue;
+                }
+                match std::io::Error::last_os_error().raw_os_error() {
+                    Some(code) if code == libc::EAGAIN || code == libc::EWOULDBLOCK => {
+                        let mut pfd = libc::pollfd {
+                            fd: dup,
+                            events: libc::POLLOUT,
+                            revents: 0,
+                        };
+                        unsafe {
+                            libc::poll(&mut pfd, 1, -1);
+                        }
+                    }
+                    Some(code) if code == libc::EINTR => {}
+                    _ => broken = true,
+                }
+            }
+            cp_push_event(CpEvent::StdinWritten {
+                handle,
+                len: chunk.len(),
+                broken,
+            });
+            if broken {
+                break;
+            }
+        }
+        if dup >= 0 {
+            unsafe {
+                libc::close(dup);
+            }
+        }
+    });
+}
+
 /// Monotonic registry key for live children.
 static CP_NEXT_LIVE_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -88,6 +258,15 @@ enum CpEvent {
     Timeout { handle: u64, signal: i32 },
     /// `AbortSignal` attached through `options.signal` fired.
     Abort { handle: u64 },
+    /// #9493: the stdin drain thread wrote `len` queued bytes (`len == 0` is
+    /// the main thread asking for a `'drain'` after an over-the-mark write
+    /// the pipe took whole). `broken` — the pipe is gone (EPIPE): the queue
+    /// is abandoned and stdin closed.
+    StdinWritten {
+        handle: u64,
+        len: usize,
+        broken: bool,
+    },
 }
 
 static CP_EVENT_QUEUE: Mutex<Vec<CpEvent>> = Mutex::new(Vec::new());
@@ -103,7 +282,7 @@ struct LiveChild {
     pipe_ids: [crate::async_hooks::AsyncResourceIds; 3],
     pipe_bits: [u64; 3],
     pid: i32,
-    stdin: Option<CpWriter>,
+    stdin: Option<CpStdin>,
     stdout_open: bool,
     stderr_open: bool,
     /// Hold stdout EOF until stderr EOF when both pipes exist. Node drains
@@ -390,7 +569,18 @@ pub(super) fn cp_register_live_child(
 
     let stdout_pipe = child.stdout.take().map(|pipe| Box::new(pipe) as CpReader);
     let stderr_pipe = child.stderr.take().map(|pipe| Box::new(pipe) as CpReader);
-    let stdin_pipe = child.stdin.take().map(|pipe| Box::new(pipe) as CpWriter);
+    let stdin_pipe = child.stdin.take().map(|pipe| {
+        #[cfg(unix)]
+        {
+            use std::os::unix::io::AsRawFd;
+            let fd = pipe.as_raw_fd();
+            CpStdin::new(Box::new(pipe) as CpWriter, fd)
+        }
+        #[cfg(not(unix))]
+        {
+            CpStdin::new(Box::new(pipe) as CpWriter)
+        }
+    });
     let waiter: CpWaiter = Box::new(move || match child.wait() {
         Ok(status) => {
             #[cfg(unix)]
@@ -470,7 +660,7 @@ pub(super) fn cp_register_windows_live_child(
         stdin_obj,
         extra_pipes,
         pid,
-        stdin.map(|pipe| Box::new(pipe) as CpWriter),
+        stdin.map(|pipe| CpStdin::new(Box::new(pipe) as CpWriter)),
         stdout.map(|pipe| Box::new(pipe) as CpReader),
         stderr.map(|pipe| Box::new(pipe) as CpReader),
         waiter,
@@ -490,7 +680,7 @@ fn cp_register_live_child_parts(
     stdin_obj: f64,
     extra_pipes: Vec<(usize, f64, std::fs::File)>,
     pid: u32,
-    stdin_pipe: Option<CpWriter>,
+    stdin_pipe: Option<CpStdin>,
     stdout_pipe: Option<CpReader>,
     stderr_pipe: Option<CpReader>,
     waiter: CpWaiter,
@@ -1520,6 +1710,11 @@ fn cp_reactor_pump_inner() {
                     cp_emit(cp, "error", &[cp_abort_error(None)]);
                 }
             }
+            CpEvent::StdinWritten {
+                handle,
+                len,
+                broken,
+            } => cp_stdin_written(handle, len, broken),
         }
     }
 
@@ -1616,6 +1811,7 @@ struct CpCloseItem {
 #[inline]
 fn cp_stdio_stream(cp: f64, fd: usize) -> f64 {
     match fd {
+        0 => cp_get_field(cp, b"stdin"),
         1 => cp_get_field(cp, b"stdout"),
         2 => cp_get_field(cp, b"stderr"),
         _ => cp_array_ptr(cp_get_field(cp, b"stdio"))
@@ -1653,25 +1849,174 @@ pub(super) fn cp_async_scope_for_target(
 // Live `stdin.write()` / `kill()` — called from the mod.rs method bodies.
 // ============================================================================
 
-/// Write `bytes` to a live child's stdin. Returns whether the write succeeded.
-pub(super) fn cp_live_stdin_write(handle: u64, bytes: &[u8]) -> bool {
+/// What `stdin.write()` hands back to the method body (#9493).
+pub(super) struct CpStdinWriteOutcome {
+    /// Node's return value: the queued length, chunk included, was below the
+    /// high-water mark.
+    pub(super) below_high_water_mark: bool,
+    /// Bytes still queued behind the pipe afterwards — `writableLength`.
+    pub(super) writable_length: usize,
+    /// The completion callback was taken over by the drain: it fires, in
+    /// order, once the queue empties. Otherwise the caller defers it as before.
+    pub(super) callback_queued: bool,
+}
+
+/// Write `bytes` to a live child's stdin — libuv's try-write (#9493). Returns
+/// `None` when there is no live child, no open stdin, or `end()` already ran;
+/// the caller then keeps its pre-existing completion path.
+pub(super) fn cp_live_stdin_write(
+    handle: u64,
+    bytes: &[u8],
+    callback_bits: Option<u64>,
+) -> Option<CpStdinWriteOutcome> {
     let mut guard = cp_live_lock();
-    if let Some(map) = guard.as_mut() {
+    let lc = guard.as_mut()?.get_mut(&handle)?;
+    let stdin = lc.stdin.as_mut()?;
+    if stdin.end_pending {
+        return None;
+    }
+    // Node counts the chunk into `writableLength` BEFORE dispatching it and
+    // judges the return value against that: a chunk at or above the mark
+    // returns `false` even when the pipe took all of it, and `'drain'` then
+    // follows on the next turn.
+    let length_with_chunk = stdin.queued.saturating_add(bytes.len());
+    let below_high_water_mark = length_with_chunk < CP_STDIN_HIGH_WATER_MARK;
+    let mut offset = 0;
+    if stdin.queued == 0 {
+        offset = stdin.try_write(bytes);
+    }
+    let remainder = &bytes[offset..];
+    if !remainder.is_empty() {
+        stdin.queued = stdin.queued.saturating_add(remainder.len());
+        stdin.enqueue(handle, remainder.to_vec());
+    }
+    let mut callback_queued = false;
+    if !below_high_water_mark {
+        stdin.need_drain = true;
+    }
+    if !remainder.is_empty() || !below_high_water_mark {
+        if let Some(bits) = callback_bits {
+            stdin.callbacks.push(bits);
+        }
+        callback_queued = true;
+        if remainder.is_empty() {
+            // Written whole but over the mark: the callback and `'drain'` land
+            // on the next turn, through the pump like a drained queue would.
+            cp_push_event(CpEvent::StdinWritten {
+                handle,
+                len: 0,
+                broken: false,
+            });
+        }
+    }
+    Some(CpStdinWriteOutcome {
+        below_high_water_mark,
+        writable_length: stdin.queued,
+        callback_queued,
+    })
+}
+
+/// Close a live child's stdin (`stdin.end()`). Returns `true` when the pipe
+/// closed now (the child sees EOF); `false` when bytes are still queued, in
+/// which case the close — and a callback queued through
+/// `cp_live_stdin_queue_callback` — happens once the drain thread reports
+/// them written (#9493). No-op if already closed / unknown.
+pub(super) fn cp_live_stdin_close(handle: u64) -> bool {
+    if let Some(map) = cp_live_lock().as_mut() {
         if let Some(lc) = map.get_mut(&handle) {
             if let Some(stdin) = lc.stdin.as_mut() {
-                return stdin.write_all(bytes).is_ok();
+                if stdin.queued > 0 {
+                    stdin.end_pending = true;
+                    return false;
+                }
+            }
+            lc.stdin = None;
+        }
+    }
+    true
+}
+
+/// Queue a completion callback behind the stdin bytes still in flight.
+/// Returns `false` (nothing queued) when the queue is already empty.
+pub(super) fn cp_live_stdin_queue_callback(handle: u64, callback_bits: u64) -> bool {
+    if let Some(map) = cp_live_lock().as_mut() {
+        if let Some(lc) = map.get_mut(&handle) {
+            if let Some(stdin) = lc.stdin.as_mut() {
+                if stdin.queued > 0 {
+                    stdin.callbacks.push(callback_bits);
+                    return true;
+                }
             }
         }
     }
     false
 }
 
-/// Close a live child's stdin (`stdin.end()`), dropping the pipe so the child
-/// sees EOF. No-op if already closed / unknown.
-pub(super) fn cp_live_stdin_close(handle: u64) {
-    if let Some(map) = cp_live_lock().as_mut() {
-        if let Some(lc) = map.get_mut(&handle) {
-            lc.stdin = None;
+/// Pump-side completion of queued stdin bytes (#9493): account for them, and
+/// once the queue is empty emit `'drain'` and then fire the waiting callbacks
+/// in order — Node's `afterWrite` order — and perform the close an `end()`
+/// left pending.
+fn cp_stdin_written(handle: u64, len: usize, broken: bool) {
+    let mut callbacks: Vec<u64> = Vec::new();
+    let mut emit_drain = false;
+    let mut writable_length = 0;
+    let mut close_now = false;
+    let mut found = false;
+    {
+        let mut guard = cp_live_lock();
+        if let Some(lc) = guard.as_mut().and_then(|m| m.get_mut(&handle)) {
+            if let Some(stdin) = lc.stdin.as_mut() {
+                found = true;
+                stdin.queued = if broken {
+                    0
+                } else {
+                    stdin.queued.saturating_sub(len)
+                };
+                writable_length = stdin.queued;
+                if stdin.queued == 0 {
+                    callbacks = std::mem::take(&mut stdin.callbacks);
+                    emit_drain = stdin.need_drain && !stdin.end_pending && !broken;
+                    stdin.need_drain = false;
+                    close_now = stdin.end_pending || broken;
+                }
+            }
+            if close_now {
+                // EOF for the child: the drain thread's dup closes with its
+                // channel, which this drop ends.
+                lc.stdin = None;
+            }
+        }
+    }
+    if !found {
+        return;
+    }
+    let Some(cp_bits) = cp_lookup_cp_bits(handle) else {
+        return;
+    };
+    // The callbacks came out of the registry root; re-root them before
+    // anything below allocates (the field setters can), and across the
+    // `'drain'` listeners and the calls.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let handles: Vec<_> = callbacks
+        .iter()
+        .map(|bits| scope.root_nanbox_f64(f64::from_bits(*bits)))
+        .collect();
+    let stream = cp_stdio_stream(f64::from_bits(cp_bits), 0);
+    if super::cp_object_ptr(stream).is_none() {
+        return;
+    }
+    cp_set_field(stream, b"writableLength", writable_length as f64);
+    if writable_length == 0 {
+        cp_set_field(stream, b"writableNeedDrain", TAG_FALSE_F64);
+    }
+    if emit_drain {
+        cp_emit(stream, "drain", &[]);
+    }
+    for callback in &handles {
+        let args: [f64; 0] = [];
+        unsafe {
+            let _ =
+                crate::closure::js_native_call_value(callback.get_nanbox_f64(), args.as_ptr(), 0);
         }
     }
 }
@@ -1923,6 +2268,12 @@ pub(crate) fn cp_reactor_scan_roots_mut(visitor: &mut crate::gc::RuntimeRootVisi
             // it fires on `close`.
             if let Some(exec) = lc.exec.as_mut() {
                 visitor.visit_nanbox_u64_slot(&mut exec.cb_bits);
+            }
+            // #9493: stdin write/end callbacks waiting on the drain thread.
+            if let Some(stdin) = lc.stdin.as_mut() {
+                for callback in &mut stdin.callbacks {
+                    visitor.visit_nanbox_u64_slot(callback);
+                }
             }
         }
     }

--- a/crates/perry-runtime/src/fs/fd_ops.rs
+++ b/crates/perry-runtime/src/fs/fd_ops.rs
@@ -19,15 +19,22 @@ pub(crate) fn array_ptr_from_value(value: f64) -> *const crate::array::ArrayHead
 }
 
 fn open_options_from_flags(flags_value: f64) -> (fs::OpenOptions, bool) {
-    let mut opts = fs::OpenOptions::new();
-    let append_mode;
     if flags_value.is_finite() {
-        let flags = flags_value as i32;
-        append_mode = apply_numeric_open_flags(&mut opts, flags);
-    } else {
-        let flags = flag_string(flags_value);
-        append_mode = matches!(flags.as_str(), "a" | "a+" | "ax" | "ax+");
-        match flags.as_str() {
+        let mut opts = fs::OpenOptions::new();
+        let append_mode = apply_numeric_open_flags(&mut opts, flags_value as i32);
+        return (opts, append_mode);
+    }
+    open_options_from_flag_str(&flag_string(flags_value))
+}
+
+/// The string-flag half of `open_options_from_flags`, callable without a
+/// NaN-boxed value: the deferred `fs.WriteStream` open (#9493) runs on a later
+/// event-loop turn holding only the Rust-side flag string.
+pub(crate) fn open_options_from_flag_str(flags: &str) -> (fs::OpenOptions, bool) {
+    let mut opts = fs::OpenOptions::new();
+    let append_mode = matches!(flags, "a" | "a+" | "ax" | "ax+");
+    {
+        match flags {
             "r" | "rs" => {
                 opts.read(true);
             }
@@ -148,21 +155,34 @@ pub(crate) unsafe fn fs_open_sync_result(
     };
     let (opts, append_mode) = open_options_from_flags(flags_value);
     match opts.open(&path_str) {
-        Ok(file) => {
-            let fd = allocate_synthetic_fd();
-            FD_REGISTRY.with(|r| {
-                r.borrow_mut().insert(fd, file);
-            });
-            FD_PATHS.with(|r| {
-                r.borrow_mut().insert(fd, path_str.to_string());
-            });
-            FD_APPEND_MODE.with(|r| {
-                r.borrow_mut().insert(fd, append_mode);
-            });
-            Ok(fd)
-        }
+        Ok(file) => Ok(register_opened_file(file, &path_str, append_mode)),
         Err(err) => Err((err, path_str)),
     }
+}
+
+/// Register an opened file under a fresh synthetic fd.
+fn register_opened_file(file: fs::File, path_str: &str, append_mode: bool) -> i32 {
+    let fd = allocate_synthetic_fd();
+    FD_REGISTRY.with(|r| {
+        r.borrow_mut().insert(fd, file);
+    });
+    FD_PATHS.with(|r| {
+        r.borrow_mut().insert(fd, path_str.to_string());
+    });
+    FD_APPEND_MODE.with(|r| {
+        r.borrow_mut().insert(fd, append_mode);
+    });
+    fd
+}
+
+/// #9493: open + register `path_str` with a flag string, for the deferred
+/// `fs.WriteStream` open. Path validation (the throwing kind) already ran on
+/// the constructing turn, so this takes the decoded Rust path and never
+/// throws; the caller turns an `Err` into the stream's `'error'` event.
+pub(crate) fn fs_open_path_str_result(path_str: &str, flags: &str) -> Result<i32, std::io::Error> {
+    let (opts, append_mode) = open_options_from_flag_str(flags);
+    let file = opts.open(path_str)?;
+    Ok(register_opened_file(file, path_str, append_mode))
 }
 
 /// `fs.openSync(path, flags)` — small fd registry for deterministic tests.

--- a/crates/perry-runtime/src/fs/stream.rs
+++ b/crates/perry-runtime/src/fs/stream.rs
@@ -41,6 +41,13 @@ struct PipeDestination {
     end: bool,
 }
 
+/// #9493: a chunk `WriteStream.write()`/`end()` accepted, awaiting its turn.
+struct PendingWrite {
+    bytes: Vec<u8>,
+    /// `write(chunk, cb)`'s callback; `undefined` when absent.
+    callback: f64,
+}
+
 /// State for a single file stream (read OR write).
 pub(crate) struct StreamState {
     kind: StreamKind,
@@ -69,7 +76,20 @@ pub(crate) struct StreamState {
     pumping: bool,
     writable_length: usize,
     writable_need_drain: bool,
-    drain_scheduled: bool,
+    /// #9493: chunks accepted by `write()`/`end()` and not yet written. Node
+    /// hands each to the thread pool; perry performs them on a later
+    /// event-loop turn (`run_write_stream_turn`), so a `process.exit()` in the
+    /// same tick abandons them exactly as Node does.
+    pending_writes: Vec<PendingWrite>,
+    /// #9493: `end(cb)`'s callback — runs before `'finish'` (Node's
+    /// `kOnFinished`). `undefined` when absent.
+    end_callback: f64,
+    /// #9493: node-shaped error value (`.code`/`.syscall`/`.path`) from the
+    /// deferred open, handed to the pending callbacks and to `'error'`.
+    /// `undefined` until then; `error_msg` stays the "errored" flag.
+    error_value: f64,
+    /// #9493: a turn is already parked on the callback-timer queue.
+    turn_pending: bool,
     bytes_read: u64,
     bytes_written: u64,
 }
@@ -144,7 +164,10 @@ impl StreamState {
             pumping: false,
             writable_length: 0,
             writable_need_drain: false,
-            drain_scheduled: false,
+            pending_writes: Vec::new(),
+            end_callback: f64::from_bits(crate::value::TAG_UNDEFINED),
+            error_value: f64::from_bits(crate::value::TAG_UNDEFINED),
+            turn_pending: false,
             bytes_read: 0,
             bytes_written: 0,
         }
@@ -200,6 +223,12 @@ pub(crate) fn scan_fs_stream_roots_mut(visitor: &mut crate::gc::RuntimeRootVisit
             for pipe in &mut state.pipes {
                 visitor.visit_nanbox_f64_slot(&mut pipe.value);
             }
+            // #9493: the deferred-write queue holds JS callbacks across turns.
+            for write in &mut state.pending_writes {
+                visitor.visit_nanbox_f64_slot(&mut write.callback);
+            }
+            visitor.visit_nanbox_f64_slot(&mut state.end_callback);
+            visitor.visit_nanbox_f64_slot(&mut state.error_value);
         }
     });
     UTF8_STREAM_REGISTRY.with(|registry| {
@@ -590,7 +619,13 @@ fn callbacks_for_event(id: usize, event: &str) -> Vec<f64> {
 /// `js_fs_create_read_stream`), and that iterator's `data`/`end`/`error`
 /// listeners register in node:stream's registry — not the per-id one above. Without
 /// this, `for await (const chunk of fs.createReadStream(p))` would hang forever.
-fn bridge_to_stream_listeners(id: usize, event: &str, args: &[f64]) {
+///
+/// `handled_locally` — this stream's own registry delivered the event. An
+/// `'error'` it handled is forwarded only to listeners node:stream actually
+/// holds: that emitter throws an `'error'` nobody listens to (#9493 — the
+/// deferred open's failure reaches here for real, where the old synchronous
+/// replay never did), and "nobody" has to mean neither registry.
+fn bridge_to_stream_listeners(id: usize, event: &str, args: &[f64], handled_locally: bool) {
     let object_value = STREAM_REGISTRY.with(|registry| {
         registry
             .borrow()
@@ -601,31 +636,39 @@ fn bridge_to_stream_listeners(id: usize, event: &str, args: &[f64]) {
     if object_value.to_bits() == crate::value::TAG_UNDEFINED {
         return;
     }
+    if event == "error"
+        && handled_locally
+        && !crate::node_stream::has_stream_listeners(object_value, event.as_bytes())
+    {
+        return;
+    }
     crate::node_stream::emit_to_stream_listeners(object_value, event.as_bytes(), args);
 }
 
 fn emit_event0(id: usize, event: &str) {
     use crate::closure::js_closure_call0;
     let callbacks = callbacks_for_event(id, event);
+    let handled_locally = !callbacks.is_empty();
     for cb in callbacks {
         let cb_ptr = extract_closure_ptr(cb);
         if !cb_ptr.is_null() {
             js_closure_call0(cb_ptr);
         }
     }
-    bridge_to_stream_listeners(id, event, &[]);
+    bridge_to_stream_listeners(id, event, &[], handled_locally);
 }
 
 fn emit_event1(id: usize, event: &str, arg: f64) {
     use crate::closure::js_closure_call1;
     let callbacks = callbacks_for_event(id, event);
+    let handled_locally = !callbacks.is_empty();
     for cb in callbacks {
         let cb_ptr = extract_closure_ptr(cb);
         if !cb_ptr.is_null() {
             js_closure_call1(cb_ptr, arg);
         }
     }
-    bridge_to_stream_listeners(id, event, &[arg]);
+    bridge_to_stream_listeners(id, event, &[arg], handled_locally);
 }
 
 fn call_js_method0(receiver: f64, name: &[u8]) -> f64 {
@@ -666,16 +709,33 @@ fn call_js_method2(receiver: f64, name: &[u8], arg0: f64, arg1: f64) -> f64 {
     }
 }
 
+/// The stream's stored error: the node-shaped value the deferred open produced
+/// when there is one (#9493), else the message an `Error` is built from —
+/// built by `stored_error_value` OUTSIDE the registry borrow, since the
+/// allocation may collect and the root scanner borrows the registry mutably.
+enum StoredError {
+    Value(f64),
+    Message(String),
+}
+
+fn stored_error(state: &StreamState) -> Option<StoredError> {
+    if !JSValue::from_bits(state.error_value.to_bits()).is_undefined() {
+        return Some(StoredError::Value(state.error_value));
+    }
+    state.error_msg.clone().map(StoredError::Message)
+}
+
+fn stored_error_value(stored: StoredError) -> f64 {
+    match stored {
+        StoredError::Value(value) => value,
+        StoredError::Message(message) => make_error_value(&message),
+    }
+}
+
 fn emit_stored_error(id: usize) {
-    let error_value = STREAM_REGISTRY.with(|registry| {
-        let registry = registry.borrow();
-        registry
-            .get(&id)
-            .and_then(|state| state.error_msg.as_deref())
-            .map(make_error_value)
-    });
-    if let Some(err) = error_value {
-        emit_event1(id, "error", err);
+    let stored = STREAM_REGISTRY.with(|registry| registry.borrow().get(&id).and_then(stored_error));
+    if let Some(stored) = stored {
+        emit_event1(id, "error", stored_error_value(stored));
     }
 }
 
@@ -815,49 +875,282 @@ fn write_to_stream_fd(id: usize, bytes: &[u8]) -> Result<(), String> {
     result
 }
 
-fn schedule_drain(id: usize) {
+fn call_stream_callback0(callback: f64) {
+    if is_callable_value(callback) {
+        let cb_ptr = extract_closure_ptr(callback);
+        if !cb_ptr.is_null() {
+            crate::closure::js_closure_call0(cb_ptr);
+        }
+    }
+}
+
+fn call_stream_callback1(callback: f64, arg: f64) {
+    if is_callable_value(callback) {
+        let cb_ptr = extract_closure_ptr(callback);
+        if !cb_ptr.is_null() {
+            crate::closure::js_closure_call1(cb_ptr, arg);
+        }
+    }
+}
+
+/// #9493: park one `WriteStream` turn on the callback-timer queue. At most one
+/// is pending per stream; a turn re-schedules while work remains.
+///
+/// This is the mechanism `fs::deferred` uses for `fs.writeFile`: the timer
+/// queue roots the closure; a pending refed callback timer is a live event
+/// source, so a program that ends by draining its loop still lands every byte
+/// and `'finish'` still fires; and `process.exit()` terminates through
+/// `libc::_exit` without ticking the queue, so an exit in the same tick
+/// abandons the parked open and writes the way Node abandons its not-yet-run
+/// thread-pool requests.
+fn schedule_write_stream_turn(id: usize) {
     let should_schedule = STREAM_REGISTRY.with(|registry| {
         let mut registry = registry.borrow_mut();
         let Some(state) = registry.get_mut(&id) else {
             return false;
         };
-        if state.drain_scheduled || !state.writable_need_drain {
+        if state.turn_pending || state.closed {
             return false;
         }
-        state.drain_scheduled = true;
+        state.turn_pending = true;
         true
     });
     if should_schedule {
-        let closure = js_closure_alloc(write_stream_drain_timer_impl as *const u8, 1);
+        let closure = js_closure_alloc(write_stream_turn_impl as *const u8, 1);
         js_closure_set_capture_ptr(closure, 0, id as i64);
         let _ = crate::timer::js_set_timeout_callback(closure as i64, 0.0);
     }
 }
 
-fn flush_write_drain(id: usize) {
-    let should_emit = STREAM_REGISTRY.with(|registry| {
-        let mut registry = registry.borrow_mut();
-        let Some(state) = registry.get_mut(&id) else {
-            return false;
-        };
-        if !state.writable_need_drain {
-            state.drain_scheduled = false;
-            return false;
+extern "C" fn write_stream_turn_impl(closure: *const ClosureHeader) -> f64 {
+    let id = stream_id_of(closure);
+    STREAM_REGISTRY.with(|registry| {
+        if let Some(state) = registry.borrow_mut().get_mut(&id) {
+            state.turn_pending = false;
         }
-        state.writable_length = 0;
-        state.writable_need_drain = false;
-        state.drain_scheduled = false;
-        update_common_props(state);
-        true
     });
-    if should_emit {
-        emit_event0(id, "drain");
+    run_write_stream_turn(id);
+    undefined_value()
+}
+
+/// What a `WriteStream` turn does, decided from the state when it runs. One
+/// step per turn, each the analogue of one Node thread-pool request: the open
+/// (`_construct` → `fs.open`), then the queued writes ending in `'finish'`,
+/// then the close. A step schedules the next when more work remains, so a
+/// microtask queued by an `'open'` or `'finish'` listener runs before the
+/// first write callback / before `'close'`, as it does in Node.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum WriteStreamStep {
+    Open,
+    Drain,
+    Close,
+    Idle,
+}
+
+fn write_stream_step(id: usize) -> WriteStreamStep {
+    STREAM_REGISTRY.with(|registry| {
+        let registry = registry.borrow();
+        let Some(state) = registry.get(&id) else {
+            return WriteStreamStep::Idle;
+        };
+        if state.kind != StreamKind::Write || state.closed {
+            return WriteStreamStep::Idle;
+        }
+        if state.destroyed {
+            return WriteStreamStep::Close;
+        }
+        if !state.opened && state.error_msg.is_none() && matches!(state.owner, FdOwner::Path) {
+            return WriteStreamStep::Open;
+        }
+        if !state.pending_writes.is_empty() || (state.ended && !state.finished) {
+            return WriteStreamStep::Drain;
+        }
+        if state.finished && state.auto_close {
+            return WriteStreamStep::Close;
+        }
+        WriteStreamStep::Idle
+    })
+}
+
+fn run_write_stream_turn(id: usize) {
+    match write_stream_step(id) {
+        WriteStreamStep::Open => write_stream_open_step(id),
+        WriteStreamStep::Drain => write_stream_drain_step(id),
+        WriteStreamStep::Close => write_stream_close_step(id),
+        WriteStreamStep::Idle => {}
     }
 }
 
-extern "C" fn write_stream_drain_timer_impl(closure: *const ClosureHeader) -> f64 {
-    flush_write_drain(stream_id_of(closure));
-    undefined_value()
+fn schedule_next_write_stream_step(id: usize) {
+    if write_stream_step(id) != WriteStreamStep::Idle {
+        schedule_write_stream_turn(id);
+    }
+}
+
+/// The deferred `open(2)`: Node's `_construct` runs `fs.open` on the pool and
+/// then emits `'open'` and `'ready'`. The queued writes are performed on a
+/// LATER turn — their `fs.write` requests are only dispatched once the open
+/// callback has returned.
+fn write_stream_open_step(id: usize) {
+    let (path, flags) = STREAM_REGISTRY.with(|registry| {
+        registry
+            .borrow()
+            .get(&id)
+            .map(|state| (state.path.clone(), state.flags.clone()))
+            .unwrap_or_default()
+    });
+    match fs_open_path_str_result(&path, &flags) {
+        Ok(fd) => {
+            STREAM_REGISTRY.with(|registry| {
+                if let Some(state) = registry.borrow_mut().get_mut(&id) {
+                    state.fd = Some(fd);
+                    state.opened = true;
+                    if matches!(state.flags.as_str(), "a" | "a+" | "ax" | "ax+") {
+                        state.position = end_position_for_fd(fd);
+                    }
+                    update_common_props(state);
+                }
+            });
+            emit_event1(id, "open", fd as f64);
+            emit_event0(id, "ready");
+            schedule_next_write_stream_step(id);
+        }
+        Err(err) => {
+            let message = err.to_string();
+            let error_value = unsafe { build_fs_error_value(&err, "open", &path) };
+            write_stream_fail(id, error_value, message);
+        }
+    }
+}
+
+/// The error cascade Node runs when the open fails: every pending write
+/// callback and the `end()` callback receive the error, then `'error'` fires,
+/// then the stream is destroyed and `'close'` follows on a later turn.
+fn write_stream_fail(id: usize, error_value: f64, message: String) {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let error_handle = scope.root_nanbox_f64(error_value);
+    // The value goes into the state first — the registry is a GC root and the
+    // callbacks below allocate.
+    let (writes, end_callback) = STREAM_REGISTRY.with(|registry| {
+        let mut registry = registry.borrow_mut();
+        let Some(state) = registry.get_mut(&id) else {
+            return (Vec::new(), undefined_value());
+        };
+        state.errored = true;
+        state.error_msg = Some(message);
+        state.error_value = error_handle.get_nanbox_f64();
+        state.destroyed = true;
+        state.writable_length = 0;
+        state.writable_need_drain = false;
+        let writes = std::mem::take(&mut state.pending_writes);
+        let end_callback = std::mem::replace(&mut state.end_callback, undefined_value());
+        update_common_props(state);
+        (writes, end_callback)
+    });
+    let callbacks: Vec<_> = writes
+        .iter()
+        .map(|write| scope.root_nanbox_f64(write.callback))
+        .collect();
+    let end_handle = scope.root_nanbox_f64(end_callback);
+    for callback in &callbacks {
+        call_stream_callback1(callback.get_nanbox_f64(), error_handle.get_nanbox_f64());
+    }
+    call_stream_callback1(end_handle.get_nanbox_f64(), error_handle.get_nanbox_f64());
+    emit_event1(id, "error", error_handle.get_nanbox_f64());
+    schedule_next_write_stream_step(id);
+}
+
+/// The queued writes, in order — Node batches them into one `writev` — then
+/// Node's `afterWrite` order: `'drain'` (when a `write()` returned `false`
+/// and the stream is not ending) BEFORE the completed writes' callbacks. Once
+/// `end()` has been called and nothing is left: the `end()` callback and
+/// `'finish'`; with `autoClose`, the close lands on the next turn.
+fn write_stream_drain_step(id: usize) {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let mut completed = Vec::new();
+    loop {
+        let next = STREAM_REGISTRY.with(|registry| {
+            let mut registry = registry.borrow_mut();
+            let state = registry.get_mut(&id)?;
+            if state.destroyed || state.pending_writes.is_empty() {
+                return None;
+            }
+            Some(state.pending_writes.remove(0))
+        });
+        let Some(write) = next else {
+            break;
+        };
+        let callback = scope.root_nanbox_f64(write.callback);
+        match write_to_stream_fd(id, &write.bytes) {
+            Ok(()) => completed.push(callback),
+            Err(message) => {
+                // The writes that did land complete normally; the failing one
+                // gets the error, then the rest of the queue does via the
+                // error cascade.
+                for done in &completed {
+                    call_stream_callback0(done.get_nanbox_f64());
+                }
+                let error_value = scope.root_nanbox_f64(make_error_value(&message));
+                call_stream_callback1(callback.get_nanbox_f64(), error_value.get_nanbox_f64());
+                write_stream_fail(id, error_value.get_nanbox_f64(), message);
+                return;
+            }
+        }
+    }
+    let (emit_drain, finish) = STREAM_REGISTRY.with(|registry| {
+        let mut registry = registry.borrow_mut();
+        let Some(state) = registry.get_mut(&id) else {
+            return (false, false);
+        };
+        if state.destroyed {
+            return (false, false);
+        }
+        state.writable_length = 0;
+        let emit_drain = state.writable_need_drain && !state.ended;
+        state.writable_need_drain = false;
+        let mut finish = false;
+        if state.ended && !state.finished {
+            if state.error_msg.is_none() {
+                state.finished = true;
+                finish = true;
+            } else {
+                state.destroyed = true;
+            }
+        }
+        update_common_props(state);
+        (emit_drain, finish)
+    });
+    if emit_drain {
+        emit_event0(id, "drain");
+    }
+    for callback in &completed {
+        call_stream_callback0(callback.get_nanbox_f64());
+    }
+    if finish {
+        let end_callback = STREAM_REGISTRY.with(|registry| {
+            registry
+                .borrow_mut()
+                .get_mut(&id)
+                .map(|state| std::mem::replace(&mut state.end_callback, undefined_value()))
+                .unwrap_or_else(undefined_value)
+        });
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let end_callback = scope.root_nanbox_f64(end_callback);
+        call_stream_callback0(end_callback.get_nanbox_f64());
+        emit_event0(id, "finish");
+    }
+    schedule_next_write_stream_step(id);
+}
+
+fn write_stream_close_step(id: usize) {
+    let force = STREAM_REGISTRY.with(|registry| {
+        registry
+            .borrow()
+            .get(&id)
+            .map(|state| state.destroyed)
+            .unwrap_or(false)
+    });
+    maybe_close_stream(id, force);
 }
 
 pub(crate) extern "C" fn write_stream_write_impl(
@@ -866,57 +1159,86 @@ pub(crate) extern "C" fn write_stream_write_impl(
     encoding: f64,
     cb: f64,
 ) -> f64 {
-    use crate::closure::js_closure_call0;
     let id = stream_id_of(closure);
     let (chunk_value, callback) = normalize_write_args(chunk, encoding, cb);
     let Some(chunk_value) = chunk_value else {
-        if let Some(callback) = callback {
-            let cb_ptr = extract_closure_ptr(callback);
-            if !cb_ptr.is_null() {
-                js_closure_call0(cb_ptr);
-            }
-        }
+        call_stream_callback0(callback.unwrap_or_else(undefined_value));
         return bool_value(true);
     };
+    // Decoding the chunk can allocate; the callback outlives that.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let callback = scope.root_nanbox_f64(callback.unwrap_or_else(undefined_value));
     let bytes = bytes_from_value(chunk_value);
-    let (should_return, should_write) = STREAM_REGISTRY.with(|registry| {
+    // #9493: accept the chunk into the queue and answer the back-pressure
+    // question from the queued length, as Node does; the write itself runs on
+    // a later turn.
+    let accepted = STREAM_REGISTRY.with(|registry| {
         let mut registry = registry.borrow_mut();
-        let Some(state) = registry.get_mut(&id) else {
-            return (true, false);
-        };
-        if state.kind != StreamKind::Write || state.finished || state.destroyed {
-            return (false, false);
+        let state = registry.get_mut(&id)?;
+        if state.kind != StreamKind::Write || state.ended || state.destroyed || state.closed {
+            return None;
         }
         state.writable_length = state.writable_length.saturating_add(bytes.len());
         let over_hwm = state.writable_length >= state.high_water_mark;
         if over_hwm {
             state.writable_need_drain = true;
         }
-        update_common_props(state);
-        (!over_hwm, true)
-    });
-    if should_write {
-        if let Err(message) = write_to_stream_fd(id, &bytes) {
-            record_stream_error(id, message);
-        }
-    }
-    if should_return {
-        STREAM_REGISTRY.with(|registry| {
-            if let Some(state) = registry.borrow_mut().get_mut(&id) {
-                state.writable_length = 0;
-                update_common_props(state);
-            }
+        state.pending_writes.push(PendingWrite {
+            bytes,
+            callback: callback.get_nanbox_f64(),
         });
+        update_common_props(state);
+        Some(!over_hwm)
+    });
+    let Some(below_hwm) = accepted else {
+        // Refused (write after `end()`, or a destroyed/closed stream). Node
+        // still completes the callback — on a later turn, with
+        // `ERR_STREAM_WRITE_AFTER_END` / `ERR_STREAM_DESTROYED` — and that is
+        // what a caller can be waiting on. (Node also emits `'error'` for a
+        // write after end; not done here, so a formerly silent divergence
+        // cannot become an unhandled-`'error'` crash.)
+        schedule_rejected_write_callback(id, callback.get_nanbox_f64());
+        return bool_value(false);
+    };
+    schedule_write_stream_turn(id);
+    bool_value(below_hwm)
+}
+
+/// Park `callback(err)` for a refused `write()` on the next turn (#9493).
+fn schedule_rejected_write_callback(id: usize, callback: f64) {
+    if !is_callable_value(callback) {
+        return;
+    }
+    let destroyed = STREAM_REGISTRY.with(|registry| {
+        registry
+            .borrow()
+            .get(&id)
+            .map(|state| state.destroyed || state.closed)
+            .unwrap_or(true)
+    });
+    let (message, code) = if destroyed {
+        (
+            "Cannot call write after a stream was destroyed",
+            "ERR_STREAM_DESTROYED",
+        )
     } else {
-        schedule_drain(id);
-    }
-    if let Some(callback) = callback {
-        let cb_ptr = extract_closure_ptr(callback);
-        if !cb_ptr.is_null() {
-            js_closure_call0(cb_ptr);
-        }
-    }
-    bool_value(should_return)
+        ("write after end", "ERR_STREAM_WRITE_AFTER_END")
+    };
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let callback = scope.root_nanbox_f64(callback);
+    let err = scope.root_nanbox_f64(make_error_value(message));
+    set_object_field_str(err.get_nanbox_f64(), b"code", code);
+    let closure = js_closure_alloc(rejected_write_callback_impl as *const u8, 2);
+    crate::closure::js_closure_set_capture_f64(closure, 0, callback.get_nanbox_f64());
+    crate::closure::js_closure_set_capture_f64(closure, 1, err.get_nanbox_f64());
+    let _ = crate::timer::js_set_timeout_callback(closure as i64, 0.0);
+}
+
+extern "C" fn rejected_write_callback_impl(closure: *const ClosureHeader) -> f64 {
+    let callback = crate::closure::js_closure_get_capture_f64(closure, 0);
+    let err = crate::closure::js_closure_get_capture_f64(closure, 1);
+    call_stream_callback1(callback, err);
+    undefined_value()
 }
 
 pub(crate) extern "C" fn write_stream_end_impl(
@@ -925,43 +1247,41 @@ pub(crate) extern "C" fn write_stream_end_impl(
     encoding: f64,
     cb: f64,
 ) -> f64 {
-    use crate::closure::js_closure_call0;
     let id = stream_id_of(closure);
     let (chunk_value, callback) = normalize_write_args(chunk, encoding, cb);
-    if let Some(chunk_value) = chunk_value {
-        let bytes = bytes_from_value(chunk_value);
-        if let Err(message) = write_to_stream_fd(id, &bytes) {
-            record_stream_error(id, message);
-        }
-    }
-    flush_write_drain(id);
-    let should_finish = STREAM_REGISTRY.with(|registry| {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let callback = scope.root_nanbox_f64(callback.unwrap_or_else(undefined_value));
+    let bytes = chunk_value.map(bytes_from_value);
+    let accepted = STREAM_REGISTRY.with(|registry| {
         let mut registry = registry.borrow_mut();
         let Some(state) = registry.get_mut(&id) else {
             return false;
         };
-        if state.finished {
+        if state.kind != StreamKind::Write || state.ended || state.destroyed || state.closed {
             return false;
         }
-        state.ended = true;
-        state.finished = state.error_msg.is_none();
-        state.writable_length = 0;
-        state.writable_need_drain = false;
-        update_common_props(state);
-        state.error_msg.is_none()
-    });
-    if should_finish {
-        if let Some(callback) = callback {
-            let cb_ptr = extract_closure_ptr(callback);
-            if !cb_ptr.is_null() {
-                js_closure_call0(cb_ptr);
+        if let Some(bytes) = bytes {
+            if !bytes.is_empty() {
+                state.writable_length = state.writable_length.saturating_add(bytes.len());
+                state.pending_writes.push(PendingWrite {
+                    bytes,
+                    callback: undefined_value(),
+                });
             }
         }
-        emit_event0(id, "finish");
+        state.ended = true;
+        state.end_callback = callback.get_nanbox_f64();
+        update_common_props(state);
+        true
+    });
+    if accepted {
+        // #9493: `'finish'` and the callback land once the queue has drained,
+        // on a later turn — `writableEnded` flips now, `writableFinished`
+        // then, as in Node.
+        schedule_write_stream_turn(id);
     } else {
         emit_stored_error(id);
     }
-    maybe_close_stream(id, false);
     current_receiver_value()
 }
 
@@ -1015,6 +1335,9 @@ pub(crate) extern "C" fn write_stream_close_impl(closure: *const ClosureHeader, 
     STREAM_REGISTRY.with(|registry| {
         if let Some(state) = registry.borrow_mut().get_mut(&id) {
             state.destroyed = true;
+            state.pending_writes.clear();
+            state.writable_length = 0;
+            state.writable_need_drain = false;
             update_common_props(state);
         }
     });
@@ -1331,23 +1654,39 @@ pub(crate) extern "C" fn read_stream_close_impl(closure: *const ClosureHeader, c
 
 fn stream_on_common(id: usize, event_value: f64, cb: f64, once: bool) {
     let event = event_name(event_value);
+    if event == "error" {
+        // A late `'error'` listener replays the stored error; the value is
+        // built outside the registry borrow (see `StoredError`).
+        let stored =
+            STREAM_REGISTRY.with(|registry| registry.borrow().get(&id).and_then(stored_error));
+        if let Some(stored) = stored {
+            let err = stored_error_value(stored);
+            call_stream_callback1(cb, err);
+            return;
+        }
+        add_listener(id, &event, cb, once);
+        return;
+    }
     let immediate = STREAM_REGISTRY.with(|registry| {
         let registry = registry.borrow();
         let Some(state) = registry.get(&id) else {
             return None;
         };
         match event.as_str() {
+            // A read stream still opens eagerly, so its `'open'`/`'ready'` are
+            // replayed to the listeners attached right after construction. A
+            // write stream opens on a later turn (#9493) and emits them for
+            // real; Node never fires either for a supplied fd.
             "open"
-                if state.opened
+                if state.kind == StreamKind::Read
+                    && state.opened
                     && !matches!(state.owner, FdOwner::External | FdOwner::FileHandle(_)) =>
             {
                 state.fd.map(|fd| ("open", fd as f64))
             }
-            "ready" if state.opened => Some(("ready", undefined_value())),
-            "error" => state
-                .error_msg
-                .as_deref()
-                .map(|message| ("error", make_error_value(message))),
+            "ready" if state.kind == StreamKind::Read && state.opened => {
+                Some(("ready", undefined_value()))
+            }
             "end" if state.kind == StreamKind::Read && state.ended => {
                 Some(("end", undefined_value()))
             }
@@ -1362,7 +1701,7 @@ fn stream_on_common(id: usize, event_value: f64, cb: f64, once: bool) {
         if is_callable_value(cb) {
             let cb_ptr = extract_closure_ptr(cb);
             if !cb_ptr.is_null() {
-                if name == "open" || name == "error" {
+                if name == "open" {
                     crate::closure::js_closure_call1(cb_ptr, arg);
                 } else {
                     crate::closure::js_closure_call0(cb_ptr);
@@ -1399,7 +1738,8 @@ fn register_stream_method_arities() {
     crate::closure::js_register_closure_arity(write_stream_once_impl as *const u8, 2);
     crate::closure::js_register_closure_arity(write_stream_close_impl as *const u8, 1);
     crate::closure::js_register_closure_arity(stream_emit_impl as *const u8, 2);
-    crate::closure::js_register_closure_arity(write_stream_drain_timer_impl as *const u8, 0);
+    crate::closure::js_register_closure_arity(write_stream_turn_impl as *const u8, 0);
+    crate::closure::js_register_closure_arity(rejected_write_callback_impl as *const u8, 0);
     crate::closure::js_register_closure_arity(read_stream_on_impl as *const u8, 2);
     crate::closure::js_register_closure_arity(read_stream_once_impl as *const u8, 2);
     crate::closure::js_register_closure_arity(read_stream_pipe_impl as *const u8, 2);
@@ -1526,20 +1866,16 @@ fn init_write_state_from_options(
         return state;
     }
 
-    let flag_value = make_flag_value(&state.flags);
-    match unsafe { fs_open_sync_result(path_value, flag_value) } {
-        Ok(fd) => {
-            state.fd = Some(fd);
-            state.owner = FdOwner::Path;
-            state.opened = true;
-            if matches!(state.flags.as_str(), "a" | "a+" | "ax" | "ax+") {
-                state.position = end_position_for_fd(fd);
-            }
-        }
-        Err((err, _path)) => {
-            state.error_msg = Some(err.to_string());
-        }
+    // #9493: Node's constructor validates the path and opens it on a later
+    // turn (`_construct` → `fs.open` on the pool): `fd` stays `null` and
+    // `pending` true until then, and a `process.exit()` in this tick leaves
+    // no file behind. The throwing validation stays here, on the calling
+    // turn; `write_stream_open_step` performs the open.
+    crate::fs::validate::validate_path("path", path_value);
+    if let Some(decoded) = unsafe { decode_path_value(path_value) } {
+        state.path = decoded;
     }
+    state.owner = FdOwner::Path;
     state
 }
 
@@ -1602,7 +1938,17 @@ fn create_write_stream_with_state(state: StreamState) -> f64 {
             update_common_props(state);
         }
     });
-    value
+    // #9493: a path-owned stream opens on the next turn. Scheduling allocates
+    // the turn closure, so the object is re-read from its rooted slot rather
+    // than from the local that created it.
+    schedule_next_write_stream_step(id);
+    STREAM_REGISTRY.with(|registry| {
+        registry
+            .borrow()
+            .get(&id)
+            .map(|state| state.object_value)
+            .unwrap_or(value)
+    })
 }
 
 fn create_read_stream_with_state(state: StreamState) -> f64 {

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -55,6 +55,11 @@ use event_emitter::{
 pub(crate) fn emit_to_stream_listeners(stream: f64, event: &[u8], args: &[f64]) {
     let _ = emit_stream_event(stream, string_value(event), args);
 }
+
+/// Whether node:stream's registry holds a listener for `event` on `stream`.
+pub(crate) fn has_stream_listeners(stream: f64, event: &[u8]) -> bool {
+    event_emitter::has_stream_listeners(stream, string_value(event))
+}
 // #3049 — `process.setMaxListeners` reuses the EventEmitter setter
 // validation (TypeError/RangeError + fractional/Infinity storage).
 pub(crate) use event_emitter::validate_max_listeners;

--- a/crates/perry-runtime/src/node_stream_event_emitter.rs
+++ b/crates/perry-runtime/src/node_stream_event_emitter.rs
@@ -733,6 +733,14 @@ pub(super) fn emit_stream_event_from_array(
     emit_stream_event(stream, event, &args)
 }
 
+/// #9493: whether `stream` has a listener for `event` in THIS registry. The
+/// fs-stream bridge asks before forwarding an `'error'` its own registry has
+/// already delivered, so the unhandled-error throw below fires only when
+/// neither registry had a listener.
+pub(super) fn has_stream_listeners(stream: f64, event: f64) -> bool {
+    event_identity_bytes(event).is_some() && !listener_snapshot(stream, event).is_empty()
+}
+
 pub(super) fn emit_stream_event(stream: f64, event: f64, args: &[f64]) -> f64 {
     if event_identity_bytes(event).is_none() {
         return f64::from_bits(super::TAG_FALSE);

--- a/test-files/test_gap_9493_child_stdin_backpressure.ts
+++ b/test-files/test_gap_9493_child_stdin_backpressure.ts
@@ -1,0 +1,144 @@
+// #9493: `child.stdin.write()` did a blocking `write_all` into the pipe. Node
+// (libuv `uv_try_write`) commits what the pipe accepts right now, queues the
+// remainder for the loop, returns `writableLength < writableHighWaterMark`,
+// and emits `'drain'` once the queue empties. Perry therefore (a) parked the
+// main thread on a full pipe until the child read, (b) always returned `true`
+// and never emitted `'drain'` — the MCP stdio client waits on exactly that
+// pair — and (c) at `process.exit()` committed every byte, where Node commits
+// only the pipe-capacity prefix and abandons the rest.
+//
+// Byte counts are platform-dependent (pipe/socketpair capacity), so the
+// silent roles report a CLASSIFICATION: `none`, `partial` or `full`. The
+// grandchild sleeps before reading so the pipe cannot drain during the write,
+// and drops a marker file once its copy is done; the parent waits for it.
+//
+// Byte-for-byte against `node --experimental-strip-types`.
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { spawn } from "node:child_process";
+
+const ROLE_ENV = "PERRY_9493_STDIN_ROLE";
+const FILE_ENV = "PERRY_9493_STDIN_FILE";
+const WATCHDOG_MS = 8000;
+const BIG = 4 * 1024 * 1024;
+
+const role = process.env[ROLE_ENV] ?? "";
+const target = process.env[FILE_ENV] ?? "";
+
+const shq = (s: string) => "'" + s.replace(/'/g, "'\\''") + "'";
+const sink = (delay: string) =>
+  spawn("sh", ["-c", "sleep " + delay + "; cat > " + shq(target) + "; echo done > " + shq(target + ".done")], {
+    stdio: ["pipe", "ignore", "ignore"],
+  });
+
+if (role === "stdin-small-exit") {
+  // Fits the pipe: committed synchronously in both engines, exit or not.
+  const c = sink("0");
+  c.stdin.write("hello\n");
+  process.exit(0);
+} else if (role === "stdin-big-exit") {
+  // Larger than the pipe: only the try-write prefix lands; the queued
+  // remainder is abandoned by the exit.
+  const c = sink("0.5");
+  c.stdin.write(Buffer.alloc(BIG, 120));
+  process.exit(0);
+} else if (role === "stdin-big-end-exit") {
+  // `end()` behind queued bytes must not close the pipe ahead of them, and
+  // the exit still abandons what was queued.
+  const c = sink("0.5");
+  c.stdin.write(Buffer.alloc(BIG, 120));
+  c.stdin.end();
+  process.exit(0);
+} else if (role === "stdin-natural") {
+  // CONTROL: no exit. The queue drains once the child reads; `end()` closes
+  // the pipe only after the last byte, so the child sees all of them.
+  const c = sink("0.5");
+  c.stdin.write(Buffer.alloc(BIG, 120));
+  c.stdin.end();
+} else if (role === "stdin-backpressure") {
+  const c = spawn("sh", ["-c", "sleep 0.3; cat > /dev/null"], { stdio: ["pipe", "ignore", "ignore"] });
+  console.log("hwm=" + c.stdin.writableHighWaterMark + " len=" + c.stdin.writableLength);
+  c.stdin.on("drain", () => {
+    console.log("drain len=" + c.stdin.writableLength + " needDrain=" + c.stdin.writableNeedDrain);
+    c.stdin.end(() => console.log("end-cb"));
+  });
+  const w1 = c.stdin.write(Buffer.alloc(BIG, 120), () => console.log("cb1"));
+  console.log("w1=" + w1 + " queued=" + (c.stdin.writableLength > 0) + " needDrain=" + c.stdin.writableNeedDrain);
+  const w2 = c.stdin.write("tail\n", () => console.log("cb2"));
+  console.log("w2=" + w2);
+  c.on("close", (code) => console.log("child close " + code));
+  console.log("sync done");
+} else if (role === "stdin-small-write-callback") {
+  // CONTROL: the pre-#9493 completion path — a small write returns `true`
+  // and its callback still fires on a later turn, before the child's data.
+  const c = spawn("sh", ["-c", "cat"], { stdio: ["pipe", "pipe", "ignore"] });
+  let out = "";
+  c.stdout.on("data", (d: Buffer) => { out += d.toString(); });
+  c.on("close", () => console.log("echoed " + JSON.stringify(out)));
+  const w = c.stdin.write("ping\n", () => console.log("cb"));
+  console.log("w=" + w + " len=" + c.stdin.writableLength);
+  c.stdin.end();
+  console.log("sync done");
+} else {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "perry9493stdin-"));
+  const childArgs = [...process.execArgv, ...process.argv.slice(1)];
+
+  const waitForMarker = (marker: string) =>
+    new Promise<boolean>((resolve) => {
+      const deadline = Date.now() + WATCHDOG_MS;
+      const poll = () => {
+        if (fs.existsSync(marker)) return resolve(true);
+        if (Date.now() > deadline) return resolve(false);
+        setTimeout(poll, 20);
+      };
+      poll();
+    });
+
+  const runRole = (name: string, silent: boolean) =>
+    new Promise<void>((resolve) => {
+      const file = path.join(tmpDir, name + ".txt");
+      if (!silent) console.log("== " + name);
+      const child = spawn(process.execPath, childArgs, {
+        env: { ...process.env, [ROLE_ENV]: name, [FILE_ENV]: file },
+        stdio: ["ignore", "inherit", "inherit"],
+      });
+      let settled = false;
+      const report = async (code: number | null | string) => {
+        if (silent) {
+          const landed = (await waitForMarker(file + ".done")) && fs.existsSync(file)
+            ? fs.statSync(file).size
+            : -1;
+          const total = name === "stdin-small-exit" ? 6 : BIG;
+          const kind = landed < 0 ? "no-marker" : landed === 0 ? "none" : landed >= total ? "full" : "partial";
+          console.log(name + " exit=" + code + " landed=" + kind);
+        } else {
+          console.log(name + " exit=" + code);
+        }
+        resolve();
+      };
+      const watchdog = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        child.kill("SIGKILL");
+        void report("WATCHDOG");
+      }, WATCHDOG_MS);
+      child.on("exit", (code) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(watchdog);
+        void report(code);
+      });
+    });
+
+  (async () => {
+    await runRole("stdin-small-exit", true);
+    await runRole("stdin-big-exit", true);
+    await runRole("stdin-big-end-exit", true);
+    await runRole("stdin-natural", true);
+    await runRole("stdin-backpressure", false);
+    await runRole("stdin-small-write-callback", false);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    console.log("done");
+  })();
+}

--- a/test-files/test_gap_9493_console_clear_tty.ts
+++ b/test-files/test_gap_9493_console_clear_tty.ts
@@ -1,0 +1,83 @@
+// #9493: `console.clear()` wrote its escape fragment into Rust's line-buffered
+// stdout; with no newline behind it, a `process.exit()` (which terminates via
+// `_exit`, no flush) swallowed it. Node's TTY writes are synchronous. The
+// fragment also differed: Node emits `cursorTo(0, 0)` + `clearScreenDown()`
+// (`\x1b[1;1H\x1b[0J`), and only when stdout is a TTY and `TERM` is not
+// `dumb`.
+//
+// Roles run under a pseudo-terminal (python's `pty.spawn` — `script(1)`
+// needs a real tty on ITS stdin, which a test harness does not have); the
+// parent prints the captured bytes, `\r` stripped, as JSON. Byte-for-byte
+// against `node --experimental-strip-types`. Skipped as a whole on win32
+// (both engines print the same line).
+import { spawn } from "node:child_process";
+
+const ROLE_ENV = "PERRY_9493_CLEAR_ROLE";
+const WATCHDOG_MS = 5000;
+const role = process.env[ROLE_ENV] ?? "";
+
+if (role === "clear-exit") {
+  console.clear();
+  process.exit(0);
+} else if (role === "log-clear-exit") {
+  console.log("before");
+  console.clear();
+  process.exit(0);
+} else if (role === "clear-natural") {
+  console.clear();
+  console.log("after");
+} else if (role === "clear-dumb-term") {
+  console.clear();
+  console.log("dumb");
+} else if (role === "clear-piped") {
+  console.clear();
+  console.log("piped");
+} else if (process.platform === "win32") {
+  console.log("pty roles skipped on win32");
+  console.log("done");
+} else {
+  const childArgs = [...process.execArgv, ...process.argv.slice(1)];
+  const PTY = "import pty, sys, os\nst = pty.spawn(sys.argv[1:])\nsys.exit(os.waitstatus_to_exitcode(st))\n";
+
+  const runRole = (name: string, term: string, viaPty: boolean) =>
+    new Promise<void>((resolve) => {
+      const env = { ...process.env, [ROLE_ENV]: name, TERM: term };
+      const child = viaPty
+        ? spawn("python3", ["-c", PTY, process.execPath, ...childArgs], { env, stdio: ["ignore", "pipe", "inherit"] })
+        : spawn(process.execPath, childArgs, { env, stdio: ["ignore", "pipe", "inherit"] });
+      let out = "";
+      let settled = false;
+      child.stdout.on("data", (d: Buffer) => { out += d.toString("latin1"); });
+      const report = (code: number | null | string) => {
+        console.log(name + " exit=" + code + " out=" + JSON.stringify(out.replace(/\r/g, "")));
+        resolve();
+      };
+      const watchdog = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        child.kill("SIGKILL");
+        report("WATCHDOG");
+      }, WATCHDOG_MS);
+      child.on("close", (code) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(watchdog);
+        report(code);
+      });
+      child.on("error", (e: Error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(watchdog);
+        report("SPAWN-ERROR " + e.message);
+      });
+    });
+
+  (async () => {
+    await runRole("clear-exit", "xterm", true);
+    await runRole("log-clear-exit", "xterm", true);
+    await runRole("clear-natural", "xterm", true);
+    await runRole("clear-dumb-term", "dumb", true);
+    await runRole("clear-piped", "xterm", false);
+    console.log("done");
+  })();
+}

--- a/test-files/test_gap_9493_utf8_stream_exit_no_flush.ts
+++ b/test-files/test_gap_9493_utf8_stream_exit_no_flush.ts
@@ -1,0 +1,92 @@
+// #9493 (measured negative): the issue suspected `fs.Utf8Stream` lost buffered
+// data at `process.exit()` "that node does not have". Node 26.5.1 has no exit
+// flush either — a chunk held back by `minLength` is lost on an explicit exit
+// AND on a natural one; only `end()`, `flush()`/`flushSync()`, or a full
+// buffer commit it. So no exit flush was added: this fixture pins the oracle,
+// so that a later "flush on exit" cannot land as a parity improvement.
+//
+// Silent roles write to their own file; the parent reports what survived.
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { spawn } from "node:child_process";
+
+const ROLE_ENV = "PERRY_9493_U8_ROLE";
+const FILE_ENV = "PERRY_9493_U8_FILE";
+const WATCHDOG_MS = 5000;
+
+const role = process.env[ROLE_ENV] ?? "";
+const target = process.env[FILE_ENV] ?? "";
+
+// `minLength` well above the payload: the write is buffered, not flushed.
+const opts = () => ({ fd: fs.openSync(target, "w"), minLength: 4096 });
+
+if (role === "u8-exit") {
+  const s = new fs.Utf8Stream(opts());
+  s.write("hello\n");
+  process.exit(0);
+} else if (role === "u8-natural") {
+  // Lost in Node too: nothing flushes a below-`minLength` buffer at exit.
+  const s = new fs.Utf8Stream(opts());
+  s.write("hello\n");
+} else if (role === "u8-end-exit") {
+  // CONTROL: `end()` drains synchronously for an already-open fd.
+  const s = new fs.Utf8Stream(opts());
+  s.write("hello\n");
+  s.end();
+  process.exit(0);
+} else if (role === "u8-flushsync-on-exit") {
+  // CONTROL: the documented way to keep the data — an `'exit'` listener
+  // calling `flushSync()` (what pino's `on-exit-leak-free` hook does).
+  const s = new fs.Utf8Stream(opts());
+  s.write("hello\n");
+  process.on("exit", () => s.flushSync());
+  process.exit(0);
+} else if (role === "u8-full-buffer-exit") {
+  // CONTROL: a write that crosses `minLength` is committed before the exit.
+  const s = new fs.Utf8Stream(opts());
+  s.write("x".repeat(5000) + "\n");
+  process.exit(0);
+} else {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "perry9493u8-"));
+  const childArgs = [...process.execArgv, ...process.argv.slice(1)];
+
+  const runRole = (name: string) =>
+    new Promise<void>((resolve) => {
+      const file = path.join(tmpDir, name + ".txt");
+      const child = spawn(process.execPath, childArgs, {
+        env: { ...process.env, [ROLE_ENV]: name, [FILE_ENV]: file },
+        stdio: ["ignore", "inherit", "inherit"],
+      });
+      let settled = false;
+      const report = (code: number | null | string) => {
+        const lines = fs.existsSync(file)
+          ? fs.readFileSync(file, "utf8").split("\n").filter((l) => l.length > 0)
+          : [];
+        console.log(name + " exit=" + code + " records=" + lines.length);
+        resolve();
+      };
+      const watchdog = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        child.kill("SIGKILL");
+        report("WATCHDOG");
+      }, WATCHDOG_MS);
+      child.on("exit", (code) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(watchdog);
+        report(code);
+      });
+    });
+
+  (async () => {
+    await runRole("u8-exit");
+    await runRole("u8-natural");
+    await runRole("u8-end-exit");
+    await runRole("u8-flushsync-on-exit");
+    await runRole("u8-full-buffer-exit");
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    console.log("done");
+  })();
+}

--- a/test-files/test_gap_9493_write_stream_process_exit.ts
+++ b/test-files/test_gap_9493_write_stream_process_exit.ts
@@ -1,0 +1,163 @@
+// #9493: `fs.createWriteStream` was synchronous under the hood — the fd was
+// opened at construction and every `write()` did `seek`+`write_all` inline —
+// so a `process.exit()` in the same tick committed bytes Node abandons. Node
+// opens the file on a later turn (`_construct` → `fs.open` on the thread
+// pool) and each `write()` is a pool request; nothing has touched the disk
+// when the call returns, and an exit in the same tick leaves no file behind.
+//
+// The fix parks the open, the queued writes and the close on successive
+// event-loop turns — the #9442 mechanism (`fs/deferred.rs`). Byte-for-byte
+// against `node --experimental-strip-types`.
+//
+// Silent roles write only to their own file; the PARENT reports what
+// survived. Printing roles inherit stdout and pin the event ORDER: `'open'`
+// then `'ready'`, a microtask boundary, then the write callbacks, the `end()`
+// callback, `'finish'`, another microtask boundary, then `'close'`; a
+// supplied fd emits no `'open'`/`'ready'`; an open failure delivers the error
+// to every pending callback before `'error'`, then `'close'`.
+//
+// Controls that keep the fix from over-abandoning: `ws-natural` (no
+// `process.exit()` — the loop drains and every record lands), `ws-finish-exit`
+// (an exit from `'finish'` must find the bytes on disk), `ws-sync-control`.
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { spawn } from "node:child_process";
+
+const ROLE_ENV = "PERRY_9493_WS_ROLE";
+const FILE_ENV = "PERRY_9493_WS_FILE";
+const WATCHDOG_MS = 5000;
+
+const role = process.env[ROLE_ENV] ?? "";
+const target = process.env[FILE_ENV] ?? "";
+
+if (role === "ws-exit") {
+  // The reported repro: the open has not even happened yet.
+  const ws = fs.createWriteStream(target);
+  ws.write("a\nb\nc\n");
+  process.exit(0);
+} else if (role === "ws-end-exit") {
+  const ws = fs.createWriteStream(target);
+  ws.write("a\n");
+  ws.end("b\n");
+  process.exit(0);
+} else if (role === "ws-open-exit") {
+  // Exit from the `'open'` listener: the file exists (the open ran) but the
+  // queued write has not — writes are dispatched on a LATER turn.
+  const ws = fs.createWriteStream(target);
+  ws.write("a\nb\n");
+  ws.on("open", () => process.exit(0));
+} else if (role === "ws-fd-exit") {
+  // A supplied fd skips the open; the write is still a pool request.
+  const fd = fs.openSync(target, "w");
+  const ws = fs.createWriteStream(target, { fd });
+  ws.write("a\n");
+  process.exit(0);
+} else if (role === "ws-natural") {
+  // CONTROL: no `process.exit()`. The pending write keeps the loop alive and
+  // every record lands, even without `end()`.
+  const ws = fs.createWriteStream(target);
+  ws.write("a\nb\nc\n");
+} else if (role === "ws-finish-exit") {
+  // CONTROL: `'finish'` means the bytes are on disk.
+  const ws = fs.createWriteStream(target);
+  ws.end("x\ny\n");
+  ws.on("finish", () => process.exit(0));
+} else if (role === "ws-sync-control") {
+  fs.writeFileSync(target, "sync\n");
+  process.exit(0);
+} else if (role === "ws-order") {
+  const ws = fs.createWriteStream(target, { highWaterMark: 8 });
+  console.log("ctor fd=" + ws.fd + " pending=" + ws.pending);
+  ws.on("open", (fd: number) => console.log("open " + typeof fd + " pending=" + ws.pending));
+  ws.on("ready", () => {
+    console.log("ready");
+    Promise.resolve().then(() => console.log("microtask after ready"));
+  });
+  ws.on("drain", () => {
+    console.log("drain len=" + ws.writableLength + " needDrain=" + ws.writableNeedDrain);
+    ws.end("tail\n", () => console.log("end-cb"));
+  });
+  ws.on("finish", () => {
+    console.log("finish finished=" + ws.writableFinished + " bytesWritten=" + ws.bytesWritten);
+    Promise.resolve().then(() => console.log("microtask after finish"));
+  });
+  ws.on("close", () => console.log("close fd=" + ws.fd + " closed=" + ws.closed));
+  const w1 = ws.write("12345\n", () => console.log("cb1"));
+  console.log("w1=" + w1 + " len=" + ws.writableLength + " needDrain=" + ws.writableNeedDrain);
+  const w2 = ws.write("67890\n", () => console.log("cb2"));
+  console.log("w2=" + w2 + " len=" + ws.writableLength + " needDrain=" + ws.writableNeedDrain);
+  console.log("sync done ended=" + ws.writableEnded);
+} else if (role === "ws-fd-order") {
+  const fd = fs.openSync(target, "w");
+  const ws = fs.createWriteStream(target, { fd });
+  ws.on("open", () => console.log("open?!"));
+  ws.on("ready", () => console.log("ready?!"));
+  ws.on("finish", () => console.log("finish"));
+  ws.on("close", () => console.log("close"));
+  console.log("pending=" + ws.pending + " fd=" + typeof ws.fd);
+  ws.end("x\n", () => console.log("end-cb"));
+  console.log("sync done");
+} else if (role === "ws-open-error") {
+  const ws = fs.createWriteStream(path.join(target, "missing-dir", "x.txt"));
+  ws.on("error", (e: NodeJS.ErrnoException) => console.log("error " + e.code));
+  ws.on("close", () => console.log("close"));
+  ws.write("a\n", (e?: NodeJS.ErrnoException | null) => console.log("write-cb " + (e ? e.code : "ok")));
+  ws.end("b\n", (e?: NodeJS.ErrnoException | null) => console.log("end-cb " + (e ? e.code : "ok")));
+  console.log("sync done");
+} else {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "perry9493ws-"));
+  const childArgs = [...process.execArgv, ...process.argv.slice(1)];
+
+  const runRole = (name: string, silent: boolean) =>
+    new Promise<void>((resolve) => {
+      const file = path.join(tmpDir, name + ".txt");
+      if (!silent) console.log("== " + name);
+      const child = spawn(process.execPath, childArgs, {
+        env: { ...process.env, [ROLE_ENV]: name, [FILE_ENV]: file },
+        stdio: ["ignore", "inherit", "inherit"],
+      });
+      let settled = false;
+      const report = (code: number | null | string) => {
+        if (silent) {
+          // Existence is the issue's own observable (Node's exit-in-tick
+          // leaves NO file); records count what a committed write landed.
+          const exists = fs.existsSync(file);
+          const lines = exists
+            ? fs.readFileSync(file, "utf8").split("\n").filter((l) => l.length > 0)
+            : [];
+          console.log(name + " exit=" + code + " exists=" + exists + " records=" + lines.length);
+        } else {
+          console.log(name + " exit=" + code);
+        }
+        resolve();
+      };
+      const watchdog = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        child.kill("SIGKILL");
+        report("WATCHDOG");
+      }, WATCHDOG_MS);
+      child.on("exit", (code) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(watchdog);
+        report(code);
+      });
+    });
+
+  (async () => {
+    await runRole("ws-exit", true);
+    await runRole("ws-end-exit", true);
+    await runRole("ws-open-exit", true);
+    await runRole("ws-fd-exit", true);
+    await runRole("ws-natural", true);
+    await runRole("ws-finish-exit", true);
+    await runRole("ws-sync-control", true);
+    await runRole("ws-order", false);
+    await runRole("ws-fd-order", false);
+    await runRole("ws-open-error", false);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    console.log("done");
+  })();
+}

--- a/test-files/test_gap_9493_write_stream_process_exit_cjs.cts
+++ b/test-files/test_gap_9493_write_stream_process_exit_cjs.cts
@@ -1,0 +1,71 @@
+// #9493, CommonJS half. `fs.createWriteStream` must open and write on later
+// turns — so a `process.exit()` in the same tick leaves no file — in a `.cts`
+// module too: the fix lives in the runtime's stream, not in the ESM lowering,
+// and this fixture proves that rather than assuming it. See
+// test_gap_9493_write_stream_process_exit.ts for the full role set; this one
+// keeps the repro plus the two controls that stop a fix from over-abandoning.
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawn } = require("node:child_process");
+
+const ROLE_ENV = "PERRY_9493_WS_CJS_ROLE";
+const FILE_ENV = "PERRY_9493_WS_CJS_FILE";
+const WATCHDOG_MS = 5000;
+
+const role = process.env[ROLE_ENV] ?? "";
+const target = process.env[FILE_ENV] ?? "";
+
+if (role === "ws-exit") {
+  const ws = fs.createWriteStream(target);
+  ws.write("a\nb\nc\n");
+  process.exit(0);
+} else if (role === "ws-natural") {
+  const ws = fs.createWriteStream(target);
+  ws.write("a\nb\nc\n");
+} else if (role === "ws-finish-exit") {
+  const ws = fs.createWriteStream(target);
+  ws.end("x\ny\n");
+  ws.on("finish", () => process.exit(0));
+} else {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "perry9493wscjs-"));
+  const childArgs = [...process.execArgv, ...process.argv.slice(1)];
+
+  const runRole = (name: string) =>
+    new Promise<void>((resolve) => {
+      const file = path.join(tmpDir, name + ".txt");
+      const child = spawn(process.execPath, childArgs, {
+        env: { ...process.env, [ROLE_ENV]: name, [FILE_ENV]: file },
+        stdio: ["ignore", "inherit", "inherit"],
+      });
+      let settled = false;
+      const report = (code: number | null | string) => {
+        const exists = fs.existsSync(file);
+        const lines = exists
+          ? fs.readFileSync(file, "utf8").split("\n").filter((l: string) => l.length > 0)
+          : [];
+        console.log(name + " exit=" + code + " exists=" + exists + " records=" + lines.length);
+        resolve();
+      };
+      const watchdog = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        child.kill("SIGKILL");
+        report("WATCHDOG");
+      }, WATCHDOG_MS);
+      child.on("exit", (code: number | null) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(watchdog);
+        report(code);
+      });
+    });
+
+  (async () => {
+    await runRole("ws-exit");
+    await runRole("ws-natural");
+    await runRole("ws-finish-exit");
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    console.log("done");
+  })();
+}


### PR DESCRIPTION
Follow-up to #9442 / PR #9492, which fixed the four `fs.{promises.,}{writeFile,appendFile}` entry points that wrote synchronously. This PR takes the three places the issue lists, each **measured against node 26.5.1 first** — and one of the four items turned out to be a measured negative. Based on `main`; independent of #9492 in code (the deferral mechanism is that PR's `fs/deferred.rs` *shape* — a zero-delay callback timer: GC-rooted, a live event source, never ticked by `_exit` — reused, not imported).

## 1. `fs.createWriteStream` — open, writes and close on successive turns

**Before:** the fd was opened at construction and every `write()` did `seek`+`write_all` inline. `ws.write("a\nb\nc\n"); process.exit(0)` left a 6-byte file; node leaves **no file** (the open itself is a later-turn `_construct` → `fs.open` pool request).

**After:** the stream runs as one step per event-loop turn, each the analogue of one node thread-pool request:

| turn | does | emits |
|---|---|---|
| open | `open(2)` (path-owned streams only) | `'open'(fd)`, `'ready'` |
| drain | the queued writes (node batches them into one `writev`) | `'drain'` if a `write()` returned `false` and the stream is not ending, THEN the completed writes' callbacks (node's `afterWrite` order), then `end()`'s callback and `'finish'` |
| close | `close(2)` when `autoClose` | `'close'` |

`write()` answers the back-pressure question from the queued length as node does; `fd` stays `null` and `pending` true until the open; an open failure hands a node-shaped error (`.code`/`.syscall`/`.path`) to every pending callback, then `'error'`, then `'close'`. Path validation still throws on the calling turn. A supplied fd skips the open and emits no `'open'`/`'ready'` — the synchronous replay of those two events on `.on()` is now confined to read streams, which still open eagerly. Microtask boundaries fall where node's do (a microtask queued from `'open'` runs before the first write callback; one queued from `'finish'` runs before `'close'`).

## 2. `child.stdin.write()` — libuv's try-write, not a blocking `write_all`

**Measured, and it changes the framing:** node does **not** abandon a small `stdin.write()` at `process.exit()`. libuv's `uv_try_write` commits whatever the pipe accepts *synchronously* (`hello\n` lands, exit or not); only the remainder past pipe capacity is queued and abandoned. What diverged in perry was (a) the main thread parked on a full pipe until the child read — an LSP that stops reading hung the program, (b) `write()` always returned `true` and `'drain'` never fired, and (c) a large write was fully committed before an exit where node commits only the capacity prefix.

**After:** the try-write happens on the calling turn (a handshake-sized write — what the MCP stdio client sends, `if (stdin.write(json)) resolve(); else once('drain', resolve)` — is committed exactly as before, exit or not); the remainder goes to a per-child drain thread (`poll`+`write` on a `dup` of the now-`O_NONBLOCK` descriptor) and is reported back through the reactor's event queue as `StdinWritten`, which emits `'drain'` and then the queued callbacks in node's order, and performs the close an `end()` left pending — so a child never sees EOF ahead of data it was sent. Return value is `writableLength < writableHighWaterMark` (64 KiB, node's default); `writableLength`/`writableHighWaterMark`/`writableNeedDrain` are maintained on the stream. Windows keeps the blocking write (no `O_NONBLOCK` on pipe handles) and never queues.

What cc depends on here (checked in the bundle's sources): `hooks.ts` does `stdin.write(json + "\n"); stdin.end()` and the MCP SDK's `StdioClientTransport.send` uses the `write()` return value + `'drain'`. Both keep their behaviour: small writes complete synchronously and return `true`; a `false` is now always followed by `'drain'`. Overlap with #9485 is limited to `cp_method_stdin_write`/`cp_method_stdin_end` — this does not touch the child stdout delivery path that issue suspects.

## 3. `console.clear()` — node's bytes, flushed

The fragment sat in Rust's line-buffered stdout with no newline behind it, and `process.exit()` (`_exit`, no flush) swallowed it. It also wasn't node's sequence: node emits `cursorTo(0,0)` + `clearScreenDown()` = `\x1b[1;1H\x1b[0J`, only when stdout is a TTY and `TERM !== 'dumb'`. Now: that sequence, through the crate's own error-dropping `print!` (#9402), then an explicit flush — node's TTY writes are synchronous.

## 4. `fs.Utf8Stream` at exit — measured negative, no change

The issue: "buffers in memory with no exit flush — data loss on explicit exit that node does not have (its sync-flush-on-exit behaviour is documented)". Node 26.5.1 has **no exit flush**: a chunk held back by `minLength` is lost on an explicit exit *and* on a natural one; only `end()`, `flush()`/`flushSync()`, or crossing `minLength` commits it (the flush-on-exit people remember is pino's `on-exit-leak-free` hook, not the stream). Perry already matched. The fixture pins the oracle so a later "flush on exit" cannot land as a parity improvement.

## Verification

Byte-compared to `node --experimental-strip-types` (26.5.1) on Linux x86-64 (perrymaster), against the unfixed tree = the #9492 tip (`7742e6408c`), then after:

| fixture | unfixed | fixed |
|---|---|---|
| `test_gap_9493_write_stream_process_exit` | **parity_fail** — first line `ws-exit exit=0 exists=true records=3` vs node `exists=false records=0` | **pass** |
| `test_gap_9493_write_stream_process_exit_cjs` (.cts) | — | **pass** |
| `test_gap_9493_child_stdin_backpressure` | **parity_fail** — 4 MiB write + exit lands `full` (blocking `write_all`) vs node `partial`; `write()` never returns `false`, no `'drain'` | **pass** |
| `test_gap_9493_console_clear_tty` | **parity_fail** — `clear-exit out=""` vs node `"[1;1H[0J"` | **pass** |
| `test_gap_9493_utf8_stream_exit_no_flush` | pass (the negative) | **pass** |

Roles per surface: the `process.exit()` arm (must abandon / must keep what node keeps), the natural-exit arm (must land), the `'finish'`-ed arm (must land), the back-pressure observable (`write() === false` → `'drain'` → callbacks), plus the ordering, supplied-fd and open-error shapes for the write stream. The pty arm runs under python's `pty.spawn` (`script(1)` needs a tty on its own stdin, which a harness does not have); it prints a fixed line on win32.

Regression slices on the fixed tree (test-files filters `fs`/`stream`/`stdin`/`child_process`/`spawn`/`console`/`exit`/`timer`/`pipe`/`1934`, node-suite modules `fs`/`child_process`/`tty` + the `async_hooks` fs-streams integration): running on perrymaster as this opens — results follow in a comment.

Runtime unit tests (`cargo test --release -p perry-runtime --lib`, single-threaded, `fs::`/`child_process::`/`console`/`node_stream` filters): same — in the comment.

The before/after runs above were on the #9492 tip (`7742e6408c`, main − 4 + 2); the branch was then rebased onto `main` (`9a567aa14e`) with no conflicts, and a main-based rebuild + fixture re-run is queued behind the slices (comment to follow). Not run: the full 1400+ gap suite and the full perry-runtime lib suite — stated rather than implied. Opened without waiting on GitHub CI, per Ralph.

Closes #9493.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deferred file-stream opening and writing to prevent data from being committed after an immediate process exit.
  * Improved child-process stdin backpressure, draining, callback ordering, and completion behavior.
  * Updated `console.clear()` to match Node.js output and flushing behavior across terminal environments.
  * Improved stream error handling and event ordering.

* **Tests**
  * Added regression coverage for streams, child processes, terminals, and process-exit behavior against Node.js.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->