### PR TITLE
fix(compile): isolate shared-tokio auto-opt graphs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3051,49 +3051,6 @@ jobs:
           SKIP=${#skip_files[@]}
           echo "Compile smoke: $PASS passed, $FAIL failed, $SKIP skipped"
 
-          # Known-failing cases (#9470). These two are NOT a compiler bug in
-          # the code under test: auto-optimize rebuilds the stdlib static into
-          # `target/perry-auto-<hash>/` WITHOUT the ext wrappers in the same
-          # cargo invocation, so tokio's features resolve differently for them
-          # and the linker correctly refuses the pair ("bundle a DIFFERENT
-          # tokio compilation"). The refusal is the right behaviour — the
-          # alternative is a binary with two `tokio::runtime::context::CONTEXT`
-          # thread-locals and "there is no reactor running" at runtime
-          # (#507, #7629) — so this list tolerates the CI red, it does NOT
-          # weaken the check that protects users.
-          #
-          # Pre-existing: the 2026-08-31 full tier (run 33372993990) failed the
-          # same way on test_issue_414_mysql_query_params. Adding ext crates to
-          # this job's `cargo build` line does NOT help — mysql2 is already
-          # there; auto-optimize's LATER rebuild is what breaks coherence.
-          #
-          # Delete an entry the moment #9470 lands — an entry that stops
-          # matching is a stale exemption, and the check below fails on one.
-          KNOWN_FAIL=(
-            test_issue_340_axios_response_props
-            test_issue_414_mysql_query_params
-          )
-          UNEXPECTED=()
-          STALE=()
-          for marker in "$LOGS_DIR"/*.fail; do
-            [[ -e "$marker" ]] || continue
-            name=$(basename "$marker" .fail)
-            known=0
-            for k in "${KNOWN_FAIL[@]}"; do [[ "$name" == "$k" ]] && known=1 && break; done
-            [[ $known -eq 1 ]] || UNEXPECTED+=("$name")
-          done
-          for k in "${KNOWN_FAIL[@]}"; do
-            [[ -e "$LOGS_DIR/$k.fail" ]] || STALE+=("$k")
-          done
-          if [[ ${#STALE[@]} -gt 0 ]]; then
-            echo "::error::known-failure entries that now PASS — delete them from KNOWN_FAIL (#9470):"
-            printf '  - %s\n' "${STALE[@]}"
-            exit 1
-          fi
-          if [[ ${#UNEXPECTED[@]} -gt 0 ]]; then
-            echo "::error::compile-smoke has ${#UNEXPECTED[@]} failure(s) beyond the known list:"
-            printf '  - %s\n' "${UNEXPECTED[@]}"
-          fi
           if [[ $FAIL -gt 0 ]]; then
             echo "Compile failures:"
             for marker in "$LOGS_DIR"/*.fail; do
@@ -3110,13 +3067,7 @@ jobs:
                 echo "    --- end ---"
               fi
             done
-            # Fail ONLY on failures outside the known list. A known one is
-            # still printed above with its stderr, so it stays visible rather
-            # than silently tolerated.
-            if [[ ${#UNEXPECTED[@]} -gt 0 ]]; then
-              exit 1
-            fi
-            echo "All ${FAIL} failure(s) are known (#9470); not failing the job."
+            exit 1
           fi
 
       - name: Upload compile-smoke error logs

--- a/changelog.d/9576-auto-opt-wrapper-cache.md
+++ b/changelog.d/9576-auto-opt-wrapper-cache.md
@@ -1,0 +1,11 @@
+**fix(compile): isolate auto-optimized shared-tokio wrapper graphs (#9470, #9094)**
+
+Auto-optimized builds now include the canonical shared-tokio wrapper package
+set in their `target/perry-auto-<hash>` cache identity. Previously, programs
+with the same stripped stdlib features but different ext wrappers shared one
+target directory. A concurrent wrapper-free build could replace the stdlib
+after an axios, mysql2, or HTTP wrapper build released its lock but before that
+compiler linked, producing mismatched tokio/futures-channel archives. Wrapper
+aliases such as `mysql2` / `mysql2/promise` and `http` / `https` are also
+deduplicated before Cargo and the linker see them, and compile-smoke is strict
+again now that its two temporary #9470 exemptions pass.

--- a/crates/perry/src/commands/compile/optimized_libs/driver.rs
+++ b/crates/perry/src/commands/compile/optimized_libs/driver.rs
@@ -294,11 +294,20 @@ pub(crate) fn build_optimized_libs(
                         binding.tracking.as_deref().unwrap_or("no tracking issue")
                     );
                 }
-                tokio_using_bindings.push((
-                    binding.krate.clone(),
-                    binding.lib.clone(),
-                    binding.tracking.clone(),
-                ));
+                // Multiple import spellings can resolve to one archive
+                // (`mysql2` + `mysql2/promise`, `http` + `https`). Keep the
+                // Cargo package set and link line unique; alias multiplicity
+                // is not a different build graph.
+                if !tokio_using_bindings
+                    .iter()
+                    .any(|(krate, lib, _tracking)| krate == &binding.krate && lib == &binding.lib)
+                {
+                    tokio_using_bindings.push((
+                        binding.krate.clone(),
+                        binding.lib.clone(),
+                        binding.tracking.clone(),
+                    ));
+                }
             }
             if matches!(module_normalized, "net" | "http" | "https" | "http2") {
                 external_net_transport = true;
@@ -653,13 +662,13 @@ pub(crate) fn build_optimized_libs(
     };
     let workspace_root = cargo_target_dir_path(workspace_root);
 
-    // Hash the (features, panic_mode, target, wasm-host) tuple into the
-    // target dir name so cargo treats each combination as its own
-    // incremental cache. `wasm-host` lives on `perry-runtime` (not
-    // perry-stdlib), so it isn't part of `feature_arg`; bake it in here
-    // separately so a wasm program's build doesn't get served from a
-    // cached non-wasm dir (which would lack `js_webassembly_*` symbols)
-    // and vice versa (would carry unresolved `perry_wasm_host_*` refs).
+    // Hash the (features, panic_mode, target, wasm-host, shared-tokio wrapper
+    // set) tuple into the target dir name so cargo treats each combination as
+    // its own incremental cache. `wasm-host` lives on `perry-runtime` (not
+    // perry-stdlib), so it isn't part of `feature_arg`; the selected ext
+    // wrappers are Cargo packages rather than features, so they are not in it
+    // either. Bake both into the key so neither graph can be served or
+    // overwritten by another compile using the same stripped stdlib features.
     //
     // The compiler version is part of the key too. Codegen emits calls to
     // runtime entrypoints (e.g. `js_promise_run_promise_jobs`,
@@ -671,8 +680,14 @@ pub(crate) fn build_optimized_libs(
     // "undefined symbol" link failure for exactly the newly-added entrypoints.
     // Keying on the version forces a matching rebuild whenever perry upgrades.
     // Cheap djb2 — no need for the SipHash overhead.
-    let key_input =
-        auto_optimized_cache_key(&feature_arg, panic_abort_safe, panic_immediate, target, ctx);
+    let key_input = auto_optimized_cache_key(
+        &feature_arg,
+        panic_abort_safe,
+        panic_immediate,
+        target,
+        ctx,
+        &tokio_using_bindings,
+    );
     let mut hash: u64 = 5381;
     for b in key_input.as_bytes() {
         hash = hash.wrapping_mul(33).wrapping_add(*b as u64);

--- a/crates/perry/src/commands/compile/optimized_libs/freshness.rs
+++ b/crates/perry/src/commands/compile/optimized_libs/freshness.rs
@@ -101,18 +101,37 @@ pub(crate) fn size_lto_fat() -> bool {
 
 /// Cache key for the auto-optimize target dir + build stamp. Hashed into the
 /// `target/perry-auto-<hash>` dir name so each (features, panic-mode, target,
-/// runtime-gate, version) combination gets its own incremental cache. Kept in
-/// one place so `build_optimized_libs` and its freshness tests can never drift.
+/// runtime-gate, shared-tokio-wrapper set, version) combination gets its own
+/// incremental cache. Kept in one place so `build_optimized_libs` and its
+/// freshness tests can never drift.
 pub(crate) fn auto_optimized_cache_key(
     feature_arg: &str,
     panic_abort_safe: bool,
     panic_immediate: bool,
     target: Option<&str>,
     ctx: &CompilationContext,
+    tokio_using_bindings: &[(String, String, Option<String>)],
 ) -> String {
     let target_str = target.unwrap_or("host");
+    // The stripped stdlib feature set is not enough to identify this Cargo
+    // graph. For example, mysql2 and a CPU-only async wrapper both reduce to
+    // `async-runtime`, but only the mysql2 build selects perry-ext-mysql2.
+    // Sharing a target dir lets the second invocation replace stdlib after
+    // the first invocation releases its build lock but before it links. The
+    // first process then sees an ext archive and stdlib archive from different
+    // dependency graphs (#9470; the same class produced #9094's Linux link).
+    //
+    // Sort and deduplicate here as a defensive measure: aliases such as
+    // `mysql2` + `mysql2/promise` name the same wrapper and must describe the
+    // same graph regardless of discovery order or alias multiplicity.
+    let mut tokio_bindings: Vec<String> = tokio_using_bindings
+        .iter()
+        .map(|(krate, lib, _tracking)| format!("{krate}:{lib}"))
+        .collect();
+    tokio_bindings.sort_unstable();
+    tokio_bindings.dedup();
     format!(
-        "{}|{}|{}|wasm={}|napi={}|regex={}|temporal={}|ee={}|url={}|norm={}|seg={}|loc={}|intlns={}|gns={}{}{}{}{}{}{}{}{}{}|diag={}|dgram={}|http2={}|nodetest={}|dyneval={}|sizeopt={}|anchors={}|v={}",
+        "{}|{}|{}|wasm={}|napi={}|regex={}|temporal={}|ee={}|url={}|norm={}|seg={}|loc={}|intlns={}|gns={}{}{}{}{}{}{}{}{}{}|diag={}|dgram={}|http2={}|nodetest={}|dyneval={}|tokio={}|sizeopt={}|anchors={}|v={}",
         feature_arg,
         panic_abort_safe,
         target_str,
@@ -150,6 +169,7 @@ pub(crate) fn auto_optimized_cache_key(
         perry_hir::has_deferred_dynamic_code_sites()
             || ctx.native_module_imports.contains("vm")
             || ctx.uses_data_url_dynamic_import,
+        tokio_bindings.join(","),
         format!(
             "{}{}{}",
             size_opt_level().unwrap_or("off"),

--- a/crates/perry/src/commands/compile/optimized_libs/tests.rs
+++ b/crates/perry/src/commands/compile/optimized_libs/tests.rs
@@ -102,8 +102,14 @@ fn build_optimized_libs_reuses_fresh_auto_archives_without_cargo() {
     let panic_abort_safe =
         !ctx.needs_ui && !ctx.needs_thread && !ctx.needs_plugins && !ctx.needs_geisterhand;
     let panic_immediate = effective_size_panic_immediate_abort(panic_abort_safe);
-    let key_input =
-        auto_optimized_cache_key(&feature_arg, panic_abort_safe, panic_immediate, None, &ctx);
+    let key_input = auto_optimized_cache_key(
+        &feature_arg,
+        panic_abort_safe,
+        panic_immediate,
+        None,
+        &ctx,
+        &[],
+    );
     let mut hash: u64 = 5381;
     for b in key_input.as_bytes() {
         hash = hash.wrapping_mul(33).wrapping_add(*b as u64);
@@ -612,9 +618,51 @@ fn node_test_gate_keys_the_auto_optimize_cache() {
     let without = CompilationContext::new(dir.path().to_path_buf());
 
     assert_ne!(
-        auto_optimized_cache_key("", true, false, None, &with_test),
-        auto_optimized_cache_key("", true, false, None, &without),
+        auto_optimized_cache_key("", true, false, None, &with_test, &[]),
+        auto_optimized_cache_key("", true, false, None, &without, &[]),
         "mod-node-test must participate in the auto-optimize cache key"
+    );
+}
+
+#[test]
+fn shared_tokio_wrapper_set_keys_the_auto_optimize_target_dir() {
+    // #9470 / #9094: wrapper selection is expressed with Cargo `-p` args,
+    // not stdlib features. Two otherwise-identical compilations therefore
+    // used to share one perry-auto target dir. Once the wrapper build released
+    // its lock, a wrapper-free build could replace stdlib before the first
+    // compiler linked, leaving archives from different dependency graphs.
+    let ctx = CompilationContext::new(std::env::current_dir().expect("cwd"));
+    let mysql = vec![(
+        "perry-ext-mysql2".to_string(),
+        "perry_ext_mysql2".to_string(),
+        Some("#466".to_string()),
+    )];
+    let axios = vec![(
+        "perry-ext-axios".to_string(),
+        "perry_ext_axios".to_string(),
+        Some("#466".to_string()),
+    )];
+
+    let without_wrapper = auto_optimized_cache_key("async-runtime", true, false, None, &ctx, &[]);
+    let with_mysql = auto_optimized_cache_key("async-runtime", true, false, None, &ctx, &mysql);
+    let with_axios = auto_optimized_cache_key("async-runtime", true, false, None, &ctx, &axios);
+
+    assert_ne!(without_wrapper, with_mysql);
+    assert_ne!(with_mysql, with_axios);
+
+    // Aliases can discover the same archive more than once. Multiplicity and
+    // tracking prose do not change the Cargo graph, so neither changes its key.
+    let duplicate_mysql = vec![
+        mysql[0].clone(),
+        (
+            "perry-ext-mysql2".to_string(),
+            "perry_ext_mysql2".to_string(),
+            Some("different tracking text".to_string()),
+        ),
+    ];
+    assert_eq!(
+        with_mysql,
+        auto_optimized_cache_key("async-runtime", true, false, None, &ctx, &duplicate_mysql,)
     );
 }
 
@@ -666,11 +714,11 @@ fn http2_import_changes_optimized_libs_cache_key() {
     let dir = tempfile::tempdir().expect("tempdir");
 
     let base = CompilationContext::new(dir.path().to_path_buf());
-    let key_without = auto_optimized_cache_key("", true, false, None, &base);
+    let key_without = auto_optimized_cache_key("", true, false, None, &base, &[]);
 
     let mut with_http2 = CompilationContext::new(dir.path().to_path_buf());
     with_http2.native_module_imports.insert("http2".to_string());
-    let key_with = auto_optimized_cache_key("", true, false, None, &with_http2);
+    let key_with = auto_optimized_cache_key("", true, false, None, &with_http2, &[]);
 
     assert_ne!(
         key_without, key_with,
@@ -681,7 +729,7 @@ fn http2_import_changes_optimized_libs_cache_key() {
     dynamic.uses_get_builtin_module = true;
     assert_ne!(
         key_without,
-        auto_optimized_cache_key("", true, false, None, &dynamic),
+        auto_optimized_cache_key("", true, false, None, &dynamic, &[]),
         "getBuiltinModule must change the auto-optimized cache key"
     );
 }
@@ -697,9 +745,9 @@ fn immediate_abort_requires_unwind_safe_reachability_and_changes_cache_identity(
     let ctx = CompilationContext::new(std::env::current_dir().expect("cwd"));
     let safe_mode = effective_size_panic_immediate_abort(true);
     let unsafe_mode = effective_size_panic_immediate_abort(false);
-    let ordinary_key = auto_optimized_cache_key("", true, false, None, &ctx);
-    let immediate_key = auto_optimized_cache_key("", true, safe_mode, None, &ctx);
-    let unsafe_key = auto_optimized_cache_key("", false, unsafe_mode, None, &ctx);
+    let ordinary_key = auto_optimized_cache_key("", true, false, None, &ctx, &[]);
+    let immediate_key = auto_optimized_cache_key("", true, safe_mode, None, &ctx, &[]);
+    let unsafe_key = auto_optimized_cache_key("", false, unsafe_mode, None, &ctx, &[]);
 
     set_env_var("PERRY_SIZE_OPT", old_size_opt.as_deref());
     set_env_var("PERRY_SIZE_PANIC", old_size_panic.as_deref());
@@ -1142,8 +1190,8 @@ fn data_url_dynamic_import_enables_dyn_eval_and_changes_cache_key() {
         "data URL modules require the dyn-eval runtime, got {cross:?}"
     );
     assert_ne!(
-        auto_optimized_cache_key("", true, false, None, &with_data_url),
-        auto_optimized_cache_key("", true, false, None, &without),
+        auto_optimized_cache_key("", true, false, None, &with_data_url, &[]),
+        auto_optimized_cache_key("", true, false, None, &without, &[]),
         "a runtime without dyn-eval must not be reused for data URL imports"
     );
 }
@@ -1359,8 +1407,8 @@ fn wasm_usage_changes_auto_optimize_cache_key() {
         ctx_no_wasm.uses_crypto_builtins,
     );
     let feature_arg = features_to_cargo_arg(&features);
-    let key_no_wasm = auto_optimized_cache_key(&feature_arg, true, false, None, &ctx_no_wasm);
-    let key_wasm = auto_optimized_cache_key(&feature_arg, true, false, None, &ctx_wasm);
+    let key_no_wasm = auto_optimized_cache_key(&feature_arg, true, false, None, &ctx_no_wasm, &[]);
+    let key_wasm = auto_optimized_cache_key(&feature_arg, true, false, None, &ctx_wasm, &[]);
     assert_ne!(
         key_no_wasm, key_wasm,
         "wasm usage must change the cache key so the target dirs don't collide"


### PR DESCRIPTION
## Summary

- include the canonical shared-tokio wrapper package set in the auto-optimize target-directory key
- deduplicate aliases such as `mysql2` / `mysql2/promise` and `http` / `https` before building and linking wrappers
- remove the temporary compile-smoke allowlist now that the two fixtures link cleanly

## Root cause

Auto-optimize keyed `target/perry-auto-<hash>` by the stripped stdlib feature set, but not by the ext packages selected with Cargo `-p` arguments. An async-only compile and an axios/mysql2 compile could therefore use the same directory. The per-directory lock covered archive construction only; after the wrapper build returned its paths, another compiler process could rebuild just runtime/stdlib in that directory before the first process reached coherence checking and linking.

The failing full-tier log shows exactly that sequence: mysql2's coherent archive set completes, a wrapper-free `async-runtime` rebuild starts in the same directory, and its stdlib replaces the first one before link.

## Validation

On `perrymaster.skelpo.net` (Linux x86_64):

- `cargo fmt --all -- --check`
- `cargo check -p perry`
- all 40 `commands::compile::optimized_libs::tests` unit tests
- concurrent compile of the mysql2 and axios issue fixtures plus an argon2 wrapper-free control: all 3 passed and used distinct auto-optimize directories
- full 13 MB `pi-bundle.mjs` reproduction from #9094: linked successfully to `/tmp/perry_9094_pi_fixed` with coherent `perry-ext-http`, `perry-ext-net`, and stdlib archives

No version bump is included.

Closes #9470
Closes #9094


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auto-optimized build caching to keep distinct shared wrapper configurations isolated.
  * Prevented duplicate package and linker entries when multiple import aliases resolve to the same library.
  * Restored strict compile-smoke failure handling so any compilation failure now fails the check.

* **Tests**
  * Added coverage ensuring wrapper configurations produce distinct cache entries while duplicate aliases are consolidated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->