### PR TITLE
fix(stdlib): the readline reader thread notifies the pump — keypress latency 600-960ms → 0-2.6ms when no timer masks it (#9588)

### DIFF
--- a/changelog.d/9588-readline-reader-wakes-the-pump.md
+++ b/changelog.d/9588-readline-reader-wakes-the-pump.md
@@ -1,0 +1,20 @@
+**fix(stdlib): the stdin reader wakes the event loop after queueing input (#9588)**
+
+Keystrokes reached the program only when the event loop happened to wake for
+some other reason. `perry-stdlib`'s readline reader thread pushed what it read
+into the shared `PENDING_DATA` / `PENDING_LINES` queues — which only the main
+thread drains, from `js_readline_process_pending` — and went straight back into
+`read(2)` without calling `js_notify_main_thread()`. The main loop was never
+told the input existed, so delivery waited out whatever `js_wait_for_event` had
+sized its sleep to: the next timer deadline, or, for a program sitting idle
+waiting for input with no timer armed, the full one-second idle cap.
+
+Measured on the claude-code bundle before the fix: 695-963 ms from keypress to
+the `'data'` handler, against Node's sub-millisecond. After: 2.6 ms.
+
+The reader now notifies once per `read(2)` that queued something, and once on
+EOF so the `'end'`/`'close'` dispatch and the liveness flip are not delayed
+either. This is the protocol the event pump documents and the one every other
+cross-thread producer in the tree already followed — the child-process reactor,
+the pty reactor, dgram, signals, and perry-runtime's own stdin reader in
+`os_process_streams`. readline's reader was the only one that skipped it.

--- a/crates/perry-stdlib/src/readline/mod.rs
+++ b/crates/perry-stdlib/src/readline/mod.rs
@@ -1105,6 +1105,9 @@ fn ensure_reader_started() {
         // chunks (`pump::coalesce_escape_sequences`), and a paste must still
         // fire one `'keypress'` per character.
         let mut raw_chunks: Vec<Vec<u8>> = Vec::new();
+        // #9588: set whenever this read(2) put something the MAIN THREAD has to
+        // dispatch into a shared queue. See the notify below.
+        let mut queued_for_main: bool;
         loop {
             let n = match reader.read(&mut buf) {
                 Ok(0) => break, // EOF
@@ -1114,6 +1117,7 @@ fn ensure_reader_started() {
             if STDIN_DESTROYED.load(Ordering::Acquire) {
                 break;
             }
+            queued_for_main = false;
             // The mode atomics are still consulted PER BYTE, exactly as
             // before: a mode flip from the main thread mid-block must land on
             // the same byte it used to. Only the syscall and the chunk
@@ -1141,6 +1145,7 @@ fn ensure_reader_started() {
                     if let Ok(mut q) = PENDING_LINES.lock() {
                         q.push(line);
                     }
+                    queued_for_main = true;
                 } else {
                     line_buf.push(b);
                 }
@@ -1150,6 +1155,7 @@ fn ensure_reader_started() {
                     q.append(&mut raw_chunks);
                 }
                 raw_chunks.clear();
+                queued_for_main = true;
             }
             // One `'data'` chunk per read(2) — Node's contract. Line splitting
             // is the CONSUMER's job (readline does its own, above); imposing
@@ -1163,6 +1169,29 @@ fn ensure_reader_started() {
                     q.push(std::mem::take(&mut line_buf));
                 }
                 line_buf = Vec::with_capacity(65536);
+                queued_for_main = true;
+            }
+            // #9588 — WAKE THE PUMP. This reader is a cross-thread producer for
+            // queues only the main thread drains (`js_readline_process_pending`,
+            // reached from `js_run_stdlib_pump`), and it used to push and loop
+            // straight back into `read(2)` without telling anyone. The main loop
+            // therefore learned about a keystroke only when it happened to wake
+            // for some *other* reason, so input latency was the whole
+            // `js_wait_for_event` budget: the next timer deadline, or — for a TUI
+            // sitting idle with no timer armed — the full `IDLE_CAP_MS` (1 s)
+            // safety cap. Measured on the claude-code bundle before this line:
+            // 695-963 ms from keypress to the `'data'` handler, against Node's
+            // sub-millisecond. That is the protocol the event pump documents
+            // ("producer: push_to_queue(); js_notify_main_thread()") and the one
+            // perry-runtime's own stdin reader in `os_process_streams` already
+            // follows; readline's reader was the one producer that skipped it.
+            //
+            // Once per read(2), not per byte: a paste arrives as one syscall and
+            // needs exactly one wake, and the flag keeps a read that queued
+            // nothing (a raw-mode byte absorbed with no listener, a partial line
+            // still accumulating) from waking the loop for no work.
+            if queued_for_main {
+                perry_runtime::event_pump::js_notify_main_thread();
             }
         }
         // Flush any trailing bytes not terminated by a newline. In cooked
@@ -1187,6 +1216,10 @@ fn ensure_reader_started() {
             }
         }
         EOF_REACHED.store(true, Ordering::Release);
+        // #9588: EOF is main-thread-visible work too — the `'end'`/`'close'`
+        // dispatch and the liveness flip that lets the loop exit. Without a wake
+        // here a piped program's exit was delayed by up to `IDLE_CAP_MS`.
+        perry_runtime::event_pump::js_notify_main_thread();
     });
 }
 

--- a/crates/perry/tests/issue_9588_readline_reader_notifies_the_pump.rs
+++ b/crates/perry/tests/issue_9588_readline_reader_notifies_the_pump.rs
@@ -1,0 +1,141 @@
+//! Regression test for #9588: the stdin reader thread must WAKE the main
+//! event-loop pump after queueing input.
+//!
+//! `perry-stdlib`'s readline reader (`readline::ensure_reader_started`) is a
+//! cross-thread producer: it blocks in `read(2)` on its own thread and pushes
+//! what it reads into `PENDING_DATA` / `PENDING_LINES`, queues that only the
+//! MAIN thread drains — from `js_readline_process_pending`, reached through
+//! `js_run_stdlib_pump` once per event-loop turn.
+//!
+//! It used to push and go straight back into `read(2)` without calling
+//! `js_notify_main_thread()`. The main loop was therefore never told the input
+//! existed: it learned about a keystroke only when it happened to wake for some
+//! *other* reason. `js_wait_for_event` sizes that sleep from the timer
+//! deadlines, so the delivery latency was whatever the next timer was — and for
+//! a program sitting idle waiting for input, with no timer armed at all, the
+//! full `IDLE_CAP_MS` (1 s) safety cap.
+//!
+//! Measured on the claude-code bundle before the fix: 695-963 ms from keypress
+//! to the `'data'` handler (Node: sub-millisecond). Every other cross-thread
+//! producer in the tree already follows the protocol the event pump documents
+//! ("producer: push_to_queue(); js_notify_main_thread()") — the child-process
+//! reactor, the pty reactor, dgram, signals, and perry-runtime's OWN stdin
+//! reader in `os_process_streams`. readline's reader was the one that skipped
+//! it.
+//!
+//! The test measures from the parent: it writes one chunk after the child is
+//! known to be parked, and times how long the child takes to echo it back. It
+//! fails on the unfixed reader (~700 ms+) and passes on the fixed one (~1 ms).
+//! Deliberately NO timers in the fixture — a single `setInterval` would mask
+//! the bug completely by capping the park at the interval period, which is
+//! exactly why the defect survived so long in programs that happen to have one.
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+/// No timers, no intervals: the only live handle is the stdin listener, so the
+/// event loop parks for the idle cap between turns.
+const SOURCE: &str = r#"
+process.stdin.on("data", (chunk: any) => {
+  console.log("DATA:" + String(chunk).trim());
+});
+console.log("READY");
+"#;
+
+fn compile(dir: &std::path::Path, source: &str) -> PathBuf {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    output
+}
+
+#[test]
+fn stdin_reader_wakes_the_event_loop_instead_of_waiting_for_the_idle_cap() {
+    let dir = std::env::temp_dir().join(format!("perry_9588_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    let bin = compile(&dir, SOURCE);
+
+    let mut child = Command::new(&bin)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn compiled binary");
+
+    let mut stdin = child.stdin.take().expect("piped stdin");
+    let stdout = child.stdout.take().expect("piped stdout");
+
+    // Reader thread: hand each complete line back with the instant it arrived.
+    let (tx, rx) = mpsc::channel::<(String, Instant)>();
+    std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines() {
+            match line {
+                Ok(l) => {
+                    if tx.send((l, Instant::now())).is_err() {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    let ready = rx
+        .recv_timeout(Duration::from_secs(30))
+        .expect("child never printed READY");
+    assert_eq!(ready.0.trim(), "READY", "unexpected first line");
+
+    // Let the loop settle into its park. With no timer armed the budget is the
+    // full idle cap, so from here nothing but a notify can wake it early.
+    std::thread::sleep(Duration::from_millis(400));
+
+    let mut latencies = Vec::new();
+    for i in 0..3 {
+        let sent = Instant::now();
+        writeln!(stdin, "chunk{i}").expect("write stdin");
+        stdin.flush().expect("flush stdin");
+        let (line, arrived) = rx
+            .recv_timeout(Duration::from_secs(10))
+            .unwrap_or_else(|_| panic!("no 'data' delivery for chunk{i} within 10 s"));
+        assert_eq!(line.trim(), format!("DATA:chunk{i}"), "wrong chunk echoed");
+        latencies.push(arrived.duration_since(sent));
+        // Re-park between chunks so each measurement starts from a fresh sleep.
+        std::thread::sleep(Duration::from_millis(300));
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = std::fs::remove_dir_all(&dir);
+
+    // The unfixed reader lands at the idle cap (~700 ms-1 s). The fixed one is
+    // a wake plus one loop turn — single-digit milliseconds. 250 ms sits an
+    // order of magnitude clear of both.
+    let worst = latencies.iter().max().copied().unwrap();
+    assert!(
+        worst < Duration::from_millis(250),
+        "stdin delivery took {worst:?} (all: {latencies:?}) — the reader queued the \
+         input without calling js_notify_main_thread, so the main loop slept out \
+         its js_wait_for_event budget before draining it"
+    );
+}


### PR DESCRIPTION
Found while root-causing #9588 with a symbolized dispatch census of the field-wedged binary. **This is not the wedge** (see the issue for the corrected diagnosis) — it is a real latency defect the investigation exposed, the exact producer/consumer-disconnection shape the issue hypothesized, in the input path.

## The defect

The readline reader thread (`perry-stdlib/src/readline/mod.rs:1071-1190`) pushes to `PENDING_DATA`/`PENDING_LINES` and goes straight back into `read(2)` — **zero `js_notify_main_thread` calls anywhere under `readline/`**. The consumer (`js_readline_process_pending`, reached once per loop turn) only runs when something *else* wakes the loop, so a keypress waits out the entire `js_wait_for_event` budget.

Measured: **603–963 ms** keypress delivery (PTY raw and pipe cooked alike) vs node's 1.3 ms. It survived this long because **any armed timer masks it** — cc's own `fs.watch` 25 ms interval caps echo latency at 32–65 ms, so real cc *feels* fine until nothing is polling.

Every other cross-thread producer already follows the documented protocol — `cp_push_event`, the pty reactor, dgram, signals, and perry-runtime's own stdin reader (`os_process_streams.rs:266,273`). readline's was the only one that skipped it. (Same one-straggler shape as the #9416 stdlib/runtime predicate split.)

## Fix

Notify once per `read(2)` that queued something — a paste is one syscall, one wake; a read that queues nothing doesn't wake — and once at EOF so `'end'`/`'close'` and the liveness flip aren't delayed either. After: **0–2.6 ms**. Idle CPU unchanged (0.01 s over 8.5 s).

## Verification

`crates/perry/tests/issue_9588_readline_reader_notifies_the_pump.rs` — a compiled-binary integration test, the only possible vehicle: the changed code is inside `#[cfg(not(test))]` (the reader thread isn't spawned under `cargo test`), so no unit test can reach it, and the test says so.

- Unfixed (fix reverted, stdlib rebuilt): `FAILED — stdin delivery took 697.6ms (all: [597.7, 696.1, 697.6ms])`
- Fixed: `ok. 1 passed`

Deliberately **not** folded in: the bare-ESC flush (held escape prefixes wait out the same budget) — a notify there would tear real arrow-key sequences split across reads on slow links; it needs a proper `escapeCodeTimeout` timer and is filed separately.

Refs #9588 (which stays open — the wedge itself is a child-process wait, not this).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved readline input responsiveness by waking the event loop as soon as input is available.
  - Readline data handlers now receive keystrokes with significantly lower latency.
  - End-of-input events and process shutdown are no longer delayed unnecessarily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->