### PR TITLE
fix(parser): enable using declarations in JavaScript

### DIFF
--- a/changelog.d/9657-explicit-resource-management-syntax.md
+++ b/changelog.d/9657-explicit-resource-management-syntax.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- JavaScript `using` and `await using` declarations no longer emit
+  `UsingDeclNotEnabled` parse warnings. Perry now enables SWC's
+  explicit-resource-management syntax for JavaScript inputs, matching the
+  already-enabled TypeScript path and the runtime support for resource
+  disposal.

--- a/crates/perry-parser/src/lib.rs
+++ b/crates/perry-parser/src/lib.rs
@@ -193,6 +193,7 @@ fn syntax_for_filename(filename: &str) -> Syntax {
             decorators_before_export: true,
             export_default_from: true,
             import_attributes: true,
+            explicit_resource_management: true,
             ..Default::default()
         })
     }
@@ -902,6 +903,67 @@ pub fn swc_span_to_span(swc_span: swc_common::Span, file_id: FileId) -> Span {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn explicit_resource_management_has_no_diagnostics_for_supported_extensions() {
+        let source = r#"
+async function exerciseResources() {
+    using syncResource = { [Symbol.dispose]() {} };
+    await using asyncResource = { async [Symbol.asyncDispose]() {} };
+}
+export { exerciseResources };
+"#;
+
+        for filename in [
+            "resources.js",
+            "resources.mjs",
+            "resources.ts",
+            "resources.mts",
+        ] {
+            let mut cache = SourceCache::new();
+            let result = parse_typescript_with_cache(source, filename, &mut cache)
+                .unwrap_or_else(|error| panic!("{filename} failed to parse: {error:?}"));
+
+            assert!(
+                result.diagnostics.is_empty(),
+                "{filename} produced diagnostics: {:?}",
+                result.diagnostics
+            );
+        }
+    }
+
+    #[test]
+    fn many_valid_using_declarations_do_not_accumulate_diagnostics() {
+        let declarations = (0..70)
+            .map(|index| format!("    using resource_{index} = null;\n"))
+            .collect::<String>();
+        let source = format!("function manyResources() {{\n{declarations}}}\n");
+        let mut cache = SourceCache::new();
+
+        let result = parse_typescript_with_cache(&source, "bundle.js", &mut cache).unwrap();
+
+        assert!(
+            result.diagnostics.is_empty(),
+            "valid declarations produced diagnostics: {:?}",
+            result.diagnostics
+        );
+    }
+
+    #[test]
+    fn invalid_using_declarations_still_report_diagnostics() {
+        for source in ["using resource;", "using { resource } = value;"] {
+            let mut cache = SourceCache::new();
+            let diagnosed = match parse_typescript_with_cache(source, "invalid.js", &mut cache) {
+                Ok(result) => !result.diagnostics.is_empty(),
+                Err(_) => true,
+            };
+
+            assert!(
+                diagnosed,
+                "invalid declaration unexpectedly had no diagnostics: {source}"
+            );
+        }
+    }
 
     #[test]
     fn test_es_module_detection_survives_regex_with_quote() {

--- a/test-files/test_gap_9609_explicit_resource_management.ts
+++ b/test-files/test_gap_9609_explicit_resource_management.ts
@@ -1,0 +1,85 @@
+// #9609: enabling SWC's JavaScript explicit-resource-management syntax must
+// not disturb Perry's existing using/await-using lowering. This fixture is
+// compiled by Perry and compared byte-for-byte with the pinned Node version.
+
+const events: string[] = [];
+
+function syncResource(name: string, disposeError?: string) {
+  return {
+    [Symbol.dispose]() {
+      events.push("dispose:" + name);
+      if (disposeError) {
+        throw new Error(disposeError);
+      }
+    },
+  };
+}
+
+function reverseOrder(): void {
+  using first = syncResource("first");
+  using second = syncResource("second");
+  events.push("body:reverse");
+}
+
+function returnCompletion(): string {
+  using resource = syncResource("return");
+  events.push("body:return");
+  return "returned";
+}
+
+function throwCompletion(): void {
+  try {
+    using resource = syncResource("throw");
+    events.push("body:throw");
+    throw new Error("body-failure");
+  } catch (error: any) {
+    events.push("caught:" + error.message);
+  }
+}
+
+function suppressedCompletion(): void {
+  try {
+    using first = syncResource("suppressed-first", "dispose-first");
+    using second = syncResource("suppressed-second", "dispose-second");
+    events.push("body:suppressed");
+    throw new Error("body-failure");
+  } catch (error: any) {
+    events.push(
+      [
+        "suppressed",
+        error instanceof SuppressedError,
+        error.error.message,
+        error.suppressed instanceof SuppressedError,
+        error.suppressed.error.message,
+        error.suppressed.suppressed.message,
+      ].join(":"),
+    );
+  }
+}
+
+async function asyncOrder(): Promise<void> {
+  await using first = {
+    async [Symbol.asyncDispose]() {
+      await Promise.resolve();
+      events.push("async-dispose:first");
+    },
+  };
+  await using second = {
+    async [Symbol.asyncDispose]() {
+      await Promise.resolve();
+      events.push("async-dispose:second");
+    },
+  };
+  events.push("body:async");
+}
+
+async function main(): Promise<void> {
+  reverseOrder();
+  events.push("result:" + returnCompletion());
+  throwCompletion();
+  suppressedCompletion();
+  await asyncOrder();
+  console.log(events.join("\n"));
+}
+
+main();


### PR DESCRIPTION
## Summary

- enable SWC explicit resource management for JavaScript parsing so valid `using` and `await using` declarations do not emit recoverable warnings
- cover `.js`, `.mjs`, `.ts`, and `.mts`, invalid declaration diagnostics, and a 70-declaration zero-diagnostic bundle
- add Perry-vs-Node conformance coverage for reverse-order disposal, return/throw cleanup, async disposal, and nested `SuppressedError` chaining

## Testing

- `cargo test -p perry-parser --lib` — 44 passed
- `./run_parity_tests.sh --filter test_gap_9609_explicit_resource_management` — 1/1 parity pass, 0 compile failures, 0 crashes
- `cargo fmt --all -- --check`
- `python3 scripts/check_test_registration.py`
- `./scripts/check_file_size.sh`
- `./scripts/pre-tag-check.sh --quick`

`./scripts/test_affected_crates.sh --base origin/main` passed all 3,064 executed `perry-runtime` tests, then stopped in the `perry` binary tests on an unrelated current-main invariant: `PERRY_CONCAT_SITE_CACHE` is present in `perry-codegen` but absent from both `BUILD_CACHE_ENV_VARS` and `BUILD_CACHE_ENV_EXCLUSIONS`. The branch does not touch either area.

No version bump.

Closes #9609

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * JavaScript and TypeScript now support `using` and `await using` declarations without parser warnings.
  * Resource disposal behavior is covered for synchronous and asynchronous usage, including errors, returns, nesting, and disposal order.

* **Bug Fixes**
  * Invalid resource-management declarations continue to report diagnostics while valid declarations parse correctly across supported JavaScript and TypeScript file types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->