### PR TITLE
fix(runtime): stdin reads 64 KiB blocks, not one byte per line (#9489); a real incremental utf8 decoder on the stream path (#9490)

### DIFF
--- a/changelog.d/9489-stdin-chunk-boundaries.md
+++ b/changelog.d/9489-stdin-chunk-boundaries.md
@@ -1,0 +1,32 @@
+### Fixed
+
+- **`process.stdin` chunks by read-buffer boundary, not by line (#9489).** The
+  fd-0 reader called `read(2)` **one byte at a time** and, in cooked flowing /
+  pull mode, cut a `'data'` chunk at every `\n`. 1 MB of `"line\n"` therefore
+  cost 1,048,576 read syscalls and produced **200,000 `'data'` events in
+  2.10 s**, where Node delivers **16 in 0.04 s** — a 52x slowdown. Input with
+  no newline in it arrived as a single chunk, which is what pinned the cause
+  on newlines rather than on size.
+
+  The reader now reads a 64 KiB block per syscall (Node's own pipe read size)
+  and emits one chunk per read. Line splitting stays where it belongs — in the
+  consumer: readline still slices `'line'` events out of the same byte stream,
+  and the raw-mode keypress path still receives the single-byte chunks its
+  escape-sequence reassembly depends on (those are now staged and enqueued
+  with one mutex acquisition per read instead of one per byte). The mode
+  atomics are still consulted per byte, so a `setRawMode` / `pause` flip
+  arriving mid-block lands on exactly the byte it used to.
+
+  User-visible consequence in claude-code: under the event flood its stdin
+  consumer gave up partway, truncating a piped prompt to a **random** prefix
+  (612k / 455k / 394k / 374k chars of 1,000,000 across four runs). Note the
+  bytes were never lost by the engine — a gap fixture that counts them under
+  the unfixed reader receives all 1,000,000 — so the truncation is the
+  bundle's own back-pressure logic reacting to event *count*; removing the
+  flood removes the trigger.
+
+  Fixture `test-files/test_gap_9489_stdin_chunk_boundaries.ts` asserts total
+  bytes, exact content and an order-of-magnitude event count (`< 100`) for
+  200k-line, no-newline and 1k-line inputs, plus a three-spaced-writes control
+  that must still produce **three** events — so gluing the whole stream into
+  one chunk fails it.

--- a/changelog.d/9490-stream-utf8-decoder.md
+++ b/changelog.d/9490-stream-utf8-decoder.md
@@ -1,0 +1,50 @@
+### Fixed
+
+- **`stream.setEncoding("utf8")` decodes like Node's `string_decoder` (#9490).**
+  Feeding bytes 0..255 through `process.stdin.setEncoding("utf8")` produced
+  **158 code units with zero U+FFFD** and raw `U+0080..U+00FF` passing
+  through, where Node yields **256 units with 128 replacements**. The encoded
+  path handed the raw bytes to `js_string_from_bytes`, which validates
+  nothing: it memcpy's them into the string payload and counts UTF-16 units
+  with a WTF-8-shaped walk, so continuation bytes were swallowed into the
+  preceding lead byte and 98 units simply vanished. `Buffer.toString("utf8")`
+  was already correct; only the stream path was wrong.
+
+  The second half of the contract is carry-over. Both the generic `Readable`
+  and stdin decoded each chunk independently, so a code point split across a
+  chunk boundary became replacement characters — which #9489's chunking change
+  makes far more likely, since chunk edges now fall wherever a read lands.
+
+  The fix reuses machinery that already existed rather than adding a second
+  copy: the incremental UTF-8 core written for `node:string_decoder`
+  (`utf8_check_incomplete` / `write_utf8` / `end_utf8`) moves down from
+  `perry-stdlib` into `perry-runtime` as `utf8_stream_decoder::Utf8StreamDecoder`,
+  where the stream paths can reach it. `node:string_decoder` now embeds that
+  struct, so its `lastNeed` / `lastTotal` / `lastChar` properties and the
+  stream decoders cannot drift apart.
+
+  Wired into: `process.stdin`'s `'data'` delivery (both the runtime pump and
+  perry-stdlib's readline pump), `process.stdin.read()` (pull mode shares the
+  same state), and the generic `Readable`, whose per-stream remainder is held
+  in a hidden field exactly like the existing base64 remainder. A sequence
+  left incomplete at EOF flushes as one U+FFFD in its own final `'data'`
+  event, ahead of `'end'`, and a chunk absorbed whole into the held partial
+  emits no event at all — both matching Node.
+
+  Both pumps also decoded the chunk **once per registered listener**. That was
+  merely wasteful with a stateless conversion; with carry-over it would have
+  fed the same bytes through the decoder N times and handed the second
+  listener a continuation of the first one's leftovers. The decode is now
+  hoisted above the listener loop, with the resulting value rooted across the
+  calls.
+
+  User-visible consequence in claude-code: transcripts of binary stdin
+  contained raw `0x80..0xFF` bytes — neither valid UTF-8 nor parseable JSON —
+  so `--resume` could not read the session back.
+
+  Fixture `test-files/test_gap_9490_stream_set_encoding_utf8.ts` covers all 256
+  byte values, a 4-byte emoji split at every boundary (1/3, 2/2, 3/1), lone
+  continuation bytes, 2- and 3-byte overlong encodings, a UTF-8-encoded
+  surrogate, a truncated sequence at `end`, and both `'data'`-event strings
+  and `readable`/`read()` pulls — asserting exact code-unit sequences and the
+  per-event breakdown.

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -255,6 +255,7 @@ mod ui_harmonyos_stubs;
 /// startup. See module docs for the ohos-napi gating story.
 pub mod ui_text_registry;
 pub mod update_notify;
+pub mod utf8_stream_decoder;
 pub mod util_abort;
 pub mod util_call_sites;
 pub mod util_debuglog;

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -135,6 +135,9 @@ const READABLE_PENDING_KEY: &[u8] = b"__perryReadablePending";
 const READABLE_RESUME_SCHEDULED_KEY: &[u8] = b"__perryReadableResumeScheduled";
 const STREAM_PIPES_KEY: &[u8] = b"__perryStreamPipes";
 const READABLE_BASE64_REMAINDER_KEY: &[u8] = b"__perryReadableBase64Remainder";
+/// #9490: the incomplete trailing UTF-8 sequence held between `push()` calls
+/// on a `setEncoding("utf8")` readable, mirroring the base64 remainder above.
+const READABLE_UTF8_REMAINDER_KEY: &[u8] = b"__perryReadableUtf8Remainder";
 const STREAM_PIPE_NO_END_KEY: &[u8] = b"__perryStreamPipeNoEnd";
 const STREAM_PIPE_END_PENDING_KEY: &[u8] = b"__perryStreamPipeEndPending";
 const STREAM_AUTO_DESTROY_KEY: &[u8] = b"__perryStreamAutoDestroy";
@@ -583,7 +586,31 @@ fn decode_readable_chunk_for_encoding(stream: f64, chunk: f64) -> Option<f64> {
     if encoding == 2 {
         return decode_readable_base64_chunk(stream, raw);
     }
+    if encoding == 0 {
+        return decode_readable_utf8_chunk(stream, raw);
+    }
     Some(buffer_chunk_to_encoded_string(raw, encoding))
+}
+
+/// UTF-8 with carry-over (#9490). `buffer_chunk_to_encoded_string` decodes
+/// each chunk on its own, so a code point straddling two `push()` calls came
+/// out as replacement characters. Hold the incomplete tail in a per-stream
+/// hidden field — the same shape the base64 arm above already uses — and
+/// re-prefix it onto the next chunk.
+fn decode_readable_utf8_chunk(stream: f64, raw: usize) -> Option<f64> {
+    let mut bytes = readable_utf8_remainder_bytes(stream);
+    append_buffer_bytes(raw, &mut bytes);
+    let mut decoder = crate::utf8_stream_decoder::Utf8StreamDecoder::new();
+    // Feeding remainder+chunk to a fresh decoder is equivalent to feeding the
+    // chunk to a decoder that already held the remainder: the held bytes are
+    // by construction the prefix of an incomplete sequence.
+    let text = decoder.write(&bytes);
+    set_readable_utf8_remainder_bytes(stream, decoder.pending_bytes());
+    if text.is_empty() {
+        // Whole chunk absorbed into the partial — Node emits no chunk here.
+        return None;
+    }
+    Some(string_value_from_str(&text))
 }
 
 fn decode_readable_base64_chunk(stream: f64, raw: usize) -> Option<f64> {
@@ -598,6 +625,21 @@ fn decode_readable_base64_chunk(stream: f64, raw: usize) -> Option<f64> {
 }
 
 fn flush_readable_decoder(stream: f64) {
+    if readable_encoding_tag(stream) == Some(0) {
+        // #9490: an incomplete UTF-8 sequence at end-of-stream flushes as a
+        // single U+FFFD, in its own final chunk.
+        let held = readable_utf8_remainder_bytes(stream);
+        set_readable_utf8_remainder_bytes(stream, &[]);
+        if !held.is_empty() {
+            let mut decoder = crate::utf8_stream_decoder::Utf8StreamDecoder::new();
+            let mut flushed = decoder.write(&held);
+            flushed.push_str(&decoder.end(None));
+            if !flushed.is_empty() {
+                append_readable_output_chunk(stream, string_value_from_str(&flushed));
+            }
+        }
+        return;
+    }
     if readable_encoding_tag(stream) != Some(2) {
         return;
     }
@@ -606,6 +648,28 @@ fn flush_readable_decoder(stream: f64) {
     if !bytes.is_empty() {
         append_readable_output_chunk(stream, encoded_string_from_bytes(&bytes, 2));
     }
+}
+
+fn string_value_from_str(text: &str) -> f64 {
+    let ptr = crate::string::js_string_from_bytes(text.as_ptr(), text.len() as u32);
+    f64::from_bits(JSValue::string_ptr(ptr).bits())
+}
+
+fn readable_utf8_remainder_bytes(stream: f64) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    if let Some(value) = get_hidden_value(stream, hidden_readable_utf8_remainder_key()) {
+        append_buffer_bytes(raw_ptr_from_value(value), &mut bytes);
+    }
+    bytes
+}
+
+fn set_readable_utf8_remainder_bytes(stream: f64, bytes: &[u8]) {
+    let value = if bytes.is_empty() {
+        f64::from_bits(TAG_UNDEFINED)
+    } else {
+        buffer_value_from_bytes(bytes)
+    };
+    set_hidden_value(stream, hidden_readable_utf8_remainder_key(), value);
 }
 
 fn readable_base64_remainder_bytes(stream: f64) -> Vec<u8> {

--- a/crates/perry-runtime/src/node_stream_keys.rs
+++ b/crates/perry-runtime/src/node_stream_keys.rs
@@ -204,6 +204,11 @@ pub(super) fn hidden_readable_base64_remainder_key() -> *mut crate::string::Stri
 }
 
 #[inline]
+pub(super) fn hidden_readable_utf8_remainder_key() -> *mut crate::string::StringHeader {
+    hidden_key(READABLE_UTF8_REMAINDER_KEY)
+}
+
+#[inline]
 pub(super) fn hidden_stream_pipe_no_end_key() -> *mut crate::string::StringHeader {
     hidden_key(STREAM_PIPE_NO_END_KEY)
 }

--- a/crates/perry-runtime/src/os.rs
+++ b/crates/perry-runtime/src/os.rs
@@ -844,8 +844,8 @@ pub(crate) use process_streams::test_set_stdin_data_listener;
 pub use process_streams::{
     js_process_stderr, js_process_stdin, js_process_stdout, mark_process_stdin_destroyed,
     pump_process_stdin, scan_process_stream_singleton_roots_mut, set_process_stdin_raw_state,
-    stdin_chunk_jsvalue, stdin_has_encoding, stdin_is_detached, stdin_listeners_keep_loop_alive,
-    stdin_push_bytes,
+    stdin_chunk_jsvalue, stdin_chunk_jsvalue_opt, stdin_encoding_flush_jsvalue, stdin_has_encoding,
+    stdin_is_detached, stdin_listeners_keep_loop_alive, stdin_push_bytes,
 };
 
 /// Get the operating system name

--- a/crates/perry-runtime/src/os_process_streams.rs
+++ b/crates/perry-runtime/src/os_process_streams.rs
@@ -328,12 +328,76 @@ pub fn stdin_has_encoding() -> bool {
     STDIN_ENCODING.lock().map(|e| e.is_some()).unwrap_or(false)
 }
 
+/// Incremental UTF-8 decode state for `process.stdin`, live once
+/// `setEncoding` has been called (#9490).
+///
+/// `process.stdin` is a process-global stream, so one decoder serves both
+/// delivery paths (the runtime's own pump and perry-stdlib's readline pump)
+/// and `read()`. Only one of those is ever active for a given program, and
+/// sharing the state is what lets a code point split across a chunk boundary
+/// survive whichever path picks the halves up.
+static STDIN_DECODER: std::sync::Mutex<crate::utf8_stream_decoder::Utf8StreamDecoder> =
+    std::sync::Mutex::new(crate::utf8_stream_decoder::Utf8StreamDecoder::new());
+
+/// Decode raw stdin bytes under the active `setEncoding`, holding back a
+/// trailing incomplete sequence for the next chunk. Returns `None` when the
+/// whole chunk was absorbed into the held partial — Node emits no `'data'`
+/// event for that.
+fn stdin_decode_encoded(chunk: &[u8]) -> Option<String> {
+    let decoded = match STDIN_DECODER.lock() {
+        Ok(mut d) => d.write(chunk),
+        // A poisoned decoder must not silently drop input; fall back to the
+        // one-shot lossy decode, which is correct except across a boundary.
+        Err(_) => String::from_utf8_lossy(chunk).into_owned(),
+    };
+    if decoded.is_empty() {
+        None
+    } else {
+        Some(decoded)
+    }
+}
+
+fn string_jsvalue(s: &str) -> f64 {
+    let sh = crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);
+    f64::from_bits(crate::value::JSValue::string_ptr(sh).bits())
+}
+
+/// End-of-stream flush: a held incomplete sequence becomes one U+FFFD,
+/// delivered as its own final `'data'` chunk before `'end'` (Node's
+/// `StringDecoder.prototype.end`, and how Node's Readable emits it).
+pub fn stdin_encoding_flush_jsvalue() -> Option<f64> {
+    if !stdin_has_encoding() {
+        return None;
+    }
+    let flushed = STDIN_DECODER.lock().ok()?.end(None);
+    if flushed.is_empty() {
+        return None;
+    }
+    Some(string_jsvalue(&flushed))
+}
+
+/// A `data` chunk as Node delivers it: a Buffer by default, a decoded string
+/// once an encoding is set. `None` means "emit no event for this chunk" —
+/// the bytes were absorbed into the decoder's held partial.
+pub fn stdin_chunk_jsvalue_opt(chunk: &[u8]) -> Option<f64> {
+    if stdin_has_encoding() {
+        return stdin_decode_encoded(chunk).map(|s| string_jsvalue(&s));
+    }
+    Some(stdin_chunk_jsvalue(chunk))
+}
+
 /// A `data` chunk as Node delivers it: a Buffer by default, a string once an
 /// encoding is set.
+///
+/// #9490: the encoded arm used to hand the raw bytes to
+/// `js_string_from_bytes`, which validates nothing — it memcpy's them into
+/// the string payload and counts UTF-16 units with a WTF-8-shaped walk. Bytes
+/// 0..255 therefore came out as 158 code units with zero U+FFFD, high bytes
+/// passed through raw, where Node yields 256 units and 128 replacements.
 pub fn stdin_chunk_jsvalue(chunk: &[u8]) -> f64 {
     if stdin_has_encoding() {
-        let s = crate::string::js_string_from_bytes(chunk.as_ptr(), chunk.len() as u32);
-        return f64::from_bits(crate::value::JSValue::string_ptr(s).bits());
+        let decoded = stdin_decode_encoded(chunk).unwrap_or_default();
+        return string_jsvalue(&decoded);
     }
     let buf = crate::buffer::buffer_alloc(chunk.len() as u32);
     unsafe {
@@ -722,9 +786,23 @@ extern "C" fn process_stdin_read(_closure: *const crate::closure::ClosureHeader,
         Err(_) => return f64::from_bits(crate::value::TAG_NULL),
     };
     if bytes.is_empty() {
+        // EOF with an incomplete sequence still held: Node's last `read()`
+        // yields the decoder's flush rather than `null` (#9490).
+        if STDIN_EOF_SEEN.load(std::sync::atomic::Ordering::Acquire) {
+            if let Some(flushed) = stdin_encoding_flush_jsvalue() {
+                return flushed;
+            }
+        }
         return f64::from_bits(crate::value::TAG_NULL);
     }
-    let s = String::from_utf8_lossy(&bytes);
+    // #9490: pull mode ("readable" + read()) shares the stream decoder, so a
+    // code point split across two reads is reassembled instead of becoming
+    // two replacement characters.
+    let s = if stdin_has_encoding() {
+        stdin_decode_encoded(&bytes).unwrap_or_default()
+    } else {
+        String::from_utf8_lossy(&bytes).into_owned()
+    };
     let sh = crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);
     // Nanbox as a STRING value (not a generic object pointer) so JS sees a
     // real string from `read()` — `typeof` / `+` / `!== null` all rely on this.
@@ -782,18 +860,29 @@ fn pump_stdin_data_chunks() {
             return;
         }
         let this = stdin_this_value();
+        // #9490: decode ONCE per chunk. The UTF-8 decoder carries state
+        // across chunks, so decoding per listener would push the same bytes
+        // through it N times and give the second listener a continuation of
+        // the first one's leftovers. `None` = the chunk was absorbed whole
+        // into a held partial, for which Node fires no `'data'` event.
+        let Some(arg) = stdin_chunk_jsvalue_opt(&bytes) else {
+            return;
+        };
+        // The value is built ONCE now, so it must survive every listener call:
+        // a GC inside listener N can move the string listener N+1 still has to
+        // receive, and a bare `f64` local would then be stale. Root it in a
+        // scope that outlives the loop and re-read the handle each iteration.
+        // (Before #9490 this was safe by accident — the arg was rebuilt inside
+        // the loop, which a stateful decoder can no longer do.)
+        let arg_scope = crate::gc::RuntimeHandleScope::new();
+        let arg_handle = arg_scope.root_nanbox_f64(arg);
         for cb in data_listeners {
             let scope = crate::gc::RuntimeHandleScope::new();
             let cb_handle = scope.root_raw_const_ptr(cb as *const crate::closure::ClosureHeader);
-            // Allocate the arg string inside the scope so GC during the call
-            // can't free or move it out from under the callback.
-            let arg = stdin_chunk_jsvalue(&bytes);
-            let arg_handles = scope.root_nanbox_f64_slice(&[arg]);
-            let a = crate::gc::RuntimeHandleScope::refreshed_nanbox_f64_slice(&arg_handles);
             let closure = cb_handle.get_raw_const_ptr::<crate::closure::ClosureHeader>();
             // Node calls stream listeners with `this === stream`.
             let prev_this = crate::object::js_implicit_this_set(this);
-            crate::closure::js_closure_call1(closure, a[0]);
+            crate::closure::js_closure_call1(closure, arg_handle.get_nanbox_f64());
             crate::object::js_implicit_this_set(prev_this);
         }
         return;
@@ -833,6 +922,36 @@ fn maybe_fire_stdin_end() {
     let has_bytes = STDIN_BUFFER.lock().map(|b| !b.is_empty()).unwrap_or(false);
     if has_bytes {
         return;
+    }
+    // #9490: a sequence left incomplete at EOF is flushed as one U+FFFD, in
+    // its own final `'data'` event, BEFORE `'end'`.
+    //
+    // Only when a `data` listener exists to receive it: in pull mode the
+    // flush belongs to the consumer's last `read()`, and taking it here would
+    // consume the decoder state and drop the replacement character.
+    let has_data_listener = STDIN_DATA_LISTENERS
+        .lock()
+        .map(|l| !l.is_empty())
+        .unwrap_or(false);
+    if has_data_listener {
+        if let Some(flushed) = stdin_encoding_flush_jsvalue() {
+            let data_listeners: Vec<i64> = STDIN_DATA_LISTENERS
+                .lock()
+                .map(|l| l.clone())
+                .unwrap_or_default();
+            let this = stdin_this_value();
+            let flush_scope = crate::gc::RuntimeHandleScope::new();
+            let flush_handle = flush_scope.root_nanbox_f64(flushed);
+            for cb in data_listeners {
+                let scope = crate::gc::RuntimeHandleScope::new();
+                let cb_handle =
+                    scope.root_raw_const_ptr(cb as *const crate::closure::ClosureHeader);
+                let closure = cb_handle.get_raw_const_ptr::<crate::closure::ClosureHeader>();
+                let prev_this = crate::object::js_implicit_this_set(this);
+                crate::closure::js_closure_call1(closure, flush_handle.get_nanbox_f64());
+                crate::object::js_implicit_this_set(prev_this);
+            }
+        }
     }
     let mut end_listeners: Vec<i64> = STDIN_END_LISTENERS
         .lock()

--- a/crates/perry-runtime/src/utf8_stream_decoder.rs
+++ b/crates/perry-runtime/src/utf8_stream_decoder.rs
@@ -1,0 +1,314 @@
+//! Node's `string_decoder` UTF-8 core: an INCREMENTAL decoder that replaces
+//! invalid sequences with U+FFFD and, crucially, holds an incomplete
+//! multi-byte sequence across a chunk boundary instead of mangling it.
+//!
+//! # Why this lives in perry-runtime (#9490)
+//!
+//! The logic below is not new — it was written for `node:string_decoder` and
+//! has always lived in `perry-stdlib/src/string_decoder.rs`. But every stream
+//! that honours `setEncoding("utf8")` lives one crate DOWN, in perry-runtime,
+//! and perry-stdlib depends on perry-runtime rather than the other way round.
+//! So the stream paths could not reach it, and each grew its own one-shot
+//! decode instead:
+//!
+//!   * `process.stdin` passed the raw bytes to `js_string_from_bytes`, which
+//!     does no validation at all — high bytes survived into the JS string and
+//!     the WTF-8 length walk swallowed continuation bytes, so bytes 0..255
+//!     came out as 158 code units with zero U+FFFD (Node: 256 and 128).
+//!   * the generic `Readable` decoded each chunk independently, so a
+//!     codepoint straddling two chunks became replacement characters.
+//!
+//! Moving the core down here — rather than copying it — keeps ONE
+//! implementation: `perry-stdlib`'s `StringDecoderHandle` now embeds this
+//! struct for its utf8 mode, so `node:string_decoder` and the stream decoders
+//! cannot drift apart.
+
+/// Incremental UTF-8 decode state: at most one partially-seen code point.
+///
+/// The fields are public because `node:string_decoder` exposes them verbatim
+/// as its `lastNeed` / `lastTotal` / `lastChar` properties.
+#[derive(Debug, Clone, Default)]
+pub struct Utf8StreamDecoder {
+    /// Number of bytes still needed to complete the current code point
+    /// (0 when no partial point is buffered).
+    pub last_need: u8,
+    /// Total byte length of the in-progress code point (2, 3, or 4).
+    pub last_total: u8,
+    /// Up to 4 bytes of partial code point captured from prior writes.
+    pub last_char: [u8; 4],
+    /// How many bytes of `last_char` are valid; never larger than 4.
+    pub last_char_len: u8,
+}
+
+impl Utf8StreamDecoder {
+    /// `const` so a decoder can live in a `static Mutex<_>` — `process.stdin`
+    /// is a process-global stream and needs exactly one decode state.
+    pub const fn new() -> Self {
+        Utf8StreamDecoder {
+            last_need: 0,
+            last_total: 0,
+            last_char: [0; 4],
+            last_char_len: 0,
+        }
+    }
+
+    /// The incomplete sequence currently being held, if any. Callers that
+    /// cannot keep a decoder alive between chunks (the generic `Readable`
+    /// stores its state in a per-stream hidden field) round-trip these bytes
+    /// and re-prefix them onto the next chunk, which is equivalent.
+    pub fn pending_bytes(&self) -> &[u8] {
+        &self.last_char[..self.last_char_len as usize]
+    }
+
+    /// True while an incomplete multi-byte sequence is being held.
+    pub fn has_pending(&self) -> bool {
+        self.last_need > 0
+    }
+
+    /// Forget any held partial without emitting a replacement. Used when a
+    /// stream is destroyed or re-opened rather than ended.
+    pub fn reset(&mut self) {
+        self.last_need = 0;
+        self.last_total = 0;
+        self.last_char_len = 0;
+        self.last_char = [0; 4];
+    }
+
+    /// Decode `bytes`, holding back any trailing incomplete sequence.
+    /// Returns "" when the whole input was consumed into the held partial —
+    /// callers must NOT emit a `'data'` event for an empty result, matching
+    /// Node.
+    pub fn write(&mut self, bytes: &[u8]) -> String {
+        write_utf8(self, bytes)
+    }
+
+    /// Flush at end-of-stream: any held partial becomes a single U+FFFD,
+    /// exactly as `StringDecoder.prototype.end` does. Node emits this as its
+    /// own final `'data'` event, before `'end'`.
+    pub fn end(&mut self, bytes: Option<&[u8]>) -> String {
+        end_utf8(self, bytes)
+    }
+}
+
+/// Detect a multi-byte UTF-8 lead in the final 0–3 bytes of `buf`.
+/// Returns the number of bytes that should be buffered for the next
+/// write (so they aren't returned as garbled output). Mirrors the
+/// `utf8CheckIncomplete` function in Node's `lib/string_decoder.js`.
+fn utf8_check_incomplete(state: &mut Utf8StreamDecoder, buf: &[u8]) -> usize {
+    let mut i = buf.len();
+    // Walk back from the end of the buffer up to 3 bytes — the longest
+    // UTF-8 lead sequence the trailing bytes could need to wait for.
+    let walk = if buf.len() >= 3 { 3 } else { buf.len() };
+    let mut steps = 0usize;
+    while steps < walk {
+        i -= 1;
+        steps += 1;
+        let b = buf[i];
+        // Continuation byte 10xxxxxx — keep walking.
+        if (b & 0xC0) == 0x80 {
+            continue;
+        }
+        // 4-byte lead 11110xxx.
+        if (b & 0xF8) == 0xF0 {
+            // We've already walked `steps - 1` continuation bytes plus
+            // this lead; we need 4 total, so we still need
+            // `4 - steps` bytes.
+            if steps < 4 {
+                state.last_need = (4 - steps) as u8;
+                state.last_total = 4;
+                let start = buf.len() - steps;
+                state.last_char_len = steps as u8;
+                state.last_char[..steps].copy_from_slice(&buf[start..]);
+                return steps;
+            }
+            return 0;
+        }
+        // 3-byte lead 1110xxxx.
+        if (b & 0xF0) == 0xE0 {
+            if steps < 3 {
+                state.last_need = (3 - steps) as u8;
+                state.last_total = 3;
+                let start = buf.len() - steps;
+                state.last_char_len = steps as u8;
+                state.last_char[..steps].copy_from_slice(&buf[start..]);
+                return steps;
+            }
+            return 0;
+        }
+        // 2-byte lead 110xxxxx.
+        if (b & 0xE0) == 0xC0 {
+            if steps < 2 {
+                state.last_need = (2 - steps) as u8;
+                state.last_total = 2;
+                let start = buf.len() - steps;
+                state.last_char_len = steps as u8;
+                state.last_char[..steps].copy_from_slice(&buf[start..]);
+                return steps;
+            }
+            return 0;
+        }
+        // ASCII byte 0xxxxxxx — nothing to buffer.
+        return 0;
+    }
+    0
+}
+
+/// Decode `bytes` against the existing partial-codepoint state, mutating
+/// `state` to reflect any new trailing partial. Returns the decoded
+/// string. UTF-8 invalid sequences are replaced with U+FFFD, matching
+/// Node's `lossy` UTF-8 decoder behavior.
+fn write_utf8(state: &mut Utf8StreamDecoder, bytes: &[u8]) -> String {
+    let mut out = String::new();
+
+    // Stitch the buffered partial together with the new input first.
+    if state.last_need > 0 {
+        let need = state.last_need as usize;
+        if bytes.len() < need {
+            // Still incomplete — append what we can and exit empty.
+            let new_len = state.last_char_len as usize + bytes.len();
+            if new_len <= 4 {
+                state.last_char[state.last_char_len as usize..new_len].copy_from_slice(bytes);
+                state.last_char_len = new_len as u8;
+                state.last_need -= bytes.len() as u8;
+            } else {
+                // Defensive: should never happen given UTF-8 is at most 4
+                // bytes, but if upstream feeds garbage we reset rather
+                // than overrun.
+                state.last_need = 0;
+                state.last_total = 0;
+                state.last_char_len = 0;
+            }
+            return out;
+        }
+
+        // We have enough new bytes to complete the buffered point.
+        let total = state.last_total as usize;
+        let buffered = state.last_char_len as usize;
+        let take_new = total - buffered;
+        let mut cp = Vec::with_capacity(total);
+        cp.extend_from_slice(&state.last_char[..buffered]);
+        cp.extend_from_slice(&bytes[..take_new]);
+
+        match std::str::from_utf8(&cp) {
+            Ok(s) => out.push_str(s),
+            Err(_) => out.push('\u{FFFD}'),
+        }
+        state.last_need = 0;
+        state.last_total = 0;
+        state.last_char_len = 0;
+
+        // The "rest" continues below — chop off the consumed prefix.
+        let rest = &bytes[take_new..];
+        // Recurse on the tail so trailing partials get caught.
+        out.push_str(&write_utf8_tail(state, rest));
+        return out;
+    }
+
+    out.push_str(&write_utf8_tail(state, bytes));
+    out
+}
+
+/// Tail half of `write_utf8`: assumes `state.last_need == 0` on entry.
+/// Splits a trailing incomplete code point off into `state`.
+fn write_utf8_tail(state: &mut Utf8StreamDecoder, bytes: &[u8]) -> String {
+    if bytes.is_empty() {
+        return String::new();
+    }
+    let trail = utf8_check_incomplete(state, bytes);
+    let head = &bytes[..bytes.len() - trail];
+    String::from_utf8_lossy(head).into_owned()
+}
+
+/// `decoder.end([buf?])` — flush any incomplete state as U+FFFD, matching
+/// Node's behavior.
+fn end_utf8(state: &mut Utf8StreamDecoder, bytes: Option<&[u8]>) -> String {
+    let mut out = match bytes {
+        Some(b) => write_utf8(state, b),
+        None => String::new(),
+    };
+    if state.last_need > 0 {
+        out.push('\u{FFFD}');
+        state.last_need = 0;
+        state.last_total = 0;
+        state.last_char_len = 0;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_euro_sign() {
+        // U+20AC EURO SIGN = E2 82 AC in UTF-8.
+        let mut d = Utf8StreamDecoder::new();
+        assert_eq!(d.write(&[0xE2, 0x82]), "");
+        assert_eq!(d.last_need, 1);
+        assert_eq!(d.last_total, 3);
+        assert!(d.has_pending());
+        assert_eq!(d.write(&[0xAC]), "\u{20AC}");
+        assert_eq!(d.last_need, 0);
+        assert!(!d.has_pending());
+    }
+
+    #[test]
+    fn emoji_split_at_every_boundary() {
+        // U+1F600 = F0 9F 98 80. #9490's fixture splits it 1/3, 2/2 and 3/1;
+        // all three must reassemble to the same single code point.
+        let emoji = [0xF0u8, 0x9F, 0x98, 0x80];
+        for cut in 1..4usize {
+            let mut d = Utf8StreamDecoder::new();
+            let a = d.write(&emoji[..cut]);
+            let b = d.write(&emoji[cut..]);
+            assert_eq!(a, "", "cut {cut} must emit nothing yet");
+            assert_eq!(b, "\u{1F600}", "cut {cut}");
+            assert!(!d.has_pending());
+        }
+    }
+
+    #[test]
+    fn end_flushes_partial_as_one_replacement() {
+        let mut d = Utf8StreamDecoder::new();
+        assert_eq!(d.write(&[0x41, 0xE2, 0x82]), "A");
+        assert_eq!(d.end(None), "\u{FFFD}");
+        assert!(!d.has_pending());
+    }
+
+    #[test]
+    fn all_256_bytes_match_node() {
+        // Node: 256 code units, 128 of them U+FFFD.
+        let bytes: Vec<u8> = (0..=255u8).collect();
+        let mut d = Utf8StreamDecoder::new();
+        let mut out = d.write(&bytes);
+        out.push_str(&d.end(None));
+        assert_eq!(out.encode_utf16().count(), 256);
+        assert_eq!(out.chars().filter(|c| *c == '\u{FFFD}').count(), 128);
+    }
+
+    #[test]
+    fn invalid_sequences_replace_per_whatwg() {
+        let mut d = Utf8StreamDecoder::new();
+        // lone continuation, 2-byte overlong, 3-byte overlong, surrogate.
+        assert_eq!(d.write(&[0x80]), "\u{FFFD}");
+        assert_eq!(d.write(&[0xC0, 0x80]), "\u{FFFD}\u{FFFD}");
+        assert_eq!(d.write(&[0xE0, 0x80, 0xAF]), "\u{FFFD}\u{FFFD}\u{FFFD}");
+        assert_eq!(d.write(&[0xED, 0xA0, 0x80]), "\u{FFFD}\u{FFFD}\u{FFFD}");
+    }
+
+    #[test]
+    fn reset_drops_the_partial_without_emitting() {
+        let mut d = Utf8StreamDecoder::new();
+        assert_eq!(d.write(&[0xF0, 0x9F]), "");
+        d.reset();
+        assert!(!d.has_pending());
+        assert_eq!(d.end(None), "");
+    }
+
+    #[test]
+    fn ascii_round_trips() {
+        let mut d = Utf8StreamDecoder::new();
+        assert_eq!(d.write(b"hello"), "hello");
+        assert_eq!(d.last_need, 0);
+    }
+}

--- a/crates/perry-stdlib/src/readline/mod.rs
+++ b/crates/perry-stdlib/src/readline/mod.rs
@@ -450,10 +450,12 @@ extern "C" fn stdin_off_op(name_ptr: *const u8, name_len: usize, cb: i64) {
     }
 }
 
-/// A `data` chunk as Node would deliver it: a Buffer by default, a string once an
-/// encoding has been set with `setEncoding`.
-fn stdin_chunk_value(chunk: &[u8]) -> f64 {
-    perry_runtime::os::stdin_chunk_jsvalue(chunk)
+/// A `data` chunk as Node would deliver it: a Buffer by default, a decoded
+/// string once an encoding has been set with `setEncoding`. `None` means the
+/// chunk was absorbed into the UTF-8 decoder's held partial and Node would
+/// fire no `'data'` event for it (#9490).
+fn stdin_chunk_value(chunk: &[u8]) -> Option<f64> {
+    perry_runtime::os::stdin_chunk_jsvalue_opt(chunk)
 }
 
 fn try_register_pump() {

--- a/crates/perry-stdlib/src/readline/mod.rs
+++ b/crates/perry-stdlib/src/readline/mod.rs
@@ -1082,54 +1082,85 @@ fn ensure_reader_started() {
     std::thread::spawn(move || {
         let stdin = io::stdin();
         let mut reader = stdin.lock();
-        let mut byte = [0u8; 1];
-        let mut line_buf: Vec<u8> = Vec::with_capacity(256);
+        // #9489: read a BLOCK per syscall, and cut `'data'` chunks at the
+        // block boundary. This loop used to `read(2)` ONE BYTE at a time and
+        // flush a chunk at every `\n`, so 1 MB of `"line\n"` cost 1,048,576
+        // read syscalls and produced 200,000 `'data'` events in 2.10 s where
+        // Node delivers 16 in 0.04 s.
+        //
+        // 64 KiB is Node's own pipe read size, and `read` still returns as
+        // soon as ANY bytes are available — it does not wait to fill the
+        // buffer — so a lone keystroke is still delivered immediately and
+        // three spaced writes are still three chunks.
+        let mut buf = [0u8; 65536];
+        // Bytes accumulated for the CURRENT read: in cooked flowing / pull
+        // mode this becomes one `'data'` chunk per read; in line mode it is
+        // the partial line carried to the next `\n`.
+        let mut line_buf: Vec<u8> = Vec::with_capacity(65536);
+        // Raw-mode chunks staged for one lock acquisition per read instead of
+        // one per byte. The per-BYTE chunking itself is preserved on purpose:
+        // the keypress path reassembles escape sequences from single-byte
+        // chunks (`pump::coalesce_escape_sequences`), and a paste must still
+        // fire one `'keypress'` per character.
+        let mut raw_chunks: Vec<Vec<u8>> = Vec::new();
         loop {
-            match reader.read(&mut byte) {
+            let n = match reader.read(&mut buf) {
                 Ok(0) => break, // EOF
-                Ok(_) => {
-                    if STDIN_DESTROYED.load(Ordering::Acquire) {
-                        break;
-                    }
-                    if RAW_MODE.load(Ordering::Acquire) {
-                        // In raw mode, queue a single-byte chunk. Multi-byte
-                        // escape sequences (e.g. arrow keys = "\x1b[A")
-                        // arrive as three separate chunks; the keypress
-                        // parser on the drain side reassembles them.
-                        if let Ok(mut q) = PENDING_DATA.lock() {
-                            q.push(vec![byte[0]]);
-                        }
-                    } else if STDIN_DATA_FLOWING.load(Ordering::Acquire)
-                        || STDIN_PULL_MODE.load(Ordering::Acquire)
-                    {
-                        // Cooked flowing mode (#5227): a `process.stdin.on('data')`
-                        // listener is attached but raw mode is off. Deliver input
-                        // as 'data' chunks (newline INCLUDED, matching Node's
-                        // line-buffered cooked tty / piped-stream chunks) rather
-                        // than routing it to the readline 'line' queue.
-                        line_buf.push(byte[0]);
-                        if byte[0] == b'\n' {
-                            let chunk = std::mem::take(&mut line_buf);
-                            if let Ok(mut q) = PENDING_DATA.lock() {
-                                q.push(chunk);
-                            }
-                            line_buf = Vec::with_capacity(256);
-                        }
-                    } else if byte[0] == b'\n' {
-                        // Strip trailing CR for Windows CRLF input.
-                        if line_buf.last() == Some(&b'\r') {
-                            line_buf.pop();
-                        }
-                        let line = String::from_utf8_lossy(&line_buf).into_owned();
-                        line_buf.clear();
-                        if let Ok(mut q) = PENDING_LINES.lock() {
-                            q.push(line);
-                        }
-                    } else {
-                        line_buf.push(byte[0]);
-                    }
-                }
+                Ok(n) => n,
                 Err(_) => break,
+            };
+            if STDIN_DESTROYED.load(Ordering::Acquire) {
+                break;
+            }
+            // The mode atomics are still consulted PER BYTE, exactly as
+            // before: a mode flip from the main thread mid-block must land on
+            // the same byte it used to. Only the syscall and the chunk
+            // boundary changed.
+            for &b in &buf[..n] {
+                if RAW_MODE.load(Ordering::Acquire) {
+                    raw_chunks.push(vec![b]);
+                } else if STDIN_DATA_FLOWING.load(Ordering::Acquire)
+                    || STDIN_PULL_MODE.load(Ordering::Acquire)
+                {
+                    // Cooked flowing mode (#5227): a `process.stdin.on('data')`
+                    // listener is attached but raw mode is off. Deliver input
+                    // as 'data' chunks (newline INCLUDED, matching Node's
+                    // piped-stream chunks) rather than routing it to the
+                    // readline 'line' queue. #9489: the chunk is cut at the
+                    // end of this read, NOT at each newline.
+                    line_buf.push(b);
+                } else if b == b'\n' {
+                    // Strip trailing CR for Windows CRLF input.
+                    if line_buf.last() == Some(&b'\r') {
+                        line_buf.pop();
+                    }
+                    let line = String::from_utf8_lossy(&line_buf).into_owned();
+                    line_buf.clear();
+                    if let Ok(mut q) = PENDING_LINES.lock() {
+                        q.push(line);
+                    }
+                } else {
+                    line_buf.push(b);
+                }
+            }
+            if !raw_chunks.is_empty() {
+                if let Ok(mut q) = PENDING_DATA.lock() {
+                    q.append(&mut raw_chunks);
+                }
+                raw_chunks.clear();
+            }
+            // One `'data'` chunk per read(2) — Node's contract. Line splitting
+            // is the CONSUMER's job (readline does its own, above); imposing
+            // it on the shared `'data'` path is what #9489 fixed.
+            if !line_buf.is_empty()
+                && !RAW_MODE.load(Ordering::Acquire)
+                && (STDIN_DATA_FLOWING.load(Ordering::Acquire)
+                    || STDIN_PULL_MODE.load(Ordering::Acquire))
+            {
+                if let Ok(mut q) = PENDING_DATA.lock() {
+                    q.push(std::mem::take(&mut line_buf));
+                }
+                line_buf = Vec::with_capacity(65536);
             }
         }
         // Flush any trailing bytes not terminated by a newline. In cooked

--- a/crates/perry-stdlib/src/readline/pump.rs
+++ b/crates/perry-stdlib/src/readline/pump.rs
@@ -292,11 +292,26 @@ pub extern "C" fn js_readline_process_pending() -> i32 {
         .map(|cb| callback_scope.root_raw_const_ptr(*cb as *const ClosureHeader))
         .collect();
     for chunk in chunks {
-        for callback in &data_callback_handles {
-            let arg = stdin_chunk_value(&chunk);
-            let closure = callback.get_raw_const_ptr::<ClosureHeader>();
-            js_closure_call1(closure, arg);
-            fired += 1;
+        // #9490: decode ONCE per chunk, above the listener loop. The UTF-8
+        // decoder is stateful; decoding per listener fed the same bytes
+        // through it once per registered callback. `None` = the chunk was
+        // absorbed whole into a held partial (a code point split across this
+        // read boundary), for which Node emits no `'data'` event.
+        let data_arg = if data_callback_handles.is_empty() {
+            None
+        } else {
+            stdin_chunk_value(&chunk)
+        };
+        if let Some(arg) = data_arg {
+            // Root the decoded value: a GC inside one listener can move the
+            // string the remaining listeners still have to receive.
+            let arg_scope = perry_runtime::gc::RuntimeHandleScope::new();
+            let arg_handle = arg_scope.root_nanbox_f64(arg);
+            for callback in &data_callback_handles {
+                let closure = callback.get_raw_const_ptr::<ClosureHeader>();
+                js_closure_call1(closure, arg_handle.get_nanbox_f64());
+                fired += 1;
+            }
         }
         if keypress_callback_handles.is_empty() {
             continue;
@@ -356,6 +371,32 @@ pub extern "C" fn js_readline_process_pending() -> i32 {
             was
         });
         if !already {
+            // #9490: flush the stream decoder first — a sequence left
+            // incomplete at EOF is one final `'data'` chunk of U+FFFD, ahead
+            // of `'end'`/`'close'`.
+            // Only when a `data` listener exists to receive it: in pull mode
+            // the flush belongs to the consumer's last `read()`, and taking
+            // it here would consume the state and drop the replacement.
+            let flush_targets = DATA_CALLBACKS.lock().map(|v| v.clone()).unwrap_or_default();
+            if let Some(flushed) = if flush_targets.is_empty() {
+                None
+            } else {
+                perry_runtime::os::stdin_encoding_flush_jsvalue()
+            } {
+                let flush_scope = perry_runtime::gc::RuntimeHandleScope::new();
+                let flush_handles: Vec<_> = flush_targets
+                    .iter()
+                    .map(|cb| flush_scope.root_raw_const_ptr(*cb as *const ClosureHeader))
+                    .collect();
+                // Root the flushed string too, and re-read it per call: a GC
+                // inside one listener can move it out from under the next.
+                let arg_handle = flush_scope.root_nanbox_f64(flushed);
+                for callback in &flush_handles {
+                    let closure = callback.get_raw_const_ptr::<ClosureHeader>();
+                    js_closure_call1(closure, arg_handle.get_nanbox_f64());
+                    fired += 1;
+                }
+            }
             let cb = CLOSE_CALLBACK.with(|c| c.borrow_mut().take());
             if let Some(cb_i64) = cb {
                 let closure = cb_i64 as *const ClosureHeader;

--- a/crates/perry-stdlib/src/string_decoder.rs
+++ b/crates/perry-stdlib/src/string_decoder.rs
@@ -49,16 +49,11 @@ pub enum DecodingMode {
 /// Each mode only touches its own fields, so they don't interact.
 pub struct StringDecoderHandle {
     mode: DecodingMode,
-    /// UTF-8: number of bytes still needed to complete the current code
-    /// point (0 when no partial point is buffered).
-    last_need: u8,
-    /// UTF-8: total byte length of the in-progress code point (2, 3, or 4).
-    last_total: u8,
-    /// UTF-8: up to 4 bytes of partial code point captured from prior writes.
-    last_char: [u8; 4],
-    /// UTF-8: how many bytes of `last_char` are valid (= last_total -
-    /// last_need at the time the partial was captured; never larger than 4).
-    last_char_len: u8,
+    /// UTF-8: the incremental decode core, shared with every stream that
+    /// honours `setEncoding("utf8")` (#9490). It owns `lastNeed` /
+    /// `lastTotal` / `lastChar`, which this module still exposes verbatim as
+    /// `StringDecoder` properties.
+    utf8: perry_runtime::utf8_stream_decoder::Utf8StreamDecoder,
     /// UTF-16LE: at most 1 trailing byte buffered for the next write.
     /// `Some(b)` means an odd-length write ended with `b` as the low byte
     /// of an unfinished code unit. `None` means clean state.
@@ -87,10 +82,7 @@ impl StringDecoderHandle {
     pub fn with_mode(mode: DecodingMode) -> Self {
         StringDecoderHandle {
             mode,
-            last_need: 0,
-            last_total: 0,
-            last_char: [0; 4],
-            last_char_len: 0,
+            utf8: perry_runtime::utf8_stream_decoder::Utf8StreamDecoder::new(),
             utf16_partial: None,
             base64_partial: Vec::new(),
             utf16_high_surrogate: None,
@@ -447,151 +439,6 @@ unsafe fn string_from_nanboxed_for_error(bits: i64) -> String {
         return format!("{}", f);
     }
     "unknown".to_string()
-}
-
-/// Detect a multi-byte UTF-8 lead in the final 0–3 bytes of `buf`.
-/// Returns the number of bytes that should be buffered for the next
-/// write (so they aren't returned as garbled output). Mirrors the
-/// `utf8CheckIncomplete` function in Node's `lib/string_decoder.js`.
-fn utf8_check_incomplete(state: &mut StringDecoderHandle, buf: &[u8]) -> usize {
-    let mut i = buf.len();
-    // Walk back from the end of the buffer up to 3 bytes — the longest
-    // UTF-8 lead sequence the trailing bytes could need to wait for.
-    let walk = if buf.len() >= 3 { 3 } else { buf.len() };
-    let mut steps = 0usize;
-    while steps < walk {
-        i -= 1;
-        steps += 1;
-        let b = buf[i];
-        // Continuation byte 10xxxxxx — keep walking.
-        if (b & 0xC0) == 0x80 {
-            continue;
-        }
-        // 4-byte lead 11110xxx.
-        if (b & 0xF8) == 0xF0 {
-            // We've already walked `steps - 1` continuation bytes plus
-            // this lead; we need 4 total, so we still need
-            // `4 - steps` bytes.
-            if steps < 4 {
-                state.last_need = (4 - steps) as u8;
-                state.last_total = 4;
-                let start = buf.len() - steps;
-                state.last_char_len = steps as u8;
-                state.last_char[..steps].copy_from_slice(&buf[start..]);
-                return steps;
-            }
-            return 0;
-        }
-        // 3-byte lead 1110xxxx.
-        if (b & 0xF0) == 0xE0 {
-            if steps < 3 {
-                state.last_need = (3 - steps) as u8;
-                state.last_total = 3;
-                let start = buf.len() - steps;
-                state.last_char_len = steps as u8;
-                state.last_char[..steps].copy_from_slice(&buf[start..]);
-                return steps;
-            }
-            return 0;
-        }
-        // 2-byte lead 110xxxxx.
-        if (b & 0xE0) == 0xC0 {
-            if steps < 2 {
-                state.last_need = (2 - steps) as u8;
-                state.last_total = 2;
-                let start = buf.len() - steps;
-                state.last_char_len = steps as u8;
-                state.last_char[..steps].copy_from_slice(&buf[start..]);
-                return steps;
-            }
-            return 0;
-        }
-        // ASCII byte 0xxxxxxx — nothing to buffer.
-        return 0;
-    }
-    0
-}
-
-/// Decode `bytes` against the existing partial-codepoint state, mutating
-/// `state` to reflect any new trailing partial. Returns the decoded
-/// string. UTF-8 invalid sequences are replaced with U+FFFD, matching
-/// Node's `lossy` UTF-8 decoder behavior.
-fn write_utf8(state: &mut StringDecoderHandle, bytes: &[u8]) -> String {
-    let mut out = String::new();
-
-    // Stitch the buffered partial together with the new input first.
-    if state.last_need > 0 {
-        let need = state.last_need as usize;
-        if bytes.len() < need {
-            // Still incomplete — append what we can and exit empty.
-            let new_len = state.last_char_len as usize + bytes.len();
-            if new_len <= 4 {
-                state.last_char[state.last_char_len as usize..new_len].copy_from_slice(bytes);
-                state.last_char_len = new_len as u8;
-                state.last_need -= bytes.len() as u8;
-            } else {
-                // Defensive: should never happen given UTF-8 is at most 4
-                // bytes, but if upstream feeds garbage we reset rather
-                // than overrun.
-                state.last_need = 0;
-                state.last_total = 0;
-                state.last_char_len = 0;
-            }
-            return out;
-        }
-
-        // We have enough new bytes to complete the buffered point.
-        let total = state.last_total as usize;
-        let buffered = state.last_char_len as usize;
-        let take_new = total - buffered;
-        let mut cp = Vec::with_capacity(total);
-        cp.extend_from_slice(&state.last_char[..buffered]);
-        cp.extend_from_slice(&bytes[..take_new]);
-
-        match std::str::from_utf8(&cp) {
-            Ok(s) => out.push_str(s),
-            Err(_) => out.push('\u{FFFD}'),
-        }
-        state.last_need = 0;
-        state.last_total = 0;
-        state.last_char_len = 0;
-
-        // The "rest" continues below — chop off the consumed prefix.
-        let rest = &bytes[take_new..];
-        // Recurse on the tail so trailing partials get caught.
-        out.push_str(&write_utf8_tail(state, rest));
-        return out;
-    }
-
-    out.push_str(&write_utf8_tail(state, bytes));
-    out
-}
-
-/// Tail half of `write_utf8`: assumes `state.last_need == 0` on entry.
-/// Splits a trailing incomplete code point off into `state`.
-fn write_utf8_tail(state: &mut StringDecoderHandle, bytes: &[u8]) -> String {
-    if bytes.is_empty() {
-        return String::new();
-    }
-    let trail = utf8_check_incomplete(state, bytes);
-    let head = &bytes[..bytes.len() - trail];
-    String::from_utf8_lossy(head).into_owned()
-}
-
-/// `decoder.end([buf?])` — flush any incomplete state as U+FFFD, matching
-/// Node's behavior.
-fn end_utf8(state: &mut StringDecoderHandle, bytes: Option<&[u8]>) -> String {
-    let mut out = match bytes {
-        Some(b) => write_utf8(state, b),
-        None => String::new(),
-    };
-    if state.last_need > 0 {
-        out.push('\u{FFFD}');
-        state.last_need = 0;
-        state.last_total = 0;
-        state.last_char_len = 0;
-    }
-    out
 }
 
 /// UTF-16LE write: pair bytes as little-endian u16 code units. The last
@@ -965,7 +812,7 @@ pub unsafe fn dispatch_string_decoder(handle: i64, method: &str, args: &[f64]) -
                 }
                 _ => {
                     let s = match h.mode {
-                        DecodingMode::Utf8 => write_utf8(h, &bytes),
+                        DecodingMode::Utf8 => h.utf8.write(&bytes),
                         DecodingMode::Base64 | DecodingMode::Base64Url => write_base64(h, &bytes),
                         DecodingMode::Hex => write_hex(h, &bytes),
                         DecodingMode::Latin1 => write_latin1(h, &bytes),
@@ -998,7 +845,7 @@ pub unsafe fn dispatch_string_decoder(handle: i64, method: &str, args: &[f64]) -
                 }
                 _ => {
                     let s = match h.mode {
-                        DecodingMode::Utf8 => end_utf8(h, bytes_ref),
+                        DecodingMode::Utf8 => h.utf8.end(bytes_ref),
                         DecodingMode::Base64 => end_base64(h, bytes_ref, true),
                         DecodingMode::Base64Url => end_base64(h, bytes_ref, false),
                         // Hex / Latin1 / Ascii have no carry-over state — `end`
@@ -1050,8 +897,8 @@ pub unsafe fn dispatch_string_decoder_property(handle: i64, property: &str) -> f
     };
 
     match property {
-        "lastNeed" => f64::from(h.last_need as i32),
-        "lastTotal" => f64::from(h.last_total as i32),
+        "lastNeed" => f64::from(h.utf8.last_need as i32),
+        "lastTotal" => f64::from(h.utf8.last_total as i32),
         "lastChar" => {
             let buf = perry_runtime::buffer::buffer_alloc(4);
             if buf.is_null() {
@@ -1059,7 +906,7 @@ pub unsafe fn dispatch_string_decoder_property(handle: i64, property: &str) -> f
             }
             (*buf).length = 4;
             let dst = perry_runtime::buffer::buffer_data_mut(buf);
-            std::ptr::copy_nonoverlapping(h.last_char.as_ptr(), dst, 4);
+            std::ptr::copy_nonoverlapping(h.utf8.last_char.as_ptr(), dst, 4);
             f64::from_bits(0x7FFD_0000_0000_0000u64 | ((buf as u64) & 0x0000_FFFF_FFFF_FFFF))
         }
         "encoding" => {
@@ -1099,43 +946,6 @@ pub unsafe fn dispatch_string_decoder_property(handle: i64, property: &str) -> f
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn split_euro_sign() {
-        // U+20AC EURO SIGN = E2 82 AC in UTF-8.
-        let mut s = StringDecoderHandle::new();
-        let a = write_utf8(&mut s, &[0xE2, 0x82]);
-        assert_eq!(a, "");
-        assert_eq!(s.last_need, 1);
-        assert_eq!(s.last_total, 3);
-        let b = write_utf8(&mut s, &[0xAC]);
-        assert_eq!(b, "\u{20AC}");
-        assert_eq!(s.last_need, 0);
-    }
-
-    #[test]
-    fn split_emoji() {
-        // U+1F600 GRINNING FACE = F0 9F 98 80 in UTF-8 (4 bytes).
-        let mut s = StringDecoderHandle::new();
-        assert_eq!(write_utf8(&mut s, &[0xF0, 0x9F]), "");
-        assert_eq!(write_utf8(&mut s, &[0x98]), "");
-        assert_eq!(write_utf8(&mut s, &[0x80]), "\u{1F600}");
-    }
-
-    #[test]
-    fn end_flushes_partial_as_replacement() {
-        let mut s = StringDecoderHandle::new();
-        write_utf8(&mut s, &[0xE2, 0x82]);
-        let final_str = end_utf8(&mut s, None);
-        assert_eq!(final_str, "\u{FFFD}");
-    }
-
-    #[test]
-    fn complete_codepoint_round_trip() {
-        let mut s = StringDecoderHandle::new();
-        assert_eq!(write_utf8(&mut s, "hello".as_bytes()), "hello");
-        assert_eq!(s.last_need, 0);
-    }
 
     #[test]
     fn utf16le_end_emits_lone_high_surrogate_as_wtf8() {

--- a/test-files/test_gap_9489_stdin_chunk_boundaries.ts
+++ b/test-files/test_gap_9489_stdin_chunk_boundaries.ts
@@ -1,0 +1,144 @@
+// #9489: `process.stdin` must chunk by READ-BUFFER boundaries, not by lines.
+//
+// Perry's fd-0 reader read stdin ONE BYTE PER `read(2)` and, in cooked
+// flowing / pull mode, cut a `'data'` chunk at every `\n`. 1 MB of
+// `"line\n"` therefore arrived as 200,000 `'data'` events in 2.10 s where
+// Node delivers 16 in 0.04 s — a 52x slowdown driven by 1,048,576 read
+// syscalls plus 200,000 JS callback dispatches. Input with no newline in it
+// arrived as a single chunk, which is what pinned the cause on newlines
+// rather than on size.
+//
+// The user-visible damage was in claude-code: under the event flood its
+// stdin consumer gave up partway, so a piped prompt was truncated to a
+// RANDOM prefix (612k / 455k / 394k / 374k chars of 1,000,000 across four
+// runs). Feeding the same megabyte as one chunk, or as 1,000 x 1,000-char
+// lines, produced the full prompt every time.
+//
+// Node's contract: a chunk is whatever one read of the underlying handle
+// returned. Line splitting belongs to the consumer (readline does its own),
+// never to the shared `'data'` path.
+//
+// The parity runner gives a fixture no stdin, so this test re-spawns itself
+// with a pipe on the child's stdin and drives each shape in a child role.
+//
+// Event counts cannot be compared byte-for-byte across engines — Node's pipe
+// reads are 64 KiB, Perry's are 64 KiB but land on a different tick boundary
+// — so the flood arms assert an ORDER OF MAGNITUDE (`< 100`, against Node's
+// 16 and the unfixed engine's 200,000) plus exact byte counts and exact
+// content. The `trickle` arm is the opposite guard: three writes spaced in
+// time must stay THREE events, so a "fix" that simply glues the whole stream
+// into one chunk fails here.
+import { spawn } from "node:child_process";
+import { existsSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const ROLE_ENV = "PERRY_9489_STDIN_ROLE";
+const READY_ENV = "PERRY_9489_READY_FILE";
+const role = process.env[ROLE_ENV] ?? "";
+
+const TOTAL = 1_000_000;
+const LINES_PAYLOAD = "line\n".repeat(TOTAL / 5); // 200,000 lines
+const FLAT_PAYLOAD = "x".repeat(TOTAL); // no newline at all
+const K1000_PAYLOAD = ("y".repeat(999) + "\n").repeat(TOTAL / 1000); // 1,000 lines
+const TRICKLE_PARTS = ["one\n", "two\n", "three\n"];
+const TRICKLE_DELAY_MS = 150;
+
+function payloadFor(name: string): string {
+  if (name === "lines") return LINES_PAYLOAD;
+  if (name === "flat") return FLAT_PAYLOAD;
+  if (name === "k1000") return K1000_PAYLOAD;
+  return TRICKLE_PARTS.join("");
+}
+
+// ---------------------------------------------------------------------------
+// Child roles
+// ---------------------------------------------------------------------------
+if (role !== "") {
+  const expected = payloadFor(role);
+  let events = 0;
+  let bytes = 0;
+  let acc = "";
+  // The literal `process.stdin.on(...)` spelling is the one codegen lowers to
+  // perry-stdlib's readline extern — the path that did the line splitting.
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("data", (chunk: string) => {
+    events += 1;
+    bytes += chunk.length;
+    acc += chunk;
+  });
+  // Readiness handshake: the `trickle` arm measures how the reader SPLITS
+  // three spaced writes, which is only meaningful once the reader exists.
+  // Child start-up costs a few hundred ms under `--experimental-strip-types`,
+  // so without this the parent's three writes all land in the pipe buffer
+  // before the child reads anything and arrive as ONE chunk under Node too.
+  const readyPath = process.env[READY_ENV] ?? "";
+  if (readyPath !== "") writeFileSync(readyPath, "1");
+  process.stdin.on("end", () => {
+    console.log(role + " bytes:", bytes);
+    console.log(role + " content ok:", acc === expected);
+    if (role === "trickle") {
+      // Three spaced writes must not be glued into one chunk.
+      console.log(role + " events >= 3:", events >= 3);
+      console.log(role + " events <= 10:", events <= 10);
+    } else {
+      console.log(role + " events >= 1:", events >= 1);
+      console.log(role + " events < 100:", events < 100);
+    }
+  });
+} else {
+  // -------------------------------------------------------------------------
+  // Parent: drive each role in a child with a real pipe on its stdin.
+  // -------------------------------------------------------------------------
+  const childArgs = [...process.execArgv, ...process.argv.slice(1)];
+
+  const runRole = (name: string) =>
+    new Promise<void>((resolve) => {
+      const readyPath = join(tmpdir(), "perry-9489-ready-" + name + "-" + process.pid);
+      try {
+        rmSync(readyPath, { force: true });
+      } catch {}
+      const child = spawn(process.execPath, childArgs, {
+        env: { ...process.env, [ROLE_ENV]: name, [READY_ENV]: readyPath },
+        stdio: ["pipe", "inherit", "inherit"],
+      });
+      child.on("exit", (code) => {
+        try {
+          rmSync(readyPath, { force: true });
+        } catch {}
+        console.log(name + " exit:", code);
+        resolve();
+      });
+      if (name === "trickle") {
+        // Spaced writes: each must reach the child as its own read.
+        let i = 0;
+        const step = () => {
+          if (i >= TRICKLE_PARTS.length) {
+            child.stdin!.end();
+            return;
+          }
+          child.stdin!.write(TRICKLE_PARTS[i]);
+          i += 1;
+          setTimeout(step, TRICKLE_DELAY_MS);
+        };
+        const waitReady = () => {
+          if (existsSync(readyPath)) {
+            step();
+            return;
+          }
+          setTimeout(waitReady, 20);
+        };
+        waitReady();
+      } else {
+        child.stdin!.end(payloadFor(name));
+      }
+    });
+
+  (async () => {
+    await runRole("lines");
+    await runRole("flat");
+    await runRole("k1000");
+    await runRole("trickle");
+    console.log("done");
+  })();
+}

--- a/test-files/test_gap_9490_stream_set_encoding_utf8.ts
+++ b/test-files/test_gap_9490_stream_set_encoding_utf8.ts
@@ -1,0 +1,187 @@
+// #9490: a stream with `setEncoding("utf8")` must decode like Node's
+// `string_decoder` — U+FFFD for every invalid sequence, and carry-over state
+// for a multi-byte sequence split across a chunk boundary.
+//
+// Perry's `stdin_chunk_jsvalue` handed the raw bytes straight to
+// `js_string_from_bytes`, which does no validation at all: it memcpy's the
+// bytes into the string payload and only *counts* UTF-16 units with a
+// WTF-8-shaped walk. Feeding bytes 0..255 through `setEncoding("utf8")`:
+//
+//            code units   U+FFFD   high bytes
+//   node        256         128    replaced per WHATWG
+//   perry       158           0    raw U+0080..U+00FF passed through
+//
+// Two failures at once — invalid sequences were not replaced, and 98 code
+// units simply vanished (the WTF-8 length walk consumed continuation bytes
+// into the preceding lead byte). `Buffer.toString("utf8")` was already
+// correct (`buf_bytes_to_utf8_string` runs `String::from_utf8_lossy`); only
+// the stream path was wrong.
+//
+// The damage in claude-code: it writes what it read into the session
+// transcript, so perry's JSONL lines carried raw 0x80..0xFF bytes — neither
+// valid UTF-8 nor parseable JSON — and `--resume` could not read the session
+// back.
+//
+// The second half of the contract is carry-over. A per-chunk decode is not
+// enough: an emoji split across two reads must NOT become two replacement
+// characters. Node holds the incomplete tail until the next chunk and
+// flushes it as U+FFFD at `end`. Node emits that flush as its own final
+// `'data'` event and emits NO event for a chunk that decodes to "" — both
+// pinned below by the per-event breakdown.
+//
+// The parity runner gives a fixture no stdin, so this test re-spawns itself
+// with a pipe on the child's stdin and drives each shape in a child role.
+import { spawn } from "node:child_process";
+import { existsSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const ROLE_ENV = "PERRY_9490_ROLE";
+const READY_ENV = "PERRY_9490_READY_FILE";
+const role = process.env[ROLE_ENV] ?? "";
+
+const ALL_256 = Array.from({ length: 256 }, (_, i) => i);
+// Lone continuation, 2-byte overlong, 3-byte overlong, UTF-16 surrogate
+// encoded as UTF-8, and the two bytes that can never appear in UTF-8 — each
+// separated by an ASCII comma so a position shift is visible in the output.
+const INVALID = [0x80, 0x2c, 0xc0, 0x80, 0x2c, 0xe0, 0x80, 0xaf, 0x2c, 0xed, 0xa0, 0x80, 0x2c, 0xfe, 0x2c, 0xff];
+// 'A' then a truncated 3-byte sequence, so the stream ends mid-character.
+const TRUNC_END = [0x41, 0xe2, 0x82];
+// Three 4-byte emoji, written in four spaced pieces that split the first
+// after 1 byte, the second after 2, and the third after 3.
+const EMOJI = [0xf0, 0x9f, 0x98, 0x80];
+const SPLIT_WRITES = [
+  EMOJI.slice(0, 1),
+  [...EMOJI.slice(1), ...EMOJI.slice(0, 2)],
+  [...EMOJI.slice(2), ...EMOJI.slice(0, 3)],
+  EMOJI.slice(3),
+];
+const SPLIT_DELAY_MS = 150;
+
+function bytesFor(name: string): number[] {
+  if (name === "invalid") return INVALID;
+  if (name === "truncend") return TRUNC_END;
+  return ALL_256;
+}
+
+// Compact, diffable rendering of a string's UTF-16 code units.
+function units(s: string): string {
+  const out: string[] = [];
+  for (let i = 0; i < s.length; i++) out.push(s.charCodeAt(i).toString(16));
+  return out.join(" ");
+}
+function fffdCount(s: string): number {
+  let n = 0;
+  for (let i = 0; i < s.length; i++) if (s.charCodeAt(i) === 0xfffd) n += 1;
+  return n;
+}
+
+// ---------------------------------------------------------------------------
+// Child roles
+// ---------------------------------------------------------------------------
+if (role !== "") {
+  const stdin = process.stdin;
+  stdin.setEncoding("utf8");
+  const events: string[] = [];
+  let acc = "";
+
+  const finish = () => {
+    console.log(role + " length:", acc.length);
+    console.log(role + " fffd:", fffdCount(acc));
+    if (role === "all256" || role === "pull") {
+      // Exact code units, and the ASCII prefix must survive untouched.
+      console.log(role + " ascii ok:", units(acc.slice(0, 128)) === units(ALL_256.slice(0, 128).map((b) => String.fromCharCode(b)).join("")));
+      console.log(role + " tail units:", units(acc.slice(128)));
+    } else {
+      console.log(role + " units:", units(acc));
+    }
+    if (role === "truncend" || role === "splits") {
+      // Per-event breakdown: proves the incomplete tail is HELD (no empty
+      // event, no premature replacement) and flushed as its own last event.
+      console.log(role + " events:", JSON.stringify(events));
+    }
+  };
+
+  if (role === "pull") {
+    // Paused / pull mode: `on("readable")` plus `read()`, the other half of
+    // the readable-side contract.
+    stdin.on("readable", () => {
+      let chunk = stdin.read();
+      while (chunk !== null) {
+        const text = String(chunk);
+        if (text.length > 0) {
+          events.push(units(text));
+          acc += text;
+        }
+        chunk = stdin.read();
+      }
+    });
+  } else {
+    stdin.on("data", (chunk: string) => {
+      events.push(units(chunk));
+      acc += chunk;
+    });
+  }
+  stdin.on("end", finish);
+
+  const readyPath = process.env[READY_ENV] ?? "";
+  if (readyPath !== "") writeFileSync(readyPath, "1");
+} else {
+  // -------------------------------------------------------------------------
+  // Parent: drive each role in a child with a real pipe on its stdin.
+  // -------------------------------------------------------------------------
+  const childArgs = [...process.execArgv, ...process.argv.slice(1)];
+
+  const runRole = (name: string) =>
+    new Promise<void>((resolve) => {
+      const readyPath = join(tmpdir(), "perry-9490-ready-" + name + "-" + process.pid);
+      try {
+        rmSync(readyPath, { force: true });
+      } catch {}
+      const child = spawn(process.execPath, childArgs, {
+        env: { ...process.env, [ROLE_ENV]: name, [READY_ENV]: readyPath },
+        stdio: ["pipe", "inherit", "inherit"],
+      });
+      child.on("exit", (code) => {
+        try {
+          rmSync(readyPath, { force: true });
+        } catch {}
+        console.log(name + " exit:", code);
+        resolve();
+      });
+      if (name === "splits") {
+        // Each piece must reach the child as its OWN read, or the split
+        // never happens and the arm proves nothing. Wait for the child to
+        // have its listener up, then space the writes.
+        let i = 0;
+        const step = () => {
+          if (i >= SPLIT_WRITES.length) {
+            child.stdin!.end();
+            return;
+          }
+          child.stdin!.write(Buffer.from(SPLIT_WRITES[i]));
+          i += 1;
+          setTimeout(step, SPLIT_DELAY_MS);
+        };
+        const waitReady = () => {
+          if (existsSync(readyPath)) {
+            step();
+            return;
+          }
+          setTimeout(waitReady, 20);
+        };
+        waitReady();
+      } else {
+        child.stdin!.end(Buffer.from(bytesFor(name)));
+      }
+    });
+
+  (async () => {
+    await runRole("all256");
+    await runRole("invalid");
+    await runRole("truncend");
+    await runRole("splits");
+    await runRole("pull");
+    console.log("done");
+  })();
+}

--- a/test-files/test_gap_9490_stream_set_encoding_utf8.ts
+++ b/test-files/test_gap_9490_stream_set_encoding_utf8.ts
@@ -32,6 +32,7 @@
 // The parity runner gives a fixture no stdin, so this test re-spawns itself
 // with a pipe on the child's stdin and drives each shape in a child role.
 import { spawn } from "node:child_process";
+import { Readable } from "node:stream";
 import { existsSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -176,7 +177,43 @@ if (role !== "") {
       }
     });
 
+  // A generic `Readable` carries the same contract, and had the same
+  // carry-over hole: `decode_readable_chunk_for_encoding` decoded each
+  // pushed chunk on its own, so a code point straddling two `push()` calls
+  // became replacement characters. This arm needs no child process.
+  const runReadable = (name: string, pushes: number[][]) =>
+    new Promise<void>((resolve) => {
+      const stream = new Readable({ read() {} });
+      stream.setEncoding("utf8");
+      const evs: string[] = [];
+      let acc = "";
+      stream.on("data", (chunk: string) => {
+        evs.push(units(chunk));
+        acc += chunk;
+      });
+      stream.on("end", () => {
+        console.log(name + " length:", acc.length);
+        console.log(name + " fffd:", fffdCount(acc));
+        console.log(name + " units:", units(acc));
+        console.log(name + " events:", JSON.stringify(evs));
+        resolve();
+      });
+      for (const p of pushes) stream.push(Buffer.from(p));
+      stream.push(null);
+    });
+
   (async () => {
+    // Emoji split 2/2, then a 3-byte sequence split 1/2 across the next two
+    // pushes, then invalid bytes — one arm covering hold, resume and replace.
+    await runReadable("readable", [
+      [0xf0, 0x9f],
+      [0x98, 0x80],
+      [0x41, 0xe2, 0x82],
+      [0xac, 0x80, 0xc0, 0x80],
+    ]);
+    // Stream ends mid-sequence: the held tail flushes as one U+FFFD, in its
+    // own final chunk.
+    await runReadable("readable_flush", [[0x41, 0xe2, 0x82]]);
     await runRole("all256");
     await runRole("invalid");
     await runRole("truncend");


### PR DESCRIPTION
Two stream-read-path fixes that restore claude-code's piped-input integrity. cc-level result: the D04 (binary stdin) and D07 (1 MB stdin) stress cases go **byte-identical to node**.

## #9489 — one `data` event per LINE, one byte per read(2)

**Root cause:** `perry-stdlib/src/readline/mod.rs`, `ensure_reader_started()` — the fd-0 reader read **one byte per `read(2)`** (`let mut byte = [0u8; 1]`) and pushed a `'data'` chunk only on `\n`. 1 MB of piped input cost 1,048,576 syscalls and 200,000 events (node: 16). Readline's own `'line'` queue is the consumer that wanted lines; one reader serves both, and it cut for the `'line'` queue's benefit on the shared `'data'` path.

**Fix:** 64 KiB block reads (node's pipe read size), one chunk per read. Blast radius held deliberately narrow: **raw mode still enqueues single-byte chunks** (the keypress path reassembles escape sequences from them) — now staged with one mutex acquisition per read instead of per byte — and the mode atomics are still consulted **per byte**, so a `setRawMode`/`pause` flip mid-block lands on exactly the byte it used to.

**The loss-location question answered honestly:** perry-side machinery loses **nothing** — under the unfixed reader all 1,000,000 bytes arrive across the 200,000 events with content intact. The prompt truncation was cc's own consumer reacting to event *count*. cc-side, not file-worthy against perry.

## #9490 — the stream utf8 decoder

**Root cause:** `os_process_streams.rs` passed raw bytes to `js_string_from_bytes`, which validates nothing — continuation bytes were swallowed into the preceding lead (158 units out for 256 bytes in, zero U+FFFD). **A correct incremental decoder already existed** — in the *upper* crate (`perry-stdlib/src/string_decoder.rs`), unreachable from the runtime's stream paths because the dependency points the other way, so each path had grown its own one-shot decode. The fix **moves the core down** into `perry-runtime/src/utf8_stream_decoder.rs`; `node:string_decoder` now embeds it, so the two cannot drift. Wired into stdin `'data'` (both pumps), pull-mode `read()` (shared carry-over state), and generic `Readable` (per-stream remainder mirroring the existing base64 remainder).

**Two hazards the change itself exposed, fixed in the same commit:** both pumps decoded the chunk **once per listener** — harmless stateless, but with carry-over it feeds the decoder N times and hands listener 2 a continuation of listener 1's leftovers — hoisted above the loop; and the hoisted value must survive every callback, so it is rooted in a scope outliving the loop and re-read per call (rebuilding it inside the loop is what made the old shape safe *by accident*).

## Verification

| check | result |
|---|---|
| both gap fixtures vs node 26.5.1 | byte-identical (before: 4 and 30 diff lines on unfixed main) |
| perry-runtime lib (`--release`, single-thread) | **2981 passed, 0 failed** (7 new decoder tests) |
| perry-stdlib lib | 122 / 0 |
| `test_gap_9416`, `test_issue_9399/9400`, 12 stream/readline/encoding gap tests | all pass |
| `mcp serve` E01–E09, rebuilt cc vs node | **9/9 stdout identical** |
| **cc D04** | transcript 16,713 B (was 12,713), 0 non-UTF-8 lines (was 3), every line `JSON.parse`s, **byte-matches node** |
| **cc D07** | **12 records, 1,000,000 prompt chars, `.claude/plans/` present** — all previously lost |

The #9490 fixture includes a 4-byte emoji split at every boundary the *new* chunking produces, a lone continuation byte, an overlong encoding, and a truncated sequence at `end` — asserting unit counts and replacement positions against node.

## Corrections to the record

- **The "E01–E09 passed before" premise was wrong as stated in the brief**: the pre-existing `app_x` binary answers 14 bytes (nothing) on seven of them — it predates the #9399 buffer-length fix. With this build they are byte-identical to node. The MCP blast radius was also verified structurally: `StdioServerTransport._ondata` frames newlines itself from its own `_readBuffer`, so block chunking cannot break it.
- `app_x` is likewise not a valid #9489 baseline (it reads the full prompt); the issue's cc numbers came from a fresh main binary.
- All baseline node-arm rows predate the server contamination window, re-verified clean before the post-fix runs.

Rebased onto current `origin/main` (post-#9491) with full local re-verification, so the branch does not read as reverting #9421's fs changes.

Closes #9489. Closes #9490.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stdin stream chunking to process larger read batches and avoid splitting data at every newline.
  * Fixed back-pressure issues that could truncate piped input.
  * Updated UTF-8 stream decoding to handle split characters, invalid sequences, and incomplete input consistently with Node.js.
  * Added final replacement-character output when incomplete UTF-8 data remains at stream end.

* **Tests**
  * Added coverage for stdin chunk boundaries and incremental UTF-8 decoding across varied input patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->