### PR TITLE
style: rustfmt after the three-fix batch

### DIFF
--- a/crates/perry-codegen/src/lib.rs
+++ b/crates/perry-codegen/src/lib.rs
@@ -8,6 +8,7 @@ pub mod block;
 pub(crate) mod boxed_vars;
 pub mod codegen;
 pub(crate) mod collectors;
+pub(crate) mod concat_site_cache;
 #[cfg(feature = "llvm-inprocess")]
 pub(crate) mod dialect;
 pub(crate) mod eh_mode;
@@ -25,7 +26,6 @@ pub(crate) mod lower_array_method;
 pub(crate) mod lower_call;
 pub(crate) mod lower_conditional;
 pub(crate) mod lower_string_concat;
-pub(crate) mod concat_site_cache;
 pub(crate) mod lower_string_method;
 pub mod module;
 pub mod nanbox;


### PR DESCRIPTION
One of #9510/#9512/#9514 landed with formatting rustfmt reformats; `cargo fmt --check` is a required lint step. Formatting only.