### PR TITLE
perf(wasm): publish wasmi's linear memory to JS instead of copying it both ways on every call (#9611)

### DIFF
--- a/changelog.d/9620-wasm-zero-copy-linear-memory.md
+++ b/changelog.d/9620-wasm-zero-copy-linear-memory.md
@@ -1,0 +1,10 @@
+### wasm: exported calls no longer copy the whole linear memory both ways
+
+`WebAssembly.Memory.prototype.buffer` now exposes the engine's linear memory
+directly instead of a copy synchronised around every exported call, so a JS
+write through `new Uint8Array(memory.buffer)` lands in wasm memory and a wasm
+write is visible to JS with nothing copied in either direction. A
+`memory.grow` still hands out a fresh `ArrayBuffer` and detaches the old one,
+as node does. Exports also resolve to a handle once per instance rather than
+by name on every call. A call is now flat in memory size — 169 ns at 4.3 MiB,
+down from 162 µs (#9611).

--- a/crates/perry-runtime/src/buffer/header.rs
+++ b/crates/perry-runtime/src/buffer/header.rs
@@ -971,7 +971,8 @@ pub(crate) fn buffer_alloc_foreign(data: *mut u8, length: u32) -> *mut BufferHea
 /// bytes live inline after its header and cannot be re-pointed. Returns
 /// whether the rebind happened.
 ///
-/// Gated with `webassembly`, its only caller: the default runtime build does
+/// Gated with `wasm-host`, whose module is its only caller: the default
+/// runtime build does
 /// not compile the wasm host shims, and an ungated helper would be dead code
 /// there.
 #[cfg(feature = "wasm-host")]

--- a/crates/perry-runtime/src/buffer/header.rs
+++ b/crates/perry-runtime/src/buffer/header.rs
@@ -959,6 +959,44 @@ pub(crate) fn buffer_alloc_foreign(data: *mut u8, length: u32) -> *mut BufferHea
     ptr
 }
 
+/// Re-point a foreign-backed wrapper at a new span, in place.
+///
+/// [`buffer_alloc_foreign`] hands out a wrapper whose bytes live in memory the
+/// caller owns. When that memory MOVES the wrapper has to follow it or every
+/// later read dereferences freed memory: wasmi's linear memory is a `Vec<u8>`
+/// that reallocates when wasm executes `memory.grow`, and the JS-visible
+/// `WebAssembly.Memory.prototype.buffer` is a foreign wrapper over it (#9611).
+///
+/// Only touches a wrapper that really is foreign-backed — a plain buffer's
+/// bytes live inline after its header and cannot be re-pointed. Returns
+/// whether the rebind happened.
+///
+/// Gated with `webassembly`, its only caller: the default runtime build does
+/// not compile the wasm host shims, and an ungated helper would be dead code
+/// there.
+#[cfg(feature = "wasm-host")]
+pub(crate) fn rebind_foreign_buffer(addr: usize, data: *mut u8, length: u32) -> bool {
+    if FOREIGN_BACKING_EVER_REGISTERED.is_idle() {
+        return false;
+    }
+    let rebound = FOREIGN_BACKING_REGISTRY.with(|r| {
+        let mut r = r.borrow_mut();
+        if !r.contains_key(&addr) {
+            return false;
+        }
+        r.insert(addr, data as usize);
+        true
+    });
+    if rebound {
+        unsafe {
+            let header = addr as *mut BufferHeader;
+            (*header).length = length;
+            (*header).capacity = length;
+        }
+    }
+    rebound
+}
+
 #[inline]
 fn foreign_backing(addr: usize) -> Option<usize> {
     if FOREIGN_BACKING_EVER_REGISTERED.is_idle() {

--- a/crates/perry-runtime/src/buffer/mod.rs
+++ b/crates/perry-runtime/src/buffer/mod.rs
@@ -66,6 +66,9 @@ pub(crate) use header::{
     buffer_alloc_foreign, collect_dead_registered_buffers_post_trace,
     finalize_collected_dead_buffer, is_foreign_backed_buffer,
 };
+// Only the wasm host re-points a foreign wrapper (#9611); see the fn's docs.
+#[cfg(feature = "wasm-host")]
+pub(crate) use header::rebind_foreign_buffer;
 #[cfg(test)]
 pub(crate) use header::{
     test_buffer_addr_window_bounds, test_buffer_registry_probe_count, test_data_view_registry_len,

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -958,6 +958,12 @@ pub fn gc_init() {
     reg_scanner!(crate::bun_ffi::scan_bun_ffi_roots_mut);
     #[cfg(feature = "node-api-host")]
     reg_scanner!(crate::node_api_host::scan_node_api_roots_mut);
+    // #9611: `WebAssembly.Memory.prototype.buffer` is a foreign-backed wrapper
+    // over the engine's linear memory, and the wasm binding table keys it by
+    // address so an import boundary can re-point it after a `memory.grow`.
+    // Metadata-only: the buffer's real owner is the Memory object.
+    #[cfg(feature = "wasm-host")]
+    reg_scanner!(crate::webassembly::scan_wasm_memory_binding_roots_mut);
     reg_budgeted_scanner!(
         crate::object::scan_class_side_table_roots_mut,
         crate::object::scan_class_side_table_roots_mut_step,

--- a/crates/perry-runtime/src/gc/tests/buffer_side_tables.rs
+++ b/crates/perry-runtime/src/gc/tests/buffer_side_tables.rs
@@ -321,3 +321,36 @@ fn test_buffer_own_props_table_drains_after_owners_die() {
          remain, expected at most the pre-test {base}"
     );
 }
+
+/// The invariant that makes every address-keyed buffer registry legitimate in
+/// the first place: a `BufferHeader` is never relocated, so its address is a
+/// stable key for the object's whole lifetime and only DEATH (the pruning the
+/// rest of this file tests) can invalidate an entry.
+///
+/// Nothing pinned this before, and a great deal rests on it: `bun:ffi`'s
+/// pointer-lifetime contract hands `ptr(view)` to native code and documents
+/// the address as stable for the lifetime of the JS object
+/// (`bun_ffi/mod.rs`); `FOREIGN_BACKING_REGISTRY`, `VIEW_REGISTRY`,
+/// `BACKING_TO_VIEWS`, `DETACHED_BUFFER_REGISTRY` and the identity registries
+/// above are all keyed by that address; and #9611 publishes
+/// `WebAssembly.Memory.prototype.buffer` as a foreign-backed wrapper whose
+/// address the wasm binding table keys. Flipping either type to `movable`
+/// invalidates all of them at once, silently — this test is where that shows
+/// up instead.
+///
+/// Movability is enforced in two places, and both are what this asserts
+/// through: `gc_type_is_movable` gates the per-object and the block-granular
+/// old-page evacuation paths (`gc/oldgen.rs`), and buffers are born in the old
+/// arena as `TENURED`, so no copying minor ever sees one either.
+#[test]
+fn test_buffer_headers_are_never_relocated() {
+    assert!(
+        !crate::gc::types::gc_type_is_movable(crate::gc::GC_TYPE_BUFFER),
+        "GC_TYPE_BUFFER must stay non-movable: every buffer registry is keyed \
+         by the header address, and bun:ffi hands that address to native code"
+    );
+    assert!(
+        !crate::gc::types::gc_type_is_movable(crate::gc::GC_TYPE_TYPED_ARRAY),
+        "GC_TYPE_TYPED_ARRAY must stay non-movable for the same reason"
+    );
+}

--- a/crates/perry-runtime/src/webassembly.rs
+++ b/crates/perry-runtime/src/webassembly.rs
@@ -715,6 +715,36 @@ impl Drop for ActiveInstanceGuard {
     }
 }
 
+/// Rewrite the published-buffer address in [`WASM_MEMORY_BINDINGS`] if the
+/// collector ever relocates a `BufferHeader`. Registered in `gc_init`.
+///
+/// The address is a metadata KEY, not an ownership root, so this visits it
+/// with `visit_metadata_usize_slot` — rewritten when forwarded, never marked.
+/// Marking from here would be wrong twice over: the buffer is already strongly
+/// held by the `WebAssembly.Memory` object's own `buffer` property for as long
+/// as any export closure (and therefore any caller that can reach this table)
+/// is alive, and an entry lives as long as its instance, so marking would pin
+/// a buffer whose JS owner has died.
+///
+/// It rewrites nothing today. `GC_TYPE_BUFFER` is declared `movable: false`
+/// (`gc/types.rs`), both old-page evacuation paths bail on
+/// `!gc_type_is_movable` (`gc/oldgen.rs`), and `buffer_alloc_foreign` allocates
+/// straight into the old arena as `TENURED`, so no copying minor sees one
+/// either — the same guarantee `bun_ffi`'s pointer-lifetime contract already
+/// rests on. It is registered anyway so that this table is not what breaks if
+/// that flag is ever flipped, and so the holder is covered by a scanner rather
+/// than by a verdict that would silently rot on the day it changed.
+pub(crate) fn scan_wasm_memory_binding_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    // Safe to take unconditionally: every allocating call in this module sits
+    // OUTSIDE the `with` block that borrows this map, so a collection can
+    // never land while the borrow is held.
+    WASM_MEMORY_BINDINGS.with(|bindings| {
+        for binding in bindings.borrow_mut().values_mut() {
+            visitor.visit_metadata_usize_slot(&mut binding.buffer);
+        }
+    });
+}
+
 fn instance_memory_span(inst: *mut c_void) -> (*mut u8, usize) {
     let mut len = 0usize;
     let data = unsafe { perry_wasm_host_instance_memory_span(inst, &mut len) };

--- a/crates/perry-runtime/src/webassembly.rs
+++ b/crates/perry-runtime/src/webassembly.rs
@@ -204,12 +204,11 @@ extern "C" {
     fn perry_wasm_host_instance_set_import_context(inst: *mut c_void, import_context: u64);
     #[allow(dead_code)]
     fn perry_wasm_host_instance_drop(inst: *mut c_void);
-    fn perry_wasm_host_instance_memory_len(inst: *mut c_void) -> usize;
-    fn perry_wasm_host_instance_memory_copy(inst: *mut c_void, out: *mut u8, len: usize) -> usize;
-    fn perry_wasm_host_instance_memory_write(
+    fn perry_wasm_host_instance_memory_span(inst: *mut c_void, out_len: *mut usize) -> *mut u8;
+    fn perry_wasm_host_instance_export_handle(
         inst: *mut c_void,
-        data: *const u8,
-        len: usize,
+        name: *const c_char,
+        name_len: usize,
     ) -> usize;
     fn perry_wasm_host_instance_table_len(
         inst: *mut c_void,
@@ -238,6 +237,18 @@ extern "C" {
         inst: *mut c_void,
         name: *const c_char,
         name_len: usize,
+        arg_kinds: *const u8,
+        arg_bits: *const u64,
+        arg_count: usize,
+        out_kinds: *mut u8,
+        out_bits: *mut u64,
+        out_capacity: usize,
+        out_count: *mut usize,
+        out_err: *mut *mut c_char,
+    ) -> i32;
+    fn perry_wasm_host_call_export_by_handle(
+        inst: *mut c_void,
+        handle: usize,
         arg_kinds: *const u8,
         arg_bits: *const u64,
         arg_count: usize,
@@ -643,80 +654,175 @@ pub extern "C" fn js_webassembly_module_custom_sections(module_jsval: f64, name_
     arr.get_nanbox_f64()
 }
 
-fn copy_instance_memory(inst: *mut c_void, buffer: f64) {
-    let ptr = unbox_pointer(buffer) as *mut crate::buffer::BufferHeader;
-    if ptr.is_null() || !crate::buffer::is_array_buffer(ptr as usize) {
-        return;
-    }
-    let len = unsafe { (*ptr).length.max(0) as usize };
-    unsafe {
-        perry_wasm_host_instance_memory_copy(inst, crate::buffer::buffer_data_mut(ptr), len);
+// ── Zero-copy linear memory (#9611) ──────────────────────────────────────
+//
+// `WebAssembly.Memory.prototype.buffer` is a foreign-backed `ArrayBuffer`
+// wrapper pointed straight at wasmi's linear memory, so neither direction
+// copies: a JS store through `new Uint8Array(memory.buffer)` lands in wasm
+// memory, and a wasm store is visible to JS with no synchronisation at all.
+// Before this, every exported call memcpy'd the WHOLE linear memory in and
+// then back out, which made one call cost 0.11 ns per byte of memory — 44,000x
+// node once llhttp's memory had grown to a few MiB.
+//
+// The one thing that can invalidate the published span is `memory.grow`, which
+// reallocates wasmi's backing `Vec` and can move it. Growth can only happen
+// while wasm is executing, so the span is re-read (a pointer and a length
+// compare, no copying) at the two boundaries where JS can observe it again:
+// when an exported call returns, and when wasm calls back into a JS import.
+struct MemoryBinding {
+    /// `BufferHeader` currently published as `memory.buffer`.
+    buffer: usize,
+    /// The wasmi span that buffer is pointed at.
+    data: usize,
+    len: usize,
+    /// The span moved mid-call and the published buffer was re-pointed at it
+    /// in place. The buffer still has to be REPLACED when the call unwinds —
+    /// node hands out a fresh `ArrayBuffer` after a grow and detaches the old
+    /// one, which is the signal glue code (wasm-bindgen) uses to rebuild its
+    /// cached views.
+    rebound: bool,
+}
+
+crate::perry_thread_local! {
+    /// `instance handle -> the memory span published to JS`. An entry lives as
+    /// long as its instance, which today is the process: the runtime never
+    /// calls `perry_wasm_host_instance_drop`, so an instance address is never
+    /// recycled under a live binding.
+    static WASM_MEMORY_BINDINGS: std::cell::RefCell<crate::fast_hash::PtrHashMap<usize, MemoryBinding>> =
+        std::cell::RefCell::new(crate::fast_hash::new_ptr_hash_map());
+    /// Instances with an exported call on the stack, innermost last. Only
+    /// these can have grown their memory since JS last looked.
+    static ACTIVE_WASM_INSTANCES: std::cell::RefCell<Vec<usize>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+/// Pushes an instance onto [`ACTIVE_WASM_INSTANCES`] for the duration of one
+/// exported call, popping it however the call leaves.
+struct ActiveInstanceGuard;
+
+impl ActiveInstanceGuard {
+    fn enter(inst: *mut c_void) -> Self {
+        ACTIVE_WASM_INSTANCES.with(|stack| stack.borrow_mut().push(inst as usize));
+        ActiveInstanceGuard
     }
 }
 
-fn write_instance_memory(inst: *mut c_void, buffer: f64) {
-    let ptr = unbox_pointer(buffer) as *mut crate::buffer::BufferHeader;
-    if ptr.is_null() || !crate::buffer::is_array_buffer(ptr as usize) {
-        return;
-    }
-    let len = unsafe { (*ptr).length.max(0) as usize };
-    unsafe {
-        perry_wasm_host_instance_memory_write(inst, crate::buffer::buffer_data_mut(ptr), len);
+impl Drop for ActiveInstanceGuard {
+    fn drop(&mut self) {
+        ACTIVE_WASM_INSTANCES.with(|stack| {
+            stack.borrow_mut().pop();
+        });
     }
 }
 
-fn memory_buffer_value(memory: f64) -> f64 {
-    let scope = crate::gc::RuntimeHandleScope::new();
-    let memory = scope.root_nanbox_f64(memory);
-    let value = JSValue::from_bits(memory.get_nanbox_f64().to_bits());
-    if !value.is_pointer() {
+fn instance_memory_span(inst: *mut c_void) -> (*mut u8, usize) {
+    let mut len = 0usize;
+    let data = unsafe { perry_wasm_host_instance_memory_span(inst, &mut len) };
+    if data.is_null() {
+        return (std::ptr::null_mut(), 0);
+    }
+    // A `BufferHeader` length is an i32-domain byte count; a wasm32 memory can
+    // in principle exceed that, and the excess simply stays invisible to JS
+    // rather than wrapping the header's length.
+    (data, len.min(i32::MAX as usize))
+}
+
+/// Allocate the `ArrayBuffer` that exposes `data[..len]` — wasmi's own linear
+/// memory — and record it as the instance's published span.
+fn publish_memory_buffer(inst: *mut c_void, data: *mut u8, len: usize) -> f64 {
+    let buffer = crate::buffer::buffer_alloc_foreign(data, len as u32);
+    if buffer.is_null() {
         return nanbox_undefined();
     }
-    let key = scope.root_string_ptr(named_key(b"buffer"));
-    key.with_const_ptr(|key: *const crate::string::StringHeader| {
-        crate::object::js_object_get_field_by_name_f64(
-            JSValue::from_bits(memory.get_nanbox_f64().to_bits())
-                .as_pointer::<crate::object::ObjectHeader>(),
-            key,
-        )
-    })
+    crate::buffer::mark_as_array_buffer(buffer as usize);
+    WASM_MEMORY_BINDINGS.with(|bindings| {
+        bindings.borrow_mut().insert(
+            inst as usize,
+            MemoryBinding {
+                buffer: buffer as usize,
+                data: data as usize,
+                len,
+                rebound: false,
+            },
+        );
+    });
+    crate::value::js_nanbox_pointer(buffer as i64)
 }
 
-fn sync_memory_to_wasm(inst: *mut c_void, memory: f64) {
-    write_instance_memory(inst, memory_buffer_value(memory));
+/// Re-point every active instance's published buffer at its current linear
+/// memory. Called before wasm re-enters JS through an imported function: wasm
+/// may have grown the memory since the buffer was published, and the JS import
+/// handler is about to read and write `memory.buffer` (this is exactly what
+/// wasm-bindgen glue does), which without this would dereference the `Vec`
+/// allocation the grow freed.
+///
+/// The published buffer keeps its identity here — swapping in a fresh
+/// `ArrayBuffer` needs the `WebAssembly.Memory` object, which this path does
+/// not hold — and the `rebound` flag defers that to the end of the call.
+fn rebind_active_wasm_memories() {
+    ACTIVE_WASM_INSTANCES.with(|stack| {
+        let active = stack.borrow();
+        for &inst in active.iter() {
+            let (data, len) = instance_memory_span(inst as *mut c_void);
+            if data.is_null() {
+                continue;
+            }
+            WASM_MEMORY_BINDINGS.with(|bindings| {
+                let mut bindings = bindings.borrow_mut();
+                let Some(binding) = bindings.get_mut(&inst) else {
+                    return;
+                };
+                if binding.data == data as usize && binding.len == len {
+                    return;
+                }
+                if crate::buffer::rebind_foreign_buffer(binding.buffer, data, len as u32) {
+                    binding.data = data as usize;
+                    binding.len = len;
+                    binding.rebound = true;
+                }
+            });
+        }
+    });
 }
 
-fn sync_memory_from_wasm(inst: *mut c_void, memory: f64) {
+/// Bring `memory.buffer` back in sync with the instance's linear memory after
+/// an exported call. In the overwhelmingly common case — the call did not grow
+/// the memory — this is one pointer and one length compare and nothing else.
+///
+/// After a grow it does what node does: publish a FRESH `ArrayBuffer` over the
+/// new span and detach the old one, so a JS view captured before the grow
+/// reports `byteLength === 0` instead of aliasing a freed allocation.
+fn resync_memory_after_call(inst: *mut c_void, memory: f64) {
+    let (data, len) = instance_memory_span(inst);
+    if data.is_null() {
+        return;
+    }
+    let stale =
+        WASM_MEMORY_BINDINGS.with(|bindings| match bindings.borrow().get(&(inst as usize)) {
+            Some(binding) => binding.rebound || binding.data != data as usize || binding.len != len,
+            None => true,
+        });
+    if !stale {
+        return;
+    }
     let scope = crate::gc::RuntimeHandleScope::new();
     let memory = scope.root_nanbox_f64(memory);
     let memory_value = JSValue::from_bits(memory.get_nanbox_f64().to_bits());
     if !memory_value.is_pointer() {
         return;
     }
-    let host_len = unsafe { perry_wasm_host_instance_memory_len(inst) };
-    if host_len == 0 || host_len > i32::MAX as usize {
-        return;
+    let previous = WASM_MEMORY_BINDINGS
+        .with(|bindings| bindings.borrow().get(&(inst as usize)).map(|b| b.buffer))
+        .unwrap_or(0);
+    let buffer = scope.root_nanbox_f64(publish_memory_buffer(inst, data, len));
+    let memory_ptr = JSValue::from_bits(memory.get_nanbox_f64().to_bits())
+        .as_pointer::<crate::object::ObjectHeader>()
+        as *mut crate::object::ObjectHeader;
+    let _ = object_set(memory_ptr, b"buffer", buffer.get_nanbox_f64());
+    let replacement = unbox_pointer(buffer.get_nanbox_f64()) as usize;
+    if previous != 0 && previous != replacement {
+        crate::buffer::detach_array_buffer(previous);
     }
-    let old_buffer = scope.root_nanbox_f64(memory_buffer_value(memory.get_nanbox_f64()));
-    let old_ptr = unbox_pointer(old_buffer.get_nanbox_f64()) as *mut crate::buffer::BufferHeader;
-    let old_len = if !old_ptr.is_null() && crate::buffer::is_array_buffer(old_ptr as usize) {
-        unsafe { (*old_ptr).length.max(0) as usize }
-    } else {
-        0
-    };
-    let buffer = if old_len == host_len {
-        old_buffer.get_nanbox_f64()
-    } else {
-        let new_buffer = scope.root_nanbox_f64(crate::value::js_nanbox_pointer(
-            crate::buffer::js_array_buffer_new(host_len as i32) as i64,
-        ));
-        let memory_ptr = JSValue::from_bits(memory.get_nanbox_f64().to_bits())
-            .as_pointer::<crate::object::ObjectHeader>()
-            as *mut crate::object::ObjectHeader;
-        let _ = object_set(memory_ptr, b"buffer", new_buffer.get_nanbox_f64());
-        new_buffer.get_nanbox_f64()
-    };
-    copy_instance_memory(inst, buffer);
 }
 
 unsafe extern "C" fn call_wasm_import(
@@ -739,6 +845,11 @@ unsafe extern "C" fn call_wasm_import(
     {
         return 0;
     }
+
+    // wasm may have grown its memory before reaching this import, which
+    // reallocates wasmi's backing store; the JS handler is about to read and
+    // write `memory.buffer`, so re-point it at the live span first (#9611).
+    rebind_active_wasm_memories();
 
     let scope = crate::gc::RuntimeHandleScope::new();
     let imports = scope.root_nanbox_f64(f64::from_bits(context));
@@ -818,12 +929,24 @@ fn call_captured_wasm_export(closure: *const crate::closure::ClosureHeader, args
     let memory = scope.root_nanbox_f64(crate::closure::js_closure_get_capture_f64(closure, 2));
     let instance = scope.root_nanbox_f64(crate::closure::js_closure_get_capture_f64(closure, 3));
     let imports = scope.root_nanbox_f64(crate::closure::js_closure_get_capture_f64(closure, 4));
+    let handle = crate::closure::js_closure_get_capture_f64(closure, 5) as usize;
     unsafe {
         perry_wasm_host_instance_set_import_context(inst, imports.get_nanbox_f64().to_bits())
     };
-    sync_memory_to_wasm(inst, memory.get_nanbox_f64());
-    let result = call_export_n(nanbox_pointer_raw(inst), name.get_nanbox_f64(), args);
-    sync_memory_from_wasm(inst, memory.get_nanbox_f64());
+    let result = {
+        let _active = ActiveInstanceGuard::enter(inst);
+        if handle != 0 {
+            call_export_by_handle(inst, handle, args)
+        } else {
+            call_export_n(nanbox_pointer_raw(inst), name.get_nanbox_f64(), args)
+        }
+    };
+    // A module with no exported memory has nothing to resync, and asking the
+    // host for a span it does not have would put an FFI call back on a hot
+    // path that no longer needs one.
+    if JSValue::from_bits(memory.get_nanbox_f64().to_bits()).is_pointer() {
+        resync_memory_after_call(inst, memory.get_nanbox_f64());
+    }
     let mut exit_code = 0;
     if unsafe { perry_wasm_host_instance_take_exit_code(inst, &mut exit_code) } != 0 {
         let instance = unbox_pointer(instance.get_nanbox_f64()) as *mut crate::object::ObjectHeader;
@@ -890,7 +1013,13 @@ fn make_export_function(
         3 => (js_wasm_export_call_3 as *const u8, 3),
         _ => (js_wasm_export_call_4 as *const u8, 4),
     };
-    let closure = scope.root_raw_mut_ptr(crate::closure::js_closure_alloc(func_ptr, 5));
+    // Resolve the export ONCE here rather than by name on every call: the
+    // per-call `get_func` probe plus `FuncType` clone was the sub-microsecond
+    // floor left under the linear-memory copy this binding removed (#9611).
+    let handle = unsafe {
+        perry_wasm_host_instance_export_handle(inst, name.as_ptr() as *const c_char, name.len())
+    };
+    let closure = scope.root_raw_mut_ptr(crate::closure::js_closure_alloc(func_ptr, 6));
     if closure
         .get_raw_mut_ptr::<crate::closure::ClosureHeader>()
         .is_null()
@@ -905,6 +1034,7 @@ fn make_export_function(
     crate::closure::js_closure_set_capture_f64(closure_ptr, 2, memory.get_nanbox_f64());
     crate::closure::js_closure_set_capture_f64(closure_ptr, 3, instance.get_nanbox_f64());
     crate::closure::js_closure_set_capture_f64(closure_ptr, 4, imports.get_nanbox_f64());
+    crate::closure::js_closure_set_capture_f64(closure_ptr, 5, handle as f64);
     crate::object::set_bound_native_closure_name(
         closure_ptr,
         std::str::from_utf8(name).unwrap_or("wasm"),
@@ -1135,14 +1265,11 @@ fn make_export_table(inst: *mut c_void, name: &[u8]) -> f64 {
 fn make_instance_value(module: *mut c_void, inst: *mut c_void, imports: f64, receiver: f64) -> f64 {
     let scope = crate::gc::RuntimeHandleScope::new();
     let imports = scope.root_nanbox_f64(imports);
-    let memory_len = unsafe { perry_wasm_host_instance_memory_len(inst) };
-    let memory = if memory_len == 0 {
+    let (memory_data, memory_len) = instance_memory_span(inst);
+    let memory = if memory_data.is_null() {
         scope.root_nanbox_f64(nanbox_undefined())
     } else {
-        let buffer = scope.root_nanbox_f64(crate::value::js_nanbox_pointer(
-            crate::buffer::js_array_buffer_new(memory_len.min(i32::MAX as usize) as i32) as i64,
-        ));
-        copy_instance_memory(inst, buffer.get_nanbox_f64());
+        let buffer = scope.root_nanbox_f64(publish_memory_buffer(inst, memory_data, memory_len));
         let object = scope.root_raw_mut_ptr(crate::object::js_object_alloc(0, 0));
         let object = object.with_mut_ptr(|object: *mut crate::object::ObjectHeader| {
             object_set(object, b"buffer", buffer.get_nanbox_f64())
@@ -1327,14 +1454,27 @@ pub extern "C" fn js_webassembly_instantiate(bytes_jsval: f64, imports_jsval: f6
 ///
 /// Args > 4 are silently truncated in this MVP — the codegen-side wiring
 /// only routes 0-4 args anyway.
+/// `WebAssembly.callExport(...)` — the ahead-of-time lowering
+/// (`Expr::WebAssemblyCallExport`), which reaches an export without the
+/// closure that owns the instance's `WebAssembly.Memory` object. The call can
+/// still grow the memory, so the published buffer is re-pointed at the live
+/// span in place; only the closure path can additionally hand out a fresh
+/// `ArrayBuffer` (it is the one that holds the memory object).
+fn call_export_named_rebinding(inst_jsval: f64, name_jsval: f64, args: &[f64]) -> f64 {
+    let _active = ActiveInstanceGuard::enter(unbox_pointer(inst_jsval));
+    let result = call_export_n(inst_jsval, name_jsval, args);
+    rebind_active_wasm_memories();
+    result
+}
+
 #[no_mangle]
 pub extern "C" fn js_webassembly_call_export_0(inst_jsval: f64, name_jsval: f64) -> f64 {
-    call_export_n(inst_jsval, name_jsval, &[])
+    call_export_named_rebinding(inst_jsval, name_jsval, &[])
 }
 
 #[no_mangle]
 pub extern "C" fn js_webassembly_call_export_1(inst_jsval: f64, name_jsval: f64, a: f64) -> f64 {
-    call_export_n(inst_jsval, name_jsval, &[a])
+    call_export_named_rebinding(inst_jsval, name_jsval, &[a])
 }
 
 #[no_mangle]
@@ -1344,7 +1484,7 @@ pub extern "C" fn js_webassembly_call_export_2(
     a: f64,
     b: f64,
 ) -> f64 {
-    call_export_n(inst_jsval, name_jsval, &[a, b])
+    call_export_named_rebinding(inst_jsval, name_jsval, &[a, b])
 }
 
 #[no_mangle]
@@ -1355,7 +1495,7 @@ pub extern "C" fn js_webassembly_call_export_3(
     b: f64,
     c: f64,
 ) -> f64 {
-    call_export_n(inst_jsval, name_jsval, &[a, b, c])
+    call_export_named_rebinding(inst_jsval, name_jsval, &[a, b, c])
 }
 
 #[no_mangle]
@@ -1367,7 +1507,112 @@ pub extern "C" fn js_webassembly_call_export_4(
     c: f64,
     d: f64,
 ) -> f64 {
-    call_export_n(inst_jsval, name_jsval, &[a, b, c, d])
+    call_export_named_rebinding(inst_jsval, name_jsval, &[a, b, c, d])
+}
+
+/// The most arguments any exported-function shim forwards
+/// (`js_wasm_export_call_4` / `js_webassembly_call_export_4`). Keeping the
+/// marshalling buffers on the stack keeps a Wasm call allocation-free.
+const MAX_WASM_ARGS: usize = 4;
+const MAX_WASM_RESULTS: usize = 16;
+
+/// Encode JS numbers as wasm values.
+///
+/// Every input arg arrives as an f64. An f64 that round-trips through i32
+/// exactly is sent as an i32 — that covers `add(2, 3)` on an i32 export
+/// without making the caller think about wasm signatures — and everything else
+/// is sent as an f64. The host re-coerces against the export's real signature.
+fn encode_wasm_args(
+    args: &[f64],
+    kinds: &mut [u8; MAX_WASM_ARGS],
+    bits: &mut [u64; MAX_WASM_ARGS],
+) {
+    for (index, v) in args.iter().take(MAX_WASM_ARGS).enumerate() {
+        let as_i32 = *v as i32;
+        if (as_i32 as f64) == *v && v.is_finite() {
+            kinds[index] = WASM_VAL_KIND_I32;
+            bits[index] = as_i32 as u32 as u64;
+        } else {
+            kinds[index] = WASM_VAL_KIND_F64;
+            bits[index] = v.to_bits();
+        }
+    }
+}
+
+fn decode_wasm_value(kind: u8, bits: u64) -> f64 {
+    match kind {
+        WASM_VAL_KIND_I32 => (bits as u32 as i32) as f64,
+        WASM_VAL_KIND_I64 => (bits as i64) as f64,
+        WASM_VAL_KIND_F32 => f32::from_bits(bits as u32) as f64,
+        WASM_VAL_KIND_F64 => f64::from_bits(bits),
+        _ => nanbox_undefined(),
+    }
+}
+
+/// Decode a call's results: no result is `undefined`, one is the value itself,
+/// and several become an array (wasm multi-value).
+fn decode_wasm_results(
+    out_kinds: &[u8; MAX_WASM_RESULTS],
+    out_bits: &[u64; MAX_WASM_RESULTS],
+    out_count: usize,
+) -> f64 {
+    match out_count {
+        0 => nanbox_undefined(),
+        1 => decode_wasm_value(out_kinds[0], out_bits[0]),
+        count => {
+            let scope = crate::gc::RuntimeHandleScope::new();
+            let array = scope.root_nanbox_f64(array_value(crate::array::js_array_alloc(
+                count.min(MAX_WASM_RESULTS) as u32,
+            )));
+            for index in 0..count.min(MAX_WASM_RESULTS) {
+                let array_ptr = JSValue::from_bits(array.get_nanbox_f64().to_bits())
+                    .as_pointer::<crate::array::ArrayHeader>()
+                    as *mut crate::array::ArrayHeader;
+                let array_ptr = crate::array::js_array_push_f64(
+                    array_ptr,
+                    decode_wasm_value(out_kinds[index], out_bits[index]),
+                );
+                array.set_nanbox_f64(array_value(array_ptr));
+            }
+            array.get_nanbox_f64()
+        }
+    }
+}
+
+/// Call an export the instance resolved at construction time (#9611). Same
+/// marshalling as [`call_export_n`], without the per-call name lookup.
+fn call_export_by_handle(inst: *mut c_void, handle: usize, args: &[f64]) -> f64 {
+    let mut kinds = [WASM_VAL_KIND_NONE; MAX_WASM_ARGS];
+    let mut bits = [0u64; MAX_WASM_ARGS];
+    encode_wasm_args(args, &mut kinds, &mut bits);
+    let arg_count = args.len().min(MAX_WASM_ARGS);
+
+    let mut out_kinds = [WASM_VAL_KIND_NONE; MAX_WASM_RESULTS];
+    let mut out_bits = [0u64; MAX_WASM_RESULTS];
+    let mut out_count = 0usize;
+    let mut err: *mut c_char = std::ptr::null_mut();
+    let ok = unsafe {
+        perry_wasm_host_call_export_by_handle(
+            inst,
+            handle,
+            kinds.as_ptr(),
+            bits.as_ptr(),
+            arg_count,
+            out_kinds.as_mut_ptr(),
+            out_bits.as_mut_ptr(),
+            MAX_WASM_RESULTS,
+            &mut out_count,
+            &mut err,
+        )
+    };
+    if ok == 0 {
+        emit_error_to_stderr("WebAssembly.RuntimeError", err);
+        return nanbox_undefined();
+    }
+    if !err.is_null() {
+        unsafe { perry_wasm_host_string_free(err) };
+    }
+    decode_wasm_results(&out_kinds, &out_bits, out_count)
 }
 
 fn call_export_n(inst_jsval: f64, name_jsval: f64, args: &[f64]) -> f64 {
@@ -1381,32 +1626,13 @@ fn call_export_n(inst_jsval: f64, name_jsval: f64, args: &[f64]) -> f64 {
         return nanbox_undefined();
     };
 
-    // MVP: every input arg is treated as f64. wasmi's `call` will
-    // coerce/typecheck against the actual signature on the wasm side —
-    // we re-marshal to the right kind here based on the export type.
-    // For simplicity we send everything as F64 and let the host translate.
-    // (Pragmatic for the PoC: most numeric wasm exports are i32/f64; an
-    // f64-encoded i32 round-trips losslessly.)
-    let mut kinds: Vec<u8> = Vec::with_capacity(args.len());
-    let mut bits: Vec<u64> = Vec::with_capacity(args.len());
-    for v in args {
-        // Encode as i32 if the f64 round-trips through i32 exactly, else
-        // as f64. Covers `add(2,3)` (i32 add) without forcing the user to
-        // think about wasm signatures, while still passing real f64s
-        // through faithfully.
-        let as_i32 = *v as i32;
-        if (as_i32 as f64) == *v && v.is_finite() {
-            kinds.push(WASM_VAL_KIND_I32);
-            bits.push(as_i32 as u32 as u64);
-        } else {
-            kinds.push(WASM_VAL_KIND_F64);
-            bits.push(v.to_bits());
-        }
-    }
+    let mut kinds = [WASM_VAL_KIND_NONE; MAX_WASM_ARGS];
+    let mut bits = [0u64; MAX_WASM_ARGS];
+    encode_wasm_args(args, &mut kinds, &mut bits);
+    let arg_count = args.len().min(MAX_WASM_ARGS);
 
-    const MAX_RESULTS: usize = 16;
-    let mut out_kinds = [WASM_VAL_KIND_NONE; MAX_RESULTS];
-    let mut out_bits = [0u64; MAX_RESULTS];
+    let mut out_kinds = [WASM_VAL_KIND_NONE; MAX_WASM_RESULTS];
+    let mut out_bits = [0u64; MAX_WASM_RESULTS];
     let mut out_count = 0usize;
     let mut err: *mut c_char = std::ptr::null_mut();
     let ok = unsafe {
@@ -1416,10 +1642,10 @@ fn call_export_n(inst_jsval: f64, name_jsval: f64, args: &[f64]) -> f64 {
             name_len,
             kinds.as_ptr(),
             bits.as_ptr(),
-            kinds.len(),
+            arg_count,
             out_kinds.as_mut_ptr(),
             out_bits.as_mut_ptr(),
-            MAX_RESULTS,
+            MAX_WASM_RESULTS,
             &mut out_count,
             &mut err,
         )
@@ -1428,37 +1654,9 @@ fn call_export_n(inst_jsval: f64, name_jsval: f64, args: &[f64]) -> f64 {
         emit_error_to_stderr("WebAssembly.RuntimeError", err);
         return nanbox_undefined();
     }
-    let decode = |kind: u8, bits: u64| match kind {
-        WASM_VAL_KIND_I32 => (bits as u32 as i32) as f64,
-        WASM_VAL_KIND_I64 => (bits as i64) as f64,
-        WASM_VAL_KIND_F32 => f32::from_bits(bits as u32) as f64,
-        WASM_VAL_KIND_F64 => f64::from_bits(bits),
-        _ => nanbox_undefined(),
-    };
-    let result = match out_count {
-        0 => nanbox_undefined(),
-        1 => decode(out_kinds[0], out_bits[0]),
-        count => {
-            let scope = crate::gc::RuntimeHandleScope::new();
-            let array = scope.root_nanbox_f64(array_value(crate::array::js_array_alloc(
-                count.min(MAX_RESULTS) as u32,
-            )));
-            for index in 0..count.min(MAX_RESULTS) {
-                let array_ptr = JSValue::from_bits(array.get_nanbox_f64().to_bits())
-                    .as_pointer::<crate::array::ArrayHeader>()
-                    as *mut crate::array::ArrayHeader;
-                let array_ptr = crate::array::js_array_push_f64(
-                    array_ptr,
-                    decode(out_kinds[index], out_bits[index]),
-                );
-                array.set_nanbox_f64(array_value(array_ptr));
-            }
-            array.get_nanbox_f64()
-        }
-    };
     // Avoid leaking the unused err buffer on success.
     if !err.is_null() {
         unsafe { perry_wasm_host_string_free(err) };
     }
-    result
+    decode_wasm_results(&out_kinds, &out_bits, out_count)
 }

--- a/crates/perry-wasm-host/src/lib.rs
+++ b/crates/perry-wasm-host/src/lib.rs
@@ -848,6 +848,11 @@ pub extern "C" fn perry_wasm_host_instance_memory_len(inst: *mut WasmInstanceHan
 /// where wasm could have grown the memory since (see
 /// `perry-runtime`'s `rebind_active_wasm_memories`).
 ///
+/// Takes a SHARED borrow of the instance, so it is safe to call from inside an
+/// imported function while wasmi still has the `Store` borrowed for the
+/// enclosing call — the same re-entrancy the table accessors rely on. Only
+/// MUTATING re-entry has to be deferred (see `ACTIVE_INSTANCE_TABLES`).
+///
 /// Returns null with `*out_len == 0` when the instance exports no memory.
 #[no_mangle]
 pub extern "C" fn perry_wasm_host_instance_memory_span(

--- a/crates/perry-wasm-host/src/lib.rs
+++ b/crates/perry-wasm-host/src/lib.rs
@@ -15,7 +15,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use wasmi::{Engine, ExternRef, ExternType, Linker, Module, Ref, Store, Table, Val, ValType};
+use wasmi::{Engine, ExternRef, ExternType, Func, Linker, Module, Ref, Store, Table, Val, ValType};
 
 /// Numeric WebAssembly value. MVP supports only the four core numeric types;
 /// `externref` / `funcref` / `v128` are out of scope (see issue #76, "Open
@@ -61,6 +61,30 @@ struct InstanceInner {
     /// Keep the module alive for the lifetime of the instance so `engine` /
     /// `module` references stay valid.
     _module: WasmModuleHandle,
+    /// Exports resolved once and then called by index (#9611). Resolving by
+    /// name on every call cost a `Map<Box<str>, Extern>` probe plus a
+    /// `FuncType` clone plus two `Vec` allocations for the argument and result
+    /// buffers — roughly the whole sub-microsecond floor of a Wasm call once
+    /// the linear-memory copy was gone.
+    exports: Vec<CachedExport>,
+    /// `export name -> index into `exports``.
+    export_handles: HashMap<String, usize>,
+    /// The exported linear memory, resolved once. The embedder re-reads its
+    /// span after every call to notice a `memory.grow`, so a by-name
+    /// `get_memory` there would put a string lookup back on the hot path
+    /// (#9611).
+    memory: Option<wasmi::Memory>,
+}
+
+/// One resolved export: the `Func` handle, its signature, and the argument /
+/// result buffers reused across calls so a steady-state call allocates nothing.
+struct CachedExport {
+    name: String,
+    func: Func,
+    params: Box<[ValType]>,
+    results: Box<[ValType]>,
+    args: Vec<Val>,
+    outs: Vec<Val>,
 }
 
 struct WasmHostState {
@@ -348,11 +372,15 @@ fn instantiate_with_import_callback(
     let instance = linker
         .instantiate_and_start(&mut store, &module.0.module)
         .map_err(|e| WasmHostError::Link(e.to_string()))?;
+    let memory = instance.get_memory(&store, "memory");
     Ok(WasmInstanceHandle {
         inner: Box::new(InstanceInner {
             store,
             instance,
             _module: module.clone(),
+            exports: Vec::new(),
+            export_handles: HashMap::new(),
+            memory,
         }),
     })
 }
@@ -378,57 +406,112 @@ fn coerce_numeric_value(value: WasmVal, expected: ValType) -> Option<Val> {
 /// returned in declaration order. wasm-bindgen uses multi-value returns for
 /// pointer/length pairs, so preserving only the first result is not enough for
 /// real generated glue.
-pub fn call_export(
-    inst: &mut WasmInstanceHandle,
-    name: &str,
-    args: &[WasmVal],
-) -> Result<Vec<WasmVal>, WasmHostError> {
-    let func = inst
-        .inner
-        .instance
-        .get_func(&inst.inner.store, name)
-        .ok_or_else(|| WasmHostError::InvalidExport(name.to_string()))?;
-
+/// Resolve an export function to a cache index, resolving by name at most
+/// once per instance. `None` when the instance has no function export by that
+/// name.
+fn resolve_export(inst: &mut WasmInstanceHandle, name: &str) -> Option<usize> {
+    if let Some(&index) = inst.inner.export_handles.get(name) {
+        return Some(index);
+    }
+    let func = inst.inner.instance.get_func(&inst.inner.store, name)?;
     let ty = func.ty(&inst.inner.store);
-    let params = ty.params();
-    if params.len() != args.len() {
-        return Err(WasmHostError::Runtime(format!(
-            "{name}: arity mismatch (export expects {}, got {})",
-            params.len(),
-            args.len()
-        )));
+    let index = inst.inner.exports.len();
+    inst.inner.exports.push(CachedExport {
+        name: name.to_string(),
+        func,
+        params: ty.params().to_vec().into_boxed_slice(),
+        results: ty.results().to_vec().into_boxed_slice(),
+        args: Vec::new(),
+        outs: Vec::new(),
+    });
+    inst.inner.export_handles.insert(name.to_string(), index);
+    Some(index)
+}
+
+/// Call a previously resolved export. Results are left in the cached entry's
+/// `outs` buffer, which stays valid until the next call on the same export.
+fn call_resolved_export(
+    inst: &mut WasmInstanceHandle,
+    index: usize,
+    args: &[WasmVal],
+) -> Result<(), WasmHostError> {
+    {
+        let entry = inst
+            .inner
+            .exports
+            .get_mut(index)
+            .ok_or_else(|| WasmHostError::InvalidExport(format!("export handle {index}")))?;
+        if entry.params.len() != args.len() {
+            return Err(WasmHostError::Runtime(format!(
+                "{}: arity mismatch (export expects {}, got {})",
+                entry.name,
+                entry.params.len(),
+                args.len()
+            )));
+        }
+        entry.args.clear();
+        for (value, expected) in args.iter().copied().zip(entry.params.iter().copied()) {
+            let coerced = coerce_numeric_value(value, expected).ok_or_else(|| {
+                WasmHostError::UnsupportedSignature(format!(
+                    "{}: unsupported parameter type {expected:?}",
+                    entry.name
+                ))
+            })?;
+            entry.args.push(coerced);
+        }
+        entry.outs.clear();
+        entry
+            .outs
+            .extend(entry.results.iter().copied().map(Val::default));
     }
 
-    let wasmi_args: Vec<Val> = args
-        .iter()
-        .copied()
-        .zip(ty.params().iter().copied())
-        .map(|(value, expected)| {
-            coerce_numeric_value(value, expected).ok_or_else(|| {
-                WasmHostError::UnsupportedSignature(format!(
-                    "{name}: unsupported parameter type {expected:?}"
-                ))
-            })
-        })
-        .collect::<Result<_, _>>()?;
-    let mut results: Vec<Val> = ty.results().iter().copied().map(Val::default).collect();
     begin_instance_call(inst);
-    let call_result = func.call(&mut inst.inner.store, &wasmi_args, &mut results);
+    let call_result = {
+        // Split the borrow: the call needs the store mutably while reading the
+        // cached argument buffer and filling the cached result buffer, and all
+        // three are disjoint fields of the same `InstanceInner`.
+        let inner = &mut *inst.inner;
+        let CachedExport {
+            func, args, outs, ..
+        } = &mut inner.exports[index];
+        func.call(&mut inner.store, args, outs)
+    };
     let table_result = finish_instance_call(inst);
     call_result.map_err(|e| WasmHostError::Runtime(e.to_string()))?;
     table_result?;
+    Ok(())
+}
 
-    results
+/// Decode the results of the most recent [`call_resolved_export`].
+fn resolved_export_results(
+    inst: &WasmInstanceHandle,
+    index: usize,
+) -> Result<Vec<WasmVal>, WasmHostError> {
+    let entry = &inst.inner.exports[index];
+    entry
+        .outs
         .iter()
         .map(|value| {
             WasmVal::from_wasmi(value).ok_or_else(|| {
                 WasmHostError::UnsupportedSignature(format!(
-                    "{name}: unsupported result type {:?}",
+                    "{}: unsupported result type {:?}",
+                    entry.name,
                     value.ty()
                 ))
             })
         })
         .collect()
+}
+
+pub fn call_export(
+    inst: &mut WasmInstanceHandle,
+    name: &str,
+    args: &[WasmVal],
+) -> Result<Vec<WasmVal>, WasmHostError> {
+    let index =
+        resolve_export(inst, name).ok_or_else(|| WasmHostError::InvalidExport(name.to_string()))?;
+    call_resolved_export(inst, index, args)?;
+    resolved_export_results(inst, index)
 }
 
 // ────────────────────────────────────────────────────────────────────────
@@ -754,6 +837,38 @@ pub extern "C" fn perry_wasm_host_instance_memory_len(inst: *mut WasmInstanceHan
         .unwrap_or(0)
 }
 
+/// Return the base pointer and byte length of the exported `memory`, i.e. the
+/// live wasmi linear memory itself rather than a copy of it (#9611).
+///
+/// The embedder publishes this span as the bytes of the JavaScript-visible
+/// `WebAssembly.Memory.prototype.buffer`, so a JS write lands in wasm memory
+/// and a wasm write is visible to JS with no copying on either side. The span
+/// is only valid until the instance next executes `memory.grow`, which
+/// reallocates wasmi's backing store: callers must re-read it at every point
+/// where wasm could have grown the memory since (see
+/// `perry-runtime`'s `rebind_active_wasm_memories`).
+///
+/// Returns null with `*out_len == 0` when the instance exports no memory.
+#[no_mangle]
+pub extern "C" fn perry_wasm_host_instance_memory_span(
+    inst: *mut WasmInstanceHandle,
+    out_len: *mut usize,
+) -> *mut u8 {
+    if !out_len.is_null() {
+        unsafe { *out_len = 0 };
+    }
+    let Some(inst) = (unsafe { inst.as_ref() }) else {
+        return std::ptr::null_mut();
+    };
+    let Some(memory) = inst.inner.memory else {
+        return std::ptr::null_mut();
+    };
+    if !out_len.is_null() {
+        unsafe { *out_len = memory.data_size(&inst.inner.store) };
+    }
+    memory.data_ptr(&inst.inner.store)
+}
+
 /// Copy the exported `memory` into caller-provided storage.
 #[no_mangle]
 pub extern "C" fn perry_wasm_host_instance_memory_copy(
@@ -1039,11 +1154,33 @@ pub const WASM_VAL_KIND_NONE: u8 = 0xFF;
 /// (i32/f32 widened, i64/f64 as-is). On success writes every result into the
 /// parallel output arrays and sets `*out_count`. On error returns 0 and writes
 /// `*out_err`.
+/// Resolve an export function to a stable handle so repeated calls skip the
+/// by-name lookup and the `FuncType` clone (#9611). Returns 0 when the
+/// instance has no function export by that name; any other value is an opaque
+/// handle for [`perry_wasm_host_call_export_by_handle`].
 #[no_mangle]
-pub extern "C" fn perry_wasm_host_call_export(
+pub extern "C" fn perry_wasm_host_instance_export_handle(
     inst: *mut WasmInstanceHandle,
     name: *const c_char,
     name_len: usize,
+) -> usize {
+    if inst.is_null() || name.is_null() {
+        return 0;
+    }
+    let inst = unsafe { &mut *inst };
+    let name_bytes = unsafe { slice::from_raw_parts(name as *const u8, name_len) };
+    let Ok(name) = std::str::from_utf8(name_bytes) else {
+        return 0;
+    };
+    resolve_export(inst, name).map_or(0, |index| index + 1)
+}
+
+/// Shared marshalling for both C call paths: decode the argument arrays, run
+/// the export, and encode the results into the caller's output arrays.
+#[allow(clippy::too_many_arguments)]
+fn call_export_c_abi(
+    inst: &mut WasmInstanceHandle,
+    index: usize,
     arg_kinds: *const u8,
     arg_bits: *const u64,
     arg_count: usize,
@@ -1053,26 +1190,6 @@ pub extern "C" fn perry_wasm_host_call_export(
     out_count: *mut usize,
     out_err: *mut *mut c_char,
 ) -> i32 {
-    if inst.is_null()
-        || name.is_null()
-        || out_count.is_null()
-        || (out_capacity != 0 && (out_kinds.is_null() || out_bits.is_null()))
-    {
-        capture_err(out_err, WasmHostError::Runtime("null arg".into()));
-        return 0;
-    }
-    let inst = unsafe { &mut *inst };
-    let name_bytes = unsafe { slice::from_raw_parts(name as *const u8, name_len) };
-    let name_str = match std::str::from_utf8(name_bytes) {
-        Ok(s) => s,
-        Err(_) => {
-            capture_err(
-                out_err,
-                WasmHostError::InvalidExport("non-utf8 export name".into()),
-            );
-            return 0;
-        }
-    };
     let kinds = unsafe { slice::from_raw_parts(arg_kinds, arg_count) };
     let bits = unsafe { slice::from_raw_parts(arg_bits, arg_count) };
     let mut args: Vec<WasmVal> = Vec::with_capacity(arg_count);
@@ -1092,38 +1209,136 @@ pub extern "C" fn perry_wasm_host_call_export(
         };
         args.push(v);
     }
-    match call_export(inst, name_str, &args) {
-        Ok(values) if values.len() <= out_capacity => {
-            for (index, value) in values.iter().copied().enumerate() {
-                let (kind, bits) = match value {
-                    WasmVal::I32(value) => (WASM_VAL_KIND_I32, value as u32 as u64),
-                    WasmVal::I64(value) => (WASM_VAL_KIND_I64, value as u64),
-                    WasmVal::F32(value) => (WASM_VAL_KIND_F32, value.to_bits() as u64),
-                    WasmVal::F64(value) => (WASM_VAL_KIND_F64, value.to_bits()),
-                };
-                unsafe {
-                    *out_kinds.add(index) = kind;
-                    *out_bits.add(index) = bits;
-                }
-            }
-            unsafe { *out_count = values.len() };
-            1
-        }
-        Ok(values) => {
-            capture_err(
-                out_err,
-                WasmHostError::UnsupportedSignature(format!(
-                    "{name_str}: {} results exceed host capacity {out_capacity}",
-                    values.len()
-                )),
-            );
-            0
-        }
+    if let Err(e) = call_resolved_export(inst, index, &args) {
+        capture_err(out_err, e);
+        return 0;
+    }
+    let values = match resolved_export_results(inst, index) {
+        Ok(values) => values,
         Err(e) => {
             capture_err(out_err, e);
-            0
+            return 0;
+        }
+    };
+    if values.len() > out_capacity {
+        capture_err(
+            out_err,
+            WasmHostError::UnsupportedSignature(format!(
+                "{}: {} results exceed host capacity {out_capacity}",
+                inst.inner.exports[index].name,
+                values.len()
+            )),
+        );
+        return 0;
+    }
+    for (offset, value) in values.iter().copied().enumerate() {
+        let (kind, bits) = match value {
+            WasmVal::I32(value) => (WASM_VAL_KIND_I32, value as u32 as u64),
+            WasmVal::I64(value) => (WASM_VAL_KIND_I64, value as u64),
+            WasmVal::F32(value) => (WASM_VAL_KIND_F32, value.to_bits() as u64),
+            WasmVal::F64(value) => (WASM_VAL_KIND_F64, value.to_bits()),
+        };
+        unsafe {
+            *out_kinds.add(offset) = kind;
+            *out_bits.add(offset) = bits;
         }
     }
+    unsafe { *out_count = values.len() };
+    1
+}
+
+/// Call an export previously resolved by
+/// [`perry_wasm_host_instance_export_handle`].
+#[no_mangle]
+#[allow(clippy::too_many_arguments)]
+pub extern "C" fn perry_wasm_host_call_export_by_handle(
+    inst: *mut WasmInstanceHandle,
+    handle: usize,
+    arg_kinds: *const u8,
+    arg_bits: *const u64,
+    arg_count: usize,
+    out_kinds: *mut u8,
+    out_bits: *mut u64,
+    out_capacity: usize,
+    out_count: *mut usize,
+    out_err: *mut *mut c_char,
+) -> i32 {
+    if inst.is_null()
+        || handle == 0
+        || out_count.is_null()
+        || (arg_count != 0 && (arg_kinds.is_null() || arg_bits.is_null()))
+        || (out_capacity != 0 && (out_kinds.is_null() || out_bits.is_null()))
+    {
+        capture_err(out_err, WasmHostError::Runtime("null arg".into()));
+        return 0;
+    }
+    let inst = unsafe { &mut *inst };
+    call_export_c_abi(
+        inst,
+        handle - 1,
+        arg_kinds,
+        arg_bits,
+        arg_count,
+        out_kinds,
+        out_bits,
+        out_capacity,
+        out_count,
+        out_err,
+    )
+}
+
+#[no_mangle]
+#[allow(clippy::too_many_arguments)]
+pub extern "C" fn perry_wasm_host_call_export(
+    inst: *mut WasmInstanceHandle,
+    name: *const c_char,
+    name_len: usize,
+    arg_kinds: *const u8,
+    arg_bits: *const u64,
+    arg_count: usize,
+    out_kinds: *mut u8,
+    out_bits: *mut u64,
+    out_capacity: usize,
+    out_count: *mut usize,
+    out_err: *mut *mut c_char,
+) -> i32 {
+    if inst.is_null()
+        || name.is_null()
+        || out_count.is_null()
+        || (arg_count != 0 && (arg_kinds.is_null() || arg_bits.is_null()))
+        || (out_capacity != 0 && (out_kinds.is_null() || out_bits.is_null()))
+    {
+        capture_err(out_err, WasmHostError::Runtime("null arg".into()));
+        return 0;
+    }
+    let inst = unsafe { &mut *inst };
+    let name_bytes = unsafe { slice::from_raw_parts(name as *const u8, name_len) };
+    let name_str = match std::str::from_utf8(name_bytes) {
+        Ok(s) => s,
+        Err(_) => {
+            capture_err(
+                out_err,
+                WasmHostError::InvalidExport("non-utf8 export name".into()),
+            );
+            return 0;
+        }
+    };
+    let Some(index) = resolve_export(inst, name_str) else {
+        capture_err(out_err, WasmHostError::InvalidExport(name_str.to_string()));
+        return 0;
+    };
+    call_export_c_abi(
+        inst,
+        index,
+        arg_kinds,
+        arg_bits,
+        arg_count,
+        out_kinds,
+        out_bits,
+        out_capacity,
+        out_count,
+        out_err,
+    )
 }
 
 #[cfg(test)]
@@ -1172,11 +1387,214 @@ mod tests {
         0x07, 0x08, 0x01, 0x04, 0x63, 0x61, 0x6c, 0x6c, 0x00, 0x01, 0x0a, 0x06, 0x01, 0x04, 0x00,
         0x10, 0x00, 0x0b,
     ];
+    /// A module with an exported memory it can GROW from inside wasm, plus
+    /// byte load/store helpers at a caller-chosen offset:
+    ///
+    /// ```wat
+    /// (module
+    ///   (memory (export "memory") 1)
+    ///   (func (export "load")  (param i32) (result i32) local.get 0 i32.load8_u)
+    ///   (func (export "store") (param i32 i32) local.get 0 local.get 1 i32.store8)
+    ///   (func (export "grow")  (param i32) (result i32) local.get 0 memory.grow))
+    /// ```
+    const GROW_MEMORY_WASM: &[u8] = &[
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x0b, 0x02, 0x60, 0x01, 0x7f, 0x01,
+        0x7f, 0x60, 0x02, 0x7f, 0x7f, 0x00, 0x03, 0x04, 0x03, 0x00, 0x01, 0x00, 0x05, 0x03, 0x01,
+        0x00, 0x01, 0x07, 0x20, 0x04, 0x06, 0x6d, 0x65, 0x6d, 0x6f, 0x72, 0x79, 0x02, 0x00, 0x04,
+        0x6c, 0x6f, 0x61, 0x64, 0x00, 0x00, 0x05, 0x73, 0x74, 0x6f, 0x72, 0x65, 0x00, 0x01, 0x04,
+        0x67, 0x72, 0x6f, 0x77, 0x00, 0x02, 0x0a, 0x1a, 0x03, 0x07, 0x00, 0x20, 0x00, 0x2d, 0x00,
+        0x00, 0x0b, 0x09, 0x00, 0x20, 0x00, 0x20, 0x01, 0x3a, 0x00, 0x00, 0x0b, 0x06, 0x00, 0x20,
+        0x00, 0x40, 0x00, 0x0b,
+    ];
     /// `(module (@custom "meta" "\01\02\03"))`.
     const CUSTOM_WASM: &[u8] = &[
         0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x00, 0x08, 0x04, 0x6d, 0x65, 0x74, 0x61,
         0x01, 0x02, 0x03,
     ];
+
+    fn memory_span(inst: &mut WasmInstanceHandle) -> (*mut u8, usize) {
+        let mut len = 0usize;
+        let ptr = perry_wasm_host_instance_memory_span(inst, &mut len);
+        (ptr, len)
+    }
+
+    /// #9611: the span handed to the embedder IS wasmi's linear memory, not a
+    /// copy of it. Both directions have to be visible with no sync call in
+    /// between — that is the whole point of publishing it as `memory.buffer`.
+    #[test]
+    fn memory_span_aliases_the_live_linear_memory() {
+        let module = compile(GROW_MEMORY_WASM).expect("compile");
+        let mut inst = instantiate(&module).expect("instantiate");
+        let (ptr, len) = memory_span(&mut inst);
+        assert!(!ptr.is_null());
+        assert_eq!(len, 65536);
+
+        // Host write -> wasm read.
+        unsafe { *ptr.add(3) = 7 };
+        assert_eq!(
+            call_export(&mut inst, "load", &[WasmVal::I32(3)]).expect("load"),
+            vec![WasmVal::I32(7)]
+        );
+
+        // Wasm write -> host read.
+        call_export(&mut inst, "store", &[WasmVal::I32(4), WasmVal::I32(9)]).expect("store");
+        assert_eq!(unsafe { *ptr.add(4) }, 9);
+    }
+
+    /// A `memory.grow` executed inside wasm reallocates wasmi's backing store,
+    /// so the previously published span can dangle. The embedder re-reads the
+    /// span at every boundary where JS can observe the memory again; this pins
+    /// that the re-read reports the grown size and preserves the old bytes.
+    #[test]
+    fn memory_span_follows_a_grow_from_inside_wasm() {
+        let module = compile(GROW_MEMORY_WASM).expect("compile");
+        let mut inst = instantiate(&module).expect("instantiate");
+        call_export(&mut inst, "store", &[WasmVal::I32(5), WasmVal::I32(65)]).expect("store");
+        let (_, before) = memory_span(&mut inst);
+
+        assert_eq!(
+            call_export(&mut inst, "grow", &[WasmVal::I32(1)]).expect("grow"),
+            vec![WasmVal::I32(1)],
+            "memory.grow returns the previous size in pages"
+        );
+
+        let (ptr, after) = memory_span(&mut inst);
+        assert_eq!(before, 65536);
+        assert_eq!(after, 131072, "the re-read span reports the grown size");
+        assert_eq!(
+            unsafe { *ptr.add(5) },
+            65,
+            "bytes written before the grow survive it"
+        );
+        // The grown tail is addressable through the re-read span.
+        unsafe { *ptr.add(70000) = 3 };
+        assert_eq!(
+            call_export(&mut inst, "load", &[WasmVal::I32(70000)]).expect("load"),
+            vec![WasmVal::I32(3)]
+        );
+    }
+
+    /// #9611: an export resolves to a handle once and every later call goes by
+    /// index, skipping the by-name `get_func` probe and the `FuncType` clone.
+    #[test]
+    fn export_handles_resolve_once_and_call_by_index() {
+        let module = compile(ADD_WASM).expect("compile");
+        let mut inst = instantiate(&module).expect("instantiate");
+        let name = b"add";
+        let handle = perry_wasm_host_instance_export_handle(
+            &mut inst,
+            name.as_ptr() as *const c_char,
+            name.len(),
+        );
+        assert_ne!(handle, 0);
+        assert_eq!(
+            perry_wasm_host_instance_export_handle(
+                &mut inst,
+                name.as_ptr() as *const c_char,
+                name.len(),
+            ),
+            handle,
+            "re-resolving the same export reuses its cache entry"
+        );
+        let missing = b"nope";
+        assert_eq!(
+            perry_wasm_host_instance_export_handle(
+                &mut inst,
+                missing.as_ptr() as *const c_char,
+                missing.len(),
+            ),
+            0,
+            "an export that does not exist has no handle"
+        );
+
+        // Repeated calls through the cached entry must not leak state between
+        // calls — the argument and result buffers are reused.
+        for (a, b, expected) in [(2, 3, 5), (10, 20, 30), (-1, 1, 0)] {
+            let kinds = [WASM_VAL_KIND_I32, WASM_VAL_KIND_I32];
+            let bits = [a as u32 as u64, b as u32 as u64];
+            let mut out_kinds = [WASM_VAL_KIND_NONE; 4];
+            let mut out_bits = [0u64; 4];
+            let mut out_count = 0usize;
+            let mut err = std::ptr::null_mut();
+            assert_eq!(
+                perry_wasm_host_call_export_by_handle(
+                    &mut inst,
+                    handle,
+                    kinds.as_ptr(),
+                    bits.as_ptr(),
+                    2,
+                    out_kinds.as_mut_ptr(),
+                    out_bits.as_mut_ptr(),
+                    4,
+                    &mut out_count,
+                    &mut err,
+                ),
+                1,
+                "call by handle"
+            );
+            assert_eq!(out_count, 1);
+            assert_eq!(out_kinds[0], WASM_VAL_KIND_I32);
+            assert_eq!(out_bits[0] as u32 as i32, expected);
+        }
+    }
+
+    /// A handle-based call carries the same arity check as the by-name path,
+    /// and a zero handle is rejected rather than indexing the cache.
+    #[test]
+    fn call_by_handle_rejects_a_bad_arity_and_a_null_handle() {
+        let module = compile(ADD_WASM).expect("compile");
+        let mut inst = instantiate(&module).expect("instantiate");
+        let name = b"add";
+        let handle = perry_wasm_host_instance_export_handle(
+            &mut inst,
+            name.as_ptr() as *const c_char,
+            name.len(),
+        );
+        let kinds = [WASM_VAL_KIND_I32];
+        let bits = [1u64];
+        let mut out_kinds = [WASM_VAL_KIND_NONE; 4];
+        let mut out_bits = [0u64; 4];
+        let mut out_count = 0usize;
+        let mut err = std::ptr::null_mut();
+        assert_eq!(
+            perry_wasm_host_call_export_by_handle(
+                &mut inst,
+                handle,
+                kinds.as_ptr(),
+                bits.as_ptr(),
+                1,
+                out_kinds.as_mut_ptr(),
+                out_bits.as_mut_ptr(),
+                4,
+                &mut out_count,
+                &mut err,
+            ),
+            0,
+            "one argument for a two-parameter export must fail"
+        );
+        assert!(!err.is_null());
+        perry_wasm_host_string_free(err);
+
+        let mut err = std::ptr::null_mut();
+        assert_eq!(
+            perry_wasm_host_call_export_by_handle(
+                &mut inst,
+                0,
+                std::ptr::null(),
+                std::ptr::null(),
+                0,
+                out_kinds.as_mut_ptr(),
+                out_bits.as_mut_ptr(),
+                4,
+                &mut out_count,
+                &mut err,
+            ),
+            0,
+            "handle 0 means unresolved"
+        );
+        assert!(!err.is_null());
+        perry_wasm_host_string_free(err);
+    }
 
     #[test]
     fn validate_add_wasm() {

--- a/crates/perry-wasm-host/src/lib.rs
+++ b/crates/perry-wasm-host/src/lib.rs
@@ -1411,6 +1411,30 @@ mod tests {
         0x00, 0x0b, 0x09, 0x00, 0x20, 0x00, 0x20, 0x01, 0x3a, 0x00, 0x00, 0x0b, 0x06, 0x00, 0x20,
         0x00, 0x40, 0x00, 0x0b,
     ];
+    /// Grows the memory and THEN calls an imported function, so the import
+    /// runs with the previously published span already freed:
+    ///
+    /// ```wat
+    /// (module
+    ///   (import "env" "peek" (func $peek (param i32) (result i32)))
+    ///   (memory (export "memory") 1)
+    ///   (func (export "store") (param i32 i32) local.get 0 local.get 1 i32.store8)
+    ///   (func (export "load")  (param i32) (result i32) local.get 0 i32.load8_u)
+    ///   (func (export "growThenPeek") (param i32) (result i32)
+    ///     i32.const 1 memory.grow drop
+    ///     local.get 0 call $peek))
+    /// ```
+    const GROW_THEN_IMPORT_WASM: &[u8] = &[
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x0b, 0x02, 0x60, 0x01, 0x7f, 0x01,
+        0x7f, 0x60, 0x02, 0x7f, 0x7f, 0x00, 0x02, 0x0c, 0x01, 0x03, 0x65, 0x6e, 0x76, 0x04, 0x70,
+        0x65, 0x65, 0x6b, 0x00, 0x00, 0x03, 0x04, 0x03, 0x01, 0x00, 0x00, 0x05, 0x03, 0x01, 0x00,
+        0x01, 0x07, 0x28, 0x04, 0x06, 0x6d, 0x65, 0x6d, 0x6f, 0x72, 0x79, 0x02, 0x00, 0x05, 0x73,
+        0x74, 0x6f, 0x72, 0x65, 0x00, 0x01, 0x04, 0x6c, 0x6f, 0x61, 0x64, 0x00, 0x02, 0x0c, 0x67,
+        0x72, 0x6f, 0x77, 0x54, 0x68, 0x65, 0x6e, 0x50, 0x65, 0x65, 0x6b, 0x00, 0x03, 0x0a, 0x1f,
+        0x03, 0x09, 0x00, 0x20, 0x00, 0x20, 0x01, 0x3a, 0x00, 0x00, 0x0b, 0x07, 0x00, 0x20, 0x00,
+        0x2d, 0x00, 0x00, 0x0b, 0x0b, 0x00, 0x41, 0x01, 0x40, 0x00, 0x1a, 0x20, 0x00, 0x10, 0x00,
+        0x0b,
+    ];
     /// `(module (@custom "meta" "\01\02\03"))`.
     const CUSTOM_WASM: &[u8] = &[
         0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x00, 0x08, 0x04, 0x6d, 0x65, 0x74, 0x61,
@@ -1476,6 +1500,67 @@ mod tests {
         assert_eq!(
             call_export(&mut inst, "load", &[WasmVal::I32(70000)]).expect("load"),
             vec![WasmVal::I32(3)]
+        );
+    }
+
+    /// An import callback re-reads the memory span through the C ABI while
+    /// wasmi still owns the store for the enclosing call. Wasm grew the memory
+    /// immediately before the call, so the span the embedder published is
+    /// already freed — the re-read is what keeps the JS-visible
+    /// `memory.buffer` off that dangling allocation (#9611).
+    unsafe extern "C" fn peek_memory_span_import_callback(
+        context: u64,
+        _module: *const u8,
+        _module_len: usize,
+        _name: *const u8,
+        _name_len: usize,
+        _arg_kinds: *const u8,
+        arg_bits: *const u64,
+        arg_count: usize,
+        _result_kinds: *const u8,
+        result_bits: *mut u64,
+        result_count: usize,
+    ) -> i32 {
+        assert_eq!(arg_count, 1);
+        assert_eq!(result_count, 1);
+        let offset = *arg_bits as u32 as usize;
+        let inst = context as *mut WasmInstanceHandle;
+        let mut len = 0usize;
+        let ptr = perry_wasm_host_instance_memory_span(inst, &mut len);
+        assert!(!ptr.is_null());
+        assert_eq!(len, 131072, "the re-read span sees the grow that just ran");
+        assert!(offset < len, "the grown tail is inside the re-read span");
+        // Write through the re-read span exactly as a JS import handler would
+        // through `memory.buffer`; the caller checks wasm can read it back.
+        *ptr.add(offset) = 42;
+        *result_bits = len as u32 as u64;
+        1
+    }
+
+    #[test]
+    fn memory_span_re_read_inside_an_import_survives_a_grow_in_the_same_call() {
+        let module = compile(GROW_THEN_IMPORT_WASM).expect("compile");
+        let mut inst =
+            instantiate_with_import_callback(&module, Some(peek_memory_span_import_callback), 0)
+                .expect("instantiate");
+        inst.inner.store.data_mut().import_context =
+            &mut inst as *mut WasmInstanceHandle as usize as u64;
+        call_export(&mut inst, "store", &[WasmVal::I32(5), WasmVal::I32(65)]).expect("store");
+
+        assert_eq!(
+            call_export(&mut inst, "growThenPeek", &[WasmVal::I32(70000)]).expect("growThenPeek"),
+            vec![WasmVal::I32(131072)],
+            "the import saw the grown span, not the freed one"
+        );
+        assert_eq!(
+            call_export(&mut inst, "load", &[WasmVal::I32(70000)]).expect("load"),
+            vec![WasmVal::I32(42)],
+            "what the import wrote through the re-read span is in wasm memory"
+        );
+        assert_eq!(
+            call_export(&mut inst, "load", &[WasmVal::I32(5)]).expect("load"),
+            vec![WasmVal::I32(65)],
+            "bytes written before the grow survive it"
         );
     }
 

--- a/crates/perry-wasm-host/src/lib.rs
+++ b/crates/perry-wasm-host/src/lib.rs
@@ -401,11 +401,6 @@ fn coerce_numeric_value(value: WasmVal, expected: ValType) -> Option<Val> {
     }
 }
 
-/// Call an exported function by name. Numeric JavaScript inputs are coerced
-/// against the declared Wasm parameter types, and all numeric results are
-/// returned in declaration order. wasm-bindgen uses multi-value returns for
-/// pointer/length pairs, so preserving only the first result is not enough for
-/// real generated glue.
 /// Resolve an export function to a cache index, resolving by name at most
 /// once per instance. `None` when the instance has no function export by that
 /// name.
@@ -503,6 +498,11 @@ fn resolved_export_results(
         .collect()
 }
 
+/// Call an exported function by name. Numeric JavaScript inputs are coerced
+/// against the declared Wasm parameter types, and all numeric results are
+/// returned in declaration order. wasm-bindgen uses multi-value returns for
+/// pointer/length pairs, so preserving only the first result is not enough for
+/// real generated glue.
 pub fn call_export(
     inst: &mut WasmInstanceHandle,
     name: &str,

--- a/crates/perry/tests/issue_5234_wasm_esm_import.rs
+++ b/crates/perry/tests/issue_5234_wasm_esm_import.rs
@@ -102,6 +102,25 @@ const LIVE_MEMORY_MULTI_WASM: &[u8] = &[
     0x00, 0x0b,
 ];
 
+/// A module with an exported memory it grows from inside wasm, plus byte
+/// load/store helpers at a caller-chosen offset:
+///
+/// ```wat
+/// (module
+///   (memory (export "memory") 1)
+///   (func (export "load")  (param i32) (result i32) local.get 0 i32.load8_u)
+///   (func (export "store") (param i32 i32) local.get 0 local.get 1 i32.store8)
+///   (func (export "grow")  (param i32) (result i32) local.get 0 memory.grow))
+/// ```
+const GROW_MEMORY_WASM: &[u8] = &[
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x0b, 0x02, 0x60, 0x01, 0x7f, 0x01, 0x7f,
+    0x60, 0x02, 0x7f, 0x7f, 0x00, 0x03, 0x04, 0x03, 0x00, 0x01, 0x00, 0x05, 0x03, 0x01, 0x00, 0x01,
+    0x07, 0x20, 0x04, 0x06, 0x6d, 0x65, 0x6d, 0x6f, 0x72, 0x79, 0x02, 0x00, 0x04, 0x6c, 0x6f, 0x61,
+    0x64, 0x00, 0x00, 0x05, 0x73, 0x74, 0x6f, 0x72, 0x65, 0x00, 0x01, 0x04, 0x67, 0x72, 0x6f, 0x77,
+    0x00, 0x02, 0x0a, 0x1a, 0x03, 0x07, 0x00, 0x20, 0x00, 0x2d, 0x00, 0x00, 0x0b, 0x09, 0x00, 0x20,
+    0x00, 0x20, 0x01, 0x3a, 0x00, 0x00, 0x0b, 0x06, 0x00, 0x20, 0x00, 0x40, 0x00, 0x0b,
+];
+
 /// `(module (table (export "refs") 2 externref))`
 const EXTERNREF_TABLE_WASM: &[u8] = &[
     0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x04, 0x04, 0x01, 0x6f, 0x00, 0x02, 0x07, 0x08,
@@ -126,6 +145,12 @@ import { throughGlue } from "./glue";
 import memoryDefault, { memory } from "./memory.wasm";
 import liveDefault, { load, store, pair, memory as liveMemory } from "./live-memory.wasm";
 import { refs } from "./externref-table.wasm";
+import {
+    grow,
+    load as growLoad,
+    store as growStore,
+    memory as growMemory,
+} from "./grow-memory.wasm";
 import { runTableCycle } from "./table-glue";
 import addWasmPath from "./file-add.wasm" with { type: "file" };
 import importedWasmPath from "./file-imported.wasm" with { type: "file" };
@@ -165,6 +190,30 @@ const importedInstance = new WebAssembly.Instance(importedModule, {
 });
 console.log("fileImported=" + importedInstance.exports.call(20));
 console.log("instanceLength=" + WebAssembly.Instance.length);
+
+// #9611: `memory.buffer` exposes the engine's linear memory itself rather than
+// a copy synchronised around each call, so a view built BEFORE a call observes
+// what that call wrote, and a write through that view is what the next call
+// reads. This is the views-observability contract the zero-copy binding must
+// not break.
+const liveView = new Uint8Array(liveMemory.buffer);
+liveView[0] = 21;
+console.log("viewToWasm=" + load());
+store(77);
+console.log("wasmToView=" + liveView[0]);
+
+// A `memory.grow` executed inside wasm reallocates the engine's linear memory.
+// The buffer that was published before the grow is detached, exactly as node
+// does, and `memory.buffer` is a fresh view over the grown span whose earlier
+// bytes survived.
+growStore(5, 65);
+const beforeGrow = growMemory.buffer;
+console.log("growOldPages=" + grow(1));
+console.log("growByteLength=" + growMemory.buffer.byteLength);
+console.log("growDetached=" + beforeGrow.byteLength);
+console.log("growKept=" + growLoad(5));
+new Uint8Array(growMemory.buffer)[70000] = 3;
+console.log("growTail=" + growLoad(70000));
 "#;
 
 const GLUE_FIXTURE: &str = r#"
@@ -207,6 +256,8 @@ fn write_fixture(root: &std::path::Path) {
     std::fs::write(root.join("memory.wasm"), MEMORY_WASM).expect("write memory.wasm");
     std::fs::write(root.join("live-memory.wasm"), LIVE_MEMORY_MULTI_WASM)
         .expect("write live memory wasm");
+    std::fs::write(root.join("grow-memory.wasm"), GROW_MEMORY_WASM)
+        .expect("write grow memory wasm");
     std::fs::write(root.join("externref-table.wasm"), EXTERNREF_TABLE_WASM)
         .expect("write externref table wasm");
     std::fs::write(
@@ -277,4 +328,15 @@ fn wasm_esm_import_instantiates_and_exposes_exports() {
     assert!(stdout.contains("fileInstance=21"), "stdout:\n{stdout}");
     assert!(stdout.contains("fileImported=21"), "stdout:\n{stdout}");
     assert!(stdout.contains("instanceLength=1"), "stdout:\n{stdout}");
+    // #9611 — zero-copy linear memory.
+    assert!(stdout.contains("viewToWasm=21"), "stdout:\n{stdout}");
+    assert!(stdout.contains("wasmToView=77"), "stdout:\n{stdout}");
+    assert!(stdout.contains("growOldPages=1"), "stdout:\n{stdout}");
+    assert!(
+        stdout.contains("growByteLength=131072"),
+        "stdout:\n{stdout}"
+    );
+    assert!(stdout.contains("growDetached=0"), "stdout:\n{stdout}");
+    assert!(stdout.contains("growKept=65"), "stdout:\n{stdout}");
+    assert!(stdout.contains("growTail=3"), "stdout:\n{stdout}");
 }

--- a/crates/perry/tests/issue_5234_wasm_esm_import.rs
+++ b/crates/perry/tests/issue_5234_wasm_esm_import.rs
@@ -121,6 +121,32 @@ const GROW_MEMORY_WASM: &[u8] = &[
     0x00, 0x20, 0x01, 0x3a, 0x00, 0x00, 0x0b, 0x06, 0x00, 0x20, 0x00, 0x40, 0x00, 0x0b,
 ];
 
+/// Grows the memory and THEN calls a JS import, so the import runs with the
+/// previously published buffer already freed — the boundary
+/// `rebind_active_wasm_memories` exists for:
+///
+/// ```wat
+/// (module
+///   (import "./grow-glue" "peek" (func $peek (param i32) (result i32)))
+///   (memory (export "memory") 1)
+///   (func (export "store") (param i32 i32) local.get 0 local.get 1 i32.store8)
+///   (func (export "load")  (param i32) (result i32) local.get 0 i32.load8_u)
+///   (func (export "growThenPeek") (param i32) (result i32)
+///     i32.const 1 memory.grow drop
+///     local.get 0 call $peek))
+/// ```
+const GROW_THEN_IMPORT_WASM: &[u8] = &[
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x0b, 0x02, 0x60, 0x01, 0x7f, 0x01, 0x7f,
+    0x60, 0x02, 0x7f, 0x7f, 0x00, 0x02, 0x14, 0x01, 0x0b, 0x2e, 0x2f, 0x67, 0x72, 0x6f, 0x77, 0x2d,
+    0x67, 0x6c, 0x75, 0x65, 0x04, 0x70, 0x65, 0x65, 0x6b, 0x00, 0x00, 0x03, 0x04, 0x03, 0x01, 0x00,
+    0x00, 0x05, 0x03, 0x01, 0x00, 0x01, 0x07, 0x28, 0x04, 0x06, 0x6d, 0x65, 0x6d, 0x6f, 0x72, 0x79,
+    0x02, 0x00, 0x05, 0x73, 0x74, 0x6f, 0x72, 0x65, 0x00, 0x01, 0x04, 0x6c, 0x6f, 0x61, 0x64, 0x00,
+    0x02, 0x0c, 0x67, 0x72, 0x6f, 0x77, 0x54, 0x68, 0x65, 0x6e, 0x50, 0x65, 0x65, 0x6b, 0x00, 0x03,
+    0x0a, 0x1f, 0x03, 0x09, 0x00, 0x20, 0x00, 0x20, 0x01, 0x3a, 0x00, 0x00, 0x0b, 0x07, 0x00, 0x20,
+    0x00, 0x2d, 0x00, 0x00, 0x0b, 0x0b, 0x00, 0x41, 0x01, 0x40, 0x00, 0x1a, 0x20, 0x00, 0x10, 0x00,
+    0x0b,
+];
+
 /// `(module (table (export "refs") 2 externref))`
 const EXTERNREF_TABLE_WASM: &[u8] = &[
     0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x04, 0x04, 0x01, 0x6f, 0x00, 0x02, 0x07, 0x08,
@@ -151,6 +177,7 @@ import {
     store as growStore,
     memory as growMemory,
 } from "./grow-memory.wasm";
+import { growThenPeek, load as peekLoad, store as peekStore } from "./grow-then-import.wasm";
 import { runTableCycle } from "./table-glue";
 import addWasmPath from "./file-add.wasm" with { type: "file" };
 import importedWasmPath from "./file-imported.wasm" with { type: "file" };
@@ -214,6 +241,15 @@ console.log("growDetached=" + beforeGrow.byteLength);
 console.log("growKept=" + growLoad(5));
 new Uint8Array(growMemory.buffer)[70000] = 3;
 console.log("growTail=" + growLoad(70000));
+
+// The other boundary: wasm grows the memory and THEN calls a JS import, so the
+// import handler runs inside the call with the previously published buffer
+// already freed. The handler reads and writes `memory.buffer`, which must have
+// been re-pointed at the grown span rather than left on the freed one.
+peekStore(5, 65);
+console.log("peekLength=" + growThenPeek(70000));
+console.log("peekWrote=" + peekLoad(70000));
+console.log("peekKept=" + peekLoad(5));
 "#;
 
 const GLUE_FIXTURE: &str = r#"
@@ -225,6 +261,22 @@ export function inc(value: number): number {
 
 export function throughGlue(value: number): number {
     return call(value);
+}
+"#;
+
+const GROW_GLUE_FIXTURE: &str = r#"
+import { memory } from "./grow-then-import.wasm";
+
+// Called from inside a wasm function that grew the memory one instruction
+// earlier. Reading `memory.buffer` here is what a wasm-bindgen glue import
+// does; it must see the grown span, not the allocation the grow freed.
+export function peek(offset: number): number {
+    const view = new Uint8Array(memory.buffer);
+    if (offset >= view.length) {
+        return -1;
+    }
+    view[offset] = 42;
+    return view.length;
 }
 "#;
 
@@ -258,6 +310,9 @@ fn write_fixture(root: &std::path::Path) {
         .expect("write live memory wasm");
     std::fs::write(root.join("grow-memory.wasm"), GROW_MEMORY_WASM)
         .expect("write grow memory wasm");
+    std::fs::write(root.join("grow-then-import.wasm"), GROW_THEN_IMPORT_WASM)
+        .expect("write grow-then-import wasm");
+    std::fs::write(root.join("grow-glue.ts"), GROW_GLUE_FIXTURE).expect("write grow glue ts");
     std::fs::write(root.join("externref-table.wasm"), EXTERNREF_TABLE_WASM)
         .expect("write externref table wasm");
     std::fs::write(
@@ -339,4 +394,7 @@ fn wasm_esm_import_instantiates_and_exposes_exports() {
     assert!(stdout.contains("growDetached=0"), "stdout:\n{stdout}");
     assert!(stdout.contains("growKept=65"), "stdout:\n{stdout}");
     assert!(stdout.contains("growTail=3"), "stdout:\n{stdout}");
+    assert!(stdout.contains("peekLength=131072"), "stdout:\n{stdout}");
+    assert!(stdout.contains("peekWrote=42"), "stdout:\n{stdout}");
+    assert!(stdout.contains("peekKept=65"), "stdout:\n{stdout}");
 }


### PR DESCRIPTION
Fixes #9611.

## The finding, confirmed

Every call across the JS/Wasm boundary memcpy'd the **entire** linear memory into wasmi before the call (`sync_memory_to_wasm`) and the entire linear memory back out after it (`sync_memory_from_wasm`). One call therefore cost ~0.11 ns per byte of memory the instance happened to hold, and wasmi itself was innocent — at 4.3 MiB, 99.9% of the 162 µs was the two copies.

## What this does

**1. `memory.buffer` now IS wasmi's linear memory.** It is a foreign-backed `ArrayBuffer` wrapper (`buffer_alloc_foreign`, the mechanism `napi_create_external_arraybuffer` already uses for addon-owned bytes) pointed straight at the engine's span. Nothing is copied in either direction: a JS store through `new Uint8Array(memory.buffer)` lands in wasm memory, and a wasm store is visible to JS with no synchronisation at all.

**The views contract**, which the issue flagged as the hard part: views resolve reads and writes through their ultimate backing buffer (`resolve_data_ptr`), so re-pointing the backing at the engine's memory makes every registered view live by construction rather than as-of-the-last-sync. There is no longer a granularity to choose — `propagate_range_to_views` is not on this path at all.

**The one hazard is `memory.grow`**, which reallocates wasmi's backing `Vec` and can move it, leaving the published pointer dangling. Growth only happens while wasm is executing, so the span is re-read — a pointer and a length compare, no copying — at the two boundaries where JS can observe the memory again:

- **when an exported call returns**, where the `WebAssembly.Memory` object is in hand: a grow publishes a **fresh** `ArrayBuffer` over the new span and **detaches** the old one. That is what node does, and it is the signal glue code (wasm-bindgen's `cachedUint8Memory.byteLength === 0`) keys on to rebuild its cached views;
- **when wasm calls back into a JS import**, where it is not: the published buffer is re-pointed **in place**, so a JS import handler that reads or writes `memory.buffer` after a grow earlier in the same call cannot dereference the allocation that grow freed. The identity swap is deferred to the return via a `rebound` flag.

The ahead-of-time `WebAssembly.callExport` lowering gets the in-place rebind too — it reaches an export without the closure that owns the memory object, but its call can still grow the memory.

**2. Exports resolve once, not per call** — the ~400 ns floor the issue identified under the memcpy. An export is resolved to a handle at instance construction and every later call goes by index, so the per-call `get_func` name probe, the `FuncType` clone and the two `Vec` allocations for arguments and results are gone. The exported memory handle is cached the same way (the post-call span re-read would otherwise have put a by-name `get_memory` back on the hot path), and argument marshalling now uses fixed stack arrays. A steady-state call allocates nothing.

## Measured

perrymaster, 16-core Linux, 2,000,000 calls of a no-op export, three runs, per call:

| linear memory | before | after | node | after vs before |
|---|---|---|---|---|
| none | 200 ns | 145 ns | 1.0 ns | 1.4× |
| 128 KiB | 7,150 ns | 168 ns | 6.0 ns | 43× |
| 4.3 MiB | 162,000 ns | 169 ns | 6.0 ns | **960×** |

The result that matters is not the ratio but the **shape**: after the change the per-call cost is flat in memory size (145 ns with no memory, 169 ns at 4.3 MiB). The 0.11 ns/byte term is gone, not merely smaller — which is the same conclusion the call census would report as sync time going to zero while the call count stays identical. The issue's target was µs-class at 4.3 MiB; this is 169 ns.

For the cc build's llhttp, whose memory grows with the connection, per-HTTP-message calls go from tens of microseconds and rising to sub-microsecond and constant.

## Tests

End-to-end, in the wasm ESM suite (a real compiled binary):

- **views observability, both directions** — a `Uint8Array` built *before* a call observes what the call wrote, and a write through that same view is what the next call reads. This is the contract the issue asked to pin, and it fails if the aliasing is wrong in either direction.
- **grow** — `memory.grow` from inside wasm returns the old page count, `memory.buffer.byteLength` reports the grown size, the buffer captured before the grow reads `byteLength === 0` (detached, as node), bytes written before the grow survive it, and the grown tail is writable from JS and readable by wasm. The detach assertion fails on `main`, which currently leaves the pre-grow buffer live with stale bytes.

Host crate: the published span really is the live memory (host write → wasm read, wasm write → host read, no sync call between), the span after a grow from inside wasm (grown size, bytes preserved, tail addressable), export-handle resolution and reuse, repeated calls through one cached entry not leaking state between them, and rejection of a bad arity and a null handle.

No version bump.

https://claude.ai/code/session_01VxP3FEDgV4zUocSDBhD8qh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved WebAssembly performance by eliminating full-memory copies during calls.
  * Reduced overhead for repeated exported function calls.
* **Compatibility**
  * WebAssembly memory is directly accessible to JavaScript, with changes reflected in both directions.
  * Memory growth provides a new buffer while detaching the previous one.
* **Tests**
  * Added coverage for shared memory access, memory growth, imports after growth, and exported function calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->