### PR TITLE
fix(codegen): launder every root-slot reload so LLVM cannot fold two safepoints onto one spill slot (#9499)

### DIFF
--- a/changelog.d/9499-root-reload-relocate-identity.md
+++ b/changelog.d/9499-root-reload-relocate-identity.md
@@ -1,0 +1,45 @@
+### Fixed
+
+- **`map.set(key, () => …)` no longer stores a completely different live
+  object as the key.** On the MCP SDK handshake, `this._responseHandlers.set(messageId, response => { … })`
+  stored the whole `jsonrpcRequest` object; `_responseHandlers.has(messageId)`
+  was then false and every request timed out (#9485). The map *worked* — with
+  wrong contents, no error and no diagnostic.
+
+  The map lowering is not at fault, and neither is the rooting order: the
+  emitted IR pushes the key into a temp-root slot **before** the closure
+  literal is lowered and re-reads it from that slot **after** the closure's
+  allocation, which is exactly the contract. The defect is one layer down, in
+  the native-root (RS4GC) slot lowering, and it is not a collection-timing bug
+  at all — `PERRY_GC_SCAVENGE=off`, `PERRY_GC_MOVING_LOOP_POLLS=0` and
+  `PERRY_GC_SCAVENGE_NURSERY_MB=1` all reproduce it identically, while
+  `PERRY_RS4GC=0` is correct.
+
+  A root slot is a `ptr addrspace(1)` alloca, so the value read back out of one
+  is a GC pointer. `function/precise_roots.rs` spelled that reload as a bare
+  `ptrtoint`, which InstCombine composes with the *next* root push's `inttoptr`
+  and folds away — making one `ptr addrspace(1)` SSA value the statepoint
+  operand at two safepoints, with a **hole** in between where the value sits in
+  a plain non-root alloca. LLVM's statepoint lowering assumes the opposite
+  (`findPreviousSpillSlot`: "spill location is known for gc relocates"), so at
+  the second safepoint it re-reads the first safepoint's stack slot without
+  re-storing — and that slot has been recycled for an intervening statepoint's
+  operand. Measured on the reduced fixture: the key handed to `js_map_set` was
+  the closure allocated three lines earlier, read out of `-0x50(%rbp)`, a slot
+  nothing had written since the unrelated closure that landed there.
+
+  Every root reload now passes through an identity barrier — an empty `asm`
+  with a tied `"=r,0"` operand, which emits no machine instruction — so
+  re-rooting a value mints a fresh statepoint operand with its own spill slot
+  instead of re-identifying it with a relocation from an earlier safepoint.
+  `freeze i64` is the prettier spelling and was tried first; it is rejected on
+  evidence, not taste: with `freeze` the reduced fixtures still pass but the
+  real MCP SDK client throws `TypeError: value is not a function` on every run,
+  where the `asm` form connects. The
+  trigger needs the key to have been rooted once already and released — the
+  common `const messageId = this._next++` shape — so `set(messageId, …)` after
+  a `++` was affected while `set(messageId + 0, …)` and `set(messageId, 7)`
+  were not.
+
+  `test-files/test_gap_9499_rooted_key_across_closure_alloc.ts` is the
+  deterministic, knob-free reproduction with its three controls.

--- a/crates/perry-codegen/src/expr/slice8_rooting_tests.rs
+++ b/crates/perry-codegen/src/expr/slice8_rooting_tests.rs
@@ -62,6 +62,12 @@ const PURE_OPS: &[&str] = &[
     "sub ",
     "getelementptr",
     "select",
+    // #9499's root-reload launder. An empty `asm` with a tied `"=r,0"` operand
+    // is a register-level identity that emits nothing, so a value defined by it
+    // is exactly as fresh as its input — which is what this list means. Without
+    // it the walk stops AT the launder and every assertion that names the
+    // reload's `load ptr addrspace(1)` line goes red on a correct lowering.
+    "call i64 asm \"\", \"=r,0\"",
 ];
 
 /// Walk `reg`'s definition chain up through [`PURE_OPS`] and return the line of
@@ -96,9 +102,12 @@ pub(super) fn producer_line(ir: &str, reg: &str) -> usize {
         else {
             return idx;
         };
-        // Follow the FIRST register operand of the pure op.
+        // Follow the FIRST register operand of the pure op. Parentheses are
+        // separators too: #9499's launder is a call, so its operand is inside
+        // `(...)` — and no existing op's first `%` token is affected, because
+        // `ptr addrspace(1)` carries no register.
         let Some(next) = rhs[op.len()..]
-            .split(&[',', ' '][..])
+            .split(&[',', ' ', '(', ')'][..])
             .find(|t| t.starts_with('%'))
         else {
             return idx; // constant-only pure op: it is its own producer

--- a/crates/perry-codegen/src/function/precise_roots.rs
+++ b/crates/perry-codegen/src/function/precise_roots.rs
@@ -32,6 +32,43 @@ fn is_local_name_char(c: char) -> bool {
     c.is_alphanumeric() || c == '%' || c == '_' || c == '.'
 }
 
+/// The identity barrier every root reload passes through (#9499).
+///
+/// A root slot is a `ptr addrspace(1)` alloca, so the value read back out of it
+/// is a GC pointer — and the reload's `ptrtoint` composed with the *next*
+/// root push's `inttoptr` folds, under InstCombine, straight back to the
+/// `gc.relocate` the first push produced. That makes ONE `ptr addrspace(1)`
+/// SSA value the statepoint operand at two different safepoints, with a HOLE
+/// in between (the value lives in a plain non-root alloca while it is not
+/// rooted). LLVM's statepoint lowering assumes the opposite: `findPreviousSpillSlot`
+/// treats "spill location is known for gc relocates" as permanent, so at the
+/// second safepoint it re-reads the FIRST safepoint's stack slot without
+/// re-storing — and that slot has been recycled for another statepoint's
+/// operand in the hole. The reload then hands the consuming call a completely
+/// different live object. Measured on `map.set(messageId, response => …)`
+/// (#9499): the key stored was the closure allocated three lines earlier.
+///
+/// The barrier states the thing that is actually true and that the fold denies:
+/// **a value read out of a root slot is an ordinary NaN-boxed datum, not the
+/// GC reference it came from.** Re-rooting it must mint a fresh statepoint
+/// operand with its own spill slot, not re-identify it with a relocation from
+/// an earlier safepoint.
+///
+/// An empty `asm` with a tied `"=r,0"` operand: the standard register-level
+/// identity, zero machine instructions, and — unlike every pure IR spelling —
+/// something InstCombine cannot see through, so it can no longer read
+/// `inttoptr(ptrtoint X)` as an identity pair. Marked `"gc-leaf-function"` so
+/// RS4GC does not try to wrap the asm itself in a statepoint (which it rejects
+/// outright: "Cannot take the address of an inline asm!").
+///
+/// `freeze i64` was tried first and is the prettier spelling — not a call, so
+/// the element-shape fast clones stay textually call-free. It is REJECTED on
+/// evidence: with `freeze` the reduced fixtures still pass but the real MCP SDK
+/// client throws `TypeError: value is not a function` on every run, where the
+/// `asm` form connects. Do not "simplify" this back to `freeze` without
+/// re-running `secret-tests`' MCP anchor end to end.
+const ROOT_RELOAD_LAUNDER: &str = "call i64 asm \"\", \"=r,0\"";
+
 /// Rewrite one root-alloca access (`store`/`load` of `i64`/`double` whose
 /// pointer operand is a root) into its `ptr addrspace(1)` form. `None` when
 /// the line is not such an access; the caller then falls through to the
@@ -83,7 +120,7 @@ fn rewrite_root_access(
             return None;
         }
         return Some(format!(
-            "  {result}.rs4p = load ptr addrspace(1), ptr {ptr}\n  {result} = ptrtoint ptr addrspace(1) {result}.rs4p to i64\n"
+            "  {result}.rs4p = load ptr addrspace(1), ptr {ptr}\n  {result}.rs4i = ptrtoint ptr addrspace(1) {result}.rs4p to i64\n  {result} = {ROOT_RELOAD_LAUNDER}(i64 {result}.rs4i) \"gc-leaf-function\"\n"
         ));
     }
     if let Some((result, ptr)) = trimmed.split_once(" = load double, ptr ") {
@@ -91,7 +128,7 @@ fn rewrite_root_access(
             return None;
         }
         return Some(format!(
-            "  {result}.rs4p = load ptr addrspace(1), ptr {ptr}\n  {result}.rs4i = ptrtoint ptr addrspace(1) {result}.rs4p to i64\n  {result} = bitcast i64 {result}.rs4i to double\n"
+            "  {result}.rs4p = load ptr addrspace(1), ptr {ptr}\n  {result}.rs4i = ptrtoint ptr addrspace(1) {result}.rs4p to i64\n  {result}.rs4o = {ROOT_RELOAD_LAUNDER}(i64 {result}.rs4i) \"gc-leaf-function\"\n  {result} = bitcast i64 {result}.rs4o to double\n"
         ));
     }
     None
@@ -356,6 +393,119 @@ mod tests {
             !rewritten.contains("= call i64 @js_map_alloc("),
             "the control callee must be statepoint-wrapped, not direct:\n{rewritten}"
         );
+    }
+
+    /// #9499, at the level the defect actually lives.
+    ///
+    /// A value is rooted, released, parked in a PLAIN (non-root) alloca across
+    /// another safepoint, then rooted AGAIN. Without the launder, the second
+    /// push's `inttoptr` composes with the first reload's `ptrtoint` and
+    /// InstCombine folds the pair away, so the third safepoint's `gc-live`
+    /// operand IS the `gc.relocate` the first safepoint produced — one GC value
+    /// serving two statepoints with a hole in between. SelectionDAG's
+    /// `findPreviousSpillSlot` then re-reads the first safepoint's stack slot
+    /// without re-storing, and that slot was recycled for the intervening
+    /// statepoint's operand.
+    ///
+    /// The assertion names the VALUE: no operand of the LAST statepoint may be
+    /// a register defined by a `gc.relocate`, because in this fixture the value
+    /// demonstrably left the GC domain in between.
+    ///
+    /// Sabotage: reverting `rewrite_root_access`'s two load arms to the bare
+    /// `ptrtoint` form fails this with the relocate's own name in the final
+    /// `gc-live` bundle.
+    #[test]
+    fn a_re_rooted_value_is_not_the_earlier_relocate() {
+        let ir = r#"declare void @js_shadow_slot_bind(i32, ptr)
+declare i64 @may_collect()
+
+define i64 @f(i64 %v) gc "statepoint-example" {
+entry:
+  %slot = alloca i64
+  store i64 0, ptr %slot
+  %park = alloca i64
+  store i64 0, ptr %park
+  call void @js_shadow_slot_bind(i32 0, ptr %slot)
+  store i64 %v, ptr %slot
+  %c1 = call i64 @may_collect()
+  %r1 = load i64, ptr %slot
+  store i64 0, ptr %slot
+  store i64 %r1, ptr %park
+  %c2 = call i64 @may_collect()
+  %r2 = load i64, ptr %park
+  store i64 %r2, ptr %slot
+  %c3 = call i64 @may_collect()
+  %r3 = load i64, ptr %slot
+  store i64 0, ptr %slot
+  ret i64 %r3
+}
+"#;
+        let lowered = lower_precise_roots_to_native_stack(ir, "f", 1);
+        // THE discriminating clause: reverting `rewrite_root_access`'s two load
+        // arms fails here. The RS4GC-level clauses below are the structural
+        // companion — they show WHY the launder is needed (the second
+        // safepoint's operand is a fresh `inttoptr`, not the first's relocate)
+        // — but they do not by themselves discriminate, because the fold this
+        // guards against happens in the `-Os` pipeline that runs after the
+        // rewrite, not inside it. The end-to-end discriminator is
+        // `test-files/test_gap_9499_rooted_key_across_closure_alloc.ts`.
+        assert!(
+            lowered.contains("asm \"\", \"=r,0\""),
+            "every root reload must be laundered:\n{lowered}"
+        );
+
+        // InstCombine is appended on purpose: the fold this guards against does
+        // NOT happen in the shipped rewrite pipeline (`mem2reg,sccp`), it
+        // happens in the `-Os` pipeline that runs AFTER it. Running one
+        // InstCombine here reproduces that stage with nothing else.
+        const PASSES: &str = "always-inline,function(mem2reg,sccp),\
+                              rewrite-statepoints-for-gc,function(instcombine)";
+        let target = crate::codegen::default_target_triple();
+        let rewritten = crate::inprocess::statepoint_rewritten_ir_with_passes(
+            &lowered, &target, "reroot_9499", PASSES,
+        )
+        .expect("fixture survives the rewrite pipeline");
+
+        let relocates: Vec<&str> = rewritten
+            .lines()
+            .filter(|line| line.contains("@llvm.experimental.gc.relocate"))
+            .filter_map(|line| line.trim().split_once(" = "))
+            .map(|(name, _)| name.trim())
+            .collect();
+        assert!(
+            !relocates.is_empty(),
+            "the fixture must relocate something, or this assertion has no \
+             subject:\n{rewritten}"
+        );
+
+        let live_bundles: Vec<&str> = rewritten
+            .lines()
+            .filter(|line| line.contains("\"gc-live\""))
+            .collect();
+        // TWO, not three: the middle safepoint carries no `gc-live` bundle at
+        // all, because the value is genuinely dead there — it is sitting in the
+        // plain alloca. That hole is the whole point of the fixture.
+        assert!(
+            live_bundles.len() >= 2,
+            "the fixture must root the value across two separate safepoints:\n{rewritten}"
+        );
+        let last = live_bundles.last().copied().expect("just checked");
+        let live = last
+            .split_once("\"gc-live\"(")
+            .map(|(_, tail)| tail.split(')').next().unwrap_or(tail))
+            .unwrap_or("");
+        for name in &relocates {
+            assert!(
+                !live
+                    .split(|c: char| !super::is_local_name_char(c))
+                    .any(|tok| tok == *name),
+                "#9499: the last safepoint's gc-live operand is {name}, the \
+                 relocate an EARLIER safepoint produced. That value is not \
+                 live in between (it sits in a plain alloca), so LLVM's \
+                 statepoint spill-slot reuse re-reads a slot that has been \
+                 recycled. gc-live was: {live}\n{rewritten}"
+            );
+        }
     }
 
     #[test]

--- a/crates/perry-codegen/src/function/precise_roots/equivalence_tests.rs
+++ b/crates/perry-codegen/src/function/precise_roots/equivalence_tests.rs
@@ -81,7 +81,8 @@ pub(super) fn reference_lower_roots_for_rs4gc(
             {
                 let result = trimmed.split(' ').next().unwrap_or("");
                 out.push_str(&format!(
-                    "  {result}.rs4p = load ptr addrspace(1), ptr {ptr}\n  {result} = ptrtoint ptr addrspace(1) {result}.rs4p to i64\n"
+                    "  {result}.rs4p = load ptr addrspace(1), ptr {ptr}\n  {result}.rs4i = ptrtoint ptr addrspace(1) {result}.rs4p to i64\n  {result} = {launder}(i64 {result}.rs4i) \"gc-leaf-function\"\n",
+                    launder = super::ROOT_RELOAD_LAUNDER,
                 ));
                 handled = true;
                 break;
@@ -94,7 +95,8 @@ pub(super) fn reference_lower_roots_for_rs4gc(
             {
                 let result = trimmed.split(' ').next().unwrap_or("");
                 out.push_str(&format!(
-                    "  {result}.rs4p = load ptr addrspace(1), ptr {ptr}\n  {result}.rs4i = ptrtoint ptr addrspace(1) {result}.rs4p to i64\n  {result} = bitcast i64 {result}.rs4i to double\n"
+                    "  {result}.rs4p = load ptr addrspace(1), ptr {ptr}\n  {result}.rs4i = ptrtoint ptr addrspace(1) {result}.rs4p to i64\n  {result}.rs4o = {launder}(i64 {result}.rs4i) \"gc-leaf-function\"\n  {result} = bitcast i64 {result}.rs4o to double\n",
+                    launder = super::ROOT_RELOAD_LAUNDER,
                 ));
                 handled = true;
                 break;

--- a/crates/perry-codegen/src/inprocess.rs
+++ b/crates/perry-codegen/src/inprocess.rs
@@ -56,7 +56,7 @@ pub(crate) fn statepoint_rewritten_ir(
 }
 
 #[cfg(test)]
-fn statepoint_rewritten_ir_with_passes(
+pub(crate) fn statepoint_rewritten_ir_with_passes(
     ll_text: &str,
     effective_target: &str,
     module_name: &str,

--- a/crates/perry-codegen/src/stmt/element_shape_loop_tests.rs
+++ b/crates/perry-codegen/src/stmt/element_shape_loop_tests.rs
@@ -378,7 +378,7 @@ fn assert_fast_clone_is_entered(ir: &str) {
 /// `br label %for.element_shape_fast.cond.N` terminator of
 /// `element_shape.loop.fast.preheader`, three lines above the slow
 /// preheader's own branch. Every assertion made against the result is a
-/// NEGATIVE (`!fast.contains(" call ")`, `!fast.contains("js_array_get_f64")`,
+/// NEGATIVE (`!fast_clone_has_a_call(&fast)`, `!fast.contains("js_array_get_f64")`,
 /// …), so that four-line stub satisfied all of them: the IR census that exists
 /// to prove the clone is really call-free had never been able to fail. The
 /// liveness assertion below is what makes it a gate — CLAUDE.md's "a gate must
@@ -419,6 +419,22 @@ fn fast_clone_slice(ir: &str) -> String {
     owned
 }
 
+/// Does the versioned-loop fast clone contain a call?
+///
+/// The clone's revocation argument is that it is **call-free**: no funnel can
+/// revoke the invariant and no allocation can move the array. #9499's
+/// root-reload launder is the one thing excluded, and it is excluded because it
+/// is not a call in any sense the argument uses — an empty `asm` with a tied
+/// `"=r,0"` operand emits no machine instruction, transfers control nowhere and
+/// clobbers nothing. It exists only to stop InstCombine reading
+/// `inttoptr(ptrtoint X)` as an identity pair (`function/precise_roots.rs`), so
+/// counting it would fail these tests for a property they do not measure.
+/// Every other `call` still fails them.
+fn fast_clone_has_a_call(fast: &str) -> bool {
+    fast.lines()
+        .any(|line| line.contains("call ") && !line.contains("asm \"\", \"=r,0\""))
+}
+
 #[test]
 fn element_shape_versioned_loop_fires_for_the_7480_access_shape() {
     let ir = emit(&element_shape_module(
@@ -454,7 +470,7 @@ fn element_shape_versioned_loop_fires_for_the_7480_access_shape() {
     // no allocation can move the array), so it is asserted directly rather
     // than by naming individual guard symbols.
     assert!(
-        !fast.contains(" call "),
+        !fast_clone_has_a_call(&fast),
         "the fast clone must be call-free; found a call in:\n{fast}"
     );
     assert!(
@@ -795,7 +811,7 @@ fn element_shape_versioned_loop_resolves_an_object_literal_element_type() {
     assert_fast_clone_is_entered(&ir);
     let fast = fast_clone_slice(&ir);
     assert!(
-        !fast.contains(" call "),
+        !fast_clone_has_a_call(&fast),
         "the fast clone must be call-free; found a call in:\n{fast}"
     );
     // The second half, and the reason the first half alone would be inert: the
@@ -1021,7 +1037,7 @@ fn element_shape_versioned_loop_admits_an_array_length_bound() {
     assert_fast_clone_is_entered(&ir);
     let fast = fast_clone_slice(&ir);
     assert!(
-        !fast.contains(" call "),
+        !fast_clone_has_a_call(&fast),
         "the fast clone must stay call-free with a `.length` bound; found a \
          call in:\n{fast}"
     );
@@ -1131,7 +1147,7 @@ fn element_shape_versioned_loop_resolves_an_aliased_object_element_type() {
     assert_fast_clone_is_entered(&ir);
     let fast = fast_clone_slice(&ir);
     assert!(
-        !fast.contains(" call "),
+        !fast_clone_has_a_call(&fast),
         "an alias-resolved fast clone must stay call-free -- a call is a GC \
          safepoint, and the element-shape guard is established BEFORE it; \
          emitted:\n{fast}"
@@ -1193,7 +1209,7 @@ fn element_shape_versioned_loop_fires_for_the_churn_read_shape() {
     assert_fast_clone_is_entered(&ir);
     let fast = fast_clone_slice(&ir);
     assert!(
-        !fast.contains(" call "),
+        !fast_clone_has_a_call(&fast),
         "the fast clone must be call-free; found a call in:\n{fast}"
     );
     assert!(
@@ -1223,7 +1239,7 @@ fn the_repair_does_not_put_a_call_inside_the_fast_clone() {
     assert_fast_clone_is_entered(&ir);
     let fast = fast_clone_slice(&ir);
     assert!(
-        !fast.contains("call "),
+        !fast_clone_has_a_call(&fast),
         "the fast clone must stay call-free after the #7480 repair; emitted:\n{fast}"
     );
     assert!(
@@ -1299,7 +1315,7 @@ fn element_shape_versioned_loop_fires_for_the_7771_element_binding_shape() {
     assert_fast_clone_is_entered(&ir);
     let fast = fast_clone_slice(&ir);
     assert!(
-        !fast.contains(" call "),
+        !fast_clone_has_a_call(&fast),
         "the fast clone must be call-free; found a call in:\n{fast}"
     );
     assert!(
@@ -1331,7 +1347,7 @@ fn element_binding_reads_every_tracked_field_through_the_fact() {
     assert_fast_clone_is_entered(&ir);
     let fast = fast_clone_slice(&ir);
     assert!(
-        !fast.contains(" call "),
+        !fast_clone_has_a_call(&fast),
         "the two-field fast clone must be call-free; found a call in:\n{fast}"
     );
     // One `element_shape.load` chain per tracked field read.
@@ -1455,7 +1471,7 @@ fn assert_clone_fires_call_free(ir: &str, what: &str) {
     assert_fast_clone_is_entered(ir);
     let fast = fast_clone_slice(ir);
     assert!(
-        !fast.contains(" call "),
+        !fast_clone_has_a_call(&fast),
         "{what}: the fast clone must be call-free; found a call in:\n{fast}"
     );
     assert!(

--- a/test-files/test_gap_9499_rooted_key_across_closure_alloc.ts
+++ b/test-files/test_gap_9499_rooted_key_across_closure_alloc.ts
@@ -1,0 +1,149 @@
+// #9499: a value re-rooted after it has already been through a `gc.relocate`
+// hands the consuming call a COMPLETELY DIFFERENT live object.
+//
+// `this._responseHandlers.set(messageId, response => { … })` in the MCP SDK
+// stored the whole `jsonrpcRequest` object as the map key, so
+// `_responseHandlers.has(messageId)` was false and every request timed out
+// (#9485). This fixture is that shape, reduced.
+//
+// THE MECHANISM IS THE NATIVE-ROOT LOWERING, NOT THE ROOTING ORDER. The
+// emitted IR is textbook: the key is pushed into a temp-root slot BEFORE the
+// closure literal is lowered and re-read from that slot AFTER the closure's
+// allocation. Only the machine code is wrong, and only under the native-root
+// (RS4GC) lowering — `PERRY_RS4GC=0` is correct, and every GC knob
+// (`PERRY_GC_SCAVENGE=off`, `PERRY_GC_MOVING_LOOP_POLLS=0`,
+// `PERRY_GC_SCAVENGE_NURSERY_MB=1`) reproduces it identically. It is not a
+// collection-timing bug at all; see `function/precise_roots.rs`'s
+// `ROOT_RELOAD_LAUNDER` for the chain.
+//
+// TWO LOAD-BEARING REPRO PROPERTIES:
+//
+// 1. The key must be a value that was ALREADY temp-rooted once and then
+//    released — here `this._next++`, whose read is rooted across the field
+//    store. Rooting it a second time (as the `set` key) makes ONE
+//    `ptr addrspace(1)` SSA value the statepoint operand at two safepoints
+//    with a hole in between, which is the shape LLVM's statepoint spill-slot
+//    reuse miscompiles. `const messageId = this._next` (never rooted) and
+//    `set(messageId + 0, …)` (a fresh, provably-numeric key that needs no
+//    root) both PASS on the unfixed compiler — they are the controls below.
+// 2. The value argument must ALLOCATE, so the key is live across a safepoint.
+//    `set(messageId, 7)` passes unfixed.
+//
+// No GC knobs, no allocation pressure, no timing: the wrong key is emitted by
+// the compiler and every run of the unfixed binary prints the same thing.
+
+function shape(m: any): string {
+  return JSON.stringify(
+    [...m.keys()].map((x: any) =>
+      x !== null && typeof x === "object"
+        ? "OBJ"
+        : typeof x === "function"
+          ? "FN"
+          : x,
+    ),
+  );
+}
+
+// THE GAP. `_next` is untyped, so `messageId` is not provably a non-pointer and
+// the `set` key takes a temp root; `this._next++` already rooted that same
+// value across the field store.
+class Gap {
+  _next: any = 0;
+  _handlers: any = new Map();
+  run(request: any, options: any) {
+    return new Promise<any>((resolve, reject) => {
+      const messageId = this._next++;
+      const jsonrpcRequest: any = { ...request, jsonrpc: "2.0", id: messageId };
+      this._handlers.set(messageId, (response: any) => {
+        if (options?.signal?.aborted) return;
+        if (response instanceof Error) return reject(response);
+        try {
+          resolve(response);
+        } catch (e) {
+          reject(e);
+        }
+      });
+      void jsonrpcRequest;
+      resolve(null);
+    });
+  }
+}
+
+// CONTROL A: the key is read plainly, so it is never rooted twice.
+class PlainKey {
+  _next: any = 0;
+  _handlers: any = new Map();
+  run(request: any, options: any) {
+    return new Promise<any>((resolve, reject) => {
+      const messageId = this._next;
+      const jsonrpcRequest: any = { ...request, jsonrpc: "2.0", id: messageId };
+      this._handlers.set(messageId, (response: any) => {
+        if (options?.signal?.aborted) return;
+        if (response instanceof Error) return reject(response);
+        try {
+          resolve(response);
+        } catch (e) {
+          reject(e);
+        }
+      });
+      void jsonrpcRequest;
+      resolve(null);
+    });
+  }
+}
+
+// CONTROL B: `messageId + 0` is provably numeric, so `operand_protection`
+// answers `Reuse` and the key pays no temp root at all. A fix that stops
+// rooting keys altogether would pass the gap and leave this one meaningless,
+// so it is here as the other side of the differential.
+class FreshKey {
+  _next: any = 0;
+  _handlers: any = new Map();
+  run(request: any, options: any) {
+    return new Promise<any>((resolve, reject) => {
+      const messageId = this._next++;
+      const jsonrpcRequest: any = { ...request, jsonrpc: "2.0", id: messageId };
+      this._handlers.set(messageId + 0, (response: any) => {
+        if (options?.signal?.aborted) return;
+        if (response instanceof Error) return reject(response);
+        try {
+          resolve(response);
+        } catch (e) {
+          reject(e);
+        }
+      });
+      void jsonrpcRequest;
+      resolve(null);
+    });
+  }
+}
+
+// CONTROL C: a non-allocating value leaves no safepoint in the key's window.
+class NoAllocValue {
+  _next: any = 0;
+  _handlers: any = new Map();
+  run() {
+    const messageId = this._next++;
+    this._handlers.set(messageId, 7);
+  }
+}
+
+async function main(): Promise<void> {
+  const gap = new Gap();
+  await gap.run({ method: "initialize" }, {});
+  console.log("gap        keys=" + shape(gap._handlers) + " has0=" + gap._handlers.has(0));
+
+  const plain = new PlainKey();
+  await plain.run({ method: "initialize" }, {});
+  console.log("plain-key  keys=" + shape(plain._handlers) + " has0=" + plain._handlers.has(0));
+
+  const fresh = new FreshKey();
+  await fresh.run({ method: "initialize" }, {});
+  console.log("fresh-key  keys=" + shape(fresh._handlers) + " has0=" + fresh._handlers.has(0));
+
+  const noalloc = new NoAllocValue();
+  noalloc.run();
+  console.log("no-alloc   keys=" + shape(noalloc._handlers) + " has0=" + noalloc._handlers.has(0));
+}
+
+main();


### PR DESCRIPTION
The `map.set(key, closure)` wrong-key bug — the sole remaining functional blocker for cc's MCP client (#9485). cc-level result: **`mcp list` → `✓ Connected`**, `notifications/initialized` present in the request stream.

## Both prior diagnoses were wrong — site AND mechanism

Not `Expr::MapSet`: the SDK's `this._responseHandlers.set(…)` is a class-field receiver in untyped JS, so it takes the generic dispatch tower — there is **no `call @js_map_set` anywhere** in the compiled protocol module. And not a rooting-order bug, not GC behaviour at all: the emitted IR at the site is textbook (push key, allocate closure, **re-read both from their slots**, call, release), and every GC knob reproduces the failure identically — `PERRY_RS4GC=0` is what goes correct.

## The real mechanism, from IR + objdump

A root slot is a `ptr addrspace(1)` alloca, so a reload's `ptrtoint` composes with the *next* root push's `inttoptr` and **InstCombine folds the pair away** — one relocated SSA value then serves as the statepoint operand at **two** safepoints with a live-range **hole** between them (parked in a plain non-root alloca). LLVM's statepoint lowering assumes the opposite (`findPreviousSpillSlot`: *"spill location is known for gc relocates"*), so at the second safepoint it re-reads the **first** safepoint's stack slot **without re-storing** — and that slot was recycled in the hole:

```
251: mov %r14,-0x50(%rbp)   ; messageId spilled for statepoint #1
27f: mov -0x50(%rbp),%r14   ; relocated reload
2ca: mov %r15,-0x50(%rbp)   ; slot RECYCLED for an unrelated closure
4d1: call js_closure_alloc_init   ; statepoint #2 — %r14 NOT re-spilled
4db: mov -0x50(%rbp),%rcx   ; key ← a slot nothing wrote since 2ca
```

The wrong key is whatever the recycled slot last held — in the SDK, `jsonrpcRequest` (confirmed `k0 === jsonrpcRequest`); in the fixture, the closure itself. This also explains the perturbation sensitivity that defeated four hand-written repros: the trigger needs rooted → released → parked across another safepoint → re-rooted.

## Fix: the choke point

`rewrite_root_access` in `function/precise_roots.rs` — the one function lowering **every** root-slot reload — now passes each reload through an identity barrier (empty asm, tied `"=r,0"`, **zero machine instructions**), so re-rooting always mints a fresh statepoint operand. Structurally covers all rooted-operand families: `RootedGroup` re-reads, named-local shadow slots, accumulator arrays, `implicit_this`, `adopt_emitted`.

**`freeze i64` was tried first and rejected on evidence**: the reduced fixtures pass under it, but the real MCP SDK then throws `TypeError: value is not a function` every run. Documented at the site so nobody "simplifies" it back.

**Cost**: `.text` **+96 bytes (+0.0007%)** on the full compiler; `.perry_gcmap` unchanged.

## Verification

- **Deterministic, no-knob gap fixture** with three controls; on unfixed main 3/3: `keys=["FN"] has0=false` (node: `keys=[0] has0=true`); fixed 3/3 byte-identical to node.
- **Sabotage**: reverting only the two load arms fails exactly the structural pin (*"every root reload must be laundered"*) and the gap test — 1384/2. The test itself documents that the RS4GC-level clauses are companions, not the discriminator (the fold happens in `-Os`), and points at the fixture as the end-to-end check.
- Suites: perry-codegen **1386/0**, perry-runtime **2960/0**. All 12 moved IR expectations investigated and explained (the launder joins `PURE_OPS`; one helper now excludes only the zero-instruction asm from a "no calls" assertion).
- **cc**: `app_9499` rc=0; `mcp list` `✓ Connected` vs baseline `✗`; all 15 MCP harness cases now have **rc matching node and zero stdout/stderr divergence** — the uniform residual is exactly #9500 (node's `mcp-logs-*` tree, which perry never writes) plus node's own 3-rep nondeterminism.

## Twins audit — one new finding, filed separately

Every Map/Set/WeakMap lowering audited. All rooted correctly **except `Expr::SetHas` and `Expr::SetDelete`** (`bigint_set.rs:873/:1113`): both unbox the receiver to a raw `i64` *before* lowering the value and consume it after — the exact #6970 shape their Map twins were fixed for. Live on main, untouched here, filed. Also filed: `map_set.rs`'s `"set"` arm returns a pre-call receiver read after a void call (latent staleness for chained `.set().set()`), and the upstream note that LLVM's `findPreviousSpillSlot` assumption will bite any frontend giving a GC value a live-range hole.

Closes #9499.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could cause requests to time out when garbage collection relocated values across allocation points.
  * Preserved the correct identity of rooted values reused as map keys and across closures.

* **Tests**
  * Added regression coverage for rooted values, closure allocations, and map key behavior.
  * Expanded compiler validation to ensure root reloads remain distinct across safepoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->