### PR TITLE
Merge train: #9612 (opt-in Bun platform global)

### DIFF
--- a/changelog.d/9599-bun-platform-global.md
+++ b/changelog.d/9599-bun-platform-global.md
@@ -1,0 +1,10 @@
+# Bun platform global namespace
+
+`perry compile --platform bun` now installs a real, stable
+`globalThis.Bun` object. Bare `Bun`, direct calls, extracted and destructured
+methods, optional chaining, and computed property access share the same native
+module registry. The namespace also exposes Perry-defined `version` and
+`isStandaloneExecutable` metadata.
+
+The default `--platform node` behavior is unchanged: `typeof Bun` remains
+`"undefined"`, preserving Node/Bun feature detection in existing bundles.

--- a/crates/perry-api-manifest/src/entries/part_4.rs
+++ b/crates/perry-api-manifest/src/entries/part_4.rs
@@ -1114,6 +1114,8 @@ pub(crate) const API_MANIFEST_PART_4: &[ApiEntry] = &[
     property("bun", "stdin"),
     property("bun", "stdout"),
     property("bun", "stderr"),
+    property("bun", "version"),
+    property("bun", "isStandaloneExecutable"),
     // --- qs (issue #8751) ---
     // Native nested query-string codec. This keeps Stripe's request encoder
     // off qs' legacy get-intrinsic/ES-shims dependency chain.

--- a/crates/perry-codegen/src/expr/helpers.rs
+++ b/crates/perry-codegen/src/expr/helpers.rs
@@ -667,6 +667,7 @@ pub(crate) fn is_global_this_builtin_name(name: &str) -> bool {
             | "crypto"
             | "localStorage"
             | "sessionStorage"
+            | "Bun"
     )
 }
 
@@ -699,6 +700,7 @@ pub(crate) fn is_global_this_builtin_function_name(name: &str) -> bool {
                 | "crypto"
                 | "localStorage"
                 | "sessionStorage"
+                | "Bun"
         )
 }
 

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -775,6 +775,7 @@ fn should_cache_native_module_namespace(module_name: &str) -> bool {
         "assert/strict"
             | "async_hooks"
             | "async_hooks.default"
+            | "bun"
             | "constants"
             | "constants.default"
             // #5263: cache the top-level namespace objects whose dynamic
@@ -997,13 +998,17 @@ unsafe fn native_module_property_by_name_impl(
     if module_name == "url" && property_name == "URLPattern" {
         return js_get_global_this_builtin_value(b"URLPattern".as_ptr(), "URLPattern".len());
     }
-    // #6560 — Bun globals shim pack: `Bun.stdin` / `Bun.stdout` / `Bun.stderr`
-    // are object-valued reads (BunFile-like handles built by `bun_compat`).
+    // #6560/#9599 — Bun globals shim pack. The stdio properties are
+    // BunFile-like handles built by `bun_compat`. In Bun platform mode the
+    // compiler installs this namespace on globalThis, so the metadata below is
+    // deliberately Perry-specific rather than pretending to be a Bun runtime.
     if module_name == "bun" {
         match property_name {
             "stdin" => return crate::bun_compat::js_bun_stdin(),
             "stdout" => return crate::bun_compat::js_bun_stdout(),
             "stderr" => return crate::bun_compat::js_bun_stderr(),
+            "version" => return native_string_value(env!("CARGO_PKG_VERSION")),
+            "isStandaloneExecutable" => return crate::embedded::is_standalone_executable_value(),
             _ => {}
         }
     }

--- a/crates/perry-runtime/src/object/native_module/callable_export_arity_table.rs
+++ b/crates/perry-runtime/src/object/native_module/callable_export_arity_table.rs
@@ -2,6 +2,11 @@
 #[cfg(test)]
 fn native_callable_export_arity_reference(module: &str, prop: &str) -> Option<u32> {
     match (module, prop) {
+        // Bun global/module surface (#9599).
+        ("bun", "Glob" | "file" | "fileURLToPath" | "hash" | "pathToFileURL" | "stringWidth") => {
+            Some(1)
+        }
+        ("bun", "write") => Some(2),
         // bun:ffi (#6562).
         ("bun:ffi", "dlopen") => Some(2),
         ("bun:ffi", "ptr" | "CString" | "CFunction" | "linkSymbols") => Some(1),
@@ -276,6 +281,18 @@ static CALLABLE_EXPORT_ARITY_TABLE: &[(&str, &[(&str, u32)])] = &[
             ("executionAsyncId", 0),
             ("executionAsyncResource", 0),
             ("triggerAsyncId", 0),
+        ],
+    ),
+    (
+        "bun",
+        &[
+            ("Glob", 1),
+            ("file", 1),
+            ("fileURLToPath", 1),
+            ("hash", 1),
+            ("pathToFileURL", 1),
+            ("stringWidth", 1),
+            ("write", 2),
         ],
     ),
     (

--- a/crates/perry-runtime/src/object/native_module/callable_export_check.rs
+++ b/crates/perry-runtime/src/object/native_module/callable_export_check.rs
@@ -35,6 +35,14 @@ pub(crate) fn is_native_module_callable_export_reference(module: &str, prop: &st
     if module == "fs" && matches!(prop, "lchmod" | "lchmodSync") {
         return crate::fs::lchmod_is_callable_on_this_platform();
     }
+    if module == "bun"
+        && matches!(
+            prop,
+            "Glob" | "file" | "fileURLToPath" | "hash" | "pathToFileURL" | "stringWidth" | "write"
+        )
+    {
+        return true;
+    }
     // bun:ffi (#6562). `FFIType` and `suffix` are constants, not callables;
     // the not-yet-supported exports are callable so they throw their
     // stage-1 error instead of "undefined is not a function".

--- a/crates/perry-runtime/src/object/native_module/callable_export_table.rs
+++ b/crates/perry-runtime/src/object/native_module/callable_export_table.rs
@@ -82,6 +82,18 @@ pub(super) static CALLABLE_EXPORT_TABLE: &[(&str, &[&str])] = &[
         ],
     ),
     (
+        "bun",
+        &[
+            "Glob",
+            "file",
+            "fileURLToPath",
+            "hash",
+            "pathToFileURL",
+            "stringWidth",
+            "write",
+        ],
+    ),
+    (
         "bun:ffi",
         &[
             "CFunction",

--- a/crates/perry-runtime/src/object/native_module/module_keys.rs
+++ b/crates/perry-runtime/src/object/native_module/module_keys.rs
@@ -1626,6 +1626,22 @@ pub(crate) fn native_module_enumerable_keys(module_name: &str) -> Option<&'stati
             b"default",
         ]),
         "sqlite.constants" => Some(SQLITE_CONSTANTS_KEYS),
+        // #9599: the opt-in globalThis.Bun object and `import * as bun from
+        // "bun"` share this one enumerable native-module surface.
+        "bun" => Some(&[
+            b"Glob",
+            b"file",
+            b"fileURLToPath",
+            b"hash",
+            b"isStandaloneExecutable",
+            b"pathToFileURL",
+            b"stderr",
+            b"stdin",
+            b"stdout",
+            b"stringWidth",
+            b"version",
+            b"write",
+        ]),
         // bun:ffi (#6562) — stage-1 surface plus the declared-but-throwing
         // exports (their reads resolve to callables that raise the stage-1
         // error).

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -676,6 +676,26 @@ fn collect_module_one(
     };
     *next_class_id = new_next_class_id; // Update the global class_id counter
 
+    // #9599: Bun platform mode is a real global mode, not merely a direct-call
+    // syntax rewrite. Seed `globalThis.Bun` before every module initializer so
+    // dependency code can observe it before the entry module runs. The native
+    // namespace is cached by the runtime, making every idempotent assignment
+    // install the same object and preserving `Bun === globalThis.Bun`.
+    if ctx.bun_platform {
+        hir_module.init.insert(
+            0,
+            perry_hir::Stmt::Expr(perry_hir::Expr::PropertySet {
+                object: Box::new(perry_hir::Expr::PropertyGet {
+                    object: Box::new(perry_hir::Expr::GlobalGet(0)),
+                    property: "globalThis".to_string(),
+                    byte_offset: 0,
+                }),
+                property: "Bun".to_string(),
+                value: Box::new(perry_hir::Expr::NativeModuleRef("bun".to_string())),
+            }),
+        );
+    }
+
     // Preserve native result types before async lowering splits awaited values
     // across synthetic locals. The later global fixup remains for inlined code.
     perry_hir::fix_local_native_instances(&mut hir_module);

--- a/crates/perry/src/commands/compile/run_pipeline.rs
+++ b/crates/perry/src/commands/compile/run_pipeline.rs
@@ -734,6 +734,7 @@ pub fn run_with_parse_cache(
         .unwrap_or_else(|| PathBuf::from("."));
 
     let mut ctx = CompilationContext::new(project_root.clone());
+    ctx.bun_platform = args.platform == JavaScriptPlatform::Bun;
     ctx.cache_root = object_cache_project_root(&args.input, &project_root);
     let explain_lowering = if args.explain_lowering {
         Some(lowering_report::ExplainLoweringRun::prepare(

--- a/crates/perry/src/commands/compile/types.rs
+++ b/crates/perry/src/commands/compile/types.rs
@@ -13,6 +13,16 @@ use std::path::PathBuf;
 use perry_hir::{Module as HirModule, ModuleKind};
 use serde::{Deserialize, Serialize};
 
+/// JavaScript host compatibility surface exposed to compiled code.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, clap::ValueEnum)]
+pub enum JavaScriptPlatform {
+    /// Preserve Perry's Node-compatible globals (the historical default).
+    #[default]
+    Node,
+    /// Install a real `globalThis.Bun` namespace backed by Perry's Bun shims.
+    Bun,
+}
+
 /// Result of a successful compilation
 pub struct CompileResult {
     pub output_path: PathBuf,
@@ -111,6 +121,11 @@ pub struct CompileArgs {
     /// for the full target table.
     #[arg(long)]
     pub target: Option<String>,
+
+    /// JavaScript host compatibility platform. `node` keeps the historical
+    /// global surface; `bun` installs a stable `globalThis.Bun` namespace.
+    #[arg(long, value_enum, default_value_t)]
+    pub platform: JavaScriptPlatform,
 
     /// C library / linkage for Linux targets: `glibc` (default, dynamic) or
     /// `musl` (fully static). `--libc musl` upgrades a Linux target
@@ -607,6 +622,9 @@ pub struct CompilationContext {
     /// `WebAssembly.*` usage OR the user passed `--enable-wasm-runtime`).
     /// Issue #76.
     pub needs_wasm_runtime: bool,
+    /// Whether this build exposes Perry's Bun compatibility namespace as the
+    /// real `Bun` / `globalThis.Bun` global. Off by default.
+    pub bun_platform: bool,
     /// Whether perry/ui module is imported (needs UI library linking).
     /// On the harmonyos target this is forced back to false after the
     /// destructive Phase-2 ArkUI harvest (see `harmonyos_index_ets`) — UI
@@ -1163,6 +1181,7 @@ impl CompilationContext {
             declaration_sidecars: BTreeMap::new(),
             import_map: BTreeMap::new(),
             needs_wasm_runtime: false,
+            bun_platform: false,
             needs_ui: false,
             harmonyos_index_ets: None,
             needs_plugins: false,

--- a/crates/perry/src/commands/dev.rs
+++ b/crates/perry/src/commands/dev.rs
@@ -289,6 +289,7 @@ fn build_once(
         no_codegen: false,
         enable_wasm_runtime: false,
         target: None,
+        platform: super::compile::JavaScriptPlatform::Node,
         libc: None,
         march: None,
         app_bundle_id: None,

--- a/crates/perry/src/commands/run/mod.rs
+++ b/crates/perry/src/commands/run/mod.rs
@@ -201,6 +201,7 @@ pub fn run(args: RunArgs, format: OutputFormat, use_color: bool, verbose: u8) ->
         no_codegen: false,
         enable_wasm_runtime: args.enable_wasm_runtime,
         target: target.clone(),
+        platform: super::compile::JavaScriptPlatform::Node,
         libc: args.libc.clone(),
         march: None,
         app_bundle_id: Some(bundle_id),

--- a/crates/perry/tests/issue_9599_bun_platform.rs
+++ b/crates/perry/tests/issue_9599_bun_platform.rs
@@ -1,0 +1,139 @@
+//! #9599 — opt-in Bun platform mode with a real global namespace.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile(dir: &Path, platform: Option<&str>) -> PathBuf {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    let mut command = Command::new(perry_bin());
+    command
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output);
+    if let Some(platform) = platform {
+        command.arg("--platform").arg(platform);
+    }
+    let compile = command.output().expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    output
+}
+
+fn run(output: &Path, dir: &Path) -> String {
+    let run = Command::new(output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+#[test]
+fn node_platform_keeps_bun_global_absent() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("main.ts"),
+        r#"
+console.log(typeof Bun);
+console.log(typeof globalThis.Bun);
+console.log(typeof globalThis["Bun"]);
+"#,
+    )
+    .expect("write entry");
+
+    let output = compile(dir.path(), None);
+    assert_eq!(
+        run(&output, dir.path()),
+        "undefined\nundefined\nundefined\n"
+    );
+}
+
+#[test]
+fn bun_platform_installs_one_shared_namespace_for_every_access_form() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("dependency.ts"),
+        r#"
+export const dependencySawBun = globalThis.Bun === Bun;
+console.log("dependency", typeof Bun, dependencySawBun);
+"#,
+    )
+    .expect("write dependency");
+    std::fs::write(
+        dir.path().join("main.ts"),
+        r#"
+import { dependencySawBun } from "./dependency.ts";
+
+console.log(typeof Bun);
+console.log(Bun === globalThis.Bun);
+console.log(Bun === globalThis["Bun"]);
+console.log(dependencySawBun);
+
+console.log(typeof Bun.hash);
+const extracted = Bun.stringWidth;
+console.log(extracted("abc"));
+const { stringWidth } = Bun;
+console.log(stringWidth("abcd"));
+const key = "file";
+console.log(typeof Bun[key]);
+console.log(Bun?.stringWidth?.("abcde"));
+
+console.log(typeof Bun.version, Bun.version.length > 0);
+console.log(Bun.isStandaloneExecutable);
+console.log(typeof Bun.notImplemented);
+const keys = Object.keys(Bun);
+console.log(keys.includes("stringWidth"), keys.includes("version"));
+
+try {
+  Bun.serve();
+} catch (error: any) {
+  console.log(error.message === "Bun.serve is not supported by Perry");
+}
+
+function scoped() {
+  const Bun = { stringWidth: (_value: string) => 99 };
+  return Bun.stringWidth("shadowed");
+}
+console.log(scoped());
+"#,
+    )
+    .expect("write entry");
+
+    let output = compile(dir.path(), Some("bun"));
+    let expected = "\
+dependency object true
+object
+true
+true
+true
+function
+3
+4
+function
+5
+string true
+true
+undefined
+true true
+true
+99
+";
+    assert_eq!(run(&output, dir.path()), expected);
+}

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 2067 entries across 136 modules
+// Coverage: 2069 entries across 136 modules
 
 type PerryI8 = number & { readonly __perryI8?: never };
 type PerryI16 = number & { readonly __perryI16?: never };
@@ -343,11 +343,15 @@ declare module "buffer" {
 
 declare module "bun" {
   /** stdlib */
+  export const isStandaloneExecutable: any;
+  /** stdlib */
   export const stderr: any;
   /** stdlib */
   export const stdin: any;
   /** stdlib */
   export const stdout: any;
+  /** stdlib */
+  export const version: any;
   /** stdlib */
   export function Glob(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 3020 entries across 138 modules.
+Total: 3022 entries across 138 modules.
 
 ## Modules
 
@@ -431,9 +431,11 @@ Total: 3020 entries across 138 modules.
 
 ### Properties
 
+- `isStandaloneExecutable`
 - `stderr`
 - `stdin`
 - `stdout`
+- `version`
 
 ## `bun:ffi`
 

--- a/docs/src/cli/flags.md
+++ b/docs/src/cli/flags.md
@@ -74,6 +74,7 @@ Use `--output-type` to change what's produced:
 | Flag | Description |
 |---|---|
 | `-o, --output <PATH>` | Output executable, bundle, shared library, archive, or object path. |
+| `--platform node\|bun` | Select the JavaScript host global surface. `node` is the default; `bun` installs a real, stable `Bun === globalThis.Bun` namespace. |
 | `--libc glibc\|musl` | Select Linux libc/linkage; `musl` upgrades the corresponding Linux target to a fully static headless build. |
 | `--app-bundle-id <ID>` | Bundle identifier required by home-screen widget targets. |
 | `--bundle-extensions <DIR>` | Discover and statically bundle native extension packages from a directory. |
@@ -85,6 +86,20 @@ Use `--output-type` to change what's produced:
 | `--harmonyos-cert <PATH>` | HarmonyOS application certificate chain. |
 | `--harmonyos-profile <PATH>` | HarmonyOS signed provisioning profile. |
 | `--harmonyos-key-alias <NAME>` | HarmonyOS keystore alias; defaults to `debugKey`. |
+
+### Bun platform mode
+
+`perry compile app.ts --platform bun` exposes Perry's implemented Bun APIs
+through one real global namespace. Direct calls, extracted or destructured
+methods, optional chaining, and computed property reads all resolve through the
+same `Bun` object. The default `node` mode preserves the historical behavior:
+`typeof Bun` remains `"undefined"`, while Perry's existing direct Bun shims and
+imports from `"bun"` continue to work.
+
+In this mode, `Bun.version` is Perry's runtime crate version, not a claimed Bun
+release number. `Bun.isStandaloneExecutable` is always `true`, because Perry
+produces standalone binaries. Unsupported properties are absent; a direct call
+to an unsupported `Bun.*` member raises Perry's Bun compatibility error.
 
 ## Embedding Assets
 


### PR DESCRIPTION
Lands #9612 (opt-in `--platform bun`: a cached native-module namespace installed as the real `Bun === globalThis.Bun` global before module init; node default unchanged; unsupported members keep the precise compat error).

Validation: release build green; RUST_TEST_THREADS=1 perry-runtime green; issue_9599_bun_platform 9/9 and issue_6560_bun_globals 2/2; lint gates green. Rebase-merge preserving authorship.
