### PR TITLE
fix(fetch): accept URL objects and expose Node-style transport errors

### DIFF
--- a/changelog.d/9582-fetch-url-transport-errors.md
+++ b/changelog.d/9582-fetch-url-transport-errors.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **Global `fetch` now accepts WHATWG `URL` instances and reports Node-shaped
+  transport failures (#9536).** Passing `new URL(...)` previously rejected
+  immediately with `Error: Invalid URL`, which prevented Claude Code's MCP HTTP
+  transport from reaching the network. URL inputs now contribute their `href`
+  while native `Request` handles retain their existing dispatch path.
+
+  Failed requests now reject with `TypeError: fetch failed` and carry the
+  underlying failure as `cause`. DNS failures expose Node-compatible
+  `ENOTFOUND`, `errno`, `syscall`, and `hostname` diagnostics. Error objects are
+  constructed on the main thread and the inner cause stays rooted while the
+  outer error allocates. A five-shape gap fixture covers string, URL, Headers,
+  Request, and AbortSignal inputs byte-for-byte against Node 26.5.1.

--- a/crates/perry-codegen/src/expr/logical_collections.rs
+++ b/crates/perry-codegen/src/expr/logical_collections.rs
@@ -545,13 +545,13 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 },
                 |ctx, vals, headers_str| {
                     let blk = ctx.block();
-                    // The runtime takes raw StringHeader pointers (i64). Unbox
-                    // each input string. `body` may be undefined → unbox produces
-                    // 0 which the runtime treats as "no body" via
-                    // string_from_header(). The unbox happens BELOW the re-read,
-                    // which is the only place it can be correct (slice 1b's
-                    // `BufferSlice` finding).
-                    let url_handle = unbox_to_i64(blk, &vals[0]);
+                    // The runtime takes a raw URL StringHeader pointer or native
+                    // Request handle (i64), followed by raw string pointers.
+                    // `body` may be undefined → unbox produces 0 which the
+                    // runtime treats as "no body" via string_from_header(). The
+                    // conversion happens BELOW the re-read, which is the only
+                    // place it can be correct (slice 1b's `BufferSlice` finding).
+                    let url_handle = blk.call(I64, "js_fetch_input_ptr", &[(DOUBLE, &vals[0])]);
                     let method_handle = unbox_to_i64(blk, &vals[1]);
                     let body_handle = unbox_to_i64(blk, &vals[2]);
                     // Stash the AbortSignal so `js_fetch_with_options` can cancel

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi/language_core.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi/language_core.rs
@@ -137,6 +137,7 @@ pub(crate) fn declare_core(module: &mut LlModule) {
     module.declare_function("js_console_create_task", DOUBLE, &[DOUBLE]);
 
     // ========== Fetch ==========
+    module.declare_function("js_fetch_input_ptr", I64, &[DOUBLE]);
     module.declare_function("js_fetch_get", I64, &[I64]);
     module.declare_function("js_fetch_get_with_auth", I64, &[I64, I64]);
     module.declare_function("js_fetch_post", I64, &[I64, I64, I64]);

--- a/crates/perry-runtime/src/error.rs
+++ b/crates/perry-runtime/src/error.rs
@@ -389,6 +389,21 @@ pub extern "C" fn js_typeerror_new(message: *mut StringHeader) -> *mut ErrorHead
     unsafe { alloc_error(ERROR_KIND_TYPE_ERROR, b"TypeError", message, true) }
 }
 
+/// Create a new TypeError with a message and a cause (raw f64 NaN-boxed).
+#[no_mangle]
+pub extern "C" fn js_typeerror_new_with_cause(
+    message: *mut StringHeader,
+    cause: f64,
+) -> *mut ErrorHeader {
+    unsafe {
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let cause_handle = scope.root_nanbox_f64(cause);
+        let ptr = alloc_error(ERROR_KIND_TYPE_ERROR, b"TypeError", message, true);
+        error_set_cause(ptr, cause_handle.get_nanbox_f64());
+        ptr
+    }
+}
+
 /// Create a new RangeError with a message
 #[no_mangle]
 pub extern "C" fn js_rangeerror_new(message: *mut StringHeader) -> *mut ErrorHeader {

--- a/crates/perry-runtime/src/object/global_fetch.rs
+++ b/crates/perry-runtime/src/object/global_fetch.rs
@@ -55,6 +55,24 @@ pub extern "C" fn js_fetch_take_pending_signal() -> f64 {
     })
 }
 
+/// Convert a fetch `RequestInfo` to the raw pointer ABI used by
+/// `js_fetch_with_options`. A `URL` contributes its `href`; strings and native
+/// `Request` handles keep their existing pointer/handle representation.
+#[no_mangle]
+pub extern "C" fn js_fetch_input_ptr(input: f64) -> i64 {
+    let input_ptr = crate::value::js_nanbox_get_pointer(input);
+    if crate::value::addr_class::is_small_handle(input_ptr as usize) {
+        return input_ptr;
+    }
+
+    let href = crate::url::url_class::js_url_href_if_url(input);
+    if href.to_bits() != crate::value::TAG_UNDEFINED {
+        crate::value::js_nanbox_get_pointer(href)
+    } else {
+        input_ptr
+    }
+}
+
 #[cfg(not(feature = "external-fetch-symbols"))]
 const FETCH_REASON: &str =
     "fetch symbol from perry-stdlib not linked into this binary (runtime-only build)";
@@ -661,7 +679,12 @@ pub(super) extern "C" fn global_this_fetch_thunk(
         .into_iter()
         .next()
         .unwrap_or_else(|| f64::from_bits(crate::value::TAG_UNDEFINED));
-    let url_ptr = crate::value::js_get_string_pointer_unified(input) as *const crate::StringHeader;
+    let input_ptr = js_fetch_input_ptr(input);
+    let url_ptr = if input_ptr == 0 {
+        crate::value::js_get_string_pointer_unified(input)
+    } else {
+        input_ptr
+    } as *const crate::StringHeader;
     let method_ptr = fetch_option_string_ptr(init, b"method");
     let body_ptr = fetch_option_string_ptr(init, b"body");
     let headers_json_ptr = fetch_headers_json_ptr(init);

--- a/crates/perry-stdlib/src/fetch/abort_bridge.rs
+++ b/crates/perry-stdlib/src/fetch/abort_bridge.rs
@@ -235,13 +235,7 @@ pub(crate) async fn run_request(
                 let result_bits = super::handle_to_f64(response_id).to_bits();
                 queue_promise_resolution(promise_ptr, true, result_bits);
             }
-            Err(e) => {
-                let err_msg = format!("Fetch error: {}", e);
-                // SAFETY: `fetch_error_bits` allocates an Error JSValue; this is
-                // the worker-side error path it replaces verbatim.
-                let err_bits = unsafe { super::fetch_error_bits(&err_msg) };
-                queue_promise_resolution(promise_ptr, false, err_bits);
-            }
+            Err(e) => super::queue_fetch_transport_error(promise_ptr, &e, &url),
         }
     };
     race_request(promise_ptr, abort_watch, request_future).await;

--- a/crates/perry-stdlib/src/fetch/mod.rs
+++ b/crates/perry-stdlib/src/fetch/mod.rs
@@ -20,6 +20,7 @@ mod abort_bridge;
 pub use abort_bridge::*;
 mod headers;
 mod request_handle;
+mod transport_error;
 pub use headers::*;
 
 // Cached bound-method values for Fetch `Headers` handles — split out to keep
@@ -369,6 +370,13 @@ unsafe fn fetch_error_bits<S: AsRef<str>>(msg: S) -> u64 {
     JSValue::pointer(err as *const u8).bits()
 }
 
+fn queue_fetch_transport_error(promise_ptr: usize, error: &reqwest::Error, url: &str) {
+    let failure = transport_error::FetchFailure::from_reqwest(error, url);
+    crate::common::async_bridge::queue_deferred_resolution(promise_ptr, false, move || {
+        failure.into_js_bits()
+    });
+}
+
 const BODY_ALREADY_USED_MESSAGE: &str = "Body is unusable: Body has already been read";
 
 unsafe fn fetch_type_error_bits<S: AsRef<str>>(msg: S) -> u64 {
@@ -452,11 +460,7 @@ pub unsafe extern "C" fn js_fetch_get(url_ptr: *const StringHeader) -> *mut perr
                 let result_bits = handle_to_f64(response_id).to_bits();
                 queue_promise_resolution(promise_ptr, true, result_bits);
             }
-            Err(e) => {
-                let err_msg = format!("Fetch error: {}", e);
-                let err_bits = fetch_error_bits(&err_msg);
-                queue_promise_resolution(promise_ptr, false, err_bits);
-            }
+            Err(e) => queue_fetch_transport_error(promise_ptr, &e, &url),
         }
     });
 
@@ -527,11 +531,7 @@ pub unsafe extern "C" fn js_fetch_get_with_auth(
                 let result_bits = handle_to_f64(response_id).to_bits();
                 queue_promise_resolution(promise_ptr, true, result_bits);
             }
-            Err(e) => {
-                let err_msg = format!("Fetch error: {}", e);
-                let err_bits = fetch_error_bits(&err_msg);
-                queue_promise_resolution(promise_ptr, false, err_bits);
-            }
+            Err(e) => queue_fetch_transport_error(promise_ptr, &e, &url),
         }
     });
 
@@ -605,11 +605,7 @@ pub unsafe extern "C" fn js_fetch_post_with_auth(
                 let result_bits = handle_to_f64(response_id).to_bits();
                 queue_promise_resolution(promise_ptr, true, result_bits);
             }
-            Err(e) => {
-                let err_msg = format!("Fetch error: {}", e);
-                let err_bits = fetch_error_bits(&err_msg);
-                queue_promise_resolution(promise_ptr, false, err_bits);
-            }
+            Err(e) => queue_fetch_transport_error(promise_ptr, &e, &url),
         }
     });
 
@@ -691,11 +687,7 @@ pub unsafe extern "C" fn js_fetch_post(
                 let result_bits = handle_to_f64(response_id).to_bits();
                 queue_promise_resolution(promise_ptr, true, result_bits);
             }
-            Err(e) => {
-                let err_msg = format!("Fetch error: {}", e);
-                let err_bits = fetch_error_bits(&err_msg);
-                queue_promise_resolution(promise_ptr, false, err_bits);
-            }
+            Err(e) => queue_fetch_transport_error(promise_ptr, &e, &url),
         }
     });
 

--- a/crates/perry-stdlib/src/fetch/transport_error.rs
+++ b/crates/perry-stdlib/src/fetch/transport_error.rs
@@ -1,0 +1,129 @@
+//! Convert reqwest transport failures to the error shape exposed by Node fetch.
+
+use std::error::Error as StdError;
+
+pub(crate) struct FetchFailure {
+    cause_message: String,
+    code: Option<&'static str>,
+    errno: Option<i32>,
+    syscall: Option<&'static str>,
+    hostname: Option<String>,
+}
+
+impl FetchFailure {
+    pub(crate) fn from_reqwest(error: &reqwest::Error, url: &str) -> Self {
+        let mut chain = String::new();
+        let mut cause_message = error.to_string();
+        let mut current: Option<&(dyn StdError + 'static)> = Some(error);
+        while let Some(source) = current {
+            let text = source.to_string();
+            if !text.is_empty() {
+                cause_message = text.clone();
+            }
+            chain.push_str(&text.to_ascii_lowercase());
+            chain.push(' ');
+            current = source.source();
+        }
+        Self::classify(url, &chain, cause_message)
+    }
+
+    fn classify(url: &str, chain: &str, fallback_message: String) -> Self {
+        let hostname = reqwest::Url::parse(url)
+            .ok()
+            .and_then(|parsed| parsed.host_str().map(str::to_owned));
+        if looks_like_dns_failure(chain) {
+            let hostname = hostname.unwrap_or_default();
+            return Self {
+                cause_message: format!("getaddrinfo ENOTFOUND {hostname}"),
+                code: Some("ENOTFOUND"),
+                errno: Some(-3008),
+                syscall: Some("getaddrinfo"),
+                hostname: Some(hostname),
+            };
+        }
+        Self {
+            cause_message: fallback_message,
+            code: None,
+            errno: None,
+            syscall: None,
+            hostname: None,
+        }
+    }
+
+    pub(crate) fn into_js_bits(self) -> u64 {
+        let cause_message = perry_runtime::js_string_from_bytes(
+            self.cause_message.as_ptr(),
+            self.cause_message.len() as u32,
+        );
+        if let Some(code) = self.code {
+            perry_runtime::node_submodules::register_error_code_pub(cause_message, code);
+        }
+        if let Some(errno) = self.errno {
+            perry_runtime::node_submodules::register_error_errno(cause_message, errno);
+        }
+        if let Some(syscall) = self.syscall {
+            perry_runtime::node_submodules::register_error_syscall(cause_message, syscall);
+        }
+        if let Some(hostname) = self.hostname {
+            perry_runtime::node_submodules::register_error_hostname(cause_message, hostname);
+        }
+        let cause = perry_runtime::error::js_error_new_with_message(cause_message);
+        let scope = perry_runtime::gc::RuntimeHandleScope::new();
+        let cause_handle =
+            scope.root_nanbox_u64(perry_runtime::JSValue::pointer(cause as *const u8).bits());
+        let message = b"fetch failed";
+        let message = perry_runtime::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+        let error = perry_runtime::error::js_typeerror_new_with_cause(
+            message,
+            cause_handle.get_nanbox_f64(),
+        );
+        perry_runtime::JSValue::pointer(error as *const u8).bits()
+    }
+}
+
+fn looks_like_dns_failure(chain: &str) -> bool {
+    chain.contains("dns error")
+        || chain.contains("failed to lookup address")
+        || chain.contains("failed to lookup")
+        || chain.contains("name or service not known")
+        || chain.contains("nodename nor servname")
+        || chain.contains("no such host")
+        || chain.contains("name resolution")
+        || chain.contains("name not resolved")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dns_failure_has_node_fetch_cause_diagnostics() {
+        let failure = FetchFailure::classify(
+            "https://example.invalid/mcp",
+            "error sending request dns error failed to lookup address information",
+            "opaque reqwest error".to_string(),
+        );
+        assert_eq!(
+            failure.cause_message,
+            "getaddrinfo ENOTFOUND example.invalid"
+        );
+        assert_eq!(failure.code, Some("ENOTFOUND"));
+        assert_eq!(failure.errno, Some(-3008));
+        assert_eq!(failure.syscall, Some("getaddrinfo"));
+        assert_eq!(failure.hostname.as_deref(), Some("example.invalid"));
+    }
+
+    #[test]
+    fn unclassified_failure_keeps_deepest_source_message() {
+        let failure = FetchFailure::classify(
+            "https://example.com/",
+            "opaque transport failure",
+            "opaque transport failure".to_string(),
+        );
+        assert_eq!(failure.cause_message, "opaque transport failure");
+        assert_eq!(failure.code, None);
+        assert_eq!(failure.errno, None);
+        assert_eq!(failure.syscall, None);
+        assert_eq!(failure.hostname, None);
+    }
+}

--- a/test-files/test_gap_9536_fetch_url_error.ts
+++ b/test-files/test_gap_9536_fetch_url_error.ts
@@ -1,0 +1,57 @@
+// Regression for #9536: WHATWG fetch accepts a URL object as RequestInfo,
+// and transport failures reject with Node's TypeError("fetch failed") whose
+// cause carries the underlying system error diagnostics.
+
+async function report(label: string, go: () => Promise<Response>): Promise<void> {
+  try {
+    const response = await go();
+    console.log(label + " -> status " + response.status);
+  } catch (error: any) {
+    const cause = error.cause;
+    console.log(
+      label + " -> " + error.name + " " + JSON.stringify(error.message) +
+      " cause: " + cause?.name + " " + JSON.stringify(cause?.message) +
+      " code=" + cause?.code + " errno=" + cause?.errno +
+      " syscall=" + cause?.syscall + " hostname=" + cause?.hostname
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  const text = "https://example.invalid/mcp";
+  const url = new URL(text);
+
+  await report("string", () => fetch(text, { method: "POST", body: "{}" }));
+  await report("URL object", () => fetch(url, { method: "POST", body: "{}" }));
+  await report("URL object + Headers", () => fetch(url, {
+    method: "POST",
+    headers: new Headers({ "X-A": "1" }),
+    body: "{}"
+  }));
+  await report("Request object", () => fetch(new Request(url, {
+    method: "POST",
+    body: "{}"
+  })));
+  await report("URL object, GET, signal", () => fetch(url, {
+    signal: AbortSignal.timeout(5000)
+  }));
+}
+
+main();
+
+/*
+@covers
+crates/perry-codegen/src/expr/logical_collections.rs:
+  - lower
+crates/perry-runtime/src/object/global_fetch.rs:
+  - js_fetch_input_ptr
+  - global_this_fetch_thunk
+crates/perry-stdlib/src/fetch/abort_bridge.rs:
+  - run_request
+crates/perry-stdlib/src/fetch/mod.rs:
+  - queue_fetch_transport_error
+  - js_fetch_with_options
+crates/perry-stdlib/src/fetch/transport_error.rs:
+  - from_reqwest
+  - into_js_bits
+*/


### PR DESCRIPTION
## Summary

- accept WHATWG `URL` instances anywhere global `fetch` accepts `RequestInfo`, while preserving native `Request` handles
- reject reqwest transport failures with Node-compatible `TypeError("fetch failed")` errors and a diagnostic `cause`; DNS failures expose `ENOTFOUND`, errno, syscall, and hostname
- add a five-shape regression fixture covering strings, URL objects, Headers, Request objects, and AbortSignal

## Testing

- `cargo test --lib -p perry-runtime` (3010 passed, 4 ignored)
- `cargo test --lib --bins -p perry-codegen` (1396 passed, 1 ignored)
- `cargo test --lib -p perry-stdlib transport_error` (2 passed)
- `PERRY_SKIP_BUILD=1 ... ./run_parity_tests.sh --filter test_gap_9536_fetch_url_error` (1/1 passed)
- standard and auto-optimized fixture output diff cleanly against Node 26.5.1
- `cargo build --release -p perry -p perry-runtime-static -p perry-stdlib-static`
- `./scripts/pre-tag-check.sh --quick`

The broader `cargo test --bins -p perry` run passed 1063 tests and hit one existing cache-key audit failure for `PERRY_CONCAT_SITE_CACHE`; the exact test fails identically on untouched `main`.

Closes #9536

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for using `URL` objects with `fetch`, including when combined with headers, requests, or signals.
  * Fetch transport failures now provide Node-compatible `TypeError("fetch failed")` errors with detailed causes, including DNS diagnostics where available.

* **Bug Fixes**
  * Improved error handling consistency across supported `fetch` request inputs.

* **Tests**
  * Added coverage for URL-based requests and transport error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->