### PR TITLE
fix(lint): repair the four main-side gate breaks; string-payload ratchet 359->358

### DIFF
--- a/crates/perry-hir/src/lower/tests/capture_stash.rs
+++ b/crates/perry-hir/src/lower/tests/capture_stash.rs
@@ -2,8 +2,6 @@
 //! stash must follow `super()`, not constructor entry. Split from `tests.rs`
 //! for the 2000-line file cap.
 
-use super::*;
-
 /// A derived class with captured outers whose `super()` is not its own
 /// statement — the minifier's `super(a), this.x = b, …` comma sequence, as in
 /// Next's `AppRouteRouteModule` — must stash the `this.__perry_cap_*` fields

--- a/crates/perry-runtime/src/builtins/formatting/errors.rs
+++ b/crates/perry-runtime/src/builtins/formatting/errors.rs
@@ -177,14 +177,12 @@ pub(super) unsafe fn format_error_subclass_headline(
             if key_ptr.is_null() {
                 continue;
             }
-            let key_len = (*key_ptr).byte_len as usize;
-            let key_data = (key_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
-            let key_bytes = std::slice::from_raw_parts(key_data, key_len);
-            if key_bytes == b"name" {
+            let key_str = string_header_to_string(key_ptr as *mut StringHeader, "");
+            if key_str == "name" {
                 own_name = Some(obj_h.with_const_ptr::<crate::object::ObjectHeader, _>(
                     |obj_ptr| crate::object::js_object_get_field_f64(obj_ptr, index),
                 ));
-            } else if key_bytes == b"message" {
+            } else if key_str == "message" {
                 own_message = Some(obj_h.with_const_ptr::<crate::object::ObjectHeader, _>(
                     |obj_ptr| crate::object::js_object_get_field_f64(obj_ptr, index),
                 ));

--- a/crates/perry-runtime/src/gc/tests/error_side_tables.rs
+++ b/crates/perry-runtime/src/gc/tests/error_side_tables.rs
@@ -138,14 +138,8 @@ fn test_moved_fs_enoent_round_trips_through_util_inspect() {
         f64::from_bits(crate::value::TAG_UNDEFINED),
     );
     let inspected = crate::value::JSValue::from_bits(inspected.to_bits());
-    let text = unsafe {
-        let ptr = inspected.as_string_ptr();
-        let bytes = std::slice::from_raw_parts(
-            (ptr as *const u8).add(std::mem::size_of::<crate::StringHeader>()),
-            (*ptr).byte_len as usize,
-        );
-        String::from_utf8_lossy(bytes).into_owned()
-    };
+    let text =
+        unsafe { crate::symbol::str_from_header(inspected.as_string_ptr()).unwrap_or_default() };
     assert!(text.contains("code: 'ENOENT'"), "missing ENOENT: {text}");
     assert!(
         text.contains("path: '/perry-9530-definitely-missing'"),

--- a/scripts/gc_root_dominance_check.py
+++ b/scripts/gc_root_dominance_check.py
@@ -1385,6 +1385,10 @@ POLL_CAPABLE_RUNTIME = {
     # already listed. So the entry is an omission at introduction, not a
     # judgement call.
     "js_string_concat_value_box",
+    # #9514's per-site concat cache: `js_string_concat_site_value` calls
+    # `js_string_concat_value_box` on its miss path, so it can allocate and
+    # re-enter a moving minor exactly like its callee (the #7616 shape).
+    "js_string_concat_site_value",
     # `js_private_brand_add` is the referent-with-no-name that NEITHER audit can
     # ask for: `--audit-poll-reach` only walks symbols `ALLOC_RE` matches, and
     # `js_private_brand_add` matches no alloc/new/create convention, so the one

--- a/scripts/local_binding_type_allowlist.json
+++ b/scripts/local_binding_type_allowlist.json
@@ -322,7 +322,7 @@
       "reason": "The proof API supplies only runtime-derived initializer evidence and rejects the binding after any write in the region."
     },
     {
-      "path": "crates/perry-codegen/src/lower_call/property_get/dynamic_dispatch.rs",
+      "path": "crates/perry-codegen/src/lower_call/property_get/dispatch_receiver_class.rs",
       "function": "guarded_declared_receiver_class_candidate",
       "access": "local_type_hint",
       "count": 1,

--- a/scripts/string_payload_access_baseline.txt
+++ b/scripts/string_payload_access_baseline.txt
@@ -12,7 +12,7 @@ inline-offset | perry-ext-nodemailer | 1
 inline-offset | perry-ext-pg | 2
 inline-offset | perry-ext-zlib | 3
 inline-offset | perry-ffi | 3
-inline-offset | perry-runtime | 359
+inline-offset | perry-runtime | 358
 inline-offset | perry-stdlib | 48
 inline-offset | perry-updater | 5
 reader-helper | perry-ext-ethers | 1


### PR DESCRIPTION
Repairs four lint-gate breaks on main, all found by running the full 60-step gate suite (three were mine, missed by hand-picked gate subsets during today's trains):

- local-binding-type allowlist still pointed at `dynamic_dispatch.rs` after the train70 split moved `guarded_declared_receiver_class_candidate` to `property_get/dispatch_receiver_class.rs` (two PR authors had to work around this).
- Two new open-coded StringHeader payload reads (#9511's key scan, #9550's test) now route through counted readers — the ratchet BASELINE DROPS 359 to 358.
- #9514's `js_string_concat_site_value` added to POLL_CAPABLE_RUNTIME (calls `js_string_concat_value_box` on miss — the #7616 shape, exactly as the checker prescribes).
- Unused `use super::*` in the train76 capture-stash test split (red under -D warnings).

`run_lint_gates.sh`: all 60 gates pass. Runtime error_side_tables suite 6/6.
