### PR TITLE
fix(runtime): root the assimilated thenable wrapper across the user `then` (#9539)

### DIFF
--- a/changelog.d/9595-thenable-assimilation-wrapper-rooting.md
+++ b/changelog.d/9595-thenable-assimilation-wrapper-rooting.md
@@ -1,0 +1,43 @@
+### Fixed
+
+- **Thenable assimilation now returns the wrapper promise's post-collection
+  address; `util.callbackify` with an object-literal thenable SIGSEGV'd at exit
+  (#9539).** ~6,000 `util.callbackify(fn)(cb)` calls whose `fn` returns
+  `{ then(resolve) { …allocate…; resolve(v) } }` produced every callback's
+  correct result and then died with status 139 in
+  `promise::microtasks::pump_protected`, where node exits 0.
+
+  `assimilate_via_then_property` (and the class-vtable arm of
+  `js_assimilate_thenable`) allocate the wrapper `Promise`, hand the user's
+  `then` two resolving closures capturing it, run that `then`, and NaN-box the
+  wrapper out of a bare `*mut Promise` Rust local. The `then` body is user
+  code: with the moving nursery a loop safepoint inside it evacuates the young
+  generation. The wrapper survives and moves — the closures' raw-`i64` capture
+  words are pointer-bearing, so the collector rewrites them and `resolve(v)`
+  settles the promise at its NEW address — but the Rust local is not a GC root,
+  so the function returned the pre-collection address, i.e. retired from-space.
+  `callbackify_outer_thunk` then classified that word as a Promise, rooted it
+  and attached its reactions to it, so a dead promise reached the task queue and
+  the final microtask checkpoint dereferenced it.
+
+  Every value that outlives an allocation or a user-JS call in these functions
+  now lives in a `RuntimeHandleScope` handle — a mutable GC root the evacuating
+  minor rewrites in place — and each use re-reads through the handle: the
+  returned wrapper, the thenable receiver and its `then` action, the resolving
+  closures, `callbackify`'s `returned` across its closure allocations and
+  across `js_assimilate_thenable`, and `callable_then_field`'s receiver across
+  the `"then"` intern.
+
+  `PERRY_GC_PROTECT_FROMSPACE=1` names the stale object exactly
+  (`RETIRED FROM-SPACE … obj_type=5 size=80`, faulting on the
+  `obj_type == GC_TYPE_PROMISE` test inside `callbackify_outer_thunk`), and
+  `PERRY_GC_MOVING_LOOP_POLLS=0` makes even the unfixed build pass — the control
+  that names the moving minor inside `then` as the mechanism. Gap test
+  `test_gap_9539_callbackify_thenable_exit_gc.ts` is status 139 on 5/5 unfixed
+  runs and exits 0 on 10/10 fixed runs, plus 5/5 each under from-space
+  protection, a 1 MiB nursery, forced evacuation and
+  `PERRY_GC_MOVING_SAFEPOINT=0`. New unit test
+  `gc/tests/runtime_roots/thenable_assimilation.rs` drives a native `then` that
+  forces a copying minor before calling `resolve(1)`; unfixed it reports
+  `Pending != Fulfilled`. `perry-runtime` is 3011 passed / 0 failed
+  single-threaded.

--- a/crates/perry-runtime/src/gc/tests/runtime_roots.rs
+++ b/crates/perry-runtime/src/gc/tests/runtime_roots.rs
@@ -18,6 +18,7 @@ mod side_table_scanners;
 mod string_normalize_form;
 mod string_slice;
 mod symbol_description;
+mod thenable_assimilation;
 mod transient_handles;
 
 fn assert_panics_with(expected: &str, f: impl FnOnce()) {

--- a/crates/perry-runtime/src/gc/tests/runtime_roots/thenable_assimilation.rs
+++ b/crates/perry-runtime/src/gc/tests/runtime_roots/thenable_assimilation.rs
@@ -1,0 +1,99 @@
+//! #9539 — thenable assimilation must hand back the wrapper promise's
+//! POST-collection address.
+//!
+//! `assimilate_via_then_property` / `js_assimilate_thenable` allocate a wrapper
+//! Promise, hand the user's `then` a pair of resolving closures that capture it,
+//! and then run that `then`. The body is arbitrary user code, and with the
+//! moving nursery a loop safepoint inside it evacuates the young generation.
+//! The wrapper survives — the closures' capture words are pointer-bearing and
+//! get rewritten — but the bare `*mut Promise` Rust local used to build the
+//! return value is not a GC root, so the pre-fix code returned the address the
+//! promise had *before* the callback collected. `util.callbackify` then
+//! classified that retired from-space word as a Promise, rooted it and attached
+//! reactions to it, and the exit-time microtask checkpoint faulted.
+
+use super::*;
+
+/// A native stand-in for a user `then(resolve, reject)` whose body allocates
+/// enough to collect — the `churn()` loop of the end-to-end fixture. It roots
+/// `resolve` the way a compiled JS frame does (its locals are precise roots),
+/// so the wrapper promise stays reachable through the closure capture and is
+/// RELOCATED rather than freed.
+extern "C" fn test_thenable_then_force_minor_gc(
+    _closure: *const crate::closure::ClosureHeader,
+    resolve: f64,
+    _reject: f64,
+) -> f64 {
+    let scope = RuntimeHandleScope::new();
+    let resolve_handle = scope.root_nanbox_f64(resolve);
+    let _ = crate::gc::gc_collect_minor();
+    let args = [1.0f64];
+    unsafe {
+        crate::closure::js_native_call_value(
+            resolve_handle.get_nanbox_f64(),
+            args.as_ptr(),
+            args.len(),
+        );
+    }
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+#[test]
+fn test_assimilated_thenable_wrapper_survives_then_callback_copied_minor_gc() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    activate_malloc_registry_for_tests();
+    register_runtime_handle_root_scanner_for_tests();
+    gc_register_mutable_root_scanner(promise_mutable_root_scanner);
+    crate::closure::js_register_closure_arity(test_thenable_then_force_minor_gc as *const u8, 2);
+
+    let scope = RuntimeHandleScope::new();
+    let then_closure =
+        crate::closure::js_closure_alloc(test_thenable_then_force_minor_gc as *const u8, 0);
+    let then_handle = scope.root_raw_mut_ptr(then_closure);
+
+    // `{ then(resolve, reject) { … } }` — an object literal (class_id 0), so
+    // assimilation takes the `then`-as-data-property path.
+    let thenable_handle = scope.root_raw_mut_ptr(crate::object::js_object_alloc(0, 1));
+    let key_handle = scope.root_string_ptr(crate::string::js_string_from_bytes(b"then".as_ptr(), 4));
+    crate::object::js_object_set_field_by_name(
+        thenable_handle.get_raw_mut_ptr(),
+        key_handle.get_raw_const_ptr::<crate::StringHeader>(),
+        f64::from_bits(ptr_bits(then_handle.get_raw_mut_ptr::<u8>() as usize)),
+    );
+
+    let before = gc_collection_count();
+    let assimilated = crate::promise::js_assimilate_thenable(f64::from_bits(ptr_bits(
+        thenable_handle.get_raw_mut_ptr::<u8>() as usize,
+    )));
+    assert!(
+        gc_collection_count() > before,
+        "the thenable's `then` body must force a copying minor GC while the wrapper is live"
+    );
+
+    let bits = assimilated.to_bits();
+    assert_eq!(
+        bits & TAG_MASK,
+        POINTER_TAG,
+        "assimilation must return a heap pointer"
+    );
+    let promise = (bits & POINTER_MASK) as *mut crate::promise::Promise;
+    unsafe {
+        assert_eq!(
+            (*header_from_user_ptr(promise as *const u8)).obj_type,
+            GC_TYPE_PROMISE,
+            "the returned address must still be a live Promise after the callback's collection"
+        );
+        // The discriminating assertion: `resolve(1)` settled the promise at its
+        // POST-collection address (the capture word was rewritten). Returning
+        // the pre-collection address — the #9539 bug — hands back the retired
+        // from-space copy, which is still Pending.
+        assert_eq!(
+            (*promise).state,
+            crate::promise::PromiseState::Fulfilled,
+            "assimilation must return the wrapper the resolving closure settled, \
+             not its pre-collection address"
+        );
+        assert_eq!((*promise).value, 1.0);
+    }
+}

--- a/crates/perry-runtime/src/promise/assimilate.rs
+++ b/crates/perry-runtime/src/promise/assimilate.rs
@@ -408,31 +408,64 @@ pub(super) fn assimilate_via_then_property(value: f64) -> f64 {
     if super::then_probe::definitely_no_then(value) {
         return value;
     }
+    // #9539: `js_native_call_value` below runs the thenable's `then` body —
+    // arbitrary user code. With the moving nursery (default-on) a loop
+    // safepoint inside it evacuates the young generation, so every heap value
+    // this function still needs afterwards must live in a transient handle the
+    // collector rewrites; a bare `*mut Promise` local would name retired
+    // from-space by the time the call returns.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let value_handle = scope.root_nanbox_f64(value);
+
     // `Get(value, "then")` (27.2.1.3.2 step 8). A throwing getter is an abrupt
     // completion → resolve-with-thenable rejects the wrapper promise with the
     // thrown value (step 9), rather than letting the exception unwind out of the
     // resolve path. Return that rejected wrapper so callers chain it.
     let then_val = match combinator_catch_js(|| unsafe {
-        crate::value::js_dynamic_object_get_property(value, b"then".as_ptr() as *const i8, 4)
+        crate::value::js_dynamic_object_get_property(
+            value_handle.get_nanbox_f64(),
+            b"then".as_ptr() as *const i8,
+            4,
+        )
     }) {
         Ok(v) => v,
         Err(reason) => {
-            let p = js_promise_new();
-            js_promise_reject(p, reason);
-            return crate::value::js_nanbox_pointer(p as i64);
+            let reason_handle = scope.root_nanbox_f64(reason);
+            let rejected_handle = scope.root_raw_mut_ptr(js_promise_new());
+            js_promise_reject(
+                rejected_handle.get_raw_mut_ptr::<Promise>(),
+                reason_handle.get_nanbox_f64(),
+            );
+            return crate::value::js_nanbox_pointer(
+                rejected_handle.get_raw_mut_ptr::<Promise>() as i64
+            );
         }
     };
-    if callable_closure_value(then_val).is_none() {
-        return value;
+    let then_handle = scope.root_nanbox_f64(then_val);
+    if callable_closure_value(then_handle.get_nanbox_f64()).is_none() {
+        return value_handle.get_nanbox_f64();
     }
 
-    let new_promise = js_promise_new();
-    let promise_i64 = new_promise as i64;
+    let promise_handle = scope.root_raw_mut_ptr(js_promise_new());
 
-    let resolve_closure = crate::closure::js_closure_alloc(promise_resolve_fn as *const u8, 1);
-    crate::closure::js_closure_set_capture_ptr(resolve_closure, 0, promise_i64);
-    let reject_closure = crate::closure::js_closure_alloc(promise_reject_fn as *const u8, 1);
-    crate::closure::js_closure_set_capture_ptr(reject_closure, 0, promise_i64);
+    let resolve_handle = scope.root_raw_mut_ptr(crate::closure::js_closure_alloc(
+        promise_resolve_fn as *const u8,
+        1,
+    ));
+    crate::closure::js_closure_set_capture_ptr(
+        resolve_handle.get_raw_mut_ptr(),
+        0,
+        promise_handle.get_raw_mut_ptr::<Promise>() as i64,
+    );
+    let reject_handle = scope.root_raw_mut_ptr(crate::closure::js_closure_alloc(
+        promise_reject_fn as *const u8,
+        1,
+    ));
+    crate::closure::js_closure_set_capture_ptr(
+        reject_handle.get_raw_mut_ptr(),
+        0,
+        promise_handle.get_raw_mut_ptr::<Promise>() as i64,
+    );
 
     // Pass the resolving functions as proper NaN-boxed function values (not the
     // raw closure-pointer-bits convention used internally by
@@ -441,20 +474,30 @@ pub(super) fn assimilate_via_then_property(value: f64) -> f64 {
     // so `typeof onFulfilled === "function"` must hold (test262
     // yield-star-async-* / yield-star-next-then-* check this). A NaN-boxed
     // closure is still invoked through the normal call path.
-    let resolve_f64 = crate::value::js_nanbox_pointer(resolve_closure as i64);
-    let reject_f64 = crate::value::js_nanbox_pointer(reject_closure as i64);
+    let resolve_f64 =
+        crate::value::js_nanbox_pointer(resolve_handle.get_raw_mut_ptr::<u8>() as i64);
+    let reject_f64 = crate::value::js_nanbox_pointer(reject_handle.get_raw_mut_ptr::<u8>() as i64);
     let args = [resolve_f64, reject_f64];
 
     // Bind `this` to the thenable so a non-arrow `then` body reads the right
     // receiver, then call `Get(value, "then")` as a value (own data property).
-    let this_scope = crate::gc::RuntimeHandleScope::new(); // #9445
-    let prev = this_scope.root_nanbox_f64(crate::object::js_implicit_this_set(value));
+    let prev = scope.root_nanbox_f64(crate::object::js_implicit_this_set(
+        value_handle.get_nanbox_f64(),
+    )); // #9445
     unsafe {
-        crate::closure::js_native_call_value(then_val, args.as_ptr(), args.len());
+        crate::closure::js_native_call_value(
+            then_handle.get_nanbox_f64(),
+            args.as_ptr(),
+            args.len(),
+        );
     }
     crate::object::js_implicit_this_set(prev.get_nanbox_f64());
 
-    crate::value::js_nanbox_pointer(new_promise as i64)
+    // Re-read the wrapper through its handle: the user `then` just ran and may
+    // have relocated it (#9539). Returning `new_promise`'s pre-call address is
+    // what handed callers (util.callbackify, await) a retired from-space
+    // pointer they then classified, rooted and attached reactions to.
+    crate::value::js_nanbox_pointer(promise_handle.get_raw_mut_ptr::<Promise>() as i64)
 }
 
 #[cfg(test)]

--- a/crates/perry-runtime/src/promise/combinators.rs
+++ b/crates/perry-runtime/src/promise/combinators.rs
@@ -1261,24 +1261,49 @@ pub extern "C" fn js_assimilate_thenable(value: f64) -> f64 {
         };
 
     // Allocate the wrapper promise plus resolve/reject closures pointing at it.
-    let new_promise = js_promise_new();
-    let promise_i64 = new_promise as i64;
+    //
+    // #9539: the vtable `then` below is user code, and with the moving nursery
+    // (default-on) a loop safepoint inside it evacuates the young generation.
+    // The wrapper survives — the closures' capture words are rewritten — but a
+    // bare `*mut Promise` local is not a GC root, so reading it after the call
+    // returns a retired from-space address. Hold every value the call outlives
+    // in transient handles and re-read them through those handles.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let this_handle = scope.root_raw_const_ptr(obj_ptr);
+    let promise_handle = scope.root_raw_mut_ptr(js_promise_new());
 
-    let resolve_closure = crate::closure::js_closure_alloc(promise_resolve_fn as *const u8, 1);
-    crate::closure::js_closure_set_capture_ptr(resolve_closure, 0, promise_i64);
-    let reject_closure = crate::closure::js_closure_alloc(promise_reject_fn as *const u8, 1);
-    crate::closure::js_closure_set_capture_ptr(reject_closure, 0, promise_i64);
+    let resolve_handle = scope.root_raw_mut_ptr(crate::closure::js_closure_alloc(
+        promise_resolve_fn as *const u8,
+        1,
+    ));
+    crate::closure::js_closure_set_capture_ptr(
+        resolve_handle.get_raw_mut_ptr(),
+        0,
+        promise_handle.get_raw_mut_ptr::<Promise>() as i64,
+    );
+    let reject_handle = scope.root_raw_mut_ptr(crate::closure::js_closure_alloc(
+        promise_reject_fn as *const u8,
+        1,
+    ));
+    crate::closure::js_closure_set_capture_ptr(
+        reject_handle.get_raw_mut_ptr(),
+        0,
+        promise_handle.get_raw_mut_ptr::<Promise>() as i64,
+    );
 
     // The user's `then(onFulfilled, onRejected)` reads each parameter as a
     // raw f64 closure pointer (matching the convention used by
     // `js_promise_new_with_executor`).
-    let resolve_f64 = f64::from_bits(resolve_closure as u64);
-    let reject_f64 = f64::from_bits(reject_closure as u64);
+    let resolve_f64 = f64::from_bits(resolve_handle.get_raw_mut_ptr::<u8>() as u64);
+    let reject_f64 = f64::from_bits(reject_handle.get_raw_mut_ptr::<u8>() as u64);
 
     // Invoke `value.then(resolve, reject)` via the vtable. Mirrors
     // `call_vtable_method` in object.rs: NaN-box `this` with POINTER_TAG so
     // the method body sees a real instance pointer.
-    let this_f64 = f64::from_bits(JSValue::pointer(obj_ptr as *mut u8).bits());
+    let this_f64 = f64::from_bits(
+        JSValue::pointer(this_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>() as *mut u8)
+            .bits(),
+    );
     unsafe {
         match then_param_count {
             0 => {
@@ -1297,7 +1322,8 @@ pub extern "C" fn js_assimilate_thenable(value: f64) -> f64 {
         }
     }
 
-    crate::value::js_nanbox_pointer(new_promise as i64)
+    // Re-read the wrapper through its handle — see the #9539 note above.
+    crate::value::js_nanbox_pointer(promise_handle.get_raw_mut_ptr::<Promise>() as i64)
 }
 
 /// Assimilate an object-literal thenable whose `then` is an own/inherited DATA

--- a/crates/perry-runtime/src/util_promisify.rs
+++ b/crates/perry-runtime/src/util_promisify.rs
@@ -702,6 +702,11 @@ extern "C" fn callbackify_outer_thunk(closure: *const ClosureHeader, rest_value:
         let data = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
         crate::closure::js_native_call_value(fn_handle.get_nanbox_f64(), data, original_arg_len)
     };
+    // #9539: `returned` is a heap value that outlives two closure allocations,
+    // an interned-key lookup and `js_assimilate_thenable` (which runs the
+    // thenable's own `then`). Root it so every later read sees the current
+    // address rather than a pre-collection one.
+    let returned_handle = scope.root_nanbox_f64(returned);
 
     // Build the onFulfilled / onRejected closures (bound to the user callback).
     let fulfilled = js_closure_alloc(callbackify_fulfilled_thunk as *const u8, 1);
@@ -727,7 +732,7 @@ extern "C" fn callbackify_outer_thunk(closure: *const ClosureHeader, rest_value:
     );
 
     // Native Perry Promise → attach our handlers directly.
-    let promise_ptr = promise_ptr_from_value(returned);
+    let promise_ptr = promise_ptr_from_value(returned_handle.get_nanbox_f64());
     if !promise_ptr.is_null() {
         let promise_handle = scope.root_raw_mut_ptr(promise_ptr);
         js_promise_attach_handlers(
@@ -740,8 +745,10 @@ extern "C" fn callbackify_outer_thunk(closure: *const ClosureHeader, rest_value:
 
     // Class-based thenable (e.g. a custom Promise subclass) → assimilate into a
     // real Promise wrapper, then attach.
-    let assimilated = crate::promise::js_assimilate_thenable(returned);
-    let assimilated_ptr = promise_ptr_from_value(assimilated);
+    let assimilated = scope.root_nanbox_f64(crate::promise::js_assimilate_thenable(
+        returned_handle.get_nanbox_f64(),
+    ));
+    let assimilated_ptr = promise_ptr_from_value(assimilated.get_nanbox_f64());
     if !assimilated_ptr.is_null() {
         let promise_handle = scope.root_raw_mut_ptr(assimilated_ptr);
         js_promise_attach_handlers(
@@ -756,14 +763,16 @@ extern "C" fn callbackify_outer_thunk(closure: *const ClosureHeader, rest_value:
     // as an own field, not a vtable method, so `js_assimilate_thenable` passes
     // it through unchanged. Probe for a callable `.then` field and invoke it
     // with the thenable as `this`, passing our fulfilled/rejected handlers.
-    if let Some(then_fn) = callable_then_field(returned) {
+    if let Some(then_fn) = callable_then_field(returned_handle.get_nanbox_f64()) {
         let then_handle = scope.root_nanbox_f64(then_fn);
         let on_fulfilled =
             nanbox_pointer(fulfilled_handle.get_raw_const_ptr::<ClosureHeader>() as *const u8);
         let on_rejected =
             nanbox_pointer(rejected_handle.get_raw_const_ptr::<ClosureHeader>() as *const u8);
         let args = [on_fulfilled, on_rejected];
-        let prev_this = scope.root_nanbox_f64(crate::object::js_implicit_this_set(returned));
+        let prev_this = scope.root_nanbox_f64(crate::object::js_implicit_this_set(
+            returned_handle.get_nanbox_f64(),
+        ));
         unsafe {
             crate::closure::js_native_call_value(
                 then_handle.get_nanbox_f64(),
@@ -777,7 +786,7 @@ extern "C" fn callbackify_outer_thunk(closure: *const ClosureHeader, rest_value:
 
     // Not a Promise or thenable — Node throws `TypeError` synchronously because
     // it attempts to call `.then` on the result.
-    throw_callbackify_not_thenable(returned);
+    throw_callbackify_not_thenable(returned_handle.get_nanbox_f64());
 }
 
 /// Locate a callable own `then` field on a heap-object value (object-literal
@@ -805,10 +814,15 @@ fn callable_then_field(value: f64) -> Option<f64> {
     if gc_header.obj_type != crate::gc::GC_TYPE_OBJECT {
         return None;
     }
-    let obj = addr as *const crate::object::ObjectHeader;
-    let key = js_string_from_bytes(b"then".as_ptr(), 4);
-    let then_value =
-        crate::object::js_object_get_field_by_name_f64(obj, key as *const crate::StringHeader);
+    // #9539: interning `"then"` allocates, so the receiver must be a root
+    // across it — a raw local would be read back at its pre-collection address.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let obj_handle = scope.root_raw_const_ptr(addr as *const crate::object::ObjectHeader);
+    let key_handle = scope.root_string_ptr(js_string_from_bytes(b"then".as_ptr(), 4));
+    let then_value = crate::object::js_object_get_field_by_name_f64(
+        obj_handle.get_raw_const_ptr::<crate::object::ObjectHeader>(),
+        key_handle.get_raw_const_ptr::<crate::StringHeader>(),
+    );
     if is_callable_closure(then_value) {
         Some(then_value)
     } else {

--- a/test-files/test_gap_9539_callbackify_thenable_exit_gc.ts
+++ b/test-files/test_gap_9539_callbackify_thenable_exit_gc.ts
@@ -1,0 +1,56 @@
+// #9539 — callbackify must keep synchronously-resolved object thenables and
+// their queued promise reactions valid across nursery collections. The
+// callbacks all complete before the observable output; the regression was an
+// exit-time SIGSEGV when the final microtask checkpoint read a stale pointer.
+
+import * as util from "node:util";
+
+const N = 6000;
+
+function churn(): number {
+  const tmp: any[] = [];
+  for (let k = 0; k < 480; k++) {
+    tmp.push({ k, s: "t" + k, pad: [k, k + 1] });
+  }
+  return tmp.length;
+}
+
+function check(name: string, factory: (i: number) => any): void {
+  let bad = 0;
+  const notes: string[] = [];
+  for (let i = 0; i < N; i++) {
+    const c: any = factory(i);
+    const want = "c" + i + ":480";
+    let got: any;
+    try {
+      got = c.run();
+    } catch (error: any) {
+      got = "THREW:" + (error && error.message);
+    }
+    if (got !== want) {
+      bad++;
+      if (bad <= 2) notes.push("[" + i + " got=" + String(got) + "]");
+    }
+  }
+  console.log(name + " bad=" + bad + notes.join(""));
+}
+
+function host(i: number, run: (this: any) => string): any {
+  return { id: i, inner: { def: "c" + i }, run };
+}
+
+check("callbackify_object_thenable", function (i) {
+  return host(i, function (this: any) {
+    let n = 0;
+    const callbackified = util.callbackify(function () {
+      return {
+        then: function (resolve: any, _reject: any) {
+          n = churn();
+          resolve(1);
+        },
+      };
+    } as any);
+    callbackified(function () {});
+    return this.inner.def + ":" + n;
+  });
+});


### PR DESCRIPTION
Fixes #9539

## Symptom

`util.callbackify(fn)(cb)` where `fn` returns an object-literal thenable whose
`then` allocates heavily and resolves synchronously printed every callback's
correct result and then SIGSEGV'd at exit (status 139) inside
`promise::microtasks::pump_protected`. Node v26.8.1 prints the same line and
exits 0. Deterministic on current `main` (5/5 runs, `8d27f7b96`).

## Root cause

`promise::assimilate::assimilate_via_then_property` — and the class-vtable arm
of `js_assimilate_thenable` — do this:

1. allocate a wrapper `Promise`;
2. allocate `resolve` / `reject` closures that capture its address;
3. call the user's `then(resolve, reject)`;
4. NaN-box the wrapper **out of the bare `*mut Promise` Rust local** and return it.

Step 3 runs arbitrary user code. With the moving nursery (default-on) a loop
safepoint inside that `then` body runs an evacuating young collection. The
wrapper itself survives and is relocated: the resolving closures are live, and
their raw-`i64` capture words are pointer-bearing by
`gc::layout::layout_pointer_bearing_bits`, so the collector rewrites them — which
is why `resolve(1)` correctly settles the promise at its **new** address.

The Rust local is not a GC root and nothing rewrites it, so step 4 returned the
**pre-collection** address, i.e. retired from-space.

`callbackify_outer_thunk` then took that word, classified it
(`promise_ptr_from_value` → `js_value_is_promise` reads its GC header), rooted
it, and called `js_promise_attach_handlers` on it. A dead promise entered the
reaction/task plumbing, and the exit-time microtask checkpoint dereferenced it —
hence a crash in `pump_protected` even though every callback had already
produced the right answer.

Two independent measurements pin this:

* `PERRY_GC_PROTECT_FROMSPACE=1` on the unfixed build faults at
  `cmpb $0x5,-0x8(%rbp)` inside `callbackify_outer_thunk` (the `obj_type ==
  GC_TYPE_PROMISE` test of `js_value_is_promise`) and reports
  `RETIRED FROM-SPACE … last-known object: obj_type=5 size=80` — a `Promise`.
* `PERRY_GC_MOVING_LOOP_POLLS=0` makes even the **unfixed** build exit 0. Turning
  off the moving minor inside loops removes the relocation, and the bug with it.

## The fix, and why the root stays valid

Every value that outlives an allocation or a user-JS call in these functions is
now held in a `gc::RuntimeHandleScope` handle, and every later use re-reads
through the handle instead of a cached local.

A `RuntimeHandleSlot` is a **mutable** GC root: `scan_runtime_handle_roots_mut`
hands each slot to the collector's `RuntimeRootVisitor` as a writable location
(`visit_tagged_usize_slot` / `visit_nanbox_u64_slot`), so an evacuating minor
both keeps the object alive and writes the forwarded address back into the slot.
Reading `promise_handle.get_raw_mut_ptr::<Promise>()` after the callback
therefore yields the post-collection address by construction — the same
mechanism `#7497` and `#9445` already rely on elsewhere in this module. Handle
scopes also survive a JS throw out of the callback: `longjmp` skips `Drop`, and
`runtime_handle_stack_restore` truncates the stack at the trap's savepoint.

Covered by this change:

* `assimilate_via_then_property` — the wrapper promise (the crashing one), the
  thenable receiver, the `then` action, the two resolving closures, and the
  early rejected-wrapper return.
* `js_assimilate_thenable`'s vtable arm — the same shape, same fix.
* `callbackify_outer_thunk` — `returned` across its two `js_closure_alloc`
  calls, across `js_assimilate_thenable` (which runs the user `then`), and at
  each later use.
* `callable_then_field` — the receiver across the `"then"` intern, which
  allocates before the raw object pointer is used.

## Baseline vs fixed

Compiler built from this worktree, `x86_64` Linux (`perrymaster`), gap fixture
`test-files/test_gap_9539_callbackify_thenable_exit_gc.ts` (6,000 iterations).

| mode | unfixed `main` | this branch |
|---|---|---|
| default GC | `rc=139` 5/5 | `rc=0` 10/10 (and 5/5 on the final committed-tree build) |
| `PERRY_GC_PROTECT_FROMSPACE=1` | `rc=139` 3/3 | `rc=0` 5/5 |
| `PERRY_GC_SCAVENGE_NURSERY_MB=1` | `rc=139` 3/3 | `rc=0` 5/5 |
| `PERRY_GC_FORCE_EVACUATE=1` | `rc=139` 3/3 | `rc=0` 5/5 |
| `PERRY_GC_MOVING_SAFEPOINT=0` | `rc=139` 3/3 | `rc=0` 5/5 |
| `PERRY_GC_MOVING_LOOP_POLLS=0` | `rc=0` 3/3 (control) | `rc=0` 5/5 |

Every passing run prints node's `callbackify_object_thenable bad=0`; node
v26.8.1 prints the same and exits 0.

The new unit test fails on the unfixed runtime with exactly the defect's
signature:

```
assertion `left == right` failed: assimilation must return the wrapper the
resolving closure settled, not its pre-collection address
  left: Pending
 right: Fulfilled
```

## Test commands

```bash
# repro / fix
cargo build --release -p perry-runtime-static -p perry-stdlib-static -p perry
./target/release/perry compile \
  test-files/test_gap_9539_callbackify_thenable_exit_gc.ts \
  -o /tmp/perry-9539 --no-cache
for i in $(seq 1 10); do /tmp/perry-9539; echo "rc=$?"; done
PERRY_GC_PROTECT_FROMSPACE=1  /tmp/perry-9539; echo "rc=$?"
PERRY_GC_SCAVENGE_NURSERY_MB=1 /tmp/perry-9539; echo "rc=$?"
PERRY_GC_FORCE_EVACUATE=1     /tmp/perry-9539; echo "rc=$?"
PERRY_GC_MOVING_LOOP_POLLS=0  /tmp/perry-9539; echo "rc=$?"   # control

# parity
./run_parity_tests.sh --filter test_gap_9539_callbackify_thenable_exit_gc   # 1/1 PASS
./run_parity_tests.sh --filter promisify                                    # PASS
./run_parity_tests.sh --filter thenable                                     # PASS
./run_parity_tests.sh --filter promise                                      # 24/26, see below

# unit tests
cargo test -p perry-runtime --lib -- --test-threads=1 \
  gc::tests::runtime_roots::thenable_assimilation
cargo test -p perry-runtime --lib -- --test-threads=1 promise
cargo test -p perry-runtime --lib -- --test-threads=1 gc::tests::runtime_roots
cargo test -p perry-runtime --lib -- --test-threads=1        # 3011 passed, 0 failed

# gates
cargo fmt -p perry-runtime -- --check
git diff --check
bash scripts/check_file_size.sh
python3 scripts/check_gc_scanner_latches.py
python3 scripts/check_gc_env_knobs.py
python3 scripts/check_gc_doc_claims.py
python3 scripts/check_cross_thread_promise_provenance.py
```

`--filter promise` is 24 pass / 2 fail. Both failures are **node-side** and
pre-existing in this environment: `test_issue_4449_thread_promise_void` and
`test_issue_859_native_promise_pin` exit 1 under node with
`ERR_MODULE_NOT_FOUND` (`perry/thread`, `argon2` — this worktree has no
`node_modules`), while Perry's arm produces the expected output in both. They
cannot be affected by a change to the Rust runtime.

## No version bump

No `Cargo.toml`, `Cargo.lock`, `package.json` or any other version/packaging file
is touched. `git diff --name-only origin/main...HEAD`:

```
changelog.d/9595-thenable-assimilation-wrapper-rooting.md
crates/perry-runtime/src/gc/tests/runtime_roots.rs
crates/perry-runtime/src/gc/tests/runtime_roots/thenable_assimilation.rs
crates/perry-runtime/src/promise/assimilate.rs
crates/perry-runtime/src/promise/combinators.rs
crates/perry-runtime/src/util_promisify.rs
test-files/test_gap_9539_callbackify_thenable_exit_gc.ts
```

https://claude.ai/code/session_01Wxt5JHraqLoMdUCPVkX1hJ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a crash in `util.callbackify` when callbacks return object-based thenables.
  - Improved promise and thenable handling during garbage collection, preventing invalid results and failures when callbacks resolve synchronously.
  - Ensured callbackified results remain correct during heavy allocation activity and queued promise processing.

- **Tests**
  - Added regression coverage for callbackified thenables, forced garbage collection, and repeated allocation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->