### PR TITLE
test: restore Linux callback-deopt GC coverage

### DIFF
--- a/changelog.d/9566-linux-callback-deopt-runtime.md
+++ b/changelog.d/9566-linux-callback-deopt-runtime.md
@@ -1,0 +1,1 @@
+test: the versioned indexed-loop callback-deopt fixture now links Perry's shipped `panic=abort` runtime, so its ordinary and forced-evacuation GC paths run on Linux again instead of aborting behind an ignore (#9482).

--- a/crates/perry/tests/versioned_indexed_loop_callback_deopt.rs
+++ b/crates/perry/tests/versioned_indexed_loop_callback_deopt.rs
@@ -44,10 +44,16 @@ fn workspace_root() -> PathBuf {
 /// Perry ships a `panic=abort` runtime. A debug `panic=unwind` archive plants
 /// abort-on-unwind guards in `extern "C"` helpers, so the raw JS exceptions in
 /// this fixture cannot reach their generated catch landing pads on Linux.
+/// Relative Cargo target overrides are rooted at the nested build's workspace.
 fn target_runtime_dir() -> PathBuf {
-    let target = std::env::var_os("CARGO_TARGET_DIR")
+    let target = match std::env::var_os("CARGO_TARGET_DIR")
+        .filter(|value| !value.is_empty())
         .map(PathBuf::from)
-        .unwrap_or_else(|| workspace_root().join("target"));
+    {
+        Some(path) if path.is_absolute() => path,
+        Some(path) => workspace_root().join(path),
+        None => workspace_root().join("target"),
+    };
     if cfg!(windows) {
         target.join("x86_64-pc-windows-msvc").join("release")
     } else {

--- a/crates/perry/tests/versioned_indexed_loop_callback_deopt.rs
+++ b/crates/perry/tests/versioned_indexed_loop_callback_deopt.rs
@@ -41,15 +41,34 @@ fn workspace_root() -> PathBuf {
         .expect("canonicalize workspace root")
 }
 
+/// Perry ships a `panic=abort` runtime. A debug `panic=unwind` archive plants
+/// abort-on-unwind guards in `extern "C"` helpers, so the raw JS exceptions in
+/// this fixture cannot reach their generated catch landing pads on Linux.
+fn target_runtime_dir() -> PathBuf {
+    let target = std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| workspace_root().join("target"));
+    if cfg!(windows) {
+        target.join("x86_64-pc-windows-msvc").join("release")
+    } else {
+        target.join("release")
+    }
+}
+
 fn runtime_dir() -> PathBuf {
     static BUILD_RUNTIME: Once = Once::new();
     BUILD_RUNTIME.call_once(|| {
         let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
         let mut command = Command::new(cargo);
-        command.current_dir(workspace_root()).arg("build");
+        command
+            .current_dir(workspace_root())
+            .arg("build")
+            // `panic` is profile-level; this must match `target_runtime_dir()`
+            // and the runtime Perry actually ships.
+            .arg("--release");
         remove_gc_env_overrides(&mut command);
-        if !cfg!(debug_assertions) {
-            command.arg("--release");
+        if cfg!(windows) {
+            command.arg("--target").arg("x86_64-pc-windows-msvc");
         }
         let build = command
             .args(["-p", "perry-runtime-static"])
@@ -63,10 +82,7 @@ fn runtime_dir() -> PathBuf {
         );
     });
 
-    perry_bin()
-        .parent()
-        .expect("Perry binary directory")
-        .to_path_buf()
+    target_runtime_dir()
 }
 
 fn run_fixture(binary: &Path, force_evacuation: bool) -> Output {
@@ -93,12 +109,6 @@ fn llvm_function_body(ir: &str, symbol: &str) -> String {
 }
 
 #[test]
-// #9482: aborts on Linux with `panic in a function that cannot unwind` inside
-// the force_evacuation=false GC fixture — consistent there, never observed
-// green; passes 3/3 on macOS at the same pin. Deferred to unblock releases,
-// NOT shown pre-existing; the diagnosis and Linux repro live in #9482, and
-// re-enabling is deleting this attribute.
-#[cfg_attr(target_os = "linux", ignore = "#9482: Linux-only GC deopt abort")]
 fn cold_callback_arms_resume_once_at_the_next_index() {
     let dir = tempfile::tempdir().expect("tempdir");
     let entry = dir.path().join("main.ts");


### PR DESCRIPTION
## Summary

- build the callback-deopt fixture's static runtime in release mode, matching Perry's shipped `panic=abort` exception-transport contract
- resolve the matching `target/release` runtime directory on Unix and Windows, including relative or empty Cargo target overrides
- remove the Linux-only ignore so both ordinary and forced-evacuation GC paths run in CI again

## Root cause

The fixture was linking a debug `panic=unwind` runtime during a normal `cargo test`. On Linux, that profile inserts abort-on-unwind guards in `extern "C"` helpers, so the fixture's raw JS exception aborts before reaching its generated catch landing pad. This is the test-environment mismatch documented in #8479, not a GC deoptimization failure.

## Verification

- `RUST_TEST_THREADS=1 cargo test -p perry --test versioned_indexed_loop_callback_deopt -- --nocapture` (passes on Linux; covers `force_evacuation=false` and `true`)
- `CARGO_TARGET_DIR=target RUST_TEST_THREADS=1 cargo test -p perry --test versioned_indexed_loop_callback_deopt -- --nocapture` (passes with a relative target override)
- `./scripts/pre-tag-check.sh --quick`
- `./scripts/test_affected_crates.sh --base origin/main` (1,063/1,064 pass; current `main` independently fails `codegen_env_vars_are_build_cache_inputs` because `PERRY_CONCAT_SITE_CACHE` is not classified)

Closes #9482


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Restored Linux test coverage for indexed-loop callback deoptimization, including standard and forced garbage-collection scenarios.
  * Improved runtime selection for test builds across supported configurations, including Windows MSVC and custom target directories.

* **Documentation**
  * Updated the changelog to reflect restored Linux test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->