### PR TITLE
fix(runtime): native-async promises are non-moving, their tokens are released, and a top-level await no longer parks on a settled promise (#9356)

### DIFF
--- a/crates/perry-codegen/src/expr/fs_await.rs
+++ b/crates/perry-codegen/src/expr/fs_await.rs
@@ -24,7 +24,7 @@ use perry_hir::Expr;
 
 use crate::nanbox::double_literal;
 use crate::rooting::{with_rooted_group, Repr};
-use crate::types::{DOUBLE, I1, I32, I64};
+use crate::types::{DOUBLE, I32, I64};
 
 use super::{lower_expr, unbox_to_i64, FnCtx};
 
@@ -206,18 +206,35 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 // server renderer) can never settle.
                 let _ = ctx.block().call(I32, "js_await_loop_tick_timers", &[]);
 
+                // #9356: the drain / pump / timer phases above can settle the
+                // awaited promise themselves — the pump delivers a native
+                // completion, and the microtask drain then runs the async
+                // chain to the point where it fulfils this promise. Promise
+                // settlements made while the drain is active deliberately skip
+                // the main-thread notify (`js_notify_promise_progress`), so
+                // `js_wait_for_event` would find nothing pending and park for
+                // the whole idle budget (up to 1 s) on a promise that is
+                // already settled — one such stall per top-level `await` of a
+                // database transaction. Re-check before parking; `check`
+                // re-reads the rooted promise and takes the settled path.
+                let park_idx = ctx.new_block("await.park");
+                let park_label = ctx.block_label(park_idx);
+                let promise_box = g.reread_emitted(ctx, promise_root);
+                let promise_handle_wait = unbox_to_i64(ctx.block(), &promise_box);
+                let state_after_tick =
+                    ctx.block()
+                        .call(I32, "js_promise_state", &[(I64, &promise_handle_wait)]);
+                let still_pending = ctx.block().icmp_eq(I32, &state_after_tick, "0");
+                ctx.block()
+                    .cond_br(&still_pending, &park_label, &check_label);
+                ctx.current_block = park_idx;
+
                 if !ctx.is_async_fn {
                     let wait_for_event_idx = ctx.new_block("await.wait_for_event");
                     let unsettled_exit_idx = ctx.new_block("await.unsettled_exit");
                     let wait_for_event_label = ctx.block_label(wait_for_event_idx);
                     let unsettled_exit_label = ctx.block_label(unsettled_exit_idx);
 
-                    let promise_box = g.reread_emitted(ctx, promise_root);
-                    let promise_handle_wait = unbox_to_i64(ctx.block(), &promise_box);
-                    let state_after_tick =
-                        ctx.block()
-                            .call(I32, "js_promise_state", &[(I64, &promise_handle_wait)]);
-                    let still_pending = ctx.block().icmp_eq(I32, &state_after_tick, "0");
                     let has_timers = ctx.block().call(I32, "js_timer_has_pending", &[]);
                     let has_callbacks = ctx.block().call(I32, "js_callback_timer_has_pending", &[]);
                     let has_intervals = ctx.block().call(I32, "js_interval_timer_has_pending", &[]);
@@ -232,9 +249,14 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     let any3 = ctx.block().or(I32, &any1, &any2);
                     let any = ctx.block().or(I32, &any3, &has_microtasks);
                     let no_refed_work = ctx.block().icmp_eq(I32, &any, "0");
-                    let should_exit = ctx.block().and(I1, &still_pending, &no_refed_work);
-                    ctx.block()
-                        .cond_br(&should_exit, &unsettled_exit_label, &wait_for_event_label);
+                    // The promise is still pending here (the settled case
+                    // branched back to `check` above); with no refed work left
+                    // nothing can ever settle it.
+                    ctx.block().cond_br(
+                        &no_refed_work,
+                        &unsettled_exit_label,
+                        &wait_for_event_label,
+                    );
 
                     ctx.current_block = unsettled_exit_idx;
                     ctx.block()

--- a/crates/perry-runtime/src/gc/tests/runtime_roots/callback_scanners.rs
+++ b/crates/perry-runtime/src/gc/tests/runtime_roots/callback_scanners.rs
@@ -736,9 +736,13 @@ fn test_native_async_completion_token_roots_survive_copied_minor_gc() {
 
     let (moved_promise, moved_payload, moved_handles) =
         crate::promise::native_async::test_native_async_slot_snapshot(token);
-    assert_ne!(
+    // #9356: the token's promise is malloc resident (non-moving) because the
+    // address is handed to native code as a raw pointer; a copied minor must
+    // leave it where it is. The payload and attached-handle slots hold
+    // nursery strings and are still rewritten.
+    assert_eq!(
         moved_promise, original_promise,
-        "token promise slot should be rewritten after copied-minor GC"
+        "token promise must not move: native code holds its raw address"
     );
     assert_ne!(
         moved_payload.unwrap() & POINTER_MASK,

--- a/crates/perry-runtime/src/promise/mod.rs
+++ b/crates/perry-runtime/src/promise/mod.rs
@@ -58,7 +58,7 @@ pub use native_async::{
     js_native_async_completion_reject_bits, js_native_async_completion_reject_promise_bits,
     js_native_async_completion_reject_string, js_native_async_completion_resolve_bits,
     js_native_async_completion_resolve_promise_bits, js_native_async_drop_promise_token,
-    js_native_async_has_active, js_native_async_process_pending,
+    js_native_async_has_active, js_native_async_process_pending, native_async_promise_has_token,
     scan_native_async_completion_roots_mut, NativeAsyncCompletion,
     PERRY_NATIVE_ASYNC_ALREADY_COMPLETED, PERRY_NATIVE_ASYNC_CLEANUP_ON_CANCEL,
     PERRY_NATIVE_ASYNC_CLEANUP_ON_REJECT, PERRY_NATIVE_ASYNC_CLEANUP_ON_SUCCESS,

--- a/crates/perry-runtime/src/promise/native_async.rs
+++ b/crates/perry-runtime/src/promise/native_async.rs
@@ -298,10 +298,39 @@ fn adopt_or_get_token_for_promise(promise: *mut Promise) -> *mut NativeAsyncComp
 }
 
 /// Allocate a native async completion token and its JS-visible Promise.
+///
+/// The Promise is allocated in malloc space (`js_promise_new_cross_thread`),
+/// never in the nursery. A token exists precisely so native code can carry
+/// the Promise across a worker thread and settle it later, and every consumer
+/// of `js_native_async_completion_promise` holds that pointer as a raw
+/// `*mut Promise` / `usize` the collector cannot see or rewrite (perry-ffi's
+/// `JsPromise`, the ext crates' pending tables). The registry scanner keeps
+/// the object alive and rewrites the token's own slot, but a copying minor
+/// still *moved* a nursery-resident promise, and the worker's captured
+/// address then named retired from-space: the eventual
+/// `perry_ffi_promise_resolve_deferred` settled the stale copy (or read
+/// garbage) and the promise the program awaited stayed pending forever
+/// (#9356 — drizzle/mysql2 transactions hanging once the nursery first
+/// filled). Malloc space is non-moving, so the address native code captured
+/// stays valid for the token's whole life.
 #[no_mangle]
 pub extern "C" fn js_native_async_completion_new(flags: u32) -> *mut NativeAsyncCompletion {
-    let promise = super::js_promise_new();
+    let promise = super::js_promise_new_cross_thread();
     make_token_for_promise(promise, flags, true)
+}
+
+/// Does `promise` currently own a registered native async token?
+///
+/// Test/diagnostic surface for the token lifecycle: a token is registered by
+/// [`js_native_async_completion_new`] and released by
+/// [`js_native_async_process_pending`] (token API settlement) or
+/// [`js_native_async_drop_promise_token`] (settlement outside the token API).
+pub fn native_async_promise_has_token(promise: *mut Promise) -> bool {
+    if promise.is_null() {
+        return false;
+    }
+    let registry = crate::gc::lock_gc_root_registry(registry());
+    registry.by_promise.contains_key(&(promise as usize))
 }
 
 /// Return the JS-visible Promise owned by a native async completion token.
@@ -706,6 +735,34 @@ mod tests {
             "Error.stack must include the rejection message: {}",
             String::from_utf8_lossy(&stack)
         );
+    }
+
+    #[test]
+    fn token_promise_is_allocated_outside_the_copying_nursery() {
+        let _guard = test_native_async_lock();
+        test_reset_native_async_registry();
+        let token = js_native_async_completion_new(0);
+        let promise = js_native_async_completion_promise(token);
+        assert!(!promise.is_null());
+        // #9356: the promise address is handed to worker threads as a raw
+        // pointer, so it must live in non-moving (malloc) space — an arena
+        // resident would be relocated by the copying minor behind that
+        // pointer's back.
+        let header = unsafe {
+            (promise as *mut u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader
+        };
+        assert_eq!(
+            unsafe { (*header).gc_flags } & crate::gc::GC_FLAG_ARENA,
+            0,
+            "native async token promise must not be arena (nursery) resident"
+        );
+        assert!(native_async_promise_has_token(promise));
+        assert_eq!(
+            js_native_async_completion_resolve_bits(token, 3.0f64.to_bits()),
+            0
+        );
+        assert_eq!(js_native_async_process_pending(), 1);
+        assert!(!native_async_promise_has_token(promise));
     }
 
     #[test]

--- a/crates/perry-stdlib/src/common/async_bridge.rs
+++ b/crates/perry-stdlib/src/common/async_bridge.rs
@@ -69,6 +69,24 @@ unsafe fn unpin_promise_after_native_resolution(promise_ptr: usize) {
     perry_runtime::gc::unpin_object(header);
 }
 
+/// Release the native async completion token a promise minted through
+/// `perry_ffi_promise_new` still owns (#9356).
+///
+/// `perry_ffi_promise_new` allocates through `js_native_async_completion_new`,
+/// which registers a token keyed by the promise address so the token API can
+/// settle it later. perry-ffi's `JsPromise::resolve_with` / `reject_with` and
+/// the legacy `resolve_*` shims do not go through the token API — they queue
+/// straight into the stdlib pump and settle the promise here — so nothing ever
+/// removed the token. Every native call (each mysql2 query, every bcrypt hash,
+/// …) leaked one registry entry: the settled promise stayed rooted and was
+/// rewritten on every minor collection, and `js_native_async_has_active`
+/// reported work forever. Dropping the token here mirrors the cleanup
+/// `js_native_async_process_pending` performs for token-API settlements; it
+/// is a no-op for promises that never had a token.
+fn release_native_async_token(promise: *mut perry_runtime::Promise) {
+    perry_runtime::promise::js_native_async_drop_promise_token(promise);
+}
+
 /// Allocate a fresh Promise and pin it for cross-thread resolution.
 /// Convenience wrapper for direct callers of [`queue_promise_resolution`]
 /// / [`queue_deferred_resolution`] (fetch, zlib, bcrypt, ioredis, ws,
@@ -539,11 +557,9 @@ pub extern "C" fn js_stdlib_process_pending() -> i32 {
         // can be reclaimed by the next GC. Resolve doesn't trigger GC
         // mid-call, so ordering here is purely about leaving a clean
         // GC state after the loop.
-        unsafe {
-            unpin_promise_after_native_resolution(
-                promise_handle.get_raw_mut_ptr::<perry_runtime::Promise>() as usize,
-            )
-        };
+        let promise_ptr = promise_handle.get_raw_mut_ptr::<perry_runtime::Promise>();
+        unsafe { unpin_promise_after_native_resolution(promise_ptr as usize) };
+        release_native_async_token(promise_ptr);
         if resolution.is_success {
             perry_runtime::js_promise_resolve(
                 promise_handle.get_raw_mut_ptr(),
@@ -578,11 +594,9 @@ pub extern "C" fn js_stdlib_process_pending() -> i32 {
         // and may itself have allocated (creating the result string,
         // etc.), but the promise stayed pinned across that work — so
         // even if the converter triggered GC, the promise survived.
-        unsafe {
-            unpin_promise_after_native_resolution(
-                promise_handle.get_raw_mut_ptr::<perry_runtime::Promise>() as usize,
-            )
-        };
+        let promise_ptr = promise_handle.get_raw_mut_ptr::<perry_runtime::Promise>();
+        unsafe { unpin_promise_after_native_resolution(promise_ptr as usize) };
+        release_native_async_token(promise_ptr);
         if resolution.is_success {
             perry_runtime::js_promise_resolve(
                 promise_handle.get_raw_mut_ptr(),
@@ -1046,6 +1060,28 @@ mod tests {
     fn clear_pending() {
         PENDING_RESOLUTIONS.lock().unwrap().clear();
         PENDING_DEFERRED.lock().unwrap().clear();
+    }
+
+    #[test]
+    fn stdlib_pump_releases_the_native_async_token_of_a_deferred_resolution() {
+        clear_pending();
+        // perry-ffi's `JsPromise::new()` mints the promise through this shim,
+        // which registers a native async token keyed by the promise address.
+        let promise = crate::perry_ffi_async::perry_ffi_promise_new();
+        assert!(!promise.is_null());
+        assert!(perry_runtime::promise::native_async_promise_has_token(
+            promise
+        ));
+        // `JsPromise::resolve_with` settles through the deferred queue, never
+        // through the token API — the pump must drop the token itself or it
+        // leaks one registry entry per native call (#9356).
+        queue_deferred_resolution(promise as usize, true, || 7.0f64.to_bits());
+        assert!(js_stdlib_process_pending() >= 1);
+        assert_eq!(perry_runtime::promise::js_promise_state(promise), 1);
+        assert_eq!(perry_runtime::promise::js_promise_value(promise), 7.0);
+        assert!(!perry_runtime::promise::native_async_promise_has_token(
+            promise
+        ));
     }
 
     #[test]

--- a/crates/perry-stdlib/src/perry_ffi_async.rs
+++ b/crates/perry-stdlib/src/perry_ffi_async.rs
@@ -57,16 +57,20 @@ extern "C" {
 /// is owned by the runtime arena; resolution / rejection is what
 /// transfers it to the awaiter.
 ///
-/// Issue #859: the promise is also PINNED before returning, because
-/// every documented use of `perry_ffi_promise_new` ships the pointer
+/// Every documented use of `perry_ffi_promise_new` ships the pointer
 /// to a worker future (via `perry_ffi_spawn_blocking*` /
-/// `perry_ffi_spawn_async`) and later resolves it from the worker.
-/// Without pinning, the await chain has no path back to the promise
-/// — `P.next = N` is a forward edge — and a GC cycle during the
-/// worker's run sweeps `P` mid-flight, turning the eventual
-/// `js_promise_resolve(P, ...)` into a use-after-free SIGBUS. The
-/// matching unpin lives in `js_stdlib_process_pending` (see
-/// `unpin_promise_after_native_resolution` in `async_bridge`).
+/// `perry_ffi_spawn_async`) and later resolves it from the worker, so
+/// the promise must survive — and keep its address — for as long as
+/// that raw pointer is out there. The await chain has no path back to
+/// the promise (`P.next = N` is a forward edge; #859), so the native
+/// async token registered here is what roots it. And because the
+/// worker's copy of the address is invisible to the collector, the
+/// promise is allocated in non-moving malloc space (see
+/// `js_native_async_completion_new`, #9356): a nursery-resident
+/// promise was relocated by the copying minor and the worker then
+/// settled its retired from-space copy, leaving the awaited promise
+/// pending forever. The token is released when the stdlib pump settles
+/// the promise (`js_stdlib_process_pending`).
 #[no_mangle]
 pub extern "C" fn perry_ffi_promise_new() -> *mut perry_runtime::Promise {
     async_bridge::ensure_pump_registered();

--- a/tests/release/packages/drizzle-mysql2-tx/entry.ts
+++ b/tests/release/packages/drizzle-mysql2-tx/entry.ts
@@ -1,0 +1,57 @@
+// #9356 acceptance: drizzle-orm transactions over the native `mysql2`
+// binding (perry-ext-mysql2), a few hundred in a row, with the young
+// generation collected every couple of transactions (fixture.sh sets
+// PERRY_GC_SCAVENGE_NURSERY_MB=1).
+//
+// Before the fix the promise minted by `perry_ffi_promise_new` lived in the
+// nursery; the first copying minor that landed while a query was in flight
+// moved it under the worker thread's raw pointer, the worker then settled
+// the retired copy, and the transaction never completed (~195 transactions
+// with a 16 MB nursery, iteration 2 with a 1 MB one). Every query also
+// leaked its native-async token, and the top-level `await` parked for the
+// full 1 s idle budget after the drain had already settled its promise.
+import mysql from "mysql2/promise";
+import { drizzle } from "drizzle-orm/mysql2";
+import { sql } from "drizzle-orm";
+
+const pool = mysql.createPool({
+    host: "127.0.0.1",
+    port: 3306,
+    user: process.env.PERRY_FIXTURE_MYSQL_USER ?? "root",
+    password: process.env.PERRY_FIXTURE_MYSQL_PASSWORD ?? "",
+    database: "perry_drizzle_test",
+});
+// `any`: the statically typed `db.transaction(...)` call currently throws
+// "Cannot convert undefined or null to object" on main (typed-dispatch
+// regression, tracked separately); the reporter's code hits the same
+// machinery through the dynamic path this exercises.
+const db: any = drizzle(pool, { mode: "default" });
+
+await db.execute(sql`DROP TABLE IF EXISTS tx_notifications`);
+await db.execute(sql`CREATE TABLE tx_notifications (id INT PRIMARY KEY AUTO_INCREMENT, body VARCHAR(32) NOT NULL)`);
+for (let i = 1; i <= 9; i++) {
+    await db.execute(sql`INSERT INTO tx_notifications (body) VALUES (${"n" + i})`);
+}
+console.log("seeded");
+
+const ITERATIONS = 400;
+let completed = 0;
+for (let iteration = 1; iteration <= ITERATIONS; iteration++) {
+    await db.transaction(async (tx: any) => {
+        const result = await tx.execute(sql`
+            SELECT a.id
+              FROM tx_notifications a
+              CROSS JOIN tx_notifications b
+             ORDER BY a.id, b.id
+        `);
+        const rows = (Array.isArray(result) ? result[0] : result) as Array<{ id: number }>;
+        if (rows.length !== 81) {
+            throw new Error(`iteration ${iteration}: expected 81 rows, received ${rows.length}`);
+        }
+    });
+    completed++;
+}
+console.log(`transactions=${completed}/${ITERATIONS}`);
+
+await pool.end();
+console.log("done");

--- a/tests/release/packages/drizzle-mysql2-tx/expected.txt
+++ b/tests/release/packages/drizzle-mysql2-tx/expected.txt
@@ -1,0 +1,3 @@
+seeded
+transactions=400/400
+done

--- a/tests/release/packages/drizzle-mysql2-tx/fixture.sh
+++ b/tests/release/packages/drizzle-mysql2-tx/fixture.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -uo pipefail
+cd "$(dirname "$0")"
+. "$(dirname "$0")/../_fixture_lib.sh"
+
+# Real-MySQL fixture (#9356): needs a running mysqld on 127.0.0.1:3306
+# reachable as root without a password (override with
+# PERRY_FIXTURE_MYSQL_USER / PERRY_FIXTURE_MYSQL_PASSWORD), with a
+# `perry_drizzle_test` database. Skip (rather than fail) if MySQL isn't
+# available — CI wiring is tracked in #804.
+MYSQL_USER="${PERRY_FIXTURE_MYSQL_USER:-root}"
+MYSQL_ARGS=(-h 127.0.0.1 -u "$MYSQL_USER")
+if [[ -n "${PERRY_FIXTURE_MYSQL_PASSWORD:-}" ]]; then
+    MYSQL_ARGS+=(-p"$PERRY_FIXTURE_MYSQL_PASSWORD")
+fi
+if ! command -v mysql >/dev/null 2>&1 || ! mysql "${MYSQL_ARGS[@]}" -e "SELECT 1" >/dev/null 2>&1; then
+    fixture_skip "drizzle-mysql2-tx" "no MySQL on 127.0.0.1:3306 (see #804 for CI wiring)"
+fi
+mysql "${MYSQL_ARGS[@]}" -e "CREATE DATABASE IF NOT EXISTS perry_drizzle_test" >/dev/null 2>&1 || \
+    fixture_skip "drizzle-mysql2-tx" "cannot create perry_drizzle_test database"
+
+# A 1 MB nursery makes the copying minor fire every couple of transactions,
+# so a promise that is not safe to hold across a young collection (the
+# #9356 defect) fails within the first few iterations instead of at ~195.
+export PERRY_GC_SCAVENGE_NURSERY_MB=1
+
+fixture_setup "drizzle-mysql2-tx" || exit 1
+fixture_compile_run_diff "drizzle-mysql2-tx"

--- a/tests/release/packages/drizzle-mysql2-tx/package-lock.json
+++ b/tests/release/packages/drizzle-mysql2-tx/package-lock.json
@@ -1,0 +1,273 @@
+{
+  "name": "perry-release-fixture-drizzle-mysql2-tx",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "perry-release-fixture-drizzle-mysql2-tx",
+      "version": "0.0.0",
+      "dependencies": {
+        "drizzle-orm": "^0.44.7",
+        "mysql2": "^3.24.2"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz",
+      "integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/drizzle-orm": {
+      "version": "0.44.7",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.44.7.tgz",
+      "integrity": "sha512-quIpnYznjU9lHshEOAYLoZ9s3jweleHlZIAWR/jX9gAWNg/JhQ1wj0KGRf7/Zm+obRrYd9GjPVJg790QY9N5AQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/client-rds-data": ">=3",
+        "@cloudflare/workers-types": ">=4",
+        "@electric-sql/pglite": ">=0.2.0",
+        "@libsql/client": ">=0.10.0",
+        "@libsql/client-wasm": ">=0.10.0",
+        "@neondatabase/serverless": ">=0.10.0",
+        "@op-engineering/op-sqlite": ">=2",
+        "@opentelemetry/api": "^1.4.1",
+        "@planetscale/database": ">=1.13",
+        "@prisma/client": "*",
+        "@tidbcloud/serverless": "*",
+        "@types/better-sqlite3": "*",
+        "@types/pg": "*",
+        "@types/sql.js": "*",
+        "@upstash/redis": ">=1.34.7",
+        "@vercel/postgres": ">=0.8.0",
+        "@xata.io/client": "*",
+        "better-sqlite3": ">=7",
+        "bun-types": "*",
+        "expo-sqlite": ">=14.0.0",
+        "gel": ">=2",
+        "knex": "*",
+        "kysely": "*",
+        "mysql2": ">=2",
+        "pg": ">=8",
+        "postgres": ">=3",
+        "sql.js": ">=1",
+        "sqlite3": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/client-rds-data": {
+          "optional": true
+        },
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "@electric-sql/pglite": {
+          "optional": true
+        },
+        "@libsql/client": {
+          "optional": true
+        },
+        "@libsql/client-wasm": {
+          "optional": true
+        },
+        "@neondatabase/serverless": {
+          "optional": true
+        },
+        "@op-engineering/op-sqlite": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "@tidbcloud/serverless": {
+          "optional": true
+        },
+        "@types/better-sqlite3": {
+          "optional": true
+        },
+        "@types/pg": {
+          "optional": true
+        },
+        "@types/sql.js": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/postgres": {
+          "optional": true
+        },
+        "@xata.io/client": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "bun-types": {
+          "optional": true
+        },
+        "expo-sqlite": {
+          "optional": true
+        },
+        "gel": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        },
+        "sql.js": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru.min": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.5.tgz",
+      "integrity": "sha512-5J9ysMYUpYIg9RF2vJpy9SinEmSviFSe0GyPpCQ4L5QSkLAgeLXlTAOu2ZwWUU5m+0SBl6gUU1R1ZQB3aKypfA==",
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=1.30.0",
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wellwelwel"
+      }
+    },
+    "node_modules/mysql2": {
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.24.3.tgz",
+      "integrity": "sha512-OKfWHkMAg9v06neq8FmSyhbxPQKABN9PAW5G9/bDTXzJBO5xXtkKL0V27vju7HQWk9UD4Od5BZsvCtBTB1CPEw==",
+      "license": "MIT",
+      "dependencies": {
+        "aws-ssl-profiles": "^1.1.2",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.7.3",
+        "long": "^5.3.2",
+        "lru.min": "^1.1.4",
+        "named-placeholders": "^1.1.6",
+        "sql-escaper": "^1.5.1"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 8"
+      }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.6.tgz",
+      "integrity": "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==",
+      "license": "MIT",
+      "dependencies": {
+        "lru.min": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/sql-escaper": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/sql-escaper/-/sql-escaper-1.5.1.tgz",
+      "integrity": "sha512-4toX5E1fQbBrpfXidaHnF0669nkAdETeIPTs2SUjxxD7RRIs9ICG4gtpmfc68JCEKehsdwLFqBu9VlQqZ1P1gg==",
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=2.0.0",
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/mysqljs/sql-escaper?sponsor=1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT",
+      "peer": true
+    }
+  }
+}

--- a/tests/release/packages/drizzle-mysql2-tx/package.json
+++ b/tests/release/packages/drizzle-mysql2-tx/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "perry-release-fixture-drizzle-mysql2-tx",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Tier-3 fixture: drizzle-orm transactions over the native mysql2 binding against a real MySQL on 127.0.0.1:3306, 400 in a row under a 1 MB nursery (the #9356 acceptance).",
+  "dependencies": {
+    "drizzle-orm": "^0.44.7",
+    "mysql2": "^3.24.2"
+  },
+  "perry": {
+    "compilePackages": ["drizzle-orm"],
+    "allow": {
+      "compilePackages": ["drizzle-orm"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #9356: `drizzle-orm` transactions over `mysql2` hang after a few hundred iterations (the promise of one `pool.query` never settles), and the `SELECT SLEEP(0.01)` variant of the same loop segfaults.

Three defects stacked on the `perry-ext-mysql2` path. All three were found with an env-gated tick/wake/pump trace of the runtime on the reporter's own script (perrymaster, MySQL 8.0.46, drizzle-orm 0.44.7).

### 1. The hang: a native-async promise moved under the worker's raw pointer

`perry_ffi_promise_new` (perry-ffi's `JsPromise::new`) mints its promise through `js_native_async_completion_new`, which allocated it in the **nursery**. The mysql2 worker captures that address as a raw `*mut Promise` and resolves it later from the blocking pool. The token registry's mutable root scanner keeps the promise alive and rewrites the token's own slot when the copying minor evacuates it, but nothing can rewrite the worker's copy. Once a young collection lands while a query is in flight, the worker queues the **retired from-space address**; the pump then settles the stale copy (or reads whatever now lives there: a non-pending `state` field turns `js_promise_resolve` into a silent no-op) and the promise the program awaits stays pending forever. With from-space reused, the same path reads garbage, which is the segfault face.

That is exactly the reporter's characterisation: deterministic at ~195 transactions (16 MB nursery ÷ per-transaction allocation of the schema-heavy client), ~390 with a bare `drizzle(pool)`, clean at 500 with raw `mysql2` (tiny allocation per query), and independent of rows, pool size, delay and locking. Shrinking the nursery to 1 MB moves the hang to iteration 2 to 29.

Fix: token promises are allocated in malloc space (`js_promise_new_cross_thread`, the same reasoning as #8770's `js_promise_new_for_native_resolution`). Malloc space is non-moving, so every address native code captured stays valid for the token's life. Unit test pins that a token promise is not arena resident.

### 2. Every native call leaked its token

`JsPromise::resolve_with` / `reject_with` and the legacy `resolve_*` shims settle through the stdlib pump (`js_stdlib_process_pending`), not the token API, so the token registered at creation was never removed: one registry entry per mysql2 query (trace: 4 tokens created, 0 drained), each keeping its settled promise rooted and rewritten on every minor, and `js_native_async_has_active()` pinned at 1. The pump now drops the token when it settles the promise, mirroring what `js_native_async_process_pending` does for token-API settlements. Unit test covers the deferred path end to end.

### 3. Top-level `await` parked for a full idle budget after its promise had settled

The codegen busy-wait `await` (`Expr::Await`, non-async context) runs drain → stdlib pump → timers → `js_wait_for_event`. The pump delivers the native completion and the drain then runs the async chain to the point where it fulfils the awaited promise, but settlements made during a drain deliberately skip the notify (`js_notify_promise_progress`), so `js_wait_for_event` found nothing pending and parked for the whole `IDLE_CAP_MS` (1 s). On perrymaster that was one 1 s stall per transaction (the reporter's box wins the race with the worker's final notify more often). The loop now re-checks the promise state after the tick phases and only parks while it is still pending.

## Evidence

Reporter's script (`issue9356-repro.ts`: `drizzle(pool, { mode: "default" })`, one 81-row `tx.execute` per transaction, top-level `await` loop), perrymaster, MySQL 8.0.46, `perry-ext-mysql2` linked, a 5 ms interval timer running so the pre-fix stall does not dominate the timing:

| build | nursery | result |
|---|---|---|
| main f1e9c370a | 16 MB (default) | hang between transaction 350 and 375 (killed at 150 s); reporter: ~390 |
| main f1e9c370a | 1 MB | hang between transaction 25 and 50, twice |
| main f1e9c370a | 4 MB | hang between transaction 75 and 100 |
| main + this PR | 16 MB (default) | 600/600 in 0.46 s (no interval timer needed) |
| main + this PR | 1 MB | 600/600 in 0.44 s |
| main + this PR | 4 MB | 600/600 in 0.45 s |

Without the interval timer (nothing else on the loop), 5 transactions took 5.0 s on main (one 1 s park per transaction, bug 3) and 600 take 0.46 s with this PR. A 20-query program exits 14 ms after `pool.end()` (previously the leaked tokens kept `js_native_async_has_active()` at 1).

Trace on main (env-gated tick/wake/pump/scanner trace, not part of this PR), 200 transactions under a 1 MB nursery: 592 token promises created, 330 of them relocated by the copying minor while registered, 0 tokens ever drained (the leak). Three times the worker queued its resolution against an address the scanner had already retired, e.g.

```
[atrace native_async scanner: promise MOVED 0x2dcb2e2c5d8 -> 0x2dcaaaebba8]
[atrace 22233681us] queue_deferred_resolution p=0x2dcb2e2c5d8 ok=true     <- worker, retired address
[atrace 22239183us] pump deferred p=0x2dcaaaebba8 ok=true state=0          <- 5.5 ms later
```

In the traced run each of the three was rescued: another collection ran in the 5 ms between queue and pump and the `PENDING_DEFERRED` root scan rewrote the queued slot to the new address. Without that coincidence (the untraced runs above, where queue and pump are microseconds apart) the pump settles the retired copy and the transaction never completes.

New release fixture `tests/release/packages/drizzle-mysql2-tx` (400 transactions under a 1 MB nursery, skips without MySQL): FAIL on 0.5.1519 (`seeded`, then no exit within 60 s), PASS with this PR (34 s including the compile).

## Not in this PR (observed while reproducing, filed separately)

- #9516 — a statically typed `db.execute` / `db.transaction` on the drizzle database object throws `TypeError: Cannot convert undefined or null to object` on main (0.5.1519 is fine; `db: any` is fine). The new fixture uses `db: any` for that reason.
- #9517 — when cargo is not on `PATH` at compile time, `perry` silently links perry-stdlib's bundled `mysql2` instead of `perry-ext-mysql2`; that implementation prepares every `query()` (so `pool.query("begin")` fails with MySQL 1295), rejects with values whose `.message` is undefined, and crashes on the string form of a dynamically dispatched `query`. None of that is on the ext path this PR fixes.

## Test plan

- `cargo test -p perry-runtime --lib native_async -- --test-threads=1`: 12 pass, including the new `token_promise_is_allocated_outside_the_copying_nursery` and `gc::tests::runtime_roots::callback_scanners::test_native_async_completion_token_roots_survive_copied_minor_gc`, updated to the new contract (the promise slot stays put; payload and attached-handle slots are still rewritten).
- `cargo test -p perry-stdlib --lib async_bridge -- --test-threads=1`: 3 pass, including the new `stdlib_pump_releases_the_native_async_token_of_a_deferred_resolution`.
- `cargo test -p perry-ext-mysql2 --lib`: 14 pass.
- `./run_parity_tests.sh --filter test_async` and `--filter events`: 100 %.
- perrymaster, `perry-ext-mysql2` linked: the reporter's script 600/600 at 16 MB / 4 MB / 1 MB nurseries; my raw `pool.query`, dynamic-dispatch and in-flight allocation-churn variants 400–500/400–500 under a 1 MB nursery; a 20-query program exits 14 ms after `pool.end()`.
- New Tier-3 fixture `tests/release/packages/drizzle-mysql2-tx`: FAIL on 0.5.1519, PASS with this PR.
- `scripts/raw_handle_debt.py` (963, at baseline), `scripts/unrooted_local_shape.py`, `rustfmt --check` on the touched files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved async waiting so already-completed operations resume promptly without unnecessary delays.
  - Fixed promise lifetime handling during garbage collection for native asynchronous operations.
  - Resolved a resource leak affecting repeated native calls, including database and encryption operations.
  - Improved reliability for asynchronous database transactions under frequent garbage collection.

- **Tests**
  - Added release coverage for 400 MySQL transactions using Drizzle ORM and mysql2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->