### PR TITLE
fix(cjs-default,test): one shared `<mod>.default` table; cc's MCP debug logger shape and exec/execFile callback order pinned (#9500)

### DIFF
--- a/changelog.d/9531-cjs-default-table-mcp-logger-exec-order.md
+++ b/changelog.d/9531-cjs-default-table-mcp-logger-exec-order.md
@@ -1,0 +1,25 @@
+**One shared table for the CommonJS-default module set; claude-code's MCP
+debug logger shape and exec/execFile callback order pinned (#9500).**
+
+The set of Node builtins whose `require()` / default import hands out a
+distinct `<mod>.default` namespace was hand-maintained in five places (two of
+them inside the HIR alone, already disagreeing on `ffi`, `inspector`,
+`inspector/promises` and `wasi`); the method-call router's copy is the one
+that drifted far enough to break `require('child_process').spawn` (#9485,
+#9498). The table now lives once in `perry-dispatch`, built from one literal
+per module, and the runtime's property-read and method-call paths, the
+`default`-export resolver and the HIR's import lowering all derive from it.
+Adding a module is one line; tests pin the table's shape, the HIR's
+classification of every row, and the router test's list against the table in
+both directions. No behaviour change.
+
+Two fixtures pin the issue's other findings. The MCP debug logger's exact
+write shape — the `using`-downlevel fs wrapper, the timer/dispose buffered
+writer, the graceful-shutdown cleanup set and the `appendFileSync` → ENOENT →
+`mkdirSync(recursive)` recovery arm that is the only code creating the log
+tree — is byte-compared to node; it fails on a pre-#9491 build (the append
+did not throw, so the tree was never created) and passes on main. The
+exec/execFile callback order is pinned as what node guarantees — completion
+order, whichever API launched the child or came first; the inverted order for
+two instant `echo`s is a same-turn batch-delivery artefact node flips with
+submission order, not a rule.

--- a/crates/perry-dispatch/src/cjs_default_modules.rs
+++ b/crates/perry-dispatch/src/cjs_default_modules.rs
@@ -1,0 +1,151 @@
+//! The one table of Node builtins whose CommonJS `module.exports` is a
+//! namespace object distinct from the ESM namespace — the modules for which
+//! `require('<mod>')`, `import x from '<mod>'` and
+//! `process.getBuiltinModule('<mod>')` hand out a `<mod>.default` namespace
+//! whose method calls and property reads must reach the base module.
+//!
+//! #9500 (from #9485 / #9498): this knowledge used to live in FOUR
+//! hand-maintained copies — the runtime's `cjs_default_base_module` and
+//! `cjs_default_namespace_name` tables, the `cjs_default_export_value` match
+//! arm, the method-call router's own `<mod>.default → base` list, and the
+//! HIR's `is_cjs_style_native_default_import` (itself duplicated in two files
+//! that had already drifted apart: one lacked `ffi`, `inspector`,
+//! `inspector/promises` and `wasi`). The router's copy drifted far enough that
+//! `require('child_process').spawn(...)` dispatched under a name with no
+//! bucket and returned `undefined` WITHOUT SPAWNING, which is why claude-code's
+//! MCP stdio client reported `Failed to connect` (#9485). Every consumer now
+//! derives from this table: adding a module here is the whole edit.
+//!
+//! Base names are the runtime's canonical spellings (`path.posix`, not
+//! `path/posix`; `util`, not `sys`) — the alias folding happens in
+//! `normalize_native_module_name` before any lookup here.
+
+/// Builds the `(base, "<base>.default")` pairs from one literal per module, so
+/// the two spellings cannot disagree.
+macro_rules! cjs_default_namespace_modules {
+    ($($base:literal),+ $(,)?) => {
+        /// `(base module, "<base>.default")` for every Node builtin with a
+        /// distinct CommonJS default namespace. Sorted by base name.
+        pub const CJS_DEFAULT_NAMESPACE_MODULES: &[(&str, &str)] =
+            &[$(($base, concat!($base, ".default"))),+];
+    };
+}
+
+cjs_default_namespace_modules!(
+    "async_hooks",
+    "child_process",
+    "cluster",
+    "constants",
+    "dns",
+    "dns/promises",
+    "ffi",
+    "inspector",
+    "inspector/promises",
+    "module",
+    "node-pty",
+    "os",
+    "path",
+    "path.posix",
+    "path.win32",
+    "process",
+    "punycode",
+    "querystring",
+    "repl",
+    "sea",
+    "url",
+    "util",
+    "wasi",
+);
+
+/// Whether `base` (canonical spelling) has a distinct `<base>.default`
+/// CommonJS namespace.
+pub fn has_cjs_default_namespace(base: &str) -> bool {
+    cjs_default_namespace_name(base).is_some()
+}
+
+/// `base` → `"<base>.default"`, the name the CJS default namespace object is
+/// created under.
+pub fn cjs_default_namespace_name(base: &str) -> Option<&'static str> {
+    CJS_DEFAULT_NAMESPACE_MODULES
+        .iter()
+        .find(|(b, _)| *b == base)
+        .map(|(_, name)| *name)
+}
+
+/// `"<base>.default"` → `base`: the module a CJS default namespace's method
+/// calls and property reads dispatch against.
+pub fn cjs_default_base_module(namespace_name: &str) -> Option<&'static str> {
+    CJS_DEFAULT_NAMESPACE_MODULES
+        .iter()
+        .find(|(_, name)| *name == namespace_name)
+        .map(|(base, _)| *base)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_row_round_trips() {
+        for (base, name) in CJS_DEFAULT_NAMESPACE_MODULES {
+            assert_eq!(*name, format!("{base}.default"));
+            assert_eq!(cjs_default_namespace_name(base), Some(*name));
+            assert_eq!(cjs_default_base_module(name), Some(*base));
+            assert!(has_cjs_default_namespace(base));
+        }
+    }
+
+    #[test]
+    fn rows_are_unique_and_sorted() {
+        let bases: Vec<&str> = CJS_DEFAULT_NAMESPACE_MODULES
+            .iter()
+            .map(|(b, _)| *b)
+            .collect();
+        let mut sorted = bases.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(bases, sorted, "keep the table sorted and duplicate-free");
+    }
+
+    #[test]
+    fn base_names_are_canonical_spellings() {
+        for (base, _) in CJS_DEFAULT_NAMESPACE_MODULES {
+            assert!(!base.starts_with("node:"), "{base}: strip the node: scheme");
+            assert!(
+                !matches!(*base, "sys" | "path/posix" | "path/win32"),
+                "{base}: an alias, not a canonical module name"
+            );
+        }
+    }
+
+    #[test]
+    fn modules_without_a_cjs_default_namespace_are_absent() {
+        for base in [
+            "fs",
+            "crypto",
+            "events",
+            "http",
+            "stream",
+            "test",
+            "child_process.default",
+        ] {
+            assert!(!has_cjs_default_namespace(base), "{base}");
+            assert_eq!(cjs_default_namespace_name(base), None, "{base}");
+        }
+        assert_eq!(cjs_default_base_module("child_process"), None);
+        assert_eq!(cjs_default_base_module("fs.default"), None);
+    }
+
+    /// The #9485 regression, pinned at the source of truth.
+    #[test]
+    fn child_process_default_maps_to_child_process() {
+        assert_eq!(
+            cjs_default_base_module("child_process.default"),
+            Some("child_process")
+        );
+        assert_eq!(
+            cjs_default_namespace_name("child_process"),
+            Some("child_process.default")
+        );
+    }
+}

--- a/crates/perry-dispatch/src/lib.rs
+++ b/crates/perry-dispatch/src/lib.rs
@@ -96,6 +96,7 @@ pub struct MethodRow {
 // re-exported below so consumers keep using `perry_dispatch::PERRY_*`.
 mod audio_table;
 mod background_table;
+mod cjs_default_modules;
 mod i18n_table;
 mod ios_table;
 mod media_table;
@@ -106,6 +107,10 @@ mod updater_table;
 
 pub use audio_table::PERRY_AUDIO_TABLE;
 pub use background_table::PERRY_BACKGROUND_TABLE;
+pub use cjs_default_modules::{
+    cjs_default_base_module, cjs_default_namespace_name, has_cjs_default_namespace,
+    CJS_DEFAULT_NAMESPACE_MODULES,
+};
 pub use i18n_table::PERRY_I18N_TABLE;
 pub use ios_table::PERRY_IOS_TABLE;
 pub use media_table::PERRY_MEDIA_TABLE;

--- a/crates/perry-hir/src/lower/lower_expr/helpers.rs
+++ b/crates/perry-hir/src/lower/lower_expr/helpers.rs
@@ -11,6 +11,10 @@ use anyhow::Result;
 use swc_ecma_ast as ast;
 
 use crate::lower_types::extract_ts_type_with_ctx;
+// #9500: one CJS-default-import predicate, derived from the shared table —
+// this file used to carry its own copy, which had drifted (no `ffi`,
+// `inspector`, `inspector/promises`, `wasi`).
+use crate::lower::module_decl::native_default_import::is_cjs_style_native_default_import;
 
 /// Whether `PERRY_GLOBAL_SCRIPT_THIS` is set — compile the program as a
 /// *global script* rather than a CJS module, so module top-level `this`
@@ -182,29 +186,6 @@ pub(crate) fn is_fetch_global_value_name(name: &str) -> bool {
     matches!(
         name,
         "fetch" | "Blob" | "File" | "FormData" | "Headers" | "Request" | "Response"
-    )
-}
-
-pub(crate) fn is_cjs_style_native_default_import(module_name: &str) -> bool {
-    matches!(
-        module_name,
-        "async_hooks"
-            | "child_process"
-            | "cluster"
-            | "constants"
-            | "dns"
-            | "dns/promises"
-            | "events"
-            | "module"
-            | "os"
-            | "path"
-            | "path/posix"
-            | "path/win32"
-            | "punycode"
-            | "querystring"
-            | "sys"
-            | "url"
-            | "util"
     )
 }
 

--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -10,7 +10,7 @@ use super::*;
 use crate::ir::*;
 
 mod namespace;
-mod native_default_import;
+pub(super) mod native_default_import;
 pub(super) mod native_profile_import;
 mod object_literal;
 mod static_import_bindings;

--- a/crates/perry-hir/src/lower/module_decl/native_default_import.rs
+++ b/crates/perry-hir/src/lower/module_decl/native_default_import.rs
@@ -10,36 +10,112 @@ pub(crate) fn canonicalize_native_import_source(raw_source: &str) -> String {
     }
 }
 
+/// Whether a native module's default import binds its CommonJS
+/// `module.exports` — a `default` property read plus a builtin-module alias
+/// for member calls — rather than the historical namespace object.
+///
+/// #9500: derived from the ONE shared table
+/// (`perry_dispatch::CJS_DEFAULT_NAMESPACE_MODULES`) that the runtime's
+/// property-read and method-call paths also consume, so the three cannot
+/// drift apart again (the HIR alone used to carry two hand-written copies of
+/// this list, and one had already lost `ffi`, `inspector`,
+/// `inspector/promises` and `wasi`). The arms below are the deliberate
+/// differences between "has a `<mod>.default` namespace at runtime" and
+/// "lowers as a CJS-style default import", each spelled out so a new table
+/// row is classified by this function automatically and only an exception
+/// needs a line here.
 pub(crate) fn is_cjs_style_native_default_import(module_name: &str) -> bool {
-    matches!(
-        module_name,
-        "async_hooks"
-            | "child_process"
-            | "cluster"
-            | "constants"
-            | "dns"
-            | "dns/promises"
-            | "events"
-            | "ffi"
-            | "inspector"
-            | "inspector/promises"
-            | "module"
-            | "os"
-            | "path"
-            | "path/posix"
-            | "path/win32"
-            | "punycode"
-            | "querystring"
-            | "sys"
-            | "url"
-            | "util"
-            | "wasi"
-    )
+    match module_name {
+        // `events`' CommonJS export is the `EventEmitter` class itself
+        // (`cjs_default_export_value("events")`), not a `<mod>.default`
+        // namespace, but the default import is still CJS-shaped.
+        "events" => true,
+        // Aliases the runtime folds before any table lookup
+        // (`normalize_native_module_name`: `sys` → `util`, `path/posix` →
+        // `path.posix`, `path/win32` → `path.win32`); the HIR sees the
+        // import's own spelling.
+        "sys" | "path/posix" | "path/win32" => true,
+        // Table rows whose default import the HIR keeps on the namespace
+        // object: `process` has its own lowering (the `source == "process"`
+        // arms in `module_decl.rs`); `node-pty`, `repl` and `sea` never took
+        // the CJS-style path — flipping them is a lowering change, not a
+        // dedup, and is left for a follow-up.
+        "node-pty" | "process" | "repl" | "sea" => false,
+        other => perry_dispatch::has_cjs_default_namespace(other),
+    }
 }
 
 pub(crate) fn node_submodule_default_export_key(module_name: &str) -> Option<&'static str> {
     match module_name {
         "test/reporters" => Some("test_reporters"),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Shared-table rows the HIR deliberately keeps on the namespace-object
+    /// default. Adding a row to the table classifies it CJS-style unless it
+    /// is listed here — so this list, not the table, is what a lowering
+    /// decision edits.
+    const NAMESPACE_OBJECT_DEFAULT_ROWS: &[&str] = &["node-pty", "process", "repl", "sea"];
+
+    #[test]
+    fn every_shared_table_row_is_classified() {
+        for (base, _) in perry_dispatch::CJS_DEFAULT_NAMESPACE_MODULES {
+            let expected = !NAMESPACE_OBJECT_DEFAULT_ROWS.contains(base);
+            assert_eq!(
+                is_cjs_style_native_default_import(base),
+                expected,
+                "`{base}`: shared-table row classified unexpectedly"
+            );
+        }
+        for base in NAMESPACE_OBJECT_DEFAULT_ROWS {
+            assert!(
+                perry_dispatch::has_cjs_default_namespace(base),
+                "`{base}` is listed as an exclusion but is not a shared-table row"
+            );
+        }
+    }
+
+    /// The spellings only the HIR sees (aliases + the callable-default
+    /// `events`) stay CJS-style.
+    #[test]
+    fn hir_only_spellings_are_cjs_style() {
+        for module in ["events", "sys", "path/posix", "path/win32"] {
+            assert!(is_cjs_style_native_default_import(module), "{module}");
+        }
+    }
+
+    /// #9485 / #9500: the rows one of the two former copies had lost, plus
+    /// the module the regression was found on.
+    #[test]
+    fn formerly_drifted_rows_are_cjs_style() {
+        for module in [
+            "child_process",
+            "ffi",
+            "inspector",
+            "inspector/promises",
+            "wasi",
+        ] {
+            assert!(is_cjs_style_native_default_import(module), "{module}");
+        }
+    }
+
+    #[test]
+    fn plain_esm_shaped_builtins_are_not() {
+        for module in [
+            "fs",
+            "fs/promises",
+            "crypto",
+            "http",
+            "stream",
+            "test",
+            "buffer",
+        ] {
+            assert!(!is_cjs_style_native_default_import(module), "{module}");
+        }
     }
 }

--- a/crates/perry-runtime/Cargo.toml
+++ b/crates/perry-runtime/Cargo.toml
@@ -278,6 +278,10 @@ node-api-host = ["dep:hex", "dep:sha2"]
 dyn-eval = ["dep:perry-parser", "dep:perry-diagnostics"]
 
 [dependencies]
+# #9500: the CJS-default module table (`<mod>.default` <-> base) is shared
+# with perry-hir through perry-dispatch, so the runtime's property-read and
+# method-call paths and the HIR's import lowering cannot drift apart.
+perry-dispatch.workspace = true
 thiserror.workspace = true
 anyhow.workspace = true
 libc.workspace = true

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -670,62 +670,16 @@ pub(crate) fn subtle_crypto_namespace() -> f64 {
     js_create_native_module_namespace(b"crypto.subtle".as_ptr(), "crypto.subtle".len())
 }
 
+/// `"<mod>.default"` → `mod`. #9500: a thin view over the ONE shared table
+/// (`perry_dispatch::CJS_DEFAULT_NAMESPACE_MODULES`); the hand-maintained copy
+/// that used to live here is what the method-call router drifted from (#9485).
 pub(crate) fn cjs_default_base_module(module_name: &str) -> Option<&'static str> {
-    match module_name {
-        "async_hooks.default" => Some("async_hooks"),
-        "child_process.default" => Some("child_process"),
-        "cluster.default" => Some("cluster"),
-        "constants.default" => Some("constants"),
-        "dns.default" => Some("dns"),
-        "dns/promises.default" => Some("dns/promises"),
-        "ffi.default" => Some("ffi"),
-        "inspector.default" => Some("inspector"),
-        "inspector/promises.default" => Some("inspector/promises"),
-        "module.default" => Some("module"),
-        "node-pty.default" => Some("node-pty"),
-        "os.default" => Some("os"),
-        "path.default" => Some("path"),
-        "path.posix.default" => Some("path.posix"),
-        "path.win32.default" => Some("path.win32"),
-        "process.default" => Some("process"),
-        "punycode.default" => Some("punycode"),
-        "querystring.default" => Some("querystring"),
-        "repl.default" => Some("repl"),
-        "sea.default" => Some("sea"),
-        "url.default" => Some("url"),
-        "util.default" => Some("util"),
-        "wasi.default" => Some("wasi"),
-        _ => None,
-    }
+    perry_dispatch::cjs_default_base_module(module_name)
 }
 
+/// `mod` → `"<mod>.default"`, from the same shared table (#9500).
 fn cjs_default_namespace_name(module_name: &str) -> Option<&'static str> {
-    match module_name {
-        "async_hooks" => Some("async_hooks.default"),
-        "child_process" => Some("child_process.default"),
-        "cluster" => Some("cluster.default"),
-        "constants" => Some("constants.default"),
-        "dns" => Some("dns.default"),
-        "dns/promises" => Some("dns/promises.default"),
-        "ffi" => Some("ffi.default"),
-        "inspector" => Some("inspector.default"),
-        "inspector/promises" => Some("inspector/promises.default"),
-        "module" => Some("module.default"),
-        "node-pty" => Some("node-pty.default"),
-        "os" => Some("os.default"),
-        "path" => Some("path.default"),
-        "path.posix" => Some("path.posix.default"),
-        "path.win32" => Some("path.win32.default"),
-        "process" => Some("process.default"),
-        "punycode" => Some("punycode.default"),
-        "querystring" => Some("querystring.default"),
-        "repl" => Some("repl.default"),
-        "sea" => Some("sea.default"),
-        "url" => Some("url.default"),
-        "util" => Some("util.default"),
-        "wasi" => Some("wasi.default"),
-        _ => None,
-    }
+    perry_dispatch::cjs_default_namespace_name(module_name)
 }
 
 fn create_cjs_default_namespace(module_name: &str) -> Option<f64> {
@@ -764,10 +718,12 @@ pub(crate) fn cjs_default_export_value(module_name: &str) -> Option<f64> {
             b"wasi.default".as_ptr(),
             "wasi.default".len(),
         )),
-        "async_hooks" | "child_process" | "constants" | "dns" | "dns/promises" | "ffi"
-        | "node-pty" | "os" | "path" | "path.posix" | "path.win32" | "punycode" | "querystring"
-        | "repl" | "sea" | "url" | "util" | "inspector" | "inspector/promises" => {
-            create_cjs_default_namespace(module_name)
+        // #9500: every remaining row of the shared CJS-default table gets its
+        // `<mod>.default` namespace — the arms above are the modules whose
+        // default export is NOT that namespace (a callable, or the plain
+        // namespace itself) and must keep winning.
+        other if perry_dispatch::has_cjs_default_namespace(other) => {
+            create_cjs_default_namespace(other)
         }
         _ => None,
     }

--- a/crates/perry-runtime/src/object/native_module_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch.rs
@@ -456,6 +456,25 @@ mod cjs_default_dispatch_tests {
         );
     }
 
+    /// #9500: the spelled-out list above IS the shared table
+    /// (`perry_dispatch::CJS_DEFAULT_NAMESPACE_MODULES`), in both directions —
+    /// so a row added there is exercised by the two tests above, and a row
+    /// listed here that the table dropped is a failure rather than a stale name.
+    #[test]
+    fn spelled_out_list_matches_the_shared_table() {
+        let mut listed: Vec<&str> = CJS_DEFAULT_NAMESPACES.to_vec();
+        let mut table: Vec<&str> = perry_dispatch::CJS_DEFAULT_NAMESPACE_MODULES
+            .iter()
+            .map(|(_, name)| *name)
+            .collect();
+        listed.sort_unstable();
+        table.sort_unstable();
+        assert_eq!(
+            listed, table,
+            "CJS_DEFAULT_NAMESPACES and perry_dispatch::CJS_DEFAULT_NAMESPACE_MODULES differ"
+        );
+    }
+
     /// The exact regression, pinned by name.
     #[test]
     fn child_process_default_dispatches_as_child_process() {

--- a/test-files/test_gap_9500_exec_callback_completion_order.ts
+++ b/test-files/test_gap_9500_exec_callback_completion_order.ts
@@ -1,0 +1,32 @@
+// #9500 (part 2): `cp.exec` / `cp.execFile` callbacks fire in COMPLETION order,
+// not submission order — a child that finishes first calls back first
+// regardless of which API launched it or which call came first. (When both
+// children finish inside the same loop turn, node's order is a libuv
+// batch-delivery artefact, not a rule — the issue's "exec→execFile vs
+// execFile→exec" for two instant `echo`s — so only the order with a real
+// completion gap is pinned here.)
+import * as cp from "node:child_process";
+
+function race(label: string, first: () => Promise<string>, second: () => Promise<string>) {
+  const order: string[] = [];
+  const tag = (name: string) => (p: Promise<string>) => p.then((out) => { order.push(`${name}:${out}`); });
+  return Promise.all([tag("A")(first()), tag("B")(second())]).then(() => {
+    console.log(label, "→", order.join(" "));
+  });
+}
+const exec = (cmd: string) => new Promise<string>((res) => cp.exec(cmd, (_e, out) => res(String(out).trim())));
+const execFile = (file: string, args: string[]) => new Promise<string>((res) => cp.execFile(file, args, (_e, out) => res(String(out).trim())));
+
+// exec submitted first but slow; execFile submitted second and instant.
+race("slow exec, instant execFile", () => exec("sleep 0.3; echo slow"), () => execFile("/bin/echo", ["fast"]))
+  // execFile submitted first but slow (via sh); exec second and instant.
+  .then(() => race("slow execFile, instant exec", () => execFile("/bin/sh", ["-c", "sleep 0.3; echo slow"]), () => exec("echo fast")))
+  // three children with staggered durations, submitted longest-first.
+  .then(() => {
+    const order: string[] = [];
+    return Promise.all([
+      exec("sleep 0.45; echo c").then((o) => { order.push(o); }),
+      execFile("/bin/sh", ["-c", "sleep 0.3; echo b"]).then((o) => { order.push(o); }),
+      exec("sleep 0.15; echo a").then((o) => { order.push(o); }),
+    ]).then(() => console.log("staggered → " + order.join(" ")));
+  });

--- a/test-files/test_gap_9500_mcp_debug_logger_shape.ts
+++ b/test-files/test_gap_9500_mcp_debug_logger_shape.ts
@@ -1,0 +1,132 @@
+// #9500: claude-code's MCP debug logger wrote NOTHING under perry — not even
+// the `~/.cache/claude-cli-nodejs/<key>/mcp-logs-<server>/` tree — although
+// the connect-failure path that feeds it demonstrably ran. This fixture is the
+// bundle's exact write shape, de-minified:
+//
+//   * every fs call goes through a wrapper compiled from a `using` declaration
+//     (esbuild's downlevel): the error is stashed by `var O=A,w=1` in the CATCH
+//     block and re-thrown from FINALLY by the dispose helper;
+//   * records go into a buffered writer flushed by a 1 s timer, a size cap, or
+//     `dispose()`; the logger registers `dispose` in a cleanup set that the
+//     graceful-shutdown path awaits (raced against a 2 s timer) before
+//     `process.exit`;
+//   * the flush's write function is `try { appendFileSync } catch { mkdirSync;
+//     appendFileSync }` — the ONLY code that ever creates the log directory
+//     tree, so it relies on the first append THROWING ENOENT.
+//
+// Under perry the append silently succeeded-without-writing (#9421, fixed for
+// this surface by #9491), the recovery arm never ran, and the tree was never
+// created. This pins the whole shape end to end: the throw, the `using`
+// re-throw, the recursive mkdir recovery, the timer/dispose flush, and the
+// exit sequencing.
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+// ── esbuild's `using` downlevel helpers, verbatim shape ──────────────────────
+const SYM_DISPOSE = Symbol.dispose || Symbol.for("Symbol.dispose");
+const SYM_ASYNC_DISPOSE = Symbol.asyncDispose || Symbol.for("Symbol.asyncDispose");
+const rz = (q: any[], K: any, _: any) => {
+  if (K != null) {
+    if (typeof K !== "object" && typeof K !== "function") throw TypeError('Object expected to be assigned to "using" declaration');
+    var z;
+    if (_) z = K[SYM_ASYNC_DISPOSE];
+    if (z === void 0) z = K[SYM_DISPOSE];
+    if (typeof z !== "function") throw TypeError("Object not disposable");
+    q.push([_, z, K]);
+  } else if (_) q.push([_]);
+  return K;
+};
+const oz = (q: any[], K: any, _: any) => {
+  var z = typeof (globalThis as any).SuppressedError === "function"
+      ? (globalThis as any).SuppressedError
+      : function (O: any, w: any, $: any, j?: any) { return (j = Error($)), (j.name = "SuppressedError"), (j.error = O), (j.suppressed = w), j; },
+    Y = (O: any) => (K = _ ? new z(O, K, "An error was suppressed during disposal") : ((_ = !0), O)),
+    A: any = (O?: any) => {
+      while ((O = q.pop()))
+        try {
+          var w = O[1] && O[1].call(O[2]);
+          if (O[0]) return Promise.resolve(w).then(A, ($: any) => (Y($), A()));
+        } catch ($) { Y($); }
+      if (_) throw K;
+    };
+  return A();
+};
+// Tracing is off in the shipped CLI: the span tag yields nothing disposable.
+function Jw(_s: TemplateStringsArray, ..._v: any[]): any { return undefined; }
+
+// ── the fs wrapper (`V8()`), the two methods the logger uses ────────────────
+const V8 = {
+  appendFileSync(q: string, K: string) { let Y: any[] = []; try { const _ = rz(Y, Jw`fs.appendFileSync(${q})`, 0); fs.appendFileSync(q, K); } catch (A) { var O = A, w = 1; } finally { oz(Y, O, w); } },
+  mkdirSync(q: string) { let Y: any[] = []; try { const _ = rz(Y, Jw`fs.mkdirSync(${q})`, 0); try { fs.mkdirSync(q, { recursive: true }); } catch ($: any) { if ($?.code !== "EEXIST") throw $; } } catch (A) { var O = A, w = 1; } finally { oz(Y, O, w); } },
+};
+
+// ── the buffered writer (`bD6`) ─────────────────────────────────────────────
+function bufferedWriter({ writeFn, flushIntervalMs = 1000, maxBufferSize = 100 }: { writeFn: (s: string) => void; flushIntervalMs?: number; maxBufferSize?: number }) {
+  let buf: string[] = [], timer: any = null, pending: string[] | null = null;
+  const clear = () => { if (timer) clearTimeout(timer), (timer = null); };
+  const flush = () => { if (pending) writeFn(pending.join("")), (pending = null); if (buf.length === 0) return; writeFn(buf.join("")), (buf = []), clear(); };
+  const arm = () => { if (!timer) timer = setTimeout(flush, flushIntervalMs); };
+  const flushSoon = () => { if (pending) { pending.push(...buf), (buf = []), clear(); return; } const M = buf; buf = [], clear(), (pending = M), setImmediate(() => { const P = pending; if (((pending = null), P)) writeFn(P.join("")); }); };
+  return { write(M: string) { buf.push(M), arm(), buf.length >= maxBufferSize && flushSoon(); }, flush, dispose() { flush(); } };
+}
+
+// ── the cleanup registry (`eq` / `_w8`) ─────────────────────────────────────
+const cleanups = new Set<() => Promise<unknown>>();
+function onCleanup(fn: () => Promise<unknown>) { cleanups.add(fn); return () => cleanups.delete(fn); }
+async function runCleanups() { await Promise.all(Array.from(cleanups).map((q) => q())); }
+
+// ── the per-file logger cache (`BJ7`) and the MCP sinks ─────────────────────
+let recoveries = 0;
+const loggers = new Map<string, ReturnType<typeof bufferedWriter>>();
+function loggerFor(file: string) {
+  let K = loggers.get(file);
+  if (!K) {
+    const dir = path.dirname(file);
+    const w = bufferedWriter({
+      writeFn: (z) => { try { V8.appendFileSync(file, z); } catch { recoveries++; V8.mkdirSync(dir); V8.appendFileSync(file, z); } },
+      flushIntervalMs: 1000,
+      maxBufferSize: 50,
+    });
+    K = { write: (o: unknown) => w.write(JSON.stringify(o) + "\n"), flush: w.flush, dispose: w.dispose };
+    loggers.set(file, K);
+    onCleanup(async () => K?.dispose());
+  }
+  return K;
+}
+const home = fs.mkdtempSync(path.join(os.tmpdir(), "gap9500-"));
+const cacheRoot = path.join(home, ".cache", "claude-cli-nodejs", "-cwd-key"); // nothing under `home` exists yet
+const mcpLogPath = (server: string) => path.join(cacheRoot, `mcp-logs-${server}`, "session.jsonl");
+function logMCPDebug(server: string, msg: string) { loggerFor(mcpLogPath(server)).write({ debug: msg, timestamp: "T" }); }
+function logMCPError(server: string, err: unknown) { loggerFor(mcpLogPath(server)).write({ error: err instanceof Error ? err.message : String(err), timestamp: "T" }); }
+
+// ── the connect-failure path, then graceful shutdown (`WK`) ─────────────────
+logMCPDebug("alpha", "Connection failed: spawn /bin/echo ENOENT");
+logMCPError("alpha", new Error("Connection failed: spawn /bin/echo ENOENT"));
+logMCPDebug("beta", "Connection failed: fetch failed");
+console.log("queued; tree exists before flush:", fs.existsSync(path.join(home, ".cache")));
+
+function report() {
+  for (const server of ["alpha", "beta"]) {
+    const p = mcpLogPath(server);
+    const exists = fs.existsSync(p);
+    const records = exists ? fs.readFileSync(p, "utf8").trim().split("\n").map((l) => JSON.parse(l)) : [];
+    console.log(`${server}: exists=${exists} records=${records.length}`, records.map((r) => r.debug ?? `ERR ${r.error}`).join(" | "));
+  }
+  console.log("recoveries:", recoveries);
+  console.log("tree:", fs.existsSync(cacheRoot) ? fs.readdirSync(cacheRoot).sort().join(",") : "<missing>");
+  fs.rmSync(home, { recursive: true, force: true });
+}
+async function gracefulShutdown(code: number) {
+  let timer: any;
+  try {
+    await Promise.race([
+      (async () => { try { await runCleanups(); } catch {} })(),
+      new Promise((_resolve, reject) => { timer = setTimeout((rej: (e: Error) => void) => rej(new Error("cleanup timeout")), 2000, reject); }),
+    ]);
+    clearTimeout(timer);
+  } catch { clearTimeout(timer); }
+  report();
+  process.exit(code);
+}
+void gracefulShutdown(0);


### PR DESCRIPTION
Closes #9500 — all three findings, one PR. Two are settled by measurement, one by code.

## 1. The MCP debug logger — already unblocked by #9491, now pinned

The bundle's logger writes through a **`using`-downlevel fs wrapper** (the error is stashed by `var O=A,w=1` in the CATCH block and re-thrown from FINALLY by esbuild's dispose helper) into a **buffered writer** flushed by a 1 s timer, a size cap, or `dispose()` — which the graceful-shutdown path awaits (raced against a 2 s timer) before `process.exit`. The flush's write function is

```js
try { V8().appendFileSync(q, z) } catch { V8().mkdirSync(dirname(q)); V8().appendFileSync(q, z) }   // mkdirSync is recursive in the wrapper
```

— the **only** code that ever creates `~/.cache/claude-cli-nodejs/<key>/mcp-logs-*/`. So it relies on the first append THROWING.

`strace` on the layer-1 binary from #9498's verification (built from `9484463d8`, which predates #9491) shows exactly where it died: both engines reach the same `openat(…/mcp-logs-alpha/….jsonl, O_WRONLY|O_CREAT|O_APPEND) = ENOENT`; node follows it with the recursive `mkdir` chain and a successful retry, perry follows it with **nothing** — the append returned success, the catch never ran. That is #9421's swallowed status, fixed for this surface by #9491 (`appendFileSync` now throws the node-shaped error). The flush itself was never the problem: node's write lands ~1.16 s after launch, i.e. the 1 s timer, and perry's pre-#9491 trace shows the same `openat` — the record reached the file system on both engines.

Verification on current main (`0b24670dd9`, post-#9491):
- a de-minified copy of the wrapper (`using` helpers verbatim, tracing off and with a live disposable span) re-throws `ENOENT` and the recovery arm creates the tree — byte-identical to node;
- `test-files/test_gap_9500_mcp_debug_logger_shape.ts` pins the whole shape end to end (wrapper, buffered writer, cleanup set, graceful shutdown, recovery). **It fails on the pre-#9491 tree** (`exists=false records=0 recoveries: 0 tree: <missing>`) and passes on main;
- **cc itself, compiled from post-#9491 main (`0b24670dd9`)**: `mcp list` now writes both `mcp-logs-*/….jsonl` files, and its strace is node's sequence to the syscall — `openat(…, O_APPEND) = ENOENT`, the `mkdir` chain `mcp-logs-alpha → <key> → claude-cli-nodejs → .cache = 0`, retry. On the 15-case `mcp` harness subset the `HOME-PATHS-ONLY-IN-NODE` flag is gone from **all 15**; every case has the same log tree on both engines (the comparer needed one normaliser widened — the log filenames use `-` between time fields, `T13-01-08-339Z`, which its timestamp pattern did not match).
- **What the logs then showed**: with content finally comparable, 14 of the 15 differ in *what* was logged — three real divergences that were invisible before, each reduced to a fixture and filed: a child's `data`/`exit`/`close` are delivered before the continuation that awaited its `'spawn'`, so the SDK's `send()` throws `Not connected` where node gets `Connection closed` (#9535, ~9 cases); `fetch(URL instance)` rejects as `Invalid URL` (#9536, the HTTP cases); null bytes in spawn args are not validated on the `require()` path (#9537, `E62`). The three self-server cases keep the #9499 timeout. Debug logging that works is exactly what the issue said it would be worth.

## 2. exec/execFile callback order — a same-turn artefact, not a scheduling rule

Measured, not inferred. With two instant children (`exec("echo ex")`, `execFile("/bin/echo", ["ef"])`), node on Linux fires **execFile→exec** — and with the two calls swapped it fires **exec→execFile**: whichever was submitted *second* calls back first, both callbacks 0.1 ms apart, both children long exited before the loop's first poll (node's `exec()` call alone takes ~4 ms on the main thread). That is libuv's batch-delivery order for completions that land in one turn, not a property of the API. Perry's reactor drains its completion queue FIFO, so it fires the *first*-submitted callback first in the same situation.

What node actually guarantees — a child that finishes first calls back first, whichever API launched it and whichever call came first — perry already matches (`exec("sleep 0.3; echo")` vs an instant `execFile` fires execFile first on both engines, and vice versa). `test-files/test_gap_9500_exec_callback_completion_order.ts` pins that property with real completion gaps, including a three-child stagger. I did not make the reactor imitate libuv's same-turn LIFO: it would be a heuristic against an accident, and no consumer can rely on it in node either.

Measured on the build host (Linux, node 26.5.1, both engines):

| shape | node | perry |
|---|---|---|
| `exec("echo ex")` then `execFile("/bin/echo",["ef"])` | execFile→exec (15/15) | exec→execFile (10/11, flips under load) |
| same two calls, submitted in the other order | exec→execFile (submitted 2nd first) | execFile→exec (submitted 1st first) |
| `exec("sleep 0.3; echo")` vs instant `execFile` | execFile first | execFile first |
| 3 instant execFiles A,B,C — twice in one process | `C B A`, then `B A C` | completion order, varies |
| 4 instant execFiles A,B,C,D | `C B A D` | completion order, varies |

Node's same-turn order is deterministic but not a rule — the same three-child batch comes out `C B A` and then `B A C` within one process — so there is nothing perry could implement short of libuv's poll-phase bookkeeping. The only order node guarantees, completion order, perry matches.

## 3. The five copies of the CJS-default module set become one table

Not four copies but five: the runtime's `cjs_default_base_module` and `cjs_default_namespace_name`, the `cjs_default_export_value` wildcard arm, the router's list (#9498 already folded that onto the canonical table), and the HIR's `is_cjs_style_native_default_import` — which existed **twice** in the HIR, and the two had already drifted: `lower_expr/helpers.rs`'s copy lacked `ffi`, `inspector`, `inspector/promises` and `wasi`.

The table now lives once, in `perry-dispatch` (the crate perry-hir and perry-runtime already share), as `CJS_DEFAULT_NAMESPACE_MODULES`, built by a macro from one literal per module so `base` and `"<base>.default"` cannot disagree. Every consumer derives from it:

- runtime: the two lookup fns are views over the table; the `cjs_default_export_value` wildcard is a guard on `has_cjs_default_namespace` (the explicit arms before it — callable and plain-namespace defaults — keep winning, so resolution is unchanged);
- HIR: one predicate, table plus its spelled-out differences (`events` and the `sys` / `path/posix` / `path/win32` aliases are CJS-style; `node-pty` / `process` / `repl` / `sea` stay on the namespace-object default — flipping those is a lowering change, left as a follow-up), used by both former call sites;
- tests: the table's shape (round-trip, sorted, canonical spellings), the HIR's classification of every row, and the router test's spelled-out list against the table in both directions.

`perry-runtime` gains `perry-dispatch` as a regular dependency (it was build-only); the crate has no dependencies of its own. A default-import probe (`inspector`, `inspector/promises`, `child_process`, `util`, `sys`, `path/posix`, bare binding identity) is byte-identical to node before and after.

## Follow-ups filed from the now-readable logs

- #9535 — child-process event delivery runs a whole short-lived child's lifecycle before the promise continuation that awaited `'spawn'` (the `Not connected` cases).
- #9536 — `fetch(url: URL)` → `Invalid URL`; DNS-failure error shape.
- #9537 — null-byte validation missing on the `require('child_process')` path; message shape on the named-import path.

## Verification

On the build host (Linux x86_64, node 26.5.1 pin), fix branch built from `0b24670dd9`:

- `cargo test --release -p perry-dispatch -p perry-hir --lib`: 6 + 375 passed, 0 failed (the 5 new table tests and 4 new HIR classification tests included).
- `cargo test --release -p perry-runtime --lib -- --test-threads=1`: **2971 passed, 0 failed, 4 ignored** (the `native_module` subset incl. the new router-vs-table ratchet: 27 passed).
- Byte-identical to node: `test_gap_9500_mcp_debug_logger_shape.ts`, `test_gap_9500_exec_callback_completion_order.ts` (3/3 runs), `test_gap_9485_cjs_default_namespace_method_call.ts` (the #9485 regression still green on the shared table), and the default-import probe.
- `test_gap_9500_mcp_debug_logger_shape.ts` **can fail**: on a pre-#9491 tree (`f1e9c370a`, built fresh) it prints `alpha: exists=false records=0 … recoveries: 0 … tree: <missing>` against node's `exists=true records=2 … recoveries: 2 … mcp-logs-alpha,mcp-logs-beta`; on main it is byte-identical.
- Lint gates (`scripts/run_lint_gates.sh`): all pass except `local_binding_type_audit.py` and `gc_root_dominance_check.py --audit-poll-reach`, which **fail identically on untouched main `0b24670dd9`** (a codegen `property_get` split entry and `js_string_concat_site_value` from #9514) — not from this branch.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility when importing Node.js built-in modules through CommonJS default imports.
  - Corrected `exec` and `execFile` callback behavior to follow completion order.
  - Improved MCP debug logging reliability, including buffered writes, directory creation, cleanup, and graceful shutdown handling.

- **Tests**
  - Added coverage for Node.js module imports, child-process callback ordering, and MCP logger output compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->