### PR TITLE
perf: narrow dispatch operand root windows

### DIFF
--- a/changelog.d/9480-dispatch-root-windows.md
+++ b/changelog.d/9480-dispatch-root-windows.md
@@ -1,0 +1,8 @@
+### Performance
+
+- Narrow instance-method dispatch temporary roots to each operand's actual
+  collection suffix. Ordinary calls no longer root the final heap argument or
+  operands followed only by the audited own-field/class-id probes, while
+  rest/synthetic argument construction and other post-argument work retain
+  their conservative protection. This removes the root-slot overhead added by
+  the #9479 soundness fix without weakening its moving-GC guarantee. (#9480)

--- a/crates/perry-codegen/src/gc_call_effects.rs
+++ b/crates/perry-codegen/src/gc_call_effects.rs
@@ -172,6 +172,20 @@ pub(crate) fn classify_direct_callee(name: &str) -> GcCallEffect {
         // `clean_arr_ptr` on a raw head: reads headers and the forwarding
         // registry, allocates nothing, never re-enters generated code.
         | "js_array_live_head"
+        // #9480 dispatch probes. `js_object_get_class_id` performs only
+        // address checks, Set/Map registry membership reads, validated GC
+        // header reads, and a scalar class-id load. `js_object_get_own_field_
+        // or_undef` validates an Object + its dense keys array, compares raw
+        // string slots, and reads the matching inline/overflow field. Its keys
+        // walk deliberately does NOT call the generic array accessors: their
+        // lazy/exotic/accessor paths would invalidate this certification.
+        // Neither call graph allocates in the Perry heap, polls, throws, or
+        // re-enters generated JS. Rust/TLS table initialization is system
+        // allocation and cannot arm Perry GC; both exports are `extern "C"`
+        // with no explicit panic path, so no unwind edge returns to generated
+        // code. Kept in the dominance checker and root-reload authorities.
+        | "js_object_get_class_id"
+        | "js_object_get_own_field_or_undef"
         // TLS dynamic-call context only. #8596 adds the `_get` reader — a bare
         // `IMPLICIT_THIS.with(|c| f64::from_bits(c.get()))` (`object/this_binding.rs`),
         // the exact shape of the already-admitted `_set` and `js_new_target_get`.
@@ -743,6 +757,31 @@ mod tests {
                 classify_direct_callee(name),
                 GcCallEffect::CannotCollect,
                 "{name}"
+            );
+        }
+    }
+
+    /// #9480: these are the only runtime calls between re-reading the
+    /// dispatch operands and the class/own-property branch that consumes
+    /// them. Their runtime bodies carry the full call-graph audit; pin both
+    /// the compiler classification and the checker's independent authority so
+    /// a future edit cannot silently reopen only one side of the window.
+    #[test]
+    fn dispatch_probe_helpers_cannot_collect_and_stay_in_checker_authority() {
+        let manifest = env!("CARGO_MANIFEST_DIR");
+        let py_path = format!("{manifest}/../../scripts/gc_root_dominance_check.py");
+        let py_src = std::fs::read_to_string(py_path).expect("read gc_root_dominance_check.py");
+        let noncollecting = extract_python_set(&py_src, "NONCOLLECTING");
+
+        for name in ["js_object_get_class_id", "js_object_get_own_field_or_undef"] {
+            assert_eq!(
+                classify_direct_callee(name),
+                GcCallEffect::CannotCollect,
+                "{name}"
+            );
+            assert!(
+                noncollecting.contains(name),
+                "{name} must stay in the root-dominance checker's NONCOLLECTING set"
             );
         }
     }

--- a/crates/perry-codegen/src/lower_call/property_get/dynamic_dispatch.rs
+++ b/crates/perry-codegen/src/lower_call/property_get/dynamic_dispatch.rs
@@ -354,14 +354,25 @@ pub(crate) fn try_lower_instance_method_call(
             // a collection point can reach, so the re-read is needed once here
             // rather than at each of the tower's ~dozen consumers.
             //
-            // The window is stated as "collects" unconditionally: the consuming
-            // calls (`js_native_call_method` / `js_native_call_value`) run user
-            // code, and the receiver is live across the override probe that
-            // precedes them, so the answer does not depend on the arguments.
-            // `operand_protection` still decides HOW each operand is protected, so
-            // a numeric or boolean argument pays nothing.
+            // #9480: state the window per operand. The receiver spans every
+            // argument; argument i spans only arguments i+1..N. The own-field
+            // and class-id probes below are certified GC leaves. Only work
+            // emitted after all source arguments (rest/`arguments` bundles or
+            // debug call-location bookkeeping) extends every window.
+            let collapse_dynamic = crate::codegen::full_outline_ic_enabled()
+                && method_dispatch_collapse_enabled()
+                && implementors
+                    .iter()
+                    .all(|(_, f)| !f.starts_with("perry_static_"));
+            let post_args_may_collect = ctx.strings.call_location_for(call_byte_offset).is_some()
+                || (!collapse_dynamic
+                    && impl_meta
+                        .iter()
+                        .any(|&(has_rest, has_synthetic, _, _)| has_rest || has_synthetic));
             let mut roots = crate::rooting::open_rooted_group(1 + args.len());
-            let recv_idx = roots.lower(ctx, object, true)?;
+            let recv_collects =
+                post_args_may_collect || crate::rooting::any_operand_may_collect(ctx, args.iter());
+            let recv_idx = roots.lower(ctx, object, recv_collects)?;
             // #1758 / epic #1785: the raw user args (no `this`, no issue-#235
             // padding, no rest-bundling) drive every concrete callee below. A
             // `perry_static_*` implementor (a class-object value reaching this
@@ -372,8 +383,10 @@ pub(crate) fn try_lower_instance_method_call(
             // args…)` direct call would pass recv as arg0 and never set
             // IMPLICIT_THIS (the #1787 broken-tower bug).
             let mut arg_idxs: Vec<usize> = Vec::with_capacity(args.len());
-            for a in args {
-                arg_idxs.push(roots.lower(ctx, a, true)?);
+            for (index, a) in args.iter().enumerate() {
+                let collects = post_args_may_collect
+                    || crate::rooting::any_operand_may_collect(ctx, args[index + 1..].iter());
+                arg_idxs.push(roots.lower(ctx, a, collects)?);
             }
             let recv_box = roots.reread(ctx, recv_idx)?;
             let mut static_user_args: Vec<String> = Vec::with_capacity(args.len());
@@ -390,12 +403,7 @@ pub(crate) fn try_lower_instance_method_call(
             // a `perry_static_*` class-object-static method, which needs
             // `js_class_static_method_call` and is NOT reproduced by the by-name
             // dispatcher. Mirrors the GET/SET/array-literal full-outline paths.
-            if crate::codegen::full_outline_ic_enabled()
-                && method_dispatch_collapse_enabled()
-                && implementors
-                    .iter()
-                    .all(|(_, f)| !f.starts_with("perry_static_"))
-            {
+            if collapse_dynamic {
                 let v = emit_collapsed_instance_dispatch(
                     ctx,
                     &recv_box,
@@ -923,39 +931,9 @@ pub(crate) fn try_lower_instance_method_call(
                 }
             }
 
-            // #9417, same defect as the dynamic-dispatch site above and for the
-            // same reason: the receiver is lowered first (JS evaluation order)
-            // and consumed by the override probe, the guarded direct calls and
-            // every arm of the class-id tower — all of it below the lowering of
-            // the argument expressions, any of which can drive an evacuating
-            // young-gen minor. `build_direct_method_args` additionally allocates
-            // a rest array between the re-read and the call.
-            //
-            // One `RootedGroup` over [receiver, ...args], re-read below the
-            // group. Every later use is a use of a register loaded out of a
-            // rooted slot, so `root_reload` re-derives the ones a collection
-            // point can reach — which is what makes a single re-read enough for
-            // a block with nine exits.
-            let mut roots = crate::rooting::open_rooted_group(1 + args.len());
-            let recv_idx = roots.lower(ctx, object, true)?;
-            let mut arg_idxs: Vec<usize> = Vec::with_capacity(args.len());
-            for a in args {
-                arg_idxs.push(roots.lower(ctx, a, true)?);
-            }
-            let recv_box = roots.reread(ctx, recv_idx)?;
-            let mut fallback_user_args: Vec<String> = Vec::with_capacity(args.len());
-            for &idx in &arg_idxs {
-                fallback_user_args.push(roots.reread(ctx, idx)?);
-            }
-            // #5391 path 4 (virtual tower): eligibility to collapse the
-            // per-overriding-subclass class-id switch to a single by-name
-            // dispatch (see the two return sites below). Requires overrides
-            // (the empty case is the compact override-check path) and no
-            // `perry_static_*` implementor (those need
-            // `js_class_static_method_call`). Computed up front so the
-            // rest-bearing case can return BEFORE the rest-array bundling below,
-            // which would otherwise materialize a dead js_array for the collapsed
-            // path (the by-name dispatch takes the raw, un-bundled args).
+            // Metadata needed to state #9480's post-argument window before
+            // lowering the receiver. Computing it emits no program IR, so JS
+            // evaluation order remains receiver-then-arguments.
             let can_collapse_virtual = crate::codegen::full_outline_ic_enabled()
                 && method_dispatch_collapse_enabled()
                 && !overrides.is_empty()
@@ -974,14 +952,86 @@ pub(crate) fn try_lower_instance_method_call(
                 Some(&true)
             );
             // `fallback_key.0` is the class the parent-chain walk resolved
-            // `property` to — the defining class, so #8162's user-rest bit is
-            // read off the body the fallback call reaches.
+            // `property` to: the defining class that owns #8162's user-rest
+            // bit and the arguments-length-only specialization metadata.
             let fallback_has_user_rest =
                 crate::codegen::arguments::method_has_user_rest(ctx, &fallback_key.0, property);
             let fallback_arguments_length_only = matches!(
                 ctx.method_arguments_length_only.get(&fallback_key),
                 Some(&true)
             );
+            let collapses_before_bundling = (fallback_has_rest
+                || override_meta.iter().any(|meta| meta.0))
+                && can_collapse_virtual;
+            // Even an `arguments.length`-only clone needs a real Arguments
+            // bundle on a guard miss / own-override route, so keep that
+            // fallback allocation in the window. The early collapse above is
+            // the only path that proves no direct bundle will be emitted.
+            let fallback_bundle_may_collect = fallback_has_rest || fallback_has_synthetic_arguments;
+            let any_bundle_may_collect = !collapses_before_bundling
+                && (fallback_bundle_may_collect
+                    || override_meta.iter().any(|meta| meta.0 || meta.1));
+            // Specialized direct paths can place typed-feedback/argument
+            // guards between the final source argument and its consuming
+            // method call. Those guards are outside #9480's two-helper audit,
+            // so retain the conservative window for those uncommon paths.
+            let typed_method_key = (class_name.clone(), property.to_string());
+            let has_specialized_guard = ctx.typed_f64_methods.contains(&typed_method_key)
+                || ctx.typed_i32_methods.contains(&typed_method_key)
+                || ctx.typed_i1_methods.contains(&typed_method_key)
+                || ctx.typed_string_methods.contains(&typed_method_key)
+                || ctx
+                    .classes
+                    .get(&class_name)
+                    .and_then(|class| {
+                        let class = *class;
+                        class
+                            .methods
+                            .iter()
+                            .find(|method| method.name == property)
+                            .and_then(|method| {
+                                crate::codegen::typed_f64_receiver_method_info(
+                                    class,
+                                    method,
+                                    ctx.classes,
+                                )
+                            })
+                    })
+                    .is_some();
+            let post_args_may_collect = any_bundle_may_collect
+                || has_specialized_guard
+                || (can_collapse_virtual
+                    && ctx.strings.call_location_for(call_byte_offset).is_some());
+
+            // #9417, same defect as the dynamic-dispatch site above and for the
+            // same reason: the receiver is lowered first (JS evaluation order)
+            // and consumed by the override probe, the guarded direct calls and
+            // every arm of the class-id tower — all of it below the lowering of
+            // the argument expressions, any of which can drive an evacuating
+            // young-gen minor. `build_direct_method_args` additionally allocates
+            // a rest array between the re-read and the call.
+            //
+            // One `RootedGroup` over [receiver, ...args], re-read below the
+            // group. #9480 protects each operand only when a later argument or
+            // an audited post-argument step can collect; `root_reload`
+            // re-derives rooted values after any remaining collection point.
+            // Rest/synthetic bundles, debug bookkeeping, and specialized
+            // guards retain the conservative post-argument window.
+            let mut roots = crate::rooting::open_rooted_group(1 + args.len());
+            let recv_collects =
+                post_args_may_collect || crate::rooting::any_operand_may_collect(ctx, args.iter());
+            let recv_idx = roots.lower(ctx, object, recv_collects)?;
+            let mut arg_idxs: Vec<usize> = Vec::with_capacity(args.len());
+            for (index, a) in args.iter().enumerate() {
+                let collects = post_args_may_collect
+                    || crate::rooting::any_operand_may_collect(ctx, args[index + 1..].iter());
+                arg_idxs.push(roots.lower(ctx, a, collects)?);
+            }
+            let recv_box = roots.reread(ctx, recv_idx)?;
+            let mut fallback_user_args: Vec<String> = Vec::with_capacity(args.len());
+            for &idx in &arg_idxs {
+                fallback_user_args.push(roots.reread(ctx, idx)?);
+            }
             // Keep the maximum declared arity only for selecting safe
             // shape-guarded/typed fast-path arms below. Direct calls no longer
             // share an ABI vector: the fallback and each virtual override are

--- a/crates/perry-codegen/src/root_reload.rs
+++ b/crates/perry-codegen/src/root_reload.rs
@@ -239,6 +239,12 @@ const NON_COLLECTING: &[&str] = &[
     "js_array_declare_all_pointer_elements",
     "js_array_live_head",
     "js_array_length",
+    // #9480 dispatch probes: validated header/registry/shape/slot reads only.
+    // Their keys walk bypasses the generic array accessors; neither helper
+    // allocates in the Perry heap, polls, throws, or re-enters generated JS.
+    // See the complete audit in `gc_call_effects.rs` and the runtime bodies.
+    "js_object_get_class_id",
+    "js_object_get_own_field_or_undef",
     "js_object_mark_class",
     "js_class_object_pin_parent",
     "js_new_target_get",

--- a/crates/perry-codegen/src/root_reload_tests.rs
+++ b/crates/perry-codegen/src/root_reload_tests.rs
@@ -83,6 +83,23 @@ fn a_non_collecting_window_is_left_byte_for_byte_alone() {
     assert_eq!(body(&f), before);
 }
 
+/// #9480: the dispatch probes sit after the operands' final re-read and before
+/// the branch that consumes them. Treating either as collecting would put the
+/// conservative reload/root window back into every dispatch tower.
+#[test]
+fn dispatch_probes_do_not_open_a_reload_window() {
+    for helper in ["js_object_get_class_id", "js_object_get_own_field_or_undef"] {
+        assert!(
+            NON_COLLECTING.contains(&helper),
+            "{helper} is missing from root_reload's leaf authority"
+        );
+        let before = body(&one_block(helper));
+        let mut f = one_block(helper);
+        assert_eq!(apply_to_function(&mut f), 0, "{helper}");
+        assert_eq!(body(&f), before, "{helper}");
+    }
+}
+
 #[test]
 fn guarded_indirect_leaf_call_does_not_reload_a_dead_on_collecting_return_handle() {
     let mut f = LlFunction::new("t", DOUBLE, vec![(DOUBLE, "%arg".into())]);

--- a/crates/perry-codegen/src/temp_root_coverage/dispatch_receiver.rs
+++ b/crates/perry-codegen/src/temp_root_coverage/dispatch_receiver.rs
@@ -25,21 +25,26 @@
 //! a shadow slot is a re-readable location that `root_reload` already re-derives,
 //! so a `LocalGet` receiver would pass against the unfixed compiler.
 //!
-//! The second test is the differential control on the other side: a numeric
-//! argument is not a heap reference, `operand_protection` answers `Reuse` for it,
-//! and it must still pay no slot. A fix that roots every operand unconditionally
-//! fails it.
+//! #9480 narrows that sound window per operand. The tests below pin the receiver
+//! across later allocating arguments, each argument across only its allocating
+//! suffix, the equivalent known-class tower, and the post-argument rest-bundle
+//! safety case. Numeric and final-argument controls fail a lowering that roots
+//! every operand unconditionally.
 
 use super::{allocating, entry_opts, under_both_lowerings};
-use crate::testing::temp_slots::{assert_rooted_across, first_call_result, temp_root_slots};
+use crate::testing::temp_slots::{
+    assert_rooted_across, first_call_result, temp_root_slot_holding, temp_root_slots,
+};
 use crate::{compile_module, AppMetadata, CompileOptions};
 use perry_hir::types::Type;
-use perry_hir::{Expr, Function, Module, Stmt};
+use perry_hir::{Expr, Function, Module, Param, Stmt};
 
 const MAKE_FN: u32 = 900;
 const TAGGED_CLASS: u32 = 901;
 const JOIN_FN: u32 = 902;
 const RECV_LOCAL: u32 = 903;
+const REST_LOCAL: u32 = 904;
+const TYPED_RECV_LOCAL: u32 = 905;
 
 fn empty_fn(id: u32, name: &str, return_type: Type) -> Function {
     Function {
@@ -99,17 +104,44 @@ fn tagged_class() -> perry_hir::Class {
     }
 }
 
+fn tagged_class_with_rest_method() -> perry_hir::Class {
+    let mut class = tagged_class();
+    class.methods[0].params.push(Param {
+        id: REST_LOCAL,
+        name: "values".to_string(),
+        ty: Type::Array(Box::new(Type::Any)),
+        default: None,
+        decorators: Vec::new(),
+        is_rest: true,
+        arguments_object: None,
+    });
+    class
+}
+
 /// `const r: any = makeTagged(); r.join(<arg>)` — but with the receiver INLINE
 /// in the call, so it is the call's result register and not a slot load.
 ///
 /// `makeTagged` returns `any`, so `receiver_class_name` cannot name a class and
 /// `needs_dynamic_dispatch` selects the tower.
-fn main_ir_for_dispatch(name: &str, arg: Expr) -> String {
+fn main_ir_for_dispatch(name: &str, args: Vec<Expr>) -> String {
+    main_ir_for_dispatch_case(name, args, Type::Any, false)
+}
+
+fn main_ir_for_dispatch_case(
+    name: &str,
+    args: Vec<Expr>,
+    receiver_type: Type,
+    method_has_rest: bool,
+) -> String {
     let mut module = Module::new(name);
-    module.classes.push(tagged_class());
+    module.classes.push(if method_has_rest {
+        tagged_class_with_rest_method()
+    } else {
+        tagged_class()
+    });
     module
         .functions
-        .push(empty_fn(MAKE_FN, "makeTagged", Type::Any));
+        .push(empty_fn(MAKE_FN, "makeTagged", receiver_type));
     // A named local so the module is not optimized down to nothing; the call's
     // receiver is still the inline `makeTagged()` result.
     module.init.push(Stmt::Let {
@@ -128,7 +160,7 @@ fn main_ir_for_dispatch(name: &str, arg: Expr) -> String {
                 property: "join".to_string(),
                 byte_offset: 0,
             }),
-            args: vec![arg],
+            args,
             type_args: Vec::new(),
             byte_offset: 0,
         }),
@@ -145,6 +177,55 @@ fn main_ir_for_dispatch(name: &str, arg: Expr) -> String {
     crate::testing::root_slots::function_slice(&ir, "main").to_string()
 }
 
+/// A declared `Tagged` local selects the known-class direct/virtual tower.
+fn main_ir_for_known_dispatch(name: &str, arg: Expr) -> String {
+    let mut module = Module::new(name);
+    module.classes.push(tagged_class());
+    module
+        .functions
+        .push(empty_fn(MAKE_FN, "makeTagged", Type::Any));
+    module.init.push(Stmt::Let {
+        id: TYPED_RECV_LOCAL,
+        name: "tagged".to_string(),
+        ty: Type::Named("Tagged".to_string()),
+        mutable: false,
+        init: Some(Expr::Call {
+            callee: Box::new(Expr::FuncRef(MAKE_FN)),
+            args: Vec::new(),
+            type_args: Vec::new(),
+            byte_offset: 0,
+        }),
+    });
+    module.init.push(Stmt::Let {
+        id: RECV_LOCAL,
+        name: "out".to_string(),
+        ty: Type::Any,
+        mutable: false,
+        init: Some(Expr::Call {
+            callee: Box::new(Expr::PropertyGet {
+                object: Box::new(Expr::LocalGet(TYPED_RECV_LOCAL)),
+                property: "join".to_string(),
+                byte_offset: 0,
+            }),
+            args: vec![arg],
+            type_args: Vec::new(),
+            byte_offset: 0,
+        }),
+    });
+    module.init.push(Stmt::Expr(Expr::LocalGet(RECV_LOCAL)));
+
+    let bytes = compile_module(
+        &module,
+        CompileOptions {
+            app_metadata: AppMetadata::default(),
+            ..entry_opts()
+        },
+    )
+    .unwrap_or_else(|e| panic!("codegen failed for {name}: {e}"));
+    let ir = String::from_utf8(bytes).expect("LLVM IR should be UTF-8");
+    crate::testing::root_slots::function_slice(&ir, "main").to_string()
+}
+
 /// THE GAP (#9417). The receiver is produced before the argument and consumed
 /// after it, so it must live in a rooted slot and the probe must read it back
 /// out of that slot.
@@ -155,7 +236,7 @@ fn main_ir_for_dispatch(name: &str, arg: Expr) -> String {
 #[test]
 fn a_dispatch_receiver_is_rooted_across_its_argument_list() {
     under_both_lowerings(|lowering| {
-        let ir = main_ir_for_dispatch("dispatch_receiver_rooted.ts", allocating());
+        let ir = main_ir_for_dispatch("dispatch_receiver_rooted.ts", vec![allocating()]);
         let producer = first_call_result(&ir, "perry_fn_dispatch_receiver_rooted_ts__makeTagged")
             .unwrap_or_else(|| {
                 panic!(
@@ -172,33 +253,128 @@ fn a_dispatch_receiver_is_rooted_across_its_argument_list() {
                  list, which allocates"
             ),
         );
+        let last_arg = first_call_result(&ir, "js_object_alloc").unwrap_or_else(|| {
+            panic!("{lowering}: allocating argument emitted no js_object_alloc:\n{ir}")
+        });
+        assert!(
+            temp_root_slot_holding(&ir, &last_arg).is_none(),
+            "{lowering}: #9480 — the final argument is consumed without an intervening \
+             collection point and must not pay a root slot; {last_arg} was rooted:\n{ir}"
+        );
     });
 }
 
-/// The control on the other side: a numeric argument is not a heap reference, so
-/// `operand_protection` answers `Reuse` and it costs no slot. Exactly one temp
-/// slot separates the two fixtures — the heap argument's.
+/// The control on the other side: with a non-collecting numeric argument, the
+/// receiver also has no collection window and the whole dispatch needs zero
+/// temp slots. The heap fixture needs exactly one: the receiver across that
+/// argument's allocation, never the final argument itself.
 ///
 /// Without this half, a lowering that roots every operand unconditionally would
 /// pass the test above and pay for it on every call in the program.
 #[test]
 fn a_numeric_dispatch_argument_still_pays_no_temp_slot() {
     under_both_lowerings(|lowering| {
-        let heap = main_ir_for_dispatch("dispatch_receiver_heap_arg.ts", allocating());
-        let numeric = main_ir_for_dispatch("dispatch_receiver_numeric_arg.ts", Expr::Integer(7));
+        let heap = main_ir_for_dispatch("dispatch_receiver_heap_arg.ts", vec![allocating()]);
+        let numeric =
+            main_ir_for_dispatch("dispatch_receiver_numeric_arg.ts", vec![Expr::Integer(7)]);
         let heap_slots = temp_root_slots(&heap).len();
         let numeric_slots = temp_root_slots(&numeric).len();
+        assert_eq!(
+            heap_slots,
+            numeric_slots + 1,
+            "{lowering}: the heap fixture adds only the receiver root; unrelated \
+             dispatch bookkeeping is shared (heap {heap_slots}, numeric {numeric_slots})"
+        );
+    });
+}
+
+/// The middle operand of `[receiver, first, second]` is protected across the
+/// second operand's allocation, while the second operand has an empty suffix
+/// and is reused directly. This pins the per-operand suffix computation rather
+/// than merely the one-argument special case.
+#[test]
+fn dispatch_arguments_use_their_individual_collection_suffixes() {
+    under_both_lowerings(|lowering| {
+        let ir = main_ir_for_dispatch(
+            "dispatch_argument_suffixes.ts",
+            vec![allocating(), allocating()],
+        );
+        let alloc_results: Vec<String> = ir
+            .lines()
+            .map(str::trim)
+            .filter_map(|line| line.split_once(" = "))
+            .filter(|(_, instruction)| {
+                instruction.starts_with("call ") && instruction.contains("@js_object_alloc(")
+            })
+            .map(|(result, _)| result.to_string())
+            .collect();
+        assert_eq!(
+            alloc_results.len(),
+            2,
+            "{lowering}: fixture must emit exactly two allocating arguments:\n{ir}"
+        );
         assert!(
-            heap_slots > 0,
-            "{lowering}: the heap-argument fixture must root something, or the \
-             comparison below is between two zeroes:\n{heap}"
+            temp_root_slot_holding(&ir, &alloc_results[0]).is_some(),
+            "{lowering}: first argument must be rooted across the second allocation:\n{ir}"
+        );
+        assert!(
+            temp_root_slot_holding(&ir, &alloc_results[1]).is_none(),
+            "{lowering}: final argument has an empty collection suffix and must not be rooted:\n{ir}"
+        );
+    });
+}
+
+/// #9479 covered the parallel known-class virtual/direct tower too. Its typed
+/// receiver still spans an allocating argument, but that final argument is
+/// consumed without another collection point and needs no slot of its own.
+#[test]
+fn known_class_dispatch_uses_the_same_suffix_windows() {
+    under_both_lowerings(|lowering| {
+        let heap = main_ir_for_known_dispatch("known_dispatch_heap_suffix.ts", allocating());
+        let numeric =
+            main_ir_for_known_dispatch("known_dispatch_numeric_suffix.ts", Expr::Integer(7));
+        assert!(
+            heap.contains("method_direct."),
+            "{lowering}: fixture did not select the known-class guarded tower:\n{heap}"
+        );
+        let argument = first_call_result(&heap, "js_object_alloc")
+            .unwrap_or_else(|| panic!("{lowering}: heap argument allocation missing:\n{heap}"));
+        assert!(
+            temp_root_slot_holding(&heap, &argument).is_none(),
+            "{lowering}: final typed-dispatch argument must not be rooted:\n{heap}"
         );
         assert_eq!(
-            numeric_slots,
-            heap_slots - 1,
-            "{lowering}: a numeric argument is provably not a heap reference and must \
-             pay no temp-root slot (heap fixture {heap_slots}, numeric fixture \
-             {numeric_slots})"
+            temp_root_slots(&heap).len(),
+            temp_root_slots(&numeric).len() + 1,
+            "{lowering}: only the receiver window may add a slot to known-class dispatch"
+        );
+    });
+}
+
+/// Rest adaptation allocates after the source arguments are evaluated. That
+/// explicitly extends every operand's window, including the final argument;
+/// this is the safety control for #9480's narrowed ordinary-call case.
+#[test]
+fn rest_dispatch_keeps_the_post_argument_window() {
+    under_both_lowerings(|lowering| {
+        let ordinary = main_ir_for_dispatch("ordinary_dispatch_window.ts", vec![allocating()]);
+        let ir = main_ir_for_dispatch_case(
+            "rest_dispatch_window.ts",
+            vec![allocating()],
+            Type::Any,
+            true,
+        );
+        let argument = first_call_result(&ir, "js_object_alloc")
+            .unwrap_or_else(|| panic!("{lowering}: heap argument allocation missing:\n{ir}"));
+        assert!(
+            temp_root_slot_holding(&ir, &argument).is_some(),
+            "{lowering}: rest-array construction follows the final argument, which must \
+             remain rooted across it:\n{ir}"
+        );
+        assert_eq!(
+            temp_root_slots(&ir).len(),
+            temp_root_slots(&ordinary).len() + 1,
+            "{lowering}: rest bundling must add the final argument's root"
         );
     });
 }

--- a/crates/perry-codegen/src/testing/temp_slots.rs
+++ b/crates/perry-codegen/src/testing/temp_slots.rs
@@ -485,6 +485,26 @@ pub fn temp_root_slots(fn_ir: &str) -> Vec<String> {
         .collect()
 }
 
+/// The pooled temporary-root slot holding `value`, if any.
+///
+/// Unlike [`slot_holding`], this excludes ordinary stack buffers and named
+/// locals. Dispatch calls marshal arguments into `alloca [N x double]`
+/// buffers after lowering, so using the broader helper for a negative rooting
+/// assertion mistakes that ABI store for GC protection.
+pub fn temp_root_slot_holding(fn_ir: &str, value: &str) -> Option<String> {
+    let defs = defs(fn_ir);
+    let temp_slots: std::collections::HashSet<String> =
+        temp_root_slots(fn_ir).into_iter().collect();
+    slot_traffic(fn_ir).into_iter().find_map(|(slot, events)| {
+        (temp_slots.contains(&slot)
+            && events.iter().any(|event| match event {
+                SlotEvent::Store { value: stored, .. } => derives_from(&defs, stored, value, 4),
+                _ => false,
+            }))
+        .then_some(slot)
+    })
+}
+
 /// No expression temporary was rooted in `fn_ir`: the #6996 / #6997 direction,
 /// where rooting a value that can never be collected is pure cost.
 ///

--- a/crates/perry-runtime/src/object/field_get_set/field_ops.rs
+++ b/crates/perry-runtime/src/object/field_get_set/field_ops.rs
@@ -192,6 +192,16 @@ pub extern "C" fn js_object_set_field(obj: *mut ObjectHeader, field_index: u32, 
 /// its `capacity` field. `js_set_alloc(0)` defaults capacity to 4, which
 /// collides with whichever user class lands at id 4, routing the call into the
 /// wrong method body and crashing on the bogus `this` pointer.
+///
+/// # Perry-GC leaf contract (#9480)
+///
+/// Codegen may keep dispatch operands in SSA across this probe. Its complete
+/// call graph is address-range checks, Set/Map registry membership reads, a
+/// validated `GcHeader` read, and the final scalar `class_id` load. Registry
+/// lookup can initialize/consult Rust TLS storage but cannot allocate in the
+/// Perry heap, poll its collector, invoke generated JavaScript, or throw. This
+/// is `extern "C"` (not `C-unwind`) and has no explicit panic/throw path, so it
+/// cannot unwind back into generated code.
 #[no_mangle]
 pub extern "C" fn js_object_get_class_id(obj: *const ObjectHeader) -> u32 {
     if crate::value::addr_class::is_handle_band(obj as usize) {

--- a/crates/perry-runtime/src/object/object_ops/accessors.rs
+++ b/crates/perry-runtime/src/object/object_ops/accessors.rs
@@ -104,6 +104,18 @@ unsafe fn lookup_accessor_annexb(this: f64, key: f64, want_getter: bool) -> f64 
 /// on first call). Distinct from `js_object_get_field_by_name` because it
 /// does NOT walk the class vtable's getter chain — we only want a raw own
 /// data-property read, not a side-effecting getter invocation.
+///
+/// # Perry-GC leaf contract (#9480)
+///
+/// Codegen keeps dispatch operands in SSA across this probe, so this helper
+/// must not allocate in the Perry heap, poll the collector, throw, or re-enter
+/// generated JavaScript. Keep the keys walk on the validated dense-array
+/// representation below: the generic `js_array_length` / `js_array_get`
+/// entry points have lazy/exotic/accessor paths and therefore cannot support
+/// that call-effect certification. Shape-table and overflow-table reads may
+/// initialize or consult Rust/TLS storage, but raw system allocation cannot
+/// arm Perry's collector. This is `extern "C"` (not `C-unwind`) and contains no
+/// explicit panic/throw path, so it cannot unwind back into generated code.
 #[no_mangle]
 pub extern "C" fn js_object_get_own_field_or_undef(
     obj_value: f64,
@@ -149,20 +161,30 @@ pub extern "C" fn js_object_get_own_field_or_undef(
         }
         let keys_gc =
             (keys as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
-        if (*keys_gc).obj_type != crate::gc::GC_TYPE_ARRAY {
+        if (*keys_gc).obj_type != crate::gc::GC_TYPE_ARRAY
+            || (*keys_gc).gc_flags & crate::gc::GC_FLAG_FORWARDED != 0
+        {
             return f64::from_bits(TAG_UNDEF);
         }
         let key_bytes = std::slice::from_raw_parts(name_ptr, name_len);
-        let key_count = crate::array::js_array_length(keys) as usize;
-        if key_count > 65536 {
+        // A shape descriptor's keys edge is a live, dense GC_TYPE_ARRAY. Read
+        // its representation directly so this leaf never enters the generic
+        // array accessors (which can materialize lazy arrays or dispatch an
+        // accessor). A forwarded edge is rejected above rather than resolved:
+        // the collector rewrites the descriptor's traced `keys` slot, so a
+        // live descriptor never legitimately retains the old stub.
+        let key_count = (*keys).length as usize;
+        if key_count > (*keys).capacity as usize || key_count > 65536 {
             return f64::from_bits(TAG_UNDEF);
         }
+        let key_slots =
+            (keys as *const u8).add(std::mem::size_of::<crate::array::ArrayHeader>()) as *const f64;
         let alloc_limit = std::cmp::max(
             crate::object::object_live_slot_count(obj),
             crate::object::INLINE_SLOT_FLOOR as u32,
         ) as usize;
         for i in 0..key_count {
-            let key_val = crate::array::js_array_get(keys, i as u32);
+            let key_val = crate::JSValue::from_bits((*key_slots.add(i)).to_bits());
             // #1781: SSO-aware match by byte slice — the
             // own-property-or-undef path was the route through which
             // hono's `c.req.X` dispatch decided to invoke the vtable

--- a/scripts/gc_root_dominance_check.py
+++ b/scripts/gc_root_dominance_check.py
@@ -511,6 +511,17 @@ NONCOLLECTING = {
     "js_tdz_suppress_begin", "js_tdz_suppress_end",  # box.rs:242/248 counter
     "js_array_note_numeric_write",                   # array/header.rs:1443
     "js_array_length",                               # array/indexing.rs:537
+    # #9480 dispatch probes. `js_object_get_class_id` is address checks,
+    # Set/Map registry membership reads, validated GcHeader reads, and one
+    # scalar load (object/field_get_set/field_ops.rs). The own-field helper
+    # validates an Object + live dense keys array, compares raw string slots,
+    # then reads the matching inline/overflow field
+    # (object/object_ops/accessors.rs). Its scan deliberately bypasses generic
+    # array accessors, whose lazy/exotic/accessor paths are not leaf-safe.
+    # Neither call graph allocates in the Perry heap, polls, throws, or enters
+    # generated JS. Rust/TLS table initialization cannot arm Perry GC; both
+    # exports are non-unwinding `extern "C"` with no explicit panic path.
+    "js_object_get_class_id", "js_object_get_own_field_or_undef",
     "js_object_mark_class", "js_class_object_pin_parent",
     "js_new_target_get", "js_new_target_set",
     # closure/unbox.rs:25 -- a tag check on the NaN-boxed callee and a low-48


### PR DESCRIPTION
## Summary

- narrow instance-method dispatch roots per operand: the receiver spans collecting arguments, while argument `i` spans only the collecting suffix after it
- retain the conservative window for rest/synthetic bundle construction, debug call-location work, and specialized guards outside this audit
- certify `js_object_get_own_field_or_undef` and `js_object_get_class_id` as Perry-GC leaves across the call-effect, reload, and dominance-check authorities
- make the own-field helper's keys scan structurally leaf-safe by reading its validated dense shape array directly
- add native-root and shadow-stack coverage for receiver, multi-argument suffix, known-class, final-argument, numeric, and rest-bundle cases

## GC leaf audit

Both helpers were audited over their complete runtime paths for Perry allocation, collector polling, generated-JS re-entry, throw, and unwind edges.

- `js_object_get_class_id`: address classification, Set/Map registry reads, validated GC-header read, scalar class-id load
- `js_object_get_own_field_or_undef`: validated object/shape/key-array reads, byte comparison, and inline/spill field lookup; it no longer calls the generic array accessors whose lazy/exotic/accessor paths prevent leaf certification
- Rust/TLS initialization may use the system allocator, which cannot arm Perry GC; both exports use non-unwinding `extern C` boundaries and contain no explicit throw path

## Verification

- `cargo check -p perry-codegen --lib`
- `cargo test -p perry-codegen dispatch_ --lib` — 17 passed
- `cargo test -p perry-runtime by_name_write_does_not_alias_the_backing_collection_field --lib`
- `cargo test -p perry-runtime test_object_alloc_and_fields --lib`
- `python scripts/gc_root_dominance_check.py --self-test`
- GC audits: `--audit-alloc-re`, `--audit-poll-capable`, `--audit-poll-reach`, `--audit-immovable-sources`
- `cargo fmt -p perry-codegen -p perry-runtime -- --check`
- `git diff --check`

The full `perry-codegen` library suite completed with 1,386 passed and 1 ignored. Its three remaining failures are Windows/platform-sensitive assertions outside the changed paths: one frameless-assembly assertion sees the Windows `%rbp` prologue, and two native-object byte-equality tests embed distinct temporary object paths. Each reproduced when rerun individually with one test thread.

No version bump is included; this uses a changelog fragment only.

Closes #9480

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved Windows method-dispatch performance by reducing unnecessary temporary value protection.
  * Optimized dispatch handling so values are protected only during operations that may require it.

* **Reliability**
  * Strengthened object and property dispatch checks to preserve safe behavior across dynamic, virtual, rest-argument, and known-class calls.
  * Improved handling of property access probes, including safer validation of key collections and object metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->