### PR TITLE
test(drizzle): restore typed mysql2 dispatch

### DIFF
--- a/tests/release/packages/drizzle-mysql2-tx/entry.ts
+++ b/tests/release/packages/drizzle-mysql2-tx/entry.ts
@@ -1,7 +1,9 @@
 // #9356 acceptance: drizzle-orm transactions over the native `mysql2`
 // binding (perry-ext-mysql2), a few hundred in a row, with the young
 // generation collected every couple of transactions (fixture.sh sets
-// PERRY_GC_SCAVENGE_NURSERY_MB=1).
+// PERRY_GC_SCAVENGE_NURSERY_MB=1). #9516 additionally keeps Drizzle's
+// inferred `MySql2Database<TSchema> & { $client: ... }` intersection intact,
+// so both `execute` and `transaction` exercise typed method dispatch.
 //
 // Before the fix the promise minted by `perry_ffi_promise_new` lived in the
 // nursery; the first copying minor that landed while a query was in flight
@@ -21,11 +23,7 @@ const pool = mysql.createPool({
     password: process.env.PERRY_FIXTURE_MYSQL_PASSWORD ?? "",
     database: "perry_drizzle_test",
 });
-// `any`: the statically typed `db.transaction(...)` call currently throws
-// "Cannot convert undefined or null to object" on main (typed-dispatch
-// regression, tracked separately); the reporter's code hits the same
-// machinery through the dynamic path this exercises.
-const db: any = drizzle(pool, { mode: "default" });
+const db = drizzle(pool, { mode: "default" });
 
 await db.execute(sql`DROP TABLE IF EXISTS tx_notifications`);
 await db.execute(sql`CREATE TABLE tx_notifications (id INT PRIMARY KEY AUTO_INCREMENT, body VARCHAR(32) NOT NULL)`);
@@ -37,7 +35,7 @@ console.log("seeded");
 const ITERATIONS = 400;
 let completed = 0;
 for (let iteration = 1; iteration <= ITERATIONS; iteration++) {
-    await db.transaction(async (tx: any) => {
+    await db.transaction(async (tx) => {
         const result = await tx.execute(sql`
             SELECT a.id
               FROM tx_notifications a


### PR DESCRIPTION
## Summary

- remove the `any` escape hatches from the existing Drizzle/MySQL2 transaction fixture
- exercise both `db.execute` and the transaction callback through Drizzle's inferred `MySql2Database<TSchema> & { $client: ... }` type
- retain regression coverage for the typed dispatch failure now fixed on main by the dispatch/rooting changes

Closes #9516.

## Testing

- `bash tests/release/packages/drizzle-mysql2-tx/fixture.sh` with the configured MySQL test credentials (`PASS drizzle-mysql2-tx`, 400 transactions, 1 MB nursery)
- `cargo fmt --all --check`
- `./scripts/test_affected_crates.sh --base origin/main --dry-run`

`./scripts/pre-tag-check.sh --quick` passes its other checks but currently reports the existing local-binding allowlist mismatch in untouched code (`dispatch_receiver_class.rs` versus `dynamic_dispatch.rs`).

No version bump.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test fixture type safety by preserving inferred database and transaction types.
  - Added documentation for garbage-collection configuration and database type inference.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->