### PR TITLE
fix(decorators): emit builtin constructors in metadata (#9501)

### DIFF
--- a/changelog.d/9578-decorator-builtin-metadata.md
+++ b/changelog.d/9578-decorator-builtin-metadata.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **Legacy decorator metadata now stores the real global constructors for
+  built-in types (#9501).** With `emitDecoratorMetadata`, reflected `number`,
+  `string`, `boolean`, Array/tuple, Function, Symbol, BigInt, Promise, and
+  Object-like types previously became numeric `0` or `undefined` instead of
+  `Number`, `String`, `Boolean`, and their corresponding constructors. This
+  restores the identities expected by NestJS injection and by
+  class-transformer/class-validator coercion while preserving user-class
+  metadata.

--- a/crates/perry-hir/src/lower/decorators.rs
+++ b/crates/perry-hir/src/lower/decorators.rs
@@ -382,16 +382,33 @@ fn append_reflect_metadata_decorator(
     }));
 }
 
+/// Read a built-in constructor through `globalThis`, producing the same
+/// first-class function value as a bare built-in identifier.
+fn builtin_metadata_constructor(name: &str) -> Expr {
+    Expr::PropertyGet {
+        object: Box::new(Expr::GlobalGet(0)),
+        property: name.to_string(),
+        byte_offset: 0,
+    }
+}
+
+/// Convert a lowered TypeScript type into its legacy `design:*` metadata
+/// value, following TypeScript's `emitDecoratorMetadata` constructor mapping.
 fn type_metadata_expr(ty: &Type) -> Expr {
     match ty {
         Type::Named(name) => Expr::ClassRef(name.clone()),
         Type::Generic { base, .. } => Expr::ClassRef(base.clone()),
-        Type::Array(_) | Type::Tuple(_) => Expr::ClassRef("Array".to_string()),
-        Type::String => Expr::ClassRef("String".to_string()),
-        Type::Number | Type::Int32 | Type::BigInt => Expr::ClassRef("Number".to_string()),
-        Type::Boolean => Expr::ClassRef("Boolean".to_string()),
-        Type::Object(_) => Expr::ClassRef("Object".to_string()),
-        Type::Function(_) => Expr::ClassRef("Function".to_string()),
+        Type::Array(_) | Type::Tuple(_) => builtin_metadata_constructor("Array"),
+        Type::String | Type::StringLiteral(_) => builtin_metadata_constructor("String"),
+        Type::Number | Type::Int32 => builtin_metadata_constructor("Number"),
+        Type::Boolean => builtin_metadata_constructor("Boolean"),
+        Type::BigInt => builtin_metadata_constructor("BigInt"),
+        Type::Symbol => builtin_metadata_constructor("Symbol"),
+        Type::Promise(_) => builtin_metadata_constructor("Promise"),
+        Type::Object(_) | Type::Union(_) | Type::Any | Type::Unknown => {
+            builtin_metadata_constructor("Object")
+        }
+        Type::Function(_) => builtin_metadata_constructor("Function"),
         _ => Expr::Undefined,
     }
 }

--- a/test-files/test_decorators_builtin_metadata_9501.ts
+++ b/test-files/test_decorators_builtin_metadata_9501.ts
@@ -1,0 +1,81 @@
+// #9501: TypeScript's legacy decorator metadata stores the global constructor
+// value for built-in types, not Perry's internal class-reference sentinel.
+// Expected output was generated with TypeScript 5.9.3 and reflect-metadata
+// 0.2.2 using --experimentalDecorators --emitDecoratorMetadata.
+import "reflect-metadata";
+
+function Decorated(): any {
+  return () => {};
+}
+
+class UserType {}
+
+class MetadataTypes {
+  @Decorated() numberValue!: number;
+  @Decorated() stringValue!: string;
+  @Decorated() booleanValue!: boolean;
+  @Decorated() objectValue!: object;
+  @Decorated() arrayValue!: number[];
+  @Decorated() tupleValue!: [number, string];
+  @Decorated() functionValue!: () => void;
+  @Decorated() symbolValue!: symbol;
+  @Decorated() bigintValue!: bigint;
+  @Decorated() promiseValue!: Promise<string>;
+  @Decorated() unionValue!: number | string;
+  @Decorated() anyValue!: any;
+  @Decorated() unknownValue!: unknown;
+  @Decorated() userValue!: UserType;
+
+  @Decorated()
+  method(
+    numberValue: number,
+    stringValue: string,
+    booleanValue: boolean,
+    objectValue: object,
+    arrayValue: number[],
+    tupleValue: [number, string],
+    functionValue: () => void,
+    symbolValue: symbol,
+    bigintValue: bigint,
+    promiseValue: Promise<string>,
+    unionValue: number | string,
+    anyValue: any,
+    unknownValue: unknown,
+    userValue: UserType,
+  ) {}
+}
+
+const expected: Array<[string, any]> = [
+  ["numberValue", Number],
+  ["stringValue", String],
+  ["booleanValue", Boolean],
+  ["objectValue", Object],
+  ["arrayValue", Array],
+  ["tupleValue", Array],
+  ["functionValue", Function],
+  ["symbolValue", Symbol],
+  ["bigintValue", BigInt],
+  ["promiseValue", Promise],
+  ["unionValue", Object],
+  ["anyValue", Object],
+  ["unknownValue", Object],
+  ["userValue", UserType],
+];
+
+for (const [property, constructor] of expected) {
+  const actual = Reflect.getMetadata("design:type", MetadataTypes.prototype, property);
+  console.log(property, typeof actual, actual === constructor, actual && actual.name);
+}
+
+const params = Reflect.getMetadata("design:paramtypes", MetadataTypes.prototype, "method");
+console.log("params length", params.length);
+console.log(
+  "params identities",
+  params.every((actual: any, index: number) => actual === expected[index][1]),
+);
+
+const numberType = Reflect.getMetadata("design:type", MetadataTypes.prototype, "numberValue");
+console.log(
+  "new via number metadata",
+  typeof numberType === "function" ? new numberType(5).valueOf() : "not a constructor",
+);

--- a/test-parity/expected/test_decorators_builtin_metadata_9501.txt
+++ b/test-parity/expected/test_decorators_builtin_metadata_9501.txt
@@ -1,0 +1,17 @@
+numberValue function true Number
+stringValue function true String
+booleanValue function true Boolean
+objectValue function true Object
+arrayValue function true Array
+tupleValue function true Array
+functionValue function true Function
+symbolValue function true Symbol
+bigintValue function true BigInt
+promiseValue function true Promise
+unionValue function true Object
+anyValue function true Object
+unknownValue function true Object
+userValue function true UserType
+params length 14
+params identities true
+new via number metadata 5


### PR DESCRIPTION
Fixes #9501.

Legacy `emitDecoratorMetadata` lowering represented built-in types with `ClassRef("Number")`, `ClassRef("String")`, and similar values. `ClassRef` is Perry's internal representation for a declared user class; an unregistered built-in name therefore became numeric `0` (or `undefined` for types without an arm) instead of the corresponding global constructor. NestJS, class-transformer, and class-validator compare or instantiate these reflected constructor values.

### Change

- Read metadata constructors through the same `globalThis.<Name>` value path used by bare built-in identifiers, preserving constructor identity.
- Map `number`, `string` (including string literals), `boolean`, `object`, arrays, tuples, functions, `symbol`, `bigint`, `Promise`, unions, `any`, and `unknown` to TypeScript's emitted constructors.
- Keep `ClassRef` for named and generic user classes.

### Fixture

`test_decorators_builtin_metadata_9501` pins both `design:type` and `design:paramtypes` for all requested built-in shapes, verifies a user class still round-trips, and constructs a boxed number through the reflected constructor. Its expected output was generated with TypeScript 5.9.3 plus reflect-metadata 0.2.2 using `--experimentalDecorators --emitDecoratorMetadata`.

On unmodified main, the fixture reports numeric `0` for Number/String/Boolean/Array/Function/BigInt, `undefined` for Object/Symbol/Promise/union/any/unknown, and `params identities false`. On this branch every row is a function with the correct identity, parameter identities are true, and construction through the Number metadata produces `5`.

### Verification

- TypeScript 5.9.3 + reflect-metadata 0.2.2 oracle: expected output captured
- `run_parity_tests.sh --filter test_decorators_builtin_metadata_9501`: 1 pass, 0 fail
- `run_parity_tests.sh --filter test_decorators`: 13 pass, 0 fail, 0 crash
- `cargo test --profile perry-dev -p perry-hir`: pass
- `cargo fmt --all -- --check`: pass
- `python3 scripts/check_test_registration.py`: pass
- `./scripts/pre-tag-check.sh --quick`: pass

No version metadata was changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed decorator metadata for built-in types to reference their actual global constructors.
  * Corrected metadata handling for `BigInt`, `String`, `Symbol`, `Promise`, unions, `any`, and `unknown`.
  * Restored compatibility with dependency injection and runtime type-conversion tools.
  * Preserved correct metadata for user-defined classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->