### PR TITLE
ci: raise the doc-tests cap to 240 min (its 34-min premise is stale)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3436,7 +3436,15 @@ jobs:
     # healthy runs: macOS 34 min end-to-end. 120 leaves generous headroom for
     # the slower Windows host while bounding a hang to a fifth of what it cost
     # (run 32298711372).
-    timeout-minutes: 120
+    #
+    # 2026-09-03: that 34-min premise is stale. The macOS leg now runs the full
+    # xcompile matrix and measured 119 min against this 120-min cap (run
+    # 33598905771), then OVERRAN it (run 33626738093) -- cancelled with its own
+    # doc-tests already reporting 30/30 passed, the kill landing in the trailing
+    # cross-compile step. A cancelled job fails `full-suite-gate`, so a minute of
+    # runner jitter cost a full release cycle. 240 restores real headroom while
+    # still bounding a hang well under GitHub's 360-min hosted-runner ceiling.
+    timeout-minutes: 240
     # Blocking host runs and the portable cross-compile subset gate the job.
     # Known platform-tail failures remain advisory at their individual steps.
     strategy:

--- a/changelog.d/9527-doc-tests-timeout-240.md
+++ b/changelog.d/9527-doc-tests-timeout-240.md
@@ -1,0 +1,8 @@
+- **`doc-tests`: `timeout-minutes` 120 → 240.** The cap's own comment sized it
+  against "macOS 34 min end-to-end", but that premise is stale — the macOS leg
+  now runs the full xcompile matrix. It measured **119 min against the 120-min
+  cap** (run 33598905771) and then overran it (run 33626738093), cancelled with
+  its own doc-tests already reporting **30/30 passed**; the kill landed in the
+  trailing cross-compile step. Since a cancelled job fails `full-suite-gate`, a
+  minute of runner jitter cost a full release cycle. 240 restores headroom while
+  still bounding a hang well under GitHub's 360-min hosted-runner ceiling.


### PR DESCRIPTION
## The problem

`doc-tests`' cap was set by #8468 against a documented premise:

```
# Measured healthy runs: macOS 34 min end-to-end. 120 leaves generous headroom
timeout-minutes: 120
```

That premise is stale. The macOS leg now runs the full xcompile matrix, and measured:

| run | outcome |
|---|---|
| `33598905771` | success, **119 min** against the 120-min cap |
| `33626738093` | **cancelled at 120 min** |

In the cancelled run the doc-tests themselves had already reported **`30/30 passed, 0 failed`** — the kill landed 55 minutes later, in the trailing `--xcompile-only` step.

A cancelled job fails `full-suite-gate`, so **one minute of runner jitter costs a full release cycle.** At 119/120 this is a coin flip on every full tier.

## The fix

`timeout-minutes: 240`.

That restores real headroom while still bounding a hang well under GitHub's 360-minute hosted-runner ceiling — preserving #8468's original intent (its motivating incident was a Windows leg burning six hours having run *zero* doc-tests).

Workflow-only; no runtime or codegen change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the documentation test workflow timeout to prevent healthy, long-running test jobs from being cancelled prematurely.

* **Documentation**
  * Added a changelog entry explaining the updated timeout and the additional execution headroom.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->