### PR TITLE
compat(claude): provide Bun.ant host hooks

### DIFF
--- a/changelog.d/9607-bun-ant.md
+++ b/changelog.d/9607-bun-ant.md
@@ -1,0 +1,9 @@
+### Bun compatibility
+
+- **The opt-in Bun platform now exposes Claude Code's vendor `Bun.ant`
+  hooks.** `getPeerUid(fd)` and `getPeerPid(fd)` read local-socket peer
+  credentials without taking ownership of the descriptor and return `null`
+  for invalid, closed, or unsupported descriptors. `memoryPressureLevel()`
+  reports `"normal"`, `"warning"`, `"critical"`, or `null` through a
+  platform-specific pressure source. Perry's `node:net` socket facade also
+  supplies the private `_handle.fd` bridge used by Claude Code.

--- a/crates/perry-api-manifest/src/entries/part_4.rs
+++ b/crates/perry-api-manifest/src/entries/part_4.rs
@@ -1130,6 +1130,7 @@ pub(crate) const API_MANIFEST_PART_4: &[ApiEntry] = &[
     property("bun", "TOML"),
     property("bun", "semver"),
     property("bun", "JSONL"),
+    property("bun", "ant"),
     // --- qs (issue #8751) ---
     // Native nested query-string codec. This keeps Stripe's request encoder
     // off qs' legacy get-intrinsic/ES-shims dependency chain.

--- a/crates/perry-ext-net/src/adopt.rs
+++ b/crates/perry-ext-net/src/adopt.rs
@@ -36,8 +36,13 @@ pub fn adopt_upgraded_tcp_stream(stream: tokio::net::TcpStream) -> i64 {
         drop(stream);
         return perry_ffi::INVALID_HANDLE;
     }
+    let transport = Transport::Plain(stream);
+    let raw_fd = transport.raw_fd();
     let (tx, rx) = mpsc::unbounded_channel::<SocketCommand>();
-    let local = stream.local_addr().ok();
+    let local = match &transport {
+        Transport::Plain(stream) => stream.local_addr().ok(),
+        _ => None,
+    };
     statics::sockets().lock().unwrap().insert(
         id,
         SocketState {
@@ -47,6 +52,7 @@ pub fn adopt_upgraded_tcp_stream(stream: tokio::net::TcpStream) -> i64 {
             cmd_tx: tx,
             pending_rx: None,
             is_open: true,
+            raw_fd,
             refed: true,
             local_addr: local,
             raw: None,
@@ -67,7 +73,7 @@ pub fn adopt_upgraded_tcp_stream(stream: tokio::net::TcpStream) -> i64 {
         .insert(id, HashMap::new());
     tokio::spawn(async move {
         let mut rx = rx;
-        run_socket_task(id, Transport::Plain(stream), &mut rx).await;
+        run_socket_task(id, transport, &mut rx).await;
     });
     id
 }

--- a/crates/perry-ext-net/src/dispatch.rs
+++ b/crates/perry-ext-net/src/dispatch.rs
@@ -7,9 +7,12 @@
 //! handle family.
 
 use perry_ffi::{
-    ArrayHeader, JsClosure, JsPromise, JsValue, Promise, RawClosureHeader, StringHeader,
+    build_object_shape, js_object_alloc_with_shape, js_object_set_field, ArrayHeader, JsClosure,
+    JsPromise, JsValue, ObjectHeader, Promise, RawClosureHeader, StringHeader,
 };
 use std::sync::Once;
+
+use crate::statics;
 
 const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
 const TAG_NULL: u64 = 0x7FFC_0000_0000_0002;
@@ -71,6 +74,23 @@ fn nanbox_handle(handle: i64) -> f64 {
 
 fn nanbox_ptr<T>(ptr: *mut T) -> f64 {
     f64::from_bits(POINTER_TAG | (ptr as u64 & POINTER_MASK))
+}
+
+fn socket_private_handle(handle: i64) -> f64 {
+    let fd = statics::sockets()
+        .lock()
+        .ok()
+        .and_then(|sockets| sockets.get(&handle).and_then(|socket| socket.raw_fd))
+        .unwrap_or(-1);
+    let keys = ["fd"];
+    let (packed, shape_id) = build_object_shape(&keys);
+    let object: *mut ObjectHeader =
+        unsafe { js_object_alloc_with_shape(shape_id, 1, packed.as_ptr(), packed.len() as u32) };
+    if object.is_null() {
+        return undefined();
+    }
+    unsafe { js_object_set_field(object, 0, JsValue::from_number(fd as f64)) };
+    nanbox_ptr(object)
 }
 
 fn unbox_to_i64(v: f64) -> i64 {
@@ -509,6 +529,8 @@ pub unsafe extern "C" fn js_ext_net_handle_property_dispatch(
             "port" => crate::js_net_socket_address_get_port(handle),
             _ => crate::js_net_socket_address_get_flowlabel(handle),
         })
+    } else if prop == "_handle" && crate::js_ext_net_is_socket_handle(handle) != 0 {
+        Some(socket_private_handle(handle))
     } else if prop == "parser"
         && crate::js_ext_net_is_socket_handle(handle) != 0
         && crate::statics::http_agent_phases()

--- a/crates/perry-ext-net/src/ipc.rs
+++ b/crates/perry-ext-net/src/ipc.rs
@@ -38,6 +38,7 @@ fn allocate_socket() -> (i64, mpsc::UnboundedReceiver<SocketCommand>) {
             cmd_tx: tx,
             pending_rx: None,
             is_open: false,
+            raw_fd: None,
             refed: true,
             local_addr: None,
             raw: None,
@@ -91,6 +92,7 @@ pub(crate) fn register_accepted_transport(
     transport: Transport,
     local_addr: Option<std::net::SocketAddr>,
 ) {
+    let raw_fd = transport.raw_fd();
     let socket_id = next_id();
     if socket_id == perry_ffi::INVALID_HANDLE {
         server_state::cancel_pending_connection(server_id);
@@ -106,6 +108,7 @@ pub(crate) fn register_accepted_transport(
             cmd_tx: tx,
             pending_rx: None,
             is_open: true,
+            raw_fd,
             refed: true,
             local_addr,
             raw: None,
@@ -177,12 +180,15 @@ fn spawn_connect(id: i64, path: String, mut rx: mpsc::UnboundedReceiver<SocketCo
                 }
             };
 
+            let transport = Transport::Ipc(stream);
+            let raw_fd = transport.raw_fd();
             if let Some(socket) = statics::sockets().lock().unwrap().get_mut(&id) {
                 socket.is_open = true;
+                socket.raw_fd = raw_fd;
             }
             tokio::task::yield_now().await;
             push_event(PendingNetEvent::Connect(id, local_server));
-            run_socket_task(id, Transport::Ipc(stream), &mut rx).await;
+            run_socket_task(id, transport, &mut rx).await;
         })
     });
 }

--- a/crates/perry-ext-net/src/lib.rs
+++ b/crates/perry-ext-net/src/lib.rs
@@ -248,6 +248,9 @@ pub(crate) struct SocketState {
     /// can move it into the spawned task at connect time.
     pub(crate) pending_rx: Option<mpsc::UnboundedReceiver<SocketCommand>>,
     pub(crate) is_open: bool,
+    /// Borrowed OS descriptor for Node's private `socket._handle.fd` shape.
+    /// The transport task remains the sole owner and clears this on close.
+    pub(crate) raw_fd: Option<i32>,
     /// Whether pending socket I/O keeps the process event loop alive.
     pub(crate) refed: bool,
     /// Issue #2131 — the kernel-assigned local address, populated after
@@ -286,6 +289,7 @@ impl SocketState {
             cmd_tx,
             pending_rx: None,
             is_open: true,
+            raw_fd: None,
             refed: true,
             local_addr: None,
             raw: None,
@@ -412,6 +416,9 @@ fn push_event(ev: PendingNetEvent) {
 }
 
 fn mark_closed(id: i64) {
+    if let Some(socket) = statics::sockets().lock().unwrap().get_mut(&id) {
+        socket.raw_fd = None;
+    }
     server_state::mark_socket_closed(id);
 }
 
@@ -535,6 +542,7 @@ pub unsafe extern "C" fn js_net_socket_alloc() -> i64 {
             cmd_tx: tx,
             pending_rx: Some(rx),
             is_open: false,
+            raw_fd: None,
             refed: true,
             local_addr: None,
             raw: None,
@@ -1065,6 +1073,7 @@ where
             cmd_tx: tx,
             pending_rx: None,
             is_open: false,
+            raw_fd: None,
             refed: true,
             local_addr: None,
             raw: None,
@@ -1126,10 +1135,12 @@ where
                 }
                 None => Transport::Plain(tcp),
             };
+            let raw_fd = transport.raw_fd();
 
             if let Some(s) = statics::sockets().lock().unwrap().get_mut(&id) {
                 s.is_open = true;
                 s.local_addr = local;
+                s.raw_fd = raw_fd;
             }
             tokio::task::yield_now().await;
             push_event(PendingNetEvent::Connect(id, local_server));

--- a/crates/perry-ext-net/src/transport.rs
+++ b/crates/perry-ext-net/src/transport.rs
@@ -7,12 +7,32 @@ use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
+#[cfg(unix)]
+use std::os::fd::{AsRawFd, RawFd};
+
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::net::TcpStream;
 use tokio_rustls::client::TlsStream;
 
+#[cfg(unix)]
+pub(crate) trait IpcStream: AsyncRead + AsyncWrite + Send + Unpin {
+    fn raw_fd(&self) -> RawFd;
+}
+
+#[cfg(unix)]
+impl<T> IpcStream for T
+where
+    T: AsyncRead + AsyncWrite + Send + Unpin + AsRawFd,
+{
+    fn raw_fd(&self) -> RawFd {
+        self.as_raw_fd()
+    }
+}
+
+#[cfg(not(unix))]
 pub(crate) trait IpcStream: AsyncRead + AsyncWrite + Send + Unpin {}
 
+#[cfg(not(unix))]
 impl<T> IpcStream for T where T: AsyncRead + AsyncWrite + Send + Unpin {}
 
 pub(crate) enum Transport {
@@ -22,6 +42,24 @@ pub(crate) enum Transport {
 }
 
 impl Transport {
+    /// Borrow the live kernel descriptor without transferring ownership.
+    /// Claude Code reads it through Node's private `socket._handle.fd` shape
+    /// before passing it to the read-only `Bun.ant` peer-credential hooks.
+    pub(crate) fn raw_fd(&self) -> Option<i32> {
+        #[cfg(unix)]
+        {
+            Some(match self {
+                Transport::Plain(stream) => stream.as_raw_fd(),
+                Transport::Tls(stream) => stream.get_ref().0.as_raw_fd(),
+                Transport::Ipc(stream) => stream.raw_fd(),
+            })
+        }
+        #[cfg(not(unix))]
+        {
+            None
+        }
+    }
+
     /// Set `TCP_NODELAY` on the underlying TCP socket. For a TLS transport the
     /// option lives on the wrapped TCP stream (`get_ref().0`), so reach through
     /// the rustls wrapper to the kernel socket. Matches Node's `socket.setNoDelay`,

--- a/crates/perry-runtime/src/bun_compat/ant.rs
+++ b/crates/perry-runtime/src/bun_compat/ant.rs
@@ -1,0 +1,386 @@
+//! Claude Code's vendor `Bun.ant` hooks.
+//!
+//! These APIs are not part of Bun's public compatibility surface.  They are
+//! nevertheless useful as small, conservative OS primitives: peer credential
+//! lookup never takes ownership of the descriptor and every unsupported or
+//! failed lookup returns `null`.
+
+use crate::value::JSValue;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum MemoryPressureLevel {
+    Normal,
+    Warning,
+    Critical,
+}
+
+impl MemoryPressureLevel {
+    fn as_bytes(self) -> &'static [u8] {
+        match self {
+            Self::Normal => b"normal",
+            Self::Warning => b"warning",
+            Self::Critical => b"critical",
+        }
+    }
+}
+
+/// Keep acquisition separate from JS conversion so platform sources can be
+/// tested without manufacturing process-wide memory pressure.
+trait MemoryPressureSource {
+    fn current_level(&self) -> Option<MemoryPressureLevel>;
+}
+
+struct PlatformMemoryPressureSource;
+
+impl MemoryPressureSource for PlatformMemoryPressureSource {
+    fn current_level(&self) -> Option<MemoryPressureLevel> {
+        platform_memory_pressure_level()
+    }
+}
+
+fn null() -> f64 {
+    f64::from_bits(JSValue::null().bits())
+}
+
+fn fd_from_value(value: f64) -> Option<libc::c_int> {
+    let value = JSValue::from_bits(value.to_bits());
+    if value.is_int32() {
+        return (value.as_int32() >= 0).then_some(value.as_int32());
+    }
+    if !value.is_number() {
+        return None;
+    }
+    let number = value.as_number();
+    if !number.is_finite()
+        || number < 0.0
+        || number.fract() != 0.0
+        || number > libc::c_int::MAX as f64
+    {
+        return None;
+    }
+    Some(number as libc::c_int)
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn linux_peer_credentials(fd: libc::c_int) -> Option<libc::ucred> {
+    let mut credentials = std::mem::MaybeUninit::<libc::ucred>::uninit();
+    let mut len = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+    let result = unsafe {
+        libc::getsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_PEERCRED,
+            credentials.as_mut_ptr().cast::<libc::c_void>(),
+            &mut len,
+        )
+    };
+    if result != 0 || (len as usize) < std::mem::size_of::<libc::ucred>() {
+        return None;
+    }
+    Some(unsafe { credentials.assume_init() })
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn peer_uid(fd: libc::c_int) -> Option<u32> {
+    linux_peer_credentials(fd).map(|credentials| credentials.uid)
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn peer_pid(fd: libc::c_int) -> Option<u32> {
+    let pid = linux_peer_credentials(fd)?.pid;
+    (pid > 0).then_some(pid as u32)
+}
+
+#[cfg(any(
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly"
+))]
+fn peer_uid(fd: libc::c_int) -> Option<u32> {
+    let mut uid = 0 as libc::uid_t;
+    let mut gid = 0 as libc::gid_t;
+    (unsafe { libc::getpeereid(fd, &mut uid, &mut gid) } == 0).then_some(uid as u32)
+}
+
+#[cfg(target_os = "macos")]
+fn peer_pid(fd: libc::c_int) -> Option<u32> {
+    let mut pid = 0 as libc::pid_t;
+    let mut len = std::mem::size_of::<libc::pid_t>() as libc::socklen_t;
+    let result = unsafe {
+        libc::getsockopt(
+            fd,
+            libc::SOL_LOCAL,
+            libc::LOCAL_PEERPID,
+            (&mut pid as *mut libc::pid_t).cast::<libc::c_void>(),
+            &mut len,
+        )
+    };
+    (result == 0 && (len as usize) >= std::mem::size_of::<libc::pid_t>() && pid > 0)
+        .then_some(pid as u32)
+}
+
+#[cfg(any(
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly"
+))]
+fn peer_pid(_fd: libc::c_int) -> Option<u32> {
+    None
+}
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly"
+)))]
+fn peer_uid(_fd: libc::c_int) -> Option<u32> {
+    None
+}
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly"
+)))]
+fn peer_pid(_fd: libc::c_int) -> Option<u32> {
+    None
+}
+
+/// `Bun.ant.getPeerUid(fd)` — effective UID for the peer of a local socket.
+#[no_mangle]
+pub extern "C" fn js_bun_ant_get_peer_uid(fd: f64) -> f64 {
+    fd_from_value(fd)
+        .and_then(peer_uid)
+        .map(|uid| uid as f64)
+        .unwrap_or_else(null)
+}
+
+/// `Bun.ant.getPeerPid(fd)` — PID for the peer when the OS exposes one.
+#[no_mangle]
+pub extern "C" fn js_bun_ant_get_peer_pid(fd: f64) -> f64 {
+    fd_from_value(fd)
+        .and_then(peer_pid)
+        .map(|pid| pid as f64)
+        .unwrap_or_else(null)
+}
+
+fn classify_availability(available: u64, limit: u64) -> Option<MemoryPressureLevel> {
+    if limit == 0 {
+        return None;
+    }
+    let available_percent = (available.min(limit) as u128 * 100) / limit as u128;
+    Some(if available_percent <= 5 {
+        MemoryPressureLevel::Critical
+    } else if available_percent <= 15 {
+        MemoryPressureLevel::Warning
+    } else {
+        MemoryPressureLevel::Normal
+    })
+}
+
+#[cfg(any(test, target_os = "macos"))]
+fn classify_dispatch_pressure_flag(flag: u32) -> Option<MemoryPressureLevel> {
+    match flag {
+        0x1 => Some(MemoryPressureLevel::Normal),
+        0x2 => Some(MemoryPressureLevel::Warning),
+        0x4 => Some(MemoryPressureLevel::Critical),
+        _ => None,
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn parse_meminfo(contents: &str) -> Option<(u64, u64)> {
+    fn kib_value(contents: &str, key: &str) -> Option<u64> {
+        let line = contents.lines().find(|line| line.starts_with(key))?;
+        line.split_ascii_whitespace().nth(1)?.parse::<u64>().ok()
+    }
+    let total = kib_value(contents, "MemTotal:")?.checked_mul(1024)?;
+    let available = kib_value(contents, "MemAvailable:")?.checked_mul(1024)?;
+    Some((available, total))
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn cgroup_v2_directory() -> Option<std::path::PathBuf> {
+    let cgroup = std::fs::read_to_string("/proc/self/cgroup").ok()?;
+    let relative = cgroup.lines().find_map(|line| {
+        let mut fields = line.splitn(3, ':');
+        let hierarchy = fields.next()?;
+        let controllers = fields.next()?;
+        let path = fields.next()?;
+        (hierarchy == "0" && controllers.is_empty()).then_some(path)
+    })?;
+    Some(std::path::Path::new("/sys/fs/cgroup").join(relative.trim_start_matches('/')))
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn read_u64(path: &std::path::Path) -> Option<u64> {
+    std::fs::read_to_string(path).ok()?.trim().parse().ok()
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn cgroup_memory_level() -> Option<MemoryPressureLevel> {
+    let directory = cgroup_v2_directory()?;
+    let current = read_u64(&directory.join("memory.current"))?;
+    let max = read_u64(&directory.join("memory.max"));
+    let high = read_u64(&directory.join("memory.high"));
+    let limit = match (max, high) {
+        (Some(max), Some(high)) => max.min(high),
+        (Some(limit), None) | (None, Some(limit)) => limit,
+        (None, None) => return None,
+    };
+    classify_availability(limit.saturating_sub(current), limit)
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn platform_memory_pressure_level() -> Option<MemoryPressureLevel> {
+    let host = std::fs::read_to_string("/proc/meminfo")
+        .ok()
+        .and_then(|contents| parse_meminfo(&contents))
+        .and_then(|(available, total)| classify_availability(available, total));
+    [host, cgroup_memory_level()].into_iter().flatten().max()
+}
+
+#[cfg(target_os = "macos")]
+fn platform_memory_pressure_level() -> Option<MemoryPressureLevel> {
+    // This masked sysctl returns the public dispatch-memory-pressure flags,
+    // not XNU's separate 0–100 memorystatus percentage.
+    const NAME: &[u8] = b"kern.memorystatus_vm_pressure_level\0";
+    let mut level = 0 as libc::c_uint;
+    let mut len = std::mem::size_of::<libc::c_uint>();
+    let result = unsafe {
+        libc::sysctlbyname(
+            NAME.as_ptr().cast::<libc::c_char>(),
+            (&mut level as *mut libc::c_uint).cast::<libc::c_void>(),
+            &mut len,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if result != 0 || len < std::mem::size_of::<libc::c_uint>() {
+        return None;
+    }
+    classify_dispatch_pressure_flag(level)
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos")))]
+fn platform_memory_pressure_level() -> Option<MemoryPressureLevel> {
+    None
+}
+
+fn memory_pressure_level_from(source: &dyn MemoryPressureSource) -> Option<MemoryPressureLevel> {
+    source.current_level()
+}
+
+/// `Bun.ant.memoryPressureLevel()` — current coarse OS pressure, or `null`
+/// when the platform has no reliable source.
+#[no_mangle]
+pub extern "C" fn js_bun_ant_memory_pressure_level() -> f64 {
+    match memory_pressure_level_from(&PlatformMemoryPressureSource) {
+        Some(level) => super::boxed_str(level.as_bytes()),
+        None => null(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct FixedSource(Option<MemoryPressureLevel>);
+
+    impl MemoryPressureSource for FixedSource {
+        fn current_level(&self) -> Option<MemoryPressureLevel> {
+            self.0
+        }
+    }
+
+    #[test]
+    fn memory_pressure_source_covers_every_public_state_and_unavailable() {
+        for expected in [
+            Some(MemoryPressureLevel::Normal),
+            Some(MemoryPressureLevel::Warning),
+            Some(MemoryPressureLevel::Critical),
+            None,
+        ] {
+            assert_eq!(memory_pressure_level_from(&FixedSource(expected)), expected);
+        }
+    }
+
+    #[test]
+    fn availability_thresholds_are_stable() {
+        assert_eq!(
+            classify_availability(16, 100),
+            Some(MemoryPressureLevel::Normal)
+        );
+        assert_eq!(
+            classify_availability(15, 100),
+            Some(MemoryPressureLevel::Warning)
+        );
+        assert_eq!(
+            classify_availability(5, 100),
+            Some(MemoryPressureLevel::Critical)
+        );
+        assert_eq!(classify_availability(0, 0), None);
+    }
+
+    #[test]
+    fn dispatch_pressure_flags_map_to_public_states() {
+        assert_eq!(
+            classify_dispatch_pressure_flag(0x1),
+            Some(MemoryPressureLevel::Normal)
+        );
+        assert_eq!(
+            classify_dispatch_pressure_flag(0x2),
+            Some(MemoryPressureLevel::Warning)
+        );
+        assert_eq!(
+            classify_dispatch_pressure_flag(0x4),
+            Some(MemoryPressureLevel::Critical)
+        );
+        assert_eq!(classify_dispatch_pressure_flag(0), None);
+    }
+
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "macos",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "dragonfly"
+    ))]
+    #[test]
+    fn peer_credentials_accept_a_local_socket_and_reject_bad_descriptors() {
+        use std::os::fd::AsRawFd;
+
+        let (left, right) = std::os::unix::net::UnixStream::pair().expect("UnixStream pair");
+        assert_eq!(peer_uid(left.as_raw_fd()), Some(unsafe { libc::geteuid() }));
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
+        assert!(peer_pid(left.as_raw_fd()).is_some_and(|pid| pid > 0));
+        assert_eq!(peer_uid(-1), None);
+        assert_eq!(peer_pid(-1), None);
+
+        let closed_fd = right.as_raw_fd();
+        drop(right);
+        assert_eq!(peer_uid(closed_fd), None);
+        assert_eq!(peer_pid(closed_fd), None);
+        drop(left);
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[test]
+    fn parses_linux_mem_available() {
+        let contents = "MemTotal:       1000 kB\nMemFree: 1 kB\nMemAvailable:    120 kB\n";
+        assert_eq!(parse_meminfo(contents), Some((120 * 1024, 1000 * 1024)));
+    }
+}

--- a/crates/perry-runtime/src/bun_compat/mod.rs
+++ b/crates/perry-runtime/src/bun_compat/mod.rs
@@ -20,6 +20,7 @@
 //! - `Bun.hash` is Zig-std Wyhash (see `wyhash.rs`) returning a BigInt, so
 //!   `.toString(16)` cache keys match bun-run installs.
 
+mod ant;
 #[cfg(feature = "bun-cli-utils")]
 mod cli_utils;
 #[cfg(not(feature = "bun-cli-utils"))]
@@ -41,6 +42,7 @@ use crate::string::{js_string_from_bytes, StringHeader};
 use crate::value::{js_jsvalue_to_string, JSValue};
 use std::io::{Read, Write};
 
+pub use ant::{js_bun_ant_get_peer_pid, js_bun_ant_get_peer_uid, js_bun_ant_memory_pressure_level};
 #[cfg(feature = "bun-cli-utils")]
 pub use cli_utils::*;
 #[cfg(not(feature = "bun-cli-utils"))]

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -776,6 +776,7 @@ fn should_cache_native_module_namespace(module_name: &str) -> bool {
             | "async_hooks"
             | "async_hooks.default"
             | "bun"
+            | "bun.ant"
             | "constants"
             | "constants.default"
             // #5263: cache the top-level namespace objects whose dynamic
@@ -1004,6 +1005,10 @@ unsafe fn native_module_property_by_name_impl(
     // deliberately Perry-specific rather than pretending to be a Bun runtime.
     if module_name == "bun" {
         match property_name {
+            "ant" => {
+                let submodule = "bun.ant";
+                return js_create_native_module_namespace(submodule.as_ptr(), submodule.len());
+            }
             "stdin" => return crate::bun_compat::js_bun_stdin(),
             "stdout" => return crate::bun_compat::js_bun_stdout(),
             "stderr" => return crate::bun_compat::js_bun_stderr(),

--- a/crates/perry-runtime/src/object/native_module/callable_export_arity_table.rs
+++ b/crates/perry-runtime/src/object/native_module/callable_export_arity_table.rs
@@ -10,6 +10,8 @@ fn native_callable_export_arity_reference(module: &str, prop: &str) -> Option<u3
         ) => Some(1),
         ("bun", "deepEquals" | "generateHeapSnapshot" | "spawn" | "write") => Some(2),
         ("bun", "wrapAnsi") => Some(3),
+        ("bun.ant", "getPeerPid" | "getPeerUid") => Some(1),
+        ("bun.ant", "memoryPressureLevel") => Some(0),
         // bun:ffi (#6562).
         ("bun:ffi", "dlopen") => Some(2),
         ("bun:ffi", "ptr" | "CString" | "CFunction" | "linkSymbols") => Some(1),
@@ -306,6 +308,14 @@ static CALLABLE_EXPORT_ARITY_TABLE: &[(&str, &[(&str, u32)])] = &[
             ("write", 2),
             ("zstdDecompress", 1),
             ("zstdDecompressSync", 1),
+        ],
+    ),
+    (
+        "bun.ant",
+        &[
+            ("getPeerPid", 1),
+            ("getPeerUid", 1),
+            ("memoryPressureLevel", 0),
         ],
     ),
     (

--- a/crates/perry-runtime/src/object/native_module/callable_export_check.rs
+++ b/crates/perry-runtime/src/object/native_module/callable_export_check.rs
@@ -59,6 +59,9 @@ pub(crate) fn is_native_module_callable_export_reference(module: &str, prop: &st
     {
         return true;
     }
+    if module == "bun.ant" && matches!(prop, "getPeerPid" | "getPeerUid" | "memoryPressureLevel") {
+        return true;
+    }
     // bun:ffi (#6562). `FFIType` and `suffix` are constants, not callables;
     // the not-yet-supported exports are callable so they throw their
     // stage-1 error instead of "undefined is not a function".

--- a/crates/perry-runtime/src/object/native_module/callable_export_table.rs
+++ b/crates/perry-runtime/src/object/native_module/callable_export_table.rs
@@ -104,6 +104,10 @@ pub(super) static CALLABLE_EXPORT_TABLE: &[(&str, &[&str])] = &[
         ],
     ),
     (
+        "bun.ant",
+        &["getPeerPid", "getPeerUid", "memoryPressureLevel"],
+    ),
+    (
         "bun:ffi",
         &[
             "CFunction",

--- a/crates/perry-runtime/src/object/native_module/module_keys.rs
+++ b/crates/perry-runtime/src/object/native_module/module_keys.rs
@@ -1634,6 +1634,7 @@ pub(crate) fn native_module_enumerable_keys(module_name: &str) -> Option<&'stati
             b"TOML",
             b"Terminal",
             b"YAML",
+            b"ant",
             b"deepEquals",
             b"file",
             b"fileURLToPath",
@@ -1656,6 +1657,7 @@ pub(crate) fn native_module_enumerable_keys(module_name: &str) -> Option<&'stati
             b"zstdDecompress",
             b"zstdDecompressSync",
         ]),
+        "bun.ant" => Some(&[b"getPeerPid", b"getPeerUid", b"memoryPressureLevel"]),
         // bun:ffi (#6562) — stage-1 surface plus the declared-but-throwing
         // exports (their reads resolve to callables that raise the stage-1
         // error).

--- a/crates/perry-runtime/src/object/native_module_dispatch/dispatch_a_c.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch/dispatch_a_c.rs
@@ -292,6 +292,9 @@ pub(crate) unsafe fn nm_dispatch_bun(ctx: &NmCtx, module_name: &str, method_name
         ("bun", "unsupported") => crate::bun_compat::js_bun_unsupported(arg(0)),
         ("bun", "pathToFileURL") => crate::url::js_url_path_to_file_url(arg(0), arg(1)),
         ("bun", "fileURLToPath") => crate::url::js_url_file_url_to_path(arg(0), arg(1)),
+        ("bun.ant", "getPeerUid") => crate::bun_compat::js_bun_ant_get_peer_uid(arg(0)),
+        ("bun.ant", "getPeerPid") => crate::bun_compat::js_bun_ant_get_peer_pid(arg(0)),
+        ("bun.ant", "memoryPressureLevel") => crate::bun_compat::js_bun_ant_memory_pressure_level(),
         _ => f64::from_bits(JSValue::undefined().bits()),
     }
 }

--- a/crates/perry-runtime/src/object/native_module_registry.rs
+++ b/crates/perry-runtime/src/object/native_module_registry.rs
@@ -79,7 +79,7 @@ fn nm_module_index(name: &str) -> Option<NmBucket> {
         "async_hooks" => Some(NmBucket::AsyncHooks),
         "bigint" => Some(NmBucket::Bigint),
         "buffer" | "buffer.Buffer" => Some(NmBucket::Buffer),
-        "bun" => Some(NmBucket::Bun),
+        "bun" | "bun.ant" => Some(NmBucket::Bun),
         // #6562: the `bun:` prefix is part of the name (not stripped like
         // `node:`).
         "bun:ffi" | "ffi" | "ffi.default" => Some(NmBucket::BunFfi),

--- a/crates/perry/tests/issue_9607_bun_ant.rs
+++ b/crates/perry/tests/issue_9607_bun_ant.rs
@@ -1,0 +1,105 @@
+//! #9607 — Claude Code's vendor Bun.ant peer-credential and pressure hooks.
+
+#![cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly"
+))]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile(dir: &Path) -> PathBuf {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg("--platform")
+        .arg("bun")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    output
+}
+
+#[test]
+fn bun_ant_reads_unix_socket_peers_and_handles_failures_conservatively() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("main.ts"),
+        r#"
+import * as net from "node:net";
+import { closeSync, openSync } from "node:fs";
+
+const socketPath = process.cwd() + "/peer.sock";
+let client: any;
+const lines = await new Promise<string[]>((resolve, reject) => {
+  const output: string[] = [];
+  const server = net.createServer((socket: any) => {
+    const fd = socket._handle?.fd;
+    output.push("fd " + (typeof fd === "number" && fd >= 0));
+    output.push("uid " + (Bun.ant.getPeerUid(fd) === process.getuid()));
+    const pid = Bun.ant.getPeerPid(fd);
+    output.push("pid " + (pid === null || pid > 0));
+    output.push("invalid " + (Bun.ant.getPeerUid(-1) === null && Bun.ant.getPeerPid(-1) === null));
+
+    const closed = openSync(process.cwd() + "/closed-fd", "w");
+    closeSync(closed);
+    output.push("closed " + (Bun.ant.getPeerUid(closed) === null && Bun.ant.getPeerPid(closed) === null));
+
+    socket.destroy();
+    client.destroy();
+    server.close();
+    resolve(output);
+  });
+  server.once("error", reject);
+  server.listen(socketPath, () => {
+    client = net.connect({ path: socketPath });
+    client.once("error", reject);
+    client.resume();
+  });
+});
+
+for (const line of lines) console.log(line);
+console.log("namespace " + (typeof Bun.ant === "object" && Bun.ant === Bun.ant));
+console.log("methods " + Object.keys(Bun.ant).sort().join(","));
+const pressure = Bun.ant.memoryPressureLevel();
+console.log("pressure " + (pressure === null || pressure === "normal" || pressure === "warning" || pressure === "critical"));
+"#,
+    )
+    .expect("write entry");
+
+    let output = compile(dir.path());
+    let run = Command::new(&output)
+        .current_dir(dir.path())
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "fd true\nuid true\npid true\ninvalid true\nclosed true\nnamespace true\nmethods getPeerPid,getPeerUid,memoryPressureLevel\npressure true\n"
+    );
+}

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 2069 entries across 136 modules
+// Coverage: 2083 entries across 136 modules
 
 type PerryI8 = number & { readonly __perryI8?: never };
 type PerryI16 = number & { readonly __perryI16?: never };
@@ -343,7 +343,17 @@ declare module "buffer" {
 
 declare module "bun" {
   /** stdlib */
+  export const JSONL: any;
+  /** stdlib */
+  export const TOML: any;
+  /** stdlib */
+  export const YAML: any;
+  /** stdlib */
+  export const ant: any;
+  /** stdlib */
   export const isStandaloneExecutable: any;
+  /** stdlib */
+  export const semver: any;
   /** stdlib */
   export const stderr: any;
   /** stdlib */
@@ -355,19 +365,37 @@ declare module "bun" {
   /** stdlib */
   export function Glob(...args: any[]): any;
   /** stdlib */
+  export function Terminal(...args: any[]): any;
+  /** stdlib */
+  export function deepEquals(...args: any[]): any;
+  /** stdlib */
   export function file(...args: any[]): any;
   /** stdlib */
   export function fileURLToPath(...args: any[]): any;
+  /** stdlib */
+  export function gc(...args: any[]): any;
+  /** stdlib */
+  export function generateHeapSnapshot(...args: any[]): any;
   /** stdlib */
   export function hash(...args: any[]): any;
   /** stdlib */
   export function pathToFileURL(...args: any[]): any;
   /** stdlib */
+  export function spawn(...args: any[]): any;
+  /** stdlib */
   export function stringWidth(...args: any[]): any;
+  /** stdlib */
+  export function stripANSI(...args: any[]): any;
   /** stdlib */
   export function unsupported(...args: any[]): any;
   /** stdlib */
+  export function which(...args: any[]): any;
+  /** stdlib */
+  export function wrapAnsi(...args: any[]): any;
+  /** stdlib */
   export function write(...args: any[]): any;
+  /** stdlib */
+  export function zstdDecompressSync(...args: any[]): any;
 }
 
 declare module "bun:ffi" {

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 3022 entries across 138 modules.
+Total: 3037 entries across 138 modules.
 
 ## Modules
 
@@ -421,17 +421,32 @@ Total: 3022 entries across 138 modules.
 ### Methods
 
 - `Glob` — module
+- `Terminal` — module
+- `deepEquals` — module
 - `file` — module
 - `fileURLToPath` — module
+- `gc` — module
+- `generateHeapSnapshot` — module
 - `hash` — module
 - `pathToFileURL` — module
+- `spawn` — module
 - `stringWidth` — module
+- `stripANSI` — module
 - `unsupported` — module
+- `which` — module
+- `wrapAnsi` — module
 - `write` — module
+- `zstdDecompress` — instance
+- `zstdDecompressSync` — module
 
 ### Properties
 
+- `JSONL`
+- `TOML`
+- `YAML`
+- `ant`
 - `isStandaloneExecutable`
+- `semver`
 - `stderr`
 - `stdin`
 - `stdout`


### PR DESCRIPTION
Fixes #9607.

## Summary

- expose a stable `Bun.ant` namespace in opt-in Bun builds, with safe peer UID/PID lookup
- surface borrowed `node:net` socket descriptors through `_handle.fd` for Claude Code's peer-credential checks
- report best-effort memory pressure from Linux proc/cgroup data and macOS pressure state, returning `null` when unavailable
- add focused unit and end-to-end coverage, API manifest entries, generated docs, and a changelog fragment

No version bump is included.

## Testing

- `cargo check -p perry-runtime -p perry-ext-net -p perry-api-manifest --tests`
- `cargo test -p perry-runtime --lib bun_compat::ant::tests`
- `cargo test -p perry-runtime --lib callable_export`
- `cargo test -p perry-ext-net --lib`
- `cargo test -p perry-api-manifest`
- `cargo test -p perry --test issue_9607_bun_ant -- --nocapture`
- `cargo test -p perry --test issue_9599_bun_platform node_platform_keeps_bun_global_absent -- --nocapture`
- `./scripts/regen_api_docs.sh`

The macOS-only libc calls were also checked against the `aarch64-apple-darwin` target in an isolated crate; the repository-wide cross-check requires an Apple-capable C toolchain that is not installed on the Linux development host.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in Bun compatibility for `Bun.ant`.
  * Added local-socket peer process and user ID lookup.
  * Added memory-pressure reporting with normal, warning, critical, or unavailable states.
  * Added socket handle file-descriptor access for supported networking scenarios.

* **Documentation**
  * Updated API declarations and reference documentation for the expanded Bun API surface.

* **Tests**
  * Added coverage for peer credentials, invalid descriptors, exposed methods, and memory-pressure results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->