### PR TITLE
Merge train: #9577 #9578

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3051,49 +3051,6 @@ jobs:
           SKIP=${#skip_files[@]}
           echo "Compile smoke: $PASS passed, $FAIL failed, $SKIP skipped"
 
-          # Known-failing cases (#9470). These two are NOT a compiler bug in
-          # the code under test: auto-optimize rebuilds the stdlib static into
-          # `target/perry-auto-<hash>/` WITHOUT the ext wrappers in the same
-          # cargo invocation, so tokio's features resolve differently for them
-          # and the linker correctly refuses the pair ("bundle a DIFFERENT
-          # tokio compilation"). The refusal is the right behaviour — the
-          # alternative is a binary with two `tokio::runtime::context::CONTEXT`
-          # thread-locals and "there is no reactor running" at runtime
-          # (#507, #7629) — so this list tolerates the CI red, it does NOT
-          # weaken the check that protects users.
-          #
-          # Pre-existing: the 2026-08-31 full tier (run 33372993990) failed the
-          # same way on test_issue_414_mysql_query_params. Adding ext crates to
-          # this job's `cargo build` line does NOT help — mysql2 is already
-          # there; auto-optimize's LATER rebuild is what breaks coherence.
-          #
-          # Delete an entry the moment #9470 lands — an entry that stops
-          # matching is a stale exemption, and the check below fails on one.
-          KNOWN_FAIL=(
-            test_issue_340_axios_response_props
-            test_issue_414_mysql_query_params
-          )
-          UNEXPECTED=()
-          STALE=()
-          for marker in "$LOGS_DIR"/*.fail; do
-            [[ -e "$marker" ]] || continue
-            name=$(basename "$marker" .fail)
-            known=0
-            for k in "${KNOWN_FAIL[@]}"; do [[ "$name" == "$k" ]] && known=1 && break; done
-            [[ $known -eq 1 ]] || UNEXPECTED+=("$name")
-          done
-          for k in "${KNOWN_FAIL[@]}"; do
-            [[ -e "$LOGS_DIR/$k.fail" ]] || STALE+=("$k")
-          done
-          if [[ ${#STALE[@]} -gt 0 ]]; then
-            echo "::error::known-failure entries that now PASS — delete them from KNOWN_FAIL (#9470):"
-            printf '  - %s\n' "${STALE[@]}"
-            exit 1
-          fi
-          if [[ ${#UNEXPECTED[@]} -gt 0 ]]; then
-            echo "::error::compile-smoke has ${#UNEXPECTED[@]} failure(s) beyond the known list:"
-            printf '  - %s\n' "${UNEXPECTED[@]}"
-          fi
           if [[ $FAIL -gt 0 ]]; then
             echo "Compile failures:"
             for marker in "$LOGS_DIR"/*.fail; do
@@ -3110,13 +3067,7 @@ jobs:
                 echo "    --- end ---"
               fi
             done
-            # Fail ONLY on failures outside the known list. A known one is
-            # still printed above with its stderr, so it stays visible rather
-            # than silently tolerated.
-            if [[ ${#UNEXPECTED[@]} -gt 0 ]]; then
-              exit 1
-            fi
-            echo "All ${FAIL} failure(s) are known (#9470); not failing the job."
+            exit 1
           fi
 
       - name: Upload compile-smoke error logs

--- a/changelog.d/9577-auto-opt-shared-tokio.md
+++ b/changelog.d/9577-auto-opt-shared-tokio.md
@@ -1,0 +1,17 @@
+**fix(compile): isolate auto-optimized shared-Tokio wrapper graphs (#9577)**
+
+Parallel `perry compile` processes no longer overwrite one another's
+auto-optimized runtime and stdlib archives when they select different native
+extension wrappers with the same stdlib feature set. The selected
+shared-Tokio wrapper set is now part of the `perry-auto-<hash>` target
+directory identity, so each Cargo dependency graph keeps a coherent stdlib
+and wrapper archive pair through the final link.
+
+Wrapper aliases that resolve to the same archive, such as `mysql2` and
+`mysql2/promise`, are deduplicated before constructing the Cargo package set
+and link line. The cache identity remains stable across alias multiplicity and
+discovery order.
+
+This removes the temporary compile-smoke exemptions for the Axios and mysql2
+fixtures. Those parallel builds now keep distinct target directories while
+each wrapper retains the same Tokio compilation ID as its colocated stdlib.

--- a/crates/perry-hir/src/lower/decorators.rs
+++ b/crates/perry-hir/src/lower/decorators.rs
@@ -382,16 +382,33 @@ fn append_reflect_metadata_decorator(
     }));
 }
 
+/// Read a built-in constructor through `globalThis`, producing the same
+/// first-class function value as a bare built-in identifier.
+fn builtin_metadata_constructor(name: &str) -> Expr {
+    Expr::PropertyGet {
+        object: Box::new(Expr::GlobalGet(0)),
+        property: name.to_string(),
+        byte_offset: 0,
+    }
+}
+
+/// Convert a lowered TypeScript type into its legacy `design:*` metadata
+/// value, following TypeScript's `emitDecoratorMetadata` constructor mapping.
 fn type_metadata_expr(ty: &Type) -> Expr {
     match ty {
         Type::Named(name) => Expr::ClassRef(name.clone()),
         Type::Generic { base, .. } => Expr::ClassRef(base.clone()),
-        Type::Array(_) | Type::Tuple(_) => Expr::ClassRef("Array".to_string()),
-        Type::String => Expr::ClassRef("String".to_string()),
-        Type::Number | Type::Int32 | Type::BigInt => Expr::ClassRef("Number".to_string()),
-        Type::Boolean => Expr::ClassRef("Boolean".to_string()),
-        Type::Object(_) => Expr::ClassRef("Object".to_string()),
-        Type::Function(_) => Expr::ClassRef("Function".to_string()),
+        Type::Array(_) | Type::Tuple(_) => builtin_metadata_constructor("Array"),
+        Type::String | Type::StringLiteral(_) => builtin_metadata_constructor("String"),
+        Type::Number | Type::Int32 => builtin_metadata_constructor("Number"),
+        Type::Boolean => builtin_metadata_constructor("Boolean"),
+        Type::BigInt => builtin_metadata_constructor("BigInt"),
+        Type::Symbol => builtin_metadata_constructor("Symbol"),
+        Type::Promise(_) => builtin_metadata_constructor("Promise"),
+        Type::Object(_) | Type::Union(_) | Type::Any | Type::Unknown => {
+            builtin_metadata_constructor("Object")
+        }
+        Type::Function(_) => builtin_metadata_constructor("Function"),
         _ => Expr::Undefined,
     }
 }

--- a/crates/perry/src/commands/compile/optimized_libs/driver.rs
+++ b/crates/perry/src/commands/compile/optimized_libs/driver.rs
@@ -294,11 +294,20 @@ pub(crate) fn build_optimized_libs(
                         binding.tracking.as_deref().unwrap_or("no tracking issue")
                     );
                 }
-                tokio_using_bindings.push((
-                    binding.krate.clone(),
-                    binding.lib.clone(),
-                    binding.tracking.clone(),
-                ));
+                // Multiple import spellings can resolve to one archive
+                // (`mysql2` + `mysql2/promise`, `http` + `https`). Keep the
+                // Cargo package set and link line unique; alias multiplicity
+                // is not a different build graph.
+                if !tokio_using_bindings
+                    .iter()
+                    .any(|(krate, lib, _tracking)| krate == &binding.krate && lib == &binding.lib)
+                {
+                    tokio_using_bindings.push((
+                        binding.krate.clone(),
+                        binding.lib.clone(),
+                        binding.tracking.clone(),
+                    ));
+                }
             }
             if matches!(module_normalized, "net" | "http" | "https" | "http2") {
                 external_net_transport = true;
@@ -653,13 +662,13 @@ pub(crate) fn build_optimized_libs(
     };
     let workspace_root = cargo_target_dir_path(workspace_root);
 
-    // Hash the (features, panic_mode, target, wasm-host) tuple into the
-    // target dir name so cargo treats each combination as its own
-    // incremental cache. `wasm-host` lives on `perry-runtime` (not
-    // perry-stdlib), so it isn't part of `feature_arg`; bake it in here
-    // separately so a wasm program's build doesn't get served from a
-    // cached non-wasm dir (which would lack `js_webassembly_*` symbols)
-    // and vice versa (would carry unresolved `perry_wasm_host_*` refs).
+    // Hash the (features, panic_mode, target, wasm-host, shared-tokio wrapper
+    // set) tuple into the target dir name so cargo treats each combination as
+    // its own incremental cache. `wasm-host` lives on `perry-runtime` (not
+    // perry-stdlib), so it isn't part of `feature_arg`; the selected ext
+    // wrappers are Cargo packages rather than features, so they are not in it
+    // either. Bake both into the key so neither graph can be served or
+    // overwritten by another compile using the same stripped stdlib features.
     //
     // The compiler version is part of the key too. Codegen emits calls to
     // runtime entrypoints (e.g. `js_promise_run_promise_jobs`,
@@ -671,8 +680,14 @@ pub(crate) fn build_optimized_libs(
     // "undefined symbol" link failure for exactly the newly-added entrypoints.
     // Keying on the version forces a matching rebuild whenever perry upgrades.
     // Cheap djb2 — no need for the SipHash overhead.
-    let key_input =
-        auto_optimized_cache_key(&feature_arg, panic_abort_safe, panic_immediate, target, ctx);
+    let key_input = auto_optimized_cache_key(
+        &feature_arg,
+        panic_abort_safe,
+        panic_immediate,
+        target,
+        ctx,
+        &tokio_using_bindings,
+    );
     let mut hash: u64 = 5381;
     for b in key_input.as_bytes() {
         hash = hash.wrapping_mul(33).wrapping_add(*b as u64);

--- a/crates/perry/src/commands/compile/optimized_libs/freshness.rs
+++ b/crates/perry/src/commands/compile/optimized_libs/freshness.rs
@@ -101,18 +101,37 @@ pub(crate) fn size_lto_fat() -> bool {
 
 /// Cache key for the auto-optimize target dir + build stamp. Hashed into the
 /// `target/perry-auto-<hash>` dir name so each (features, panic-mode, target,
-/// runtime-gate, version) combination gets its own incremental cache. Kept in
-/// one place so `build_optimized_libs` and its freshness tests can never drift.
+/// runtime-gate, shared-tokio-wrapper set, version) combination gets its own
+/// incremental cache. Kept in one place so `build_optimized_libs` and its
+/// freshness tests can never drift.
 pub(crate) fn auto_optimized_cache_key(
     feature_arg: &str,
     panic_abort_safe: bool,
     panic_immediate: bool,
     target: Option<&str>,
     ctx: &CompilationContext,
+    tokio_using_bindings: &[(String, String, Option<String>)],
 ) -> String {
     let target_str = target.unwrap_or("host");
+    // The stripped stdlib feature set is not enough to identify this Cargo
+    // graph. For example, mysql2 and a CPU-only async wrapper both reduce to
+    // `async-runtime`, but only the mysql2 build selects perry-ext-mysql2.
+    // Sharing a target dir lets the second invocation replace stdlib after
+    // the first invocation releases its build lock but before it links. The
+    // first process then sees an ext archive and stdlib archive from different
+    // dependency graphs (#9470; the same class produced #9094's Linux link).
+    //
+    // Sort and deduplicate here as a defensive measure: aliases such as
+    // `mysql2` + `mysql2/promise` name the same wrapper and must describe the
+    // same graph regardless of discovery order or alias multiplicity.
+    let mut tokio_bindings: Vec<String> = tokio_using_bindings
+        .iter()
+        .map(|(krate, lib, _tracking)| format!("{krate}:{lib}"))
+        .collect();
+    tokio_bindings.sort_unstable();
+    tokio_bindings.dedup();
     format!(
-        "{}|{}|{}|wasm={}|napi={}|regex={}|temporal={}|ee={}|url={}|norm={}|seg={}|loc={}|intlns={}|gns={}{}{}{}{}{}{}{}{}{}|diag={}|dgram={}|http2={}|nodetest={}|dyneval={}|sizeopt={}|anchors={}|v={}",
+        "{}|{}|{}|wasm={}|napi={}|regex={}|temporal={}|ee={}|url={}|norm={}|seg={}|loc={}|intlns={}|gns={}{}{}{}{}{}{}{}{}{}|diag={}|dgram={}|http2={}|nodetest={}|dyneval={}|tokio={}|sizeopt={}|anchors={}|v={}",
         feature_arg,
         panic_abort_safe,
         target_str,
@@ -150,6 +169,7 @@ pub(crate) fn auto_optimized_cache_key(
         perry_hir::has_deferred_dynamic_code_sites()
             || ctx.native_module_imports.contains("vm")
             || ctx.uses_data_url_dynamic_import,
+        tokio_bindings.join(","),
         format!(
             "{}{}{}",
             size_opt_level().unwrap_or("off"),

--- a/crates/perry/src/commands/compile/optimized_libs/tests.rs
+++ b/crates/perry/src/commands/compile/optimized_libs/tests.rs
@@ -102,8 +102,14 @@ fn build_optimized_libs_reuses_fresh_auto_archives_without_cargo() {
     let panic_abort_safe =
         !ctx.needs_ui && !ctx.needs_thread && !ctx.needs_plugins && !ctx.needs_geisterhand;
     let panic_immediate = effective_size_panic_immediate_abort(panic_abort_safe);
-    let key_input =
-        auto_optimized_cache_key(&feature_arg, panic_abort_safe, panic_immediate, None, &ctx);
+    let key_input = auto_optimized_cache_key(
+        &feature_arg,
+        panic_abort_safe,
+        panic_immediate,
+        None,
+        &ctx,
+        &[],
+    );
     let mut hash: u64 = 5381;
     for b in key_input.as_bytes() {
         hash = hash.wrapping_mul(33).wrapping_add(*b as u64);
@@ -612,9 +618,51 @@ fn node_test_gate_keys_the_auto_optimize_cache() {
     let without = CompilationContext::new(dir.path().to_path_buf());
 
     assert_ne!(
-        auto_optimized_cache_key("", true, false, None, &with_test),
-        auto_optimized_cache_key("", true, false, None, &without),
+        auto_optimized_cache_key("", true, false, None, &with_test, &[]),
+        auto_optimized_cache_key("", true, false, None, &without, &[]),
         "mod-node-test must participate in the auto-optimize cache key"
+    );
+}
+
+#[test]
+fn shared_tokio_wrapper_set_keys_the_auto_optimize_target_dir() {
+    // #9470 / #9094: wrapper selection is expressed with Cargo `-p` args,
+    // not stdlib features. Two otherwise-identical compilations therefore
+    // used to share one perry-auto target dir. Once the wrapper build released
+    // its lock, a wrapper-free build could replace stdlib before the first
+    // compiler linked, leaving archives from different dependency graphs.
+    let ctx = CompilationContext::new(std::env::current_dir().expect("cwd"));
+    let mysql = vec![(
+        "perry-ext-mysql2".to_string(),
+        "perry_ext_mysql2".to_string(),
+        Some("#466".to_string()),
+    )];
+    let axios = vec![(
+        "perry-ext-axios".to_string(),
+        "perry_ext_axios".to_string(),
+        Some("#466".to_string()),
+    )];
+
+    let without_wrapper = auto_optimized_cache_key("async-runtime", true, false, None, &ctx, &[]);
+    let with_mysql = auto_optimized_cache_key("async-runtime", true, false, None, &ctx, &mysql);
+    let with_axios = auto_optimized_cache_key("async-runtime", true, false, None, &ctx, &axios);
+
+    assert_ne!(without_wrapper, with_mysql);
+    assert_ne!(with_mysql, with_axios);
+
+    // Aliases can discover the same archive more than once. Multiplicity and
+    // tracking prose do not change the Cargo graph, so neither changes its key.
+    let duplicate_mysql = vec![
+        mysql[0].clone(),
+        (
+            "perry-ext-mysql2".to_string(),
+            "perry_ext_mysql2".to_string(),
+            Some("different tracking text".to_string()),
+        ),
+    ];
+    assert_eq!(
+        with_mysql,
+        auto_optimized_cache_key("async-runtime", true, false, None, &ctx, &duplicate_mysql,)
     );
 }
 
@@ -666,11 +714,11 @@ fn http2_import_changes_optimized_libs_cache_key() {
     let dir = tempfile::tempdir().expect("tempdir");
 
     let base = CompilationContext::new(dir.path().to_path_buf());
-    let key_without = auto_optimized_cache_key("", true, false, None, &base);
+    let key_without = auto_optimized_cache_key("", true, false, None, &base, &[]);
 
     let mut with_http2 = CompilationContext::new(dir.path().to_path_buf());
     with_http2.native_module_imports.insert("http2".to_string());
-    let key_with = auto_optimized_cache_key("", true, false, None, &with_http2);
+    let key_with = auto_optimized_cache_key("", true, false, None, &with_http2, &[]);
 
     assert_ne!(
         key_without, key_with,
@@ -681,7 +729,7 @@ fn http2_import_changes_optimized_libs_cache_key() {
     dynamic.uses_get_builtin_module = true;
     assert_ne!(
         key_without,
-        auto_optimized_cache_key("", true, false, None, &dynamic),
+        auto_optimized_cache_key("", true, false, None, &dynamic, &[]),
         "getBuiltinModule must change the auto-optimized cache key"
     );
 }
@@ -697,9 +745,9 @@ fn immediate_abort_requires_unwind_safe_reachability_and_changes_cache_identity(
     let ctx = CompilationContext::new(std::env::current_dir().expect("cwd"));
     let safe_mode = effective_size_panic_immediate_abort(true);
     let unsafe_mode = effective_size_panic_immediate_abort(false);
-    let ordinary_key = auto_optimized_cache_key("", true, false, None, &ctx);
-    let immediate_key = auto_optimized_cache_key("", true, safe_mode, None, &ctx);
-    let unsafe_key = auto_optimized_cache_key("", false, unsafe_mode, None, &ctx);
+    let ordinary_key = auto_optimized_cache_key("", true, false, None, &ctx, &[]);
+    let immediate_key = auto_optimized_cache_key("", true, safe_mode, None, &ctx, &[]);
+    let unsafe_key = auto_optimized_cache_key("", false, unsafe_mode, None, &ctx, &[]);
 
     set_env_var("PERRY_SIZE_OPT", old_size_opt.as_deref());
     set_env_var("PERRY_SIZE_PANIC", old_size_panic.as_deref());
@@ -1142,8 +1190,8 @@ fn data_url_dynamic_import_enables_dyn_eval_and_changes_cache_key() {
         "data URL modules require the dyn-eval runtime, got {cross:?}"
     );
     assert_ne!(
-        auto_optimized_cache_key("", true, false, None, &with_data_url),
-        auto_optimized_cache_key("", true, false, None, &without),
+        auto_optimized_cache_key("", true, false, None, &with_data_url, &[]),
+        auto_optimized_cache_key("", true, false, None, &without, &[]),
         "a runtime without dyn-eval must not be reused for data URL imports"
     );
 }
@@ -1359,8 +1407,8 @@ fn wasm_usage_changes_auto_optimize_cache_key() {
         ctx_no_wasm.uses_crypto_builtins,
     );
     let feature_arg = features_to_cargo_arg(&features);
-    let key_no_wasm = auto_optimized_cache_key(&feature_arg, true, false, None, &ctx_no_wasm);
-    let key_wasm = auto_optimized_cache_key(&feature_arg, true, false, None, &ctx_wasm);
+    let key_no_wasm = auto_optimized_cache_key(&feature_arg, true, false, None, &ctx_no_wasm, &[]);
+    let key_wasm = auto_optimized_cache_key(&feature_arg, true, false, None, &ctx_wasm, &[]);
     assert_ne!(
         key_no_wasm, key_wasm,
         "wasm usage must change the cache key so the target dirs don't collide"

--- a/test-files/test_decorators_builtin_metadata_9501.ts
+++ b/test-files/test_decorators_builtin_metadata_9501.ts
@@ -1,0 +1,81 @@
+// #9501: TypeScript's legacy decorator metadata stores the global constructor
+// value for built-in types, not Perry's internal class-reference sentinel.
+// Expected output was generated with TypeScript 5.9.3 and reflect-metadata
+// 0.2.2 using --experimentalDecorators --emitDecoratorMetadata.
+import "reflect-metadata";
+
+function Decorated(): any {
+  return () => {};
+}
+
+class UserType {}
+
+class MetadataTypes {
+  @Decorated() numberValue!: number;
+  @Decorated() stringValue!: string;
+  @Decorated() booleanValue!: boolean;
+  @Decorated() objectValue!: object;
+  @Decorated() arrayValue!: number[];
+  @Decorated() tupleValue!: [number, string];
+  @Decorated() functionValue!: () => void;
+  @Decorated() symbolValue!: symbol;
+  @Decorated() bigintValue!: bigint;
+  @Decorated() promiseValue!: Promise<string>;
+  @Decorated() unionValue!: number | string;
+  @Decorated() anyValue!: any;
+  @Decorated() unknownValue!: unknown;
+  @Decorated() userValue!: UserType;
+
+  @Decorated()
+  method(
+    numberValue: number,
+    stringValue: string,
+    booleanValue: boolean,
+    objectValue: object,
+    arrayValue: number[],
+    tupleValue: [number, string],
+    functionValue: () => void,
+    symbolValue: symbol,
+    bigintValue: bigint,
+    promiseValue: Promise<string>,
+    unionValue: number | string,
+    anyValue: any,
+    unknownValue: unknown,
+    userValue: UserType,
+  ) {}
+}
+
+const expected: Array<[string, any]> = [
+  ["numberValue", Number],
+  ["stringValue", String],
+  ["booleanValue", Boolean],
+  ["objectValue", Object],
+  ["arrayValue", Array],
+  ["tupleValue", Array],
+  ["functionValue", Function],
+  ["symbolValue", Symbol],
+  ["bigintValue", BigInt],
+  ["promiseValue", Promise],
+  ["unionValue", Object],
+  ["anyValue", Object],
+  ["unknownValue", Object],
+  ["userValue", UserType],
+];
+
+for (const [property, constructor] of expected) {
+  const actual = Reflect.getMetadata("design:type", MetadataTypes.prototype, property);
+  console.log(property, typeof actual, actual === constructor, actual && actual.name);
+}
+
+const params = Reflect.getMetadata("design:paramtypes", MetadataTypes.prototype, "method");
+console.log("params length", params.length);
+console.log(
+  "params identities",
+  params.every((actual: any, index: number) => actual === expected[index][1]),
+);
+
+const numberType = Reflect.getMetadata("design:type", MetadataTypes.prototype, "numberValue");
+console.log(
+  "new via number metadata",
+  typeof numberType === "function" ? new numberType(5).valueOf() : "not a constructor",
+);

--- a/test-parity/expected/test_decorators_builtin_metadata_9501.txt
+++ b/test-parity/expected/test_decorators_builtin_metadata_9501.txt
@@ -1,0 +1,17 @@
+numberValue function true Number
+stringValue function true String
+booleanValue function true Boolean
+objectValue function true Object
+arrayValue function true Array
+tupleValue function true Array
+functionValue function true Function
+symbolValue function true Symbol
+bigintValue function true BigInt
+promiseValue function true Promise
+unionValue function true Object
+anyValue function true Object
+unknownValue function true Object
+userValue function true UserType
+params length 14
+params identities true
+new via number metadata 5


### PR DESCRIPTION
Lands the validated train: #9577 (auto-optimize target dirs keyed by the ext wrapper package set + alias dedup — closes the cross-process archive-clobber race behind the full-tier link failures and the compile-smoke allowlist; supersedes #9576, which is byte-identical minus the fragment) and #9578 (emitDecoratorMetadata reads builtin constructors through globalThis — NestJS/class-transformer identity, #9501).

Validation: release build green; perry optimized_libs 40/40; perry-hir 377/0; decorator fixture byte-identical to node; lint gates green.

Rebase-merge preserving authorship.
