### PR TITLE
test(9542): restore the held-out frozen-`caller`-class-field case — it was #9499, not a property-set bug

### DIFF
--- a/changelog.d/9542-object-index-set-stale-root-reload.md
+++ b/changelog.d/9542-object-index-set-stale-root-reload.md
@@ -1,0 +1,52 @@
+### Fixed
+
+- **`o[k] += 1` on an ordinary object could hand the setter the RECEIVER as its
+  key and SIGSEGV** — the second witness for #9499, fixed by #9522's root-reload
+  launder. The held-out `test_gap_9459_property_set_strictness.cts` case goes
+  back in as the regression pin.
+
+  Reported as #9542: adding a frozen class instance whose field is named
+  `caller` to that fixture made the module segfault on an *earlier* statement,
+  `computedPlus[computedKey] += 1`, inside `set_field_by_name_object_tail` while
+  it hashed the key. The issue's three leads were all wrong, and each is worth
+  recording because each looks right:
+
+  - **`caller` is not load-bearing.** Renaming the field to `zzz`, writing it
+    with `=` instead of `+=`, or never writing it at all reproduces the crash
+    byte-identically. Any perturbation of the module's object-literal shape set
+    does. The `caller`/`arguments` poison-pill special cases in
+    `field_set_by_name.rs` and `field_set_by_name/write_helpers.rs` are not on
+    the path.
+  - **It is not a rooting gap in `expr/index_set.rs`.** The
+    `with_operands_rooted_across(ctx, &[object, index], &[value], …)` group is
+    present and correct, and the emitted IR for the crashing statement is
+    structurally identical with and without the added class — only SSA
+    numbering and two `AnonShape` hashes differ.
+  - **It is not a stale interned-key handle or a string-pool collision.** The
+    key handed to `js_object_set_field_by_name` was neither stale nor
+    mis-interned: it was the receiver. Instrumenting
+    `js_get_string_pointer_unified` caught it taking the `POINTER_TAG` branch on
+    `0x7ffd_046b_fceb_06f0`, and the setter then hashed the receiver's
+    `parent_class_id` word as a `byte_len` of `0x800011bc` and walked off the
+    end of the heap.
+
+  The real mechanism is #9499's: `load %root_slot` folded back into an earlier
+  safepoint's spill slot, which had been recycled in the hole, so the reload
+  produced a different live object. A GDB watchpoint on the machine slot backing
+  the key shows the last write before the faulting read storing the receiver.
+  Proved by A/B on Linux x86-64 with one variable: the `#9459` branch
+  (`9f40f65f5`) SIGSEGVs on this fixture, and the same tree with **only**
+  `c405ce4981` (#9499 → #9522, `ROOT_RELOAD_LAUNDER`) cherry-picked runs it
+  clean, three for three. Current `main` already carries that commit; #9542 is
+  fixed there and needs no further code change.
+
+  - `test-files/test_gap_9459_property_set_strictness.cts` — restores the case
+    the file held out with a comment pointing at #9542: a `CallerCell` class
+    whose field is literally named `caller`, frozen and written with `+=` in
+    **both** arms, plus the unfrozen control that proves the store still lands.
+    A field named `caller` on an ordinary object is not the poison pill — that
+    accessor lives on `Function.prototype` and is keyed on the receiver — so
+    this must behave exactly like the `Cell` case beside it: silent in sloppy
+    code, `TypeError` in strict, value unchanged either way. Reverting #9522's
+    launder turns it back into a SIGSEGV with the arm's output truncated
+    mid-run, so it fails for the reason it was added.

--- a/test-files/test_gap_9459_property_set_strictness.cts
+++ b/test-files/test_gap_9459_property_set_strictness.cts
@@ -115,6 +115,32 @@ function frozenCell(): any {
   return c;
 }
 
+// #9542: the class-field lane of the `caller` receiver rule. A field literally
+// named `caller` on an ORDINARY object is not the poison pill -- that accessor
+// lives on Function.prototype and is keyed on the RECEIVER, so a class INSTANCE
+// carrying the name must behave exactly like `Cell` above.
+//
+// This case was held out of the file when #9459 landed: adding it made the
+// module SIGSEGV on an unrelated earlier statement
+// (`computedPlus[computedKey] += 1`) with a garbage key inside
+// `set_field_by_name_object_tail`. That was #9499, not a property-set bug --
+// a root-slot reload folded back into an earlier safepoint's spill slot, so
+// the setter was handed the RECEIVER as its key. #9522's reload launder fixed
+// it; this case is the second witness, and it goes red again (SIGSEGV, output
+// truncated mid-arm) if that launder is reverted.
+class CallerCell {
+  caller: number;
+  constructor(caller: number) {
+    this.caller = caller;
+  }
+}
+
+function frozenCallerCell(): any {
+  const c = new CallerCell(1);
+  Object.freeze(c);
+  return c;
+}
+
 class RestrictedClassTarget {
   static marker = 1;
 }
@@ -556,6 +582,29 @@ function sloppyArm(): void {
     threw,
     hasOwn(RestrictedClassTarget, "caller"),
   );
+
+  // #9542: a frozen CLASS INSTANCE whose field is named `caller`. The receiver
+  // is an ordinary object, so the poison pill must NOT apply -- only the
+  // assignment's own Throw flag decides, exactly as for `Cell` above.
+  const sloppyCallerCell = frozenCallerCell();
+  threw = false;
+  try {
+    sloppyCallerCell.caller += 1;
+  } catch {
+    threw = true;
+  }
+  report("sloppy frozen class field .caller +=:", threw, sloppyCallerCell.caller);
+
+  // Not frozen: the store must still LAND, so a fix that silenced the lane
+  // rather than un-rejecting it fails here.
+  const sloppyLiveCallerCell = new CallerCell(1);
+  threw = false;
+  try {
+    sloppyLiveCallerCell.caller += 1;
+  } catch {
+    threw = true;
+  }
+  report("sloppy live class field .caller +=:", threw, sloppyLiveCallerCell.caller);
 
   // ---- `++` (Expr::PropertyUpdate) alongside `+=`, so the two spellings of
   //      one operation are asserted in the same file and mode ----
@@ -1018,6 +1067,29 @@ function strictArm(): void {
     threw,
     hasOwn(RestrictedClassTarget, "caller"),
   );
+
+  // #9542: a frozen CLASS INSTANCE whose field is named `caller`. The receiver
+  // is an ordinary object, so the poison pill must NOT apply -- only the
+  // assignment's own Throw flag decides, exactly as for `Cell` above.
+  const strictCallerCell = frozenCallerCell();
+  threw = false;
+  try {
+    strictCallerCell.caller += 1;
+  } catch {
+    threw = true;
+  }
+  report("strict frozen class field .caller +=:", threw, strictCallerCell.caller);
+
+  // Not frozen: the store must still LAND, so a fix that silenced the lane
+  // rather than un-rejecting it fails here.
+  const strictLiveCallerCell = new CallerCell(1);
+  threw = false;
+  try {
+    strictLiveCallerCell.caller += 1;
+  } catch {
+    threw = true;
+  }
+  report("strict live class field .caller +=:", threw, strictLiveCallerCell.caller);
 
   // ---- `++` (Expr::PropertyUpdate) alongside `+=`, so the two spellings of
   //      one operation are asserted in the same file and mode ----


### PR DESCRIPTION
Closes #9542.

## TL;DR

**#9542 is #9499, and current `main` already fixes it.** All this PR adds is the
fixture case #9542 was blocking, as the second regression witness for #9522's
root-reload launder. No code change.

## What the crash actually was

`test-files/test_gap_9459_property_set_strictness.cts` held out one case with a
comment pointing at #9542: a frozen class instance whose field is named
`caller`. Adding it made the module SIGSEGV on an **earlier** statement,
`computedPlus[computedKey] += 1`, inside `set_field_by_name_object_tail` while
it hashed the key.

Every lead in the issue is wrong, and each is worth recording because each looks
right:

| Issue's lead | What is actually true |
| --- | --- |
| "a field literally named `caller` is load-bearing" | It is not. Renaming the field to `zzz`, writing it with `=` instead of `+=`, or never writing it at all reproduces byte-identically. Any perturbation of the module's object-literal shape set does. The `caller`/`arguments` poison-pill special cases are not on the path. |
| "more likely a stale interned-key handle or a dispatch-id / string-pool collision" | The key was neither stale nor mis-interned — **it was the receiver.** Instrumenting `js_get_string_pointer_unified` caught it taking the `POINTER_TAG` branch on `0x7ffd_046b_fceb_06f0`; the setter then read the receiver's `parent_class_id` word as a `byte_len` of `0x800011bc` and walked off the end of the heap. |
| "the `with_operands_rooted_across` guard is present, so the pointer is probably wrong rather than merely moved" | The guard is present and correct. The emitted IR for the crashing statement is *structurally identical* with and without the added class — only SSA numbering and two `AnonShape` hashes differ. Nothing about the lowering changes. |

The real mechanism is the one #9499 named: a `load %root_slot` folded back into
an earlier safepoint's spill slot, which had been recycled in the hole, so the
reload produced a different live object. #9499 measured it as "the key stored
was the closure allocated three lines earlier"; here it is "the key stored was
the receiver". A GDB watchpoint on the machine stack slot backing the key shows
the last write before the faulting read storing the receiver:

```
WRITE val=0x7fff031d8c620058 pc=0x5555556c69fc   <- the key string "x"
WRITE val=0x7ffd031d8c6b06f0 pc=0x5555556c6b55   <- the RECEIVER, same slot
Program received signal SIGSEGV
#0  set_field_by_name_object_tail
#1  js_typed_feedback_object_set_field_by_name
#2  perry_fn_..._strictArm
```

## A/B, one variable, on the file this PR adds

| build | result |
| --- | --- |
| `c405ce4981^` — `main` immediately before #9522 | **SIGSEGV 3/3**, output truncated at `strict frozen for-of head computed` |
| `c405ce4981` — #9499 → #9522 `ROOT_RELOAD_LAUNDER` | **exit 0, 82 lines, byte-identical to node v26.5.1**, 3/3 |

Independently confirmed on the `#9459` branch (`9f40f65f5`, which predates
#9522): it SIGSEGVs on this shape, and the same tree with **only** `c405ce4981`
cherry-picked runs clean 3/3. The crash reproduces on macOS arm64 (the
reporter's platform) and on Linux x86-64; the fix verification above is Linux
x86-64.

So the reporter's "pre-existing on `main`" bisect was correct — it just landed
before #9522 did (15:29 today).

## What changed

- `test-files/test_gap_9459_property_set_strictness.cts` — a `CallerCell` class
  whose field is literally named `caller`, frozen and written with `+=` in
  **both** arms, plus the unfrozen control that proves the store still lands.
  A field named `caller` on an ordinary object is not the poison pill — that
  accessor lives on `Function.prototype` and is keyed on the receiver — so this
  must behave exactly like the `Cell` case beside it: silent in sloppy code,
  `TypeError` in strict, value unchanged either way. Verified byte-identical to
  node v26.5.1.
- `changelog.d/9542-object-index-set-stale-root-reload.md`.

No `crates/` files are touched and there is no version bump.

## Why this is a test that can fail

Reverting #9522's launder turns the new case back into a SIGSEGV with the arm's
output truncated mid-run — measured above, not assumed. It fails for exactly the
reason it was added, and it is a *different* shape from #9522's own
`test_gap_9499_rooted_key_across_closure_alloc.ts` (object index-set lane vs.
`map.set` with a closure argument), so the two pin the launder from two sides.

Its one weakness, stated plainly: the witness is register-allocation sensitive —
it depends on the module's shape set, so an unrelated future edit to this file
could stop exercising the fold. That is the nature of the bug class, and it is
why the comment in the fixture explains what the case is for.

https://claude.ai/code/session_01GxbQau35regom2rbbLVpax


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected stale-root behavior affecting property assignments after a root reload.
  - Compound assignments to ordinary properties on frozen instances now behave correctly in both strict and non-strict modes.
  - Preserved expected behavior for live instances and unchanged property values.
- **Tests**
  - Added regression coverage for frozen class instances and distinctions from restricted function properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->