### PR TITLE
fix(hir): shadow native tags in destructured bindings

### DIFF
--- a/changelog.d/9512-destructured-native-shadowing.md
+++ b/changelog.d/9512-destructured-native-shadowing.md
@@ -1,0 +1,18 @@
+### Fixed
+
+- **Destructured locals no longer inherit native receiver metadata from an
+  unrelated same-named binding (#9487).** Perry retains native-instance
+  classifications by binding name so large minified bundles can route calls to
+  their native implementations. Simple declarations and parameters already
+  shadowed stale classifications, but destructuring leaves did not. A prior
+  `z = childProcess.spawnSync(...)` could therefore make a later, unrelated
+  `const { install: z } = command` lower `z.call(...)` as a `child_process`
+  native method rather than an ordinary JavaScript property call.
+
+  Object shorthand and every recursively lowered keyed, array, nested, and
+  rest leaf now apply the same native-instance tombstone as other fresh
+  bindings. In Claude Code 2.1.112 this restores the install completion
+  callback: the generated 64-hex `userID` is persisted and an invalid install
+  exits 1 instead of falling out naturally with status 0. A HIR regression
+  pins both keyed and shorthand binding hygiene, and the parity fixture checks
+  failed/successful exits plus serialized `userID` validity against Node.

--- a/crates/perry-hir/src/destructuring/pattern_binding.rs
+++ b/crates/perry-hir/src/destructuring/pattern_binding.rs
@@ -347,6 +347,14 @@ pub(crate) fn lower_pattern_binding_into(
     match pat {
         ast::Pat::Ident(ident) => {
             let name = ident.id.sym.to_string();
+            // A destructured leaf is a fresh lexical binding just like a
+            // simple `let`/`const` declarator. Minified bundles routinely
+            // reuse short names, so hide any native-instance classification
+            // left by an unrelated earlier binding before lowering uses of
+            // this local. Otherwise `{ install: z }` can inherit a prior
+            // `z = childProcess.spawn(...)` tag and misroute `z.call(...)`
+            // through child_process native dispatch.
+            ctx.shadow_native_instance_if_present(&name);
             let ty = ident
                 .type_ann
                 .as_ref()
@@ -616,6 +624,11 @@ pub(crate) fn lower_pattern_binding_into(
                     ast::ObjectPatProp::Assign(assign) => {
                         // Shorthand { key } or { key = default }
                         let name = assign.key.sym.to_string();
+                        // This arm creates its leaf directly rather than
+                        // recursing through `Pat::Ident`, so apply the same
+                        // native-instance hygiene here as for keyed, array,
+                        // rest, and nested destructuring leaves.
+                        ctx.shadow_native_instance_if_present(&name);
                         static_keys.push(name.clone());
                         if source_is_global_this {
                             if let Some(class_name) = global_this_constructor_alias(&name) {

--- a/crates/perry-hir/tests/destructured_binding_native_hygiene.rs
+++ b/crates/perry-hir/tests/destructured_binding_native_hygiene.rs
@@ -1,0 +1,61 @@
+use perry_diagnostics::SourceCache;
+use perry_hir::lower_module;
+use perry_parser::parse_typescript_with_cache;
+
+fn lower_result(src: &str) -> Result<perry_hir::Module, String> {
+    let src = src.to_string();
+    std::thread::Builder::new()
+        .stack_size(32 * 1024 * 1024)
+        .spawn(move || {
+            let mut cache = SourceCache::new();
+            let parsed = parse_typescript_with_cache(
+                &src,
+                "destructured_binding_native_hygiene.ts",
+                &mut cache,
+            )
+            .expect("parse should succeed");
+            lower_module(
+                &parsed.module,
+                "test",
+                "destructured_binding_native_hygiene.ts",
+            )
+            .map_err(|error| error.to_string())
+        })
+        .expect("spawn lower thread")
+        .join()
+        .expect("lower thread panicked")
+}
+
+#[test]
+fn destructured_bindings_shadow_stale_native_instance_names() {
+    let module = lower_result(
+        r#"
+        import * as childProcess from "node:child_process";
+
+        let z;
+        z = childProcess.spawnSync(process.execPath, ["--version"]);
+        function keyed(command) {
+            const { install: z } = command;
+            z.call(() => {}, {}, []);
+        }
+
+        let q;
+        q = childProcess.spawnSync(process.execPath, ["--version"]);
+        function shorthand(command) {
+            const { q } = command;
+            q.call(() => {}, {}, []);
+        }
+        "#,
+    )
+    .expect("destructured native-name collisions should lower");
+
+    let debug = format!("{module:#?}");
+    assert!(
+        debug.matches("property: \"call\"").count() >= 2,
+        "destructured receivers should keep ordinary property-call lowering: {debug}"
+    );
+    assert!(
+        !debug.contains("method: \"call\""),
+        "destructured receivers must not inherit child_process native dispatch: {debug}"
+    );
+}

--- a/test-files/test_gap_9487_async_process_exit_code.ts
+++ b/test-files/test_gap_9487_async_process_exit_code.ts
@@ -1,0 +1,98 @@
+import * as childProcess from "node:child_process";
+import * as fs from "node:fs";
+import { randomBytes } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const marker = "__perry_9487_exit_child__";
+const markerIndex = process.argv.indexOf(marker);
+
+// Minified bundles reuse short names aggressively. An earlier assignment from
+// a native module used to leave module-wide receiver metadata behind for `z`,
+// even though this branch is unreachable and the later destructured `z` is an
+// unrelated lexical binding.
+let z: unknown;
+if (false) z = childProcess.spawnSync(process.execPath, ["--version"]);
+
+function fillNursery(): object[] {
+  const retained: object[] = [];
+  for (let index = 0; index < 80_000; index++) {
+    retained.push({ index, label: "exit-" + index });
+  }
+  return retained;
+}
+
+async function runInstallCompletion(
+  message: string,
+  configPath: string,
+): Promise<void> {
+  const command = await Promise.resolve({
+    install: {
+      async call(
+        onDone: (result: string, metadata: object) => void,
+        _options: object,
+        _args: string[],
+      ): Promise<void> {
+        setTimeout(onDone, 0, message, { display: "system" });
+      },
+    },
+  });
+  const { install: z } = command;
+
+  await new Promise<void>((resolve) => {
+    z.call(
+      (result) => {
+        const retained = fillNursery();
+        const userID = randomBytes(32).toString("hex");
+        fs.writeFileSync(configPath, JSON.stringify({ migrationVersion: 11, userID }));
+        // Match Claude Code 2.1.112's ordering: resolve the outer promise, then
+        // synchronously terminate from the same callback.
+        resolve();
+        if (retained.length !== 80_000) process.exit(3);
+        process.exit(result.includes("failed") ? 1 : 0);
+      },
+      {},
+      [],
+    );
+  });
+}
+
+if (markerIndex >= 0) {
+  const outcome = process.argv[markerIndex + 1];
+  const configPath = process.argv[markerIndex + 2];
+  const message = outcome === "failure"
+    ? "Claude Code installation failed"
+    : "Claude Code installation completed successfully";
+  await runInstallCompletion(message, configPath);
+} else {
+  const script = process.argv[1];
+  const selfArgs = (outcome: string, configPath: string): string[] =>
+    typeof script === "string" && script.endsWith(".ts")
+      ? [script, marker, outcome, configPath]
+      : [marker, outcome, configPath];
+
+  for (const outcome of ["failure", "success"]) {
+    const configPath = join(tmpdir(), `perry-9487-${process.pid}-${outcome}.json`);
+    try {
+      try {
+        fs.unlinkSync(configPath);
+      } catch {}
+      const result = childProcess.spawnSync(
+        process.execPath,
+        selfArgs(outcome, configPath),
+        { encoding: "utf8" },
+      );
+      let hasUserID = false;
+      if (fs.existsSync(configPath)) {
+        const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+        hasUserID = typeof config.userID === "string" &&
+          /^[0-9a-f]{64}$/.test(config.userID);
+      }
+      console.log(outcome, "status", result.status, "userID", hasUserID);
+    } finally {
+      try {
+        fs.unlinkSync(configPath);
+      } catch {}
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- shadow stale native-instance classifications when object, array, nested, or rest destructuring introduces a fresh lexical binding
- cover both keyed (`{ install: z }`) and shorthand (`{ q }`) leaves with a HIR regression test that fails on unfixed main
- add a Node-parity fixture for Claude Code's combined behavior: persist a 64-hex `userID`, return 1 on failed install, and return 0 on success

## Root cause

Native receiver metadata is tracked by binding name across a module so minified bundles can retain native dispatch information. Simple declarations and parameters already tombstone stale metadata when a new lexical binding reuses a short name, but destructuring leaves bypassed that guard.

Claude Code 2.1.112 first classifies a minified `z` as a `child_process` result, then later declares `let { install: z } = ...`. Perry therefore lowered `z.call(...)` as `NativeMethodCall { module: "child_process", class_name: "Instance" }` rather than calling the ordinary JavaScript property. The completion callback did not run, leaving the generated ID unwritten and the failure exit unpropagated.

Focused tracing also verified that `randomBytes(32).toString("hex")`, the nested config updater, and the synchronous config writer lower correctly; the missing value was downstream of the bad receiver dispatch rather than a crypto primitive defect.

## Verification

- `cargo test -p perry-hir` (full crate suite)
- regression sabotage check: removing the two tombstones makes the new HIR test fail with both `.call` sites classified as `child_process` native calls
- official parity harness: `test_gap_9487_async_process_exit_code` — 1 pass, 0 parity/compile/crash failures
- manual Node/Perry output on the final fixture:
  - `failure status 1 userID true`
  - `success status 0 userID true`
- `cargo fmt -p perry-hir -- --check`
- `python scripts/check_test_registration.py`
- quick lint equivalents: benchmark harness/verifier/syntax, workspace architecture, public-baseline freshness, local-binding audit, GC store inventory, address classification, and gap-snapshot self-test

No version bump is included.

Closes #9487.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed destructured bindings so they no longer inherit native-instance behavior from unrelated bindings with the same name.
  * Restored correct install-completion behavior in Claude Code 2.1.112 scenarios.
  * Corrected child-process exit status handling when exiting from asynchronous callbacks after promise resolution.

* **Tests**
  * Added regression coverage for destructuring, native method dispatch, install completion, and success or failure exit codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->