### PR TITLE
fix(hir): preserve class captures across loop iterations (#9528)

### DIFF
--- a/changelog.d/9548-loop-class-captures.md
+++ b/changelog.d/9548-loop-class-captures.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **Classes declared in a `for (let …)` body now retain that iteration's
+  captured loop values.** Perry's shared-mutable class-capture lowering placed
+  the loop binding in a one-element cell, but reused that cell across every
+  iteration. Instances kept after the loop therefore all observed the final
+  counter value (`3,3,3` instead of Node's `0,1,2`). The loop backedge now
+  copies the current value into a fresh cell before evaluating the update,
+  matching ECMAScript's per-iteration lexical environment while preserving
+  the intentionally shared behavior of `for (var …)`.

--- a/crates/perry-hir/src/lower/shared_mutable_capture.rs
+++ b/crates/perry-hir/src/lower/shared_mutable_capture.rs
@@ -867,6 +867,15 @@ fn rewrite_stmt(stmt: &mut Stmt, shared: &HashSet<LocalId>, index_uses: &HashSet
             update,
             body,
         } => {
+            // A lexical classic-for head has a distinct binding on every
+            // iteration.  Its `Stmt::Let` is the one source-level binding that
+            // lives in `For::init`; `var` heads are hoisted ahead of the loop
+            // and leave this slot empty.  Remember a shared capture before
+            // rewriting the Let into its one-element cell.
+            let per_iteration_capture = init.as_deref().and_then(|stmt| match stmt {
+                Stmt::Let { id, .. } if shared.contains(id) => Some(*id),
+                _ => None,
+            });
             if let Some(i) = init {
                 rewrite_stmt(i, shared, index_uses);
             }
@@ -877,6 +886,28 @@ fn rewrite_stmt(stmt: &mut Stmt, shared: &HashSet<LocalId>, index_uses: &HashSet
                 rewrite_expr(u, shared, index_uses);
             }
             rewrite_stmts(body, shared, index_uses);
+
+            if let Some(id) = per_iteration_capture {
+                // CreatePerIterationEnvironment copies the current lexical
+                // value before evaluating the update expression.  The shared-
+                // mutable class-capture representation needs the equivalent
+                // operation at the cell level: replace the loop local with a
+                // fresh `[old[0]]` cell, leaving classes from the completed
+                // iteration attached to the old cell.  Insert this AFTER the
+                // ordinary rewrite so the whole-cell LocalSet is not itself
+                // changed into an IndexSet.
+                let freshen = Expr::LocalSet(
+                    id,
+                    Box::new(Expr::Array(vec![Expr::IndexGet {
+                        object: Box::new(Expr::LocalGet(id)),
+                        index: Box::new(Expr::Integer(0)),
+                    }])),
+                );
+                *update = Some(match update.take() {
+                    Some(original) => Expr::Sequence(vec![freshen, original]),
+                    None => freshen,
+                });
+            }
         }
         Stmt::Labeled { body, .. } => rewrite_stmt(body, shared, index_uses),
         Stmt::Try {

--- a/crates/perry-hir/src/lower/tests.rs
+++ b/crates/perry-hir/src/lower/tests.rs
@@ -1415,6 +1415,75 @@ fn fresh_class_refresh_keeps_shared_capture_cell_handle() {
     );
 }
 
+/// A mutable lexical classic-for binding captured by a class uses the shared
+/// one-element cell representation.  The backedge must copy its current value
+/// into a fresh cell before the update, matching CreatePerIterationEnvironment:
+/// instances from completed iterations retain their own capture cell, while a
+/// `var` head continues to share one binding for the whole loop.
+#[test]
+fn classic_for_class_capture_freshens_lexical_cell_before_update() {
+    let source = r#"
+        const lexical = [];
+        for (let i = 0; i < 3; i++) {
+            class Lexical { value() { return i; } }
+            lexical.push(new Lexical());
+        }
+
+        const shared = [];
+        for (var i = 0; i < 3; i++) {
+            class Shared { value() { return i; } }
+            shared.push(new Shared());
+        }
+    "#;
+    let module = perry_parser::parse_typescript(source, "t.ts").expect("source parses");
+    let hir = super::lower_module(&module, "t", "t.ts").expect("source lowers");
+    let loops: Vec<_> = hir
+        .init
+        .iter()
+        .filter_map(|stmt| match stmt {
+            crate::Stmt::For { init, update, .. } => Some((init, update)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(loops.len(), 2, "fixture lowers to lexical and var loops");
+
+    let lexical_id = match loops[0].0.as_deref() {
+        Some(crate::Stmt::Let {
+            id,
+            init: Some(crate::Expr::Array(items)),
+            ..
+        }) if items.len() == 1 => *id,
+        other => panic!("lexical head must lower to one shared capture cell: {other:#?}"),
+    };
+    assert!(matches!(
+        loops[0].1,
+        Some(crate::Expr::Sequence(items))
+            if matches!(
+                items.as_slice(),
+                [
+                    crate::Expr::LocalSet(set_id, fresh),
+                    crate::Expr::IndexUpdate { object, .. },
+                ] if *set_id == lexical_id
+                    && matches!(
+                        fresh.as_ref(),
+                        crate::Expr::Array(values)
+                            if matches!(
+                                values.as_slice(),
+                                [crate::Expr::IndexGet { object, .. }]
+                                    if matches!(object.as_ref(), crate::Expr::LocalGet(id) if *id == lexical_id)
+                            )
+                    )
+                    && matches!(object.as_ref(), crate::Expr::LocalGet(id) if *id == lexical_id)
+            )
+    ));
+
+    assert!(
+        loops[1].0.is_none(),
+        "var head is hoisted outside For::init"
+    );
+    assert!(matches!(loops[1].1, Some(crate::Expr::IndexUpdate { .. })));
+}
+
 /// Companion (the case the depth rule must NOT break): a module-scope `class e`
 /// and a factory-local `let e` holding a different constructor. JS says the
 /// nearer local wins, so `new e()` inside the factory must still construct the

--- a/test-files/test_gap_9528_loop_class_capture.ts
+++ b/test-files/test_gap_9528_loop_class_capture.ts
@@ -1,0 +1,71 @@
+// A class declaration inside a lexical loop body must snapshot that
+// iteration's loop-head binding.  Class methods and field initializers can run
+// after the loop has advanced (or ended), so sharing the class capture table
+// across iterations makes every instance observe the final value.
+
+const classicImmediate: string[] = [];
+const classicDelayed: Array<{ method(): string; field: string }> = [];
+
+for (let i = 0; i < 3; i++) {
+  class Classic {
+    field = "field-" + i;
+
+    method(): string {
+      return "method-" + i;
+    }
+  }
+
+  const instance = new Classic();
+  classicImmediate.push(instance.method() + "/" + instance.field);
+  classicDelayed.push(instance);
+}
+
+console.log("classic immediate:", classicImmediate.join(","));
+console.log(
+  "classic delayed methods:",
+  classicDelayed.map((instance) => instance.method()).join(","),
+);
+console.log(
+  "classic delayed fields:",
+  classicDelayed.map((instance) => instance.field).join(","),
+);
+
+const forOfDelayed: Array<{ method(): string; field: string }> = [];
+
+for (const value of ["a", "b", "c"]) {
+  class ForOf {
+    field = "field-" + value;
+
+    method(): string {
+      return "method-" + value;
+    }
+  }
+
+  forOfDelayed.push(new ForOf());
+}
+
+console.log(
+  "for-of delayed methods:",
+  forOfDelayed.map((instance) => instance.method()).join(","),
+);
+console.log(
+  "for-of delayed fields:",
+  forOfDelayed.map((instance) => instance.field).join(","),
+);
+
+const varDelayed: Array<{ method(): string }> = [];
+
+for (var shared = 0; shared < 3; shared++) {
+  class VarControl {
+    method(): string {
+      return "method-" + shared;
+    }
+  }
+
+  varDelayed.push(new VarControl());
+}
+
+console.log(
+  "var control:",
+  varDelayed.map((instance) => instance.method()).join(","),
+);


### PR DESCRIPTION
Fixes lexical classic-for class captures that shared the final loop value across every evaluated class instance.

## What changed

- Freshen the one-element shared-mutable capture cell at the ECMAScript per-iteration environment boundary, before the update expression runs.
- Leave var-headed loops on their existing shared-binding path.
- Add a structural HIR regression test and a Node-differential gap fixture covering immediate and delayed methods, field initializers, for-of, and the var control.

## Verification

- Demonstrated the fixture on unfixed main: delayed classic-loop methods returned method-3 three times while Node returned method-0, method-1, method-2.
- cargo test -p perry-hir --lib: 376 passed, 0 failed, 1 ignored.
- Focused parity harness: 1 passed, 0 failed; output byte-identical to Node.
- Test registration checker passed.

Closes #9528

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed class closures in `for (let …)` loops so each iteration retains its own captured value.
  * Preserved shared binding behavior for `for (var …)` loops.
  * Corrected per-iteration captures across classic `for` and `for-of` loops, including delayed methods and field initializers.

* **Tests**
  * Added regression coverage for lexical and `var` loop capture behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->