### PR TITLE
Merge train: #9660 (Readable.toWeb for file streams)

### DIFF
--- a/changelog.d/9660-readable-to-web-fs.md
+++ b/changelog.d/9660-readable-to-web-fs.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- `Readable.toWeb()` now streams event-backed sources such as `fs.ReadStream`
+  instead of closing with an empty body. File read errors propagate to the web
+  stream, backpressure stays bounded, and cancellation destroys the source.

--- a/crates/perry-runtime/src/fs/stream.rs
+++ b/crates/perry-runtime/src/fs/stream.rs
@@ -1429,6 +1429,10 @@ fn end_pipes(id: usize) {
 }
 
 fn read_stream_pump(id: usize) {
+    if emit_pending_read_error(id) {
+        return;
+    }
+
     let should_start = STREAM_REGISTRY.with(|registry| {
         let mut registry = registry.borrow_mut();
         let Some(state) = registry.get_mut(&id) else {

--- a/crates/perry-runtime/src/fs/stream/options_init.rs
+++ b/crates/perry-runtime/src/fs/stream/options_init.rs
@@ -3,6 +3,25 @@
 
 use super::*;
 
+/// Starting a ReadStream must deliver a constructor-time open failure. Without
+/// this transition, event-backed consumers wait forever for data/end/error
+/// after `createReadStream()` recorded an invalid path (#9616).
+pub(super) fn emit_pending_read_error(id: usize) -> bool {
+    let pending = STREAM_REGISTRY.with(|registry| {
+        registry.borrow().get(&id).and_then(|state| {
+            (state.kind == StreamKind::Read && !state.errored)
+                .then(|| state.error_msg.clone())
+                .flatten()
+        })
+    });
+    let Some(message) = pending else {
+        return false;
+    };
+    record_stream_error(id, message);
+    maybe_close_stream(id, false);
+    true
+}
+
 pub(super) fn register_stream_method_arities() {
     crate::closure::js_register_closure_arity(write_stream_write_impl as *const u8, 3);
     crate::closure::js_register_closure_arity(write_stream_end_impl as *const u8, 3);

--- a/crates/perry-runtime/src/node_stream/async_iterator.rs
+++ b/crates/perry-runtime/src/node_stream/async_iterator.rs
@@ -299,6 +299,41 @@ fn iterator_set_error(iterator: f64, err: f64) {
 
 // ── persistent stream-event listeners feeding the iterator ─────────────────
 
+pub(super) fn is_foreign_readable(stream: f64) -> bool {
+    has_truthy_hidden(stream, hidden_key(FOREIGN_READABLE_KEY))
+}
+
+/// Pause/resume an event-backed readable through both stream models. Foreign
+/// sources such as `fs.ReadStream` do not carry node:stream's private flowing
+/// flag, so the internal helper alone is a no-op for them; their public method
+/// owns the actual producer. Keeping that source paused whenever no iterator
+/// pull is waiting gives `Readable.toWeb()` one-file-chunk backpressure instead
+/// of eagerly buffering the complete file on its first read (#9616).
+fn call_foreign_flow_method(stream: f64, method: &[u8]) {
+    if !is_foreign_readable(stream) {
+        return;
+    }
+    unsafe {
+        crate::object::js_native_call_method(
+            stream,
+            method.as_ptr() as *const i8,
+            method.len(),
+            std::ptr::null(),
+            0,
+        );
+    }
+}
+
+fn pause_iterator_source(stream: f64) {
+    pause_readable_stream(stream);
+    call_foreign_flow_method(stream, b"pause");
+}
+
+fn resume_iterator_source(stream: f64) {
+    resume_readable_stream(stream);
+    call_foreign_flow_method(stream, b"resume");
+}
+
 fn iterator_from_listener(closure: *const ClosureHeader) -> f64 {
     js_closure_get_capture_f64(closure, 0)
 }
@@ -332,9 +367,9 @@ extern "C" fn ns_readable_iter_on_data(closure: *const ClosureHeader, chunk: f64
     }
     if let Some(stream) = get_hidden_value(iterator, hidden_key(READABLE_ITERATOR_STREAM_KEY)) {
         if iterator_has_pending(iterator) {
-            resume_readable_stream(stream);
+            resume_iterator_source(stream);
         } else {
-            pause_readable_stream(stream);
+            pause_iterator_source(stream);
         }
     }
     f64::from_bits(TAG_UNDEFINED)
@@ -469,22 +504,7 @@ fn iterator_ensure_attached(iterator: f64, stream: f64) {
 
     // Start flow: delivers any already-buffered chunks via `data` (on the
     // resume/drain microtask) and schedules `end` if the source is finite.
-    resume_readable_stream(stream);
-
-    // A foreign readable has no node:stream state for the call above to act on;
-    // it starts reading only when its own `resume()` runs.
-    if has_truthy_hidden(stream, hidden_key(FOREIGN_READABLE_KEY)) {
-        let name = b"resume";
-        unsafe {
-            crate::object::js_native_call_method(
-                stream,
-                name.as_ptr() as *const i8,
-                name.len(),
-                std::ptr::null(),
-                0,
-            );
-        }
-    }
+    resume_iterator_source(stream);
 }
 
 fn remove_iterator_listener(iterator: f64, stream: f64, event: &[u8], store_key: &[u8]) {
@@ -650,7 +670,7 @@ extern "C" fn ns_readable_iterator_next(closure: *const ClosureHeader) -> f64 {
     let promise = crate::promise::js_promise_new();
     let promise = scope.root_raw_mut_ptr(promise);
     iterator_push_pending(iterator.get_nanbox_f64(), promise.get_raw_mut_ptr());
-    resume_readable_stream(stream.get_nanbox_f64());
+    resume_iterator_source(stream.get_nanbox_f64());
     box_pointer(promise.get_raw_const_ptr())
 }
 
@@ -697,7 +717,7 @@ fn install_async_iterator_symbol(target: f64, func: extern "C" fn(*const Closure
     }
 }
 
-fn build_readable_async_iterator(stream: f64, destroy_on_return: bool) -> f64 {
+pub(super) fn build_readable_async_iterator(stream: f64, destroy_on_return: bool) -> f64 {
     let methods = [
         ("next", cast0(ns_readable_iterator_next)),
         ("return", cast0(ns_readable_iterator_return)),

--- a/crates/perry-runtime/src/node_stream_constructors/web_adapter.rs
+++ b/crates/perry-runtime/src/node_stream_constructors/web_adapter.rs
@@ -93,7 +93,6 @@ fn web_readable_close() -> Option<WebReadableCloseFn> {
     load_web_callback!(WEB_READABLE_CLOSE_PTR, WebReadableCloseFn)
 }
 
-#[allow(dead_code)] // accessor for the deliberately-registered WEB_READABLE_ERROR_PTR callback (set in register); consumer not yet wired
 fn web_readable_error() -> Option<WebReadableErrorFn> {
     load_web_callback!(WEB_READABLE_ERROR_PTR, WebReadableErrorFn)
 }
@@ -155,6 +154,31 @@ fn property_value(value: f64, name: &[u8]) -> f64 {
     unsafe { crate::value::js_get_property(value, name.as_ptr() as i64, name.len() as i64) }
 }
 
+fn call_method_no_args(receiver: f64, name: &[u8]) -> f64 {
+    unsafe {
+        crate::object::js_native_call_method(
+            receiver,
+            name.as_ptr() as *const i8,
+            name.len(),
+            std::ptr::null(),
+            0,
+        )
+    }
+}
+
+fn destroy_foreign_readable(stream: f64, reason: f64) {
+    let args = [reason];
+    unsafe {
+        let _ = crate::object::js_native_call_method(
+            stream,
+            b"destroy".as_ptr() as *const i8,
+            7,
+            args.as_ptr(),
+            args.len(),
+        );
+    }
+}
+
 fn call_stream_callback(callback: f64, err: f64) {
     if !is_callable_value(callback) {
         return;
@@ -196,6 +220,87 @@ extern "C" fn node_to_web_readable_pull(closure: *const ClosureHeader, controlle
     f64::from_bits(TAG_UNDEFINED)
 }
 
+fn settle_foreign_readable_pull(controller: f64, result: f64) {
+    if crate::value::js_is_truthy(property_value(result, b"done")) != 0 {
+        if let Some(close) = web_readable_close() {
+            unsafe {
+                close(controller);
+            }
+        }
+        return;
+    }
+    if let Some(enqueue) = web_readable_enqueue() {
+        unsafe {
+            enqueue(controller, property_value(result, b"value"));
+        }
+    }
+}
+
+extern "C" fn foreign_readable_pull_fulfilled(closure: *const ClosureHeader, result: f64) -> f64 {
+    if !closure.is_null() {
+        settle_foreign_readable_pull(js_closure_get_capture_f64(closure, 0), result);
+    }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+extern "C" fn foreign_readable_pull_rejected(closure: *const ClosureHeader, reason: f64) -> f64 {
+    if !closure.is_null() {
+        if let Some(error) = web_readable_error() {
+            unsafe {
+                error(js_closure_get_capture_f64(closure, 0), reason);
+            }
+        }
+    }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+/// Pull one event-backed chunk through the source's async iterator. Unlike the
+/// private-buffer path above, this works for `fs.ReadStream`, child stdio, and
+/// other foreign Readables whose bytes live outside node:stream's hidden chunk
+/// array. Returning the chained promise keeps the Web-stream pull in flight
+/// until the foreign source yields, ends, or rejects (#9616).
+extern "C" fn foreign_readable_to_web_pull(closure: *const ClosureHeader, controller: f64) -> f64 {
+    if closure.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let iterator = scope.root_nanbox_f64(js_closure_get_capture_f64(closure, 0));
+    let next = scope.root_nanbox_f64(call_method_no_args(iterator.get_nanbox_f64(), b"next"));
+    if crate::promise::js_value_is_promise(next.get_nanbox_f64()) == 0 {
+        settle_foreign_readable_pull(controller, next.get_nanbox_f64());
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+
+    let fulfilled = scope.root_raw_mut_ptr(js_closure_alloc(
+        foreign_readable_pull_fulfilled as *const u8,
+        1,
+    ));
+    let rejected = scope.root_raw_mut_ptr(js_closure_alloc(
+        foreign_readable_pull_rejected as *const u8,
+        1,
+    ));
+    js_closure_set_capture_f64(fulfilled.get_raw_mut_ptr(), 0, controller);
+    js_closure_set_capture_f64(rejected.get_raw_mut_ptr(), 0, controller);
+    let promise =
+        crate::value::js_nanbox_get_pointer(next.get_nanbox_f64()) as *mut crate::promise::Promise;
+    box_pointer(crate::promise::js_promise_then(
+        promise,
+        fulfilled.get_raw_mut_ptr(),
+        rejected.get_raw_mut_ptr(),
+    ) as *const u8)
+}
+
+extern "C" fn foreign_readable_to_web_cancel(closure: *const ClosureHeader, reason: f64) -> f64 {
+    if closure.is_null() {
+        return resolved_promise(f64::from_bits(TAG_UNDEFINED));
+    }
+    let iterator = js_closure_get_capture_f64(closure, 0);
+    let stream = js_closure_get_capture_f64(closure, 1);
+    let returned = call_method_no_args(iterator, b"return");
+    destroy_foreign_readable(stream, reason);
+    returned
+}
+
 extern "C" fn node_to_web_readable_cancel(closure: *const ClosureHeader, reason: f64) -> f64 {
     if !closure.is_null() {
         destroy_stream(js_closure_get_capture_f64(closure, 0), reason);
@@ -205,6 +310,27 @@ extern "C" fn node_to_web_readable_cancel(closure: *const ClosureHeader, reason:
 
 fn node_readable_to_web(node_stream: f64) -> Option<f64> {
     let readable_new = web_readable_new()?;
+    if async_iterator::is_foreign_readable(node_stream) {
+        crate::closure::js_register_closure_arity(foreign_readable_to_web_pull as *const u8, 1);
+        crate::closure::js_register_closure_arity(foreign_readable_to_web_cancel as *const u8, 1);
+        crate::closure::js_register_closure_arity(foreign_readable_pull_fulfilled as *const u8, 1);
+        crate::closure::js_register_closure_arity(foreign_readable_pull_rejected as *const u8, 1);
+
+        let iterator = async_iterator::build_readable_async_iterator(node_stream, true);
+        let pull = js_closure_alloc(foreign_readable_to_web_pull as *const u8, 1);
+        js_closure_set_capture_f64(pull, 0, iterator);
+        let cancel = js_closure_alloc(foreign_readable_to_web_cancel as *const u8, 2);
+        js_closure_set_capture_f64(cancel, 0, iterator);
+        js_closure_set_capture_f64(cancel, 1, node_stream);
+        return Some(unsafe {
+            readable_new(
+                f64::from_bits(TAG_UNDEFINED),
+                closure_value(pull),
+                closure_value(cancel),
+                1.0,
+            )
+        });
+    }
     crate::closure::js_register_closure_arity(node_to_web_readable_pull as *const u8, 1);
     crate::closure::js_register_closure_arity(node_to_web_readable_cancel as *const u8, 1);
     let pull = js_closure_alloc(node_to_web_readable_pull as *const u8, 1);
@@ -263,7 +389,56 @@ extern "C" fn fallback_web_readable_get_reader(closure: *const ClosureHeader) ->
     ])
 }
 
+extern "C" fn fallback_foreign_reader_read(closure: *const ClosureHeader) -> f64 {
+    if closure.is_null() {
+        return resolved_promise(build_web_read_result(f64::from_bits(TAG_UNDEFINED), true));
+    }
+    call_method_no_args(js_closure_get_capture_f64(closure, 0), b"next")
+}
+
+extern "C" fn fallback_foreign_reader_cancel(closure: *const ClosureHeader, reason: f64) -> f64 {
+    foreign_readable_to_web_cancel(closure, reason)
+}
+
+extern "C" fn fallback_foreign_get_reader(closure: *const ClosureHeader) -> f64 {
+    if closure.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let iterator = js_closure_get_capture_f64(closure, 0);
+    let stream = js_closure_get_capture_f64(closure, 1);
+    crate::closure::js_register_closure_arity(fallback_foreign_reader_read as *const u8, 0);
+    crate::closure::js_register_closure_arity(fallback_foreign_reader_cancel as *const u8, 1);
+    let read = js_closure_alloc(fallback_foreign_reader_read as *const u8, 1);
+    js_closure_set_capture_f64(read, 0, iterator);
+    let cancel = js_closure_alloc(fallback_foreign_reader_cancel as *const u8, 2);
+    js_closure_set_capture_f64(cancel, 0, iterator);
+    js_closure_set_capture_f64(cancel, 1, stream);
+    build_enumerable_object(&[
+        (b"read", closure_value(read)),
+        (b"cancel", closure_value(cancel)),
+    ])
+}
+
+fn fallback_foreign_readable_to_web(node_stream: f64) -> f64 {
+    crate::closure::js_register_closure_arity(fallback_foreign_get_reader as *const u8, 0);
+    crate::closure::js_register_closure_arity(fallback_foreign_reader_cancel as *const u8, 1);
+    let iterator = async_iterator::build_readable_async_iterator(node_stream, true);
+    let get_reader = js_closure_alloc(fallback_foreign_get_reader as *const u8, 2);
+    js_closure_set_capture_f64(get_reader, 0, iterator);
+    js_closure_set_capture_f64(get_reader, 1, node_stream);
+    let cancel = js_closure_alloc(fallback_foreign_reader_cancel as *const u8, 2);
+    js_closure_set_capture_f64(cancel, 0, iterator);
+    js_closure_set_capture_f64(cancel, 1, node_stream);
+    build_enumerable_object(&[
+        (b"getReader", closure_value(get_reader)),
+        (b"cancel", closure_value(cancel)),
+    ])
+}
+
 fn fallback_node_readable_to_web(node_stream: f64) -> f64 {
+    if async_iterator::is_foreign_readable(node_stream) {
+        return fallback_foreign_readable_to_web(node_stream);
+    }
     crate::closure::js_register_closure_arity(fallback_web_readable_get_reader as *const u8, 0);
     crate::closure::js_register_closure_arity(fallback_web_reader_cancel as *const u8, 1);
     build_enumerable_object(&[

--- a/crates/perry-runtime/src/node_stream_constructors/web_adapter.rs
+++ b/crates/perry-runtime/src/node_stream_constructors/web_adapter.rs
@@ -279,15 +279,15 @@ extern "C" fn foreign_readable_to_web_pull(closure: *const ClosureHeader, contro
         foreign_readable_pull_rejected as *const u8,
         1,
     ));
-    js_closure_set_capture_f64(fulfilled.get_raw_mut_ptr(), 0, controller);
-    js_closure_set_capture_f64(rejected.get_raw_mut_ptr(), 0, controller);
+    fulfilled.with_mut_ptr(|f| js_closure_set_capture_f64(f, 0, controller));
+    rejected.with_mut_ptr(|r| js_closure_set_capture_f64(r, 0, controller));
     let promise =
         crate::value::js_nanbox_get_pointer(next.get_nanbox_f64()) as *mut crate::promise::Promise;
-    box_pointer(crate::promise::js_promise_then(
-        promise,
-        fulfilled.get_raw_mut_ptr(),
-        rejected.get_raw_mut_ptr(),
-    ) as *const u8)
+    box_pointer(
+        fulfilled.with_mut_ptr(|f| {
+            rejected.with_mut_ptr(|r| crate::promise::js_promise_then(promise, f, r))
+        }) as *const u8,
+    )
 }
 
 extern "C" fn foreign_readable_to_web_cancel(closure: *const ClosureHeader, reason: f64) -> f64 {

--- a/test-files/test_gap_9616_readable_to_web_fs.ts
+++ b/test-files/test_gap_9616_readable_to_web_fs.ts
@@ -1,0 +1,152 @@
+// #9616: Readable.toWeb() must consume foreign/event-backed Readables such as
+// fs.ReadStream. The old adapter only inspected node:stream's private chunk
+// buffer, mistook an fs stream for an already-drained stream, and closed the
+// Web stream with zero bytes on its first pull.
+import {
+  createReadStream,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Readable } from "node:stream";
+
+function digest(bytes: Uint8Array): string {
+  let hash = 2166136261;
+  for (let i = 0; i < bytes.length; i++) {
+    hash = Math.imul(hash ^ bytes[i], 16777619) >>> 0;
+  }
+  return hash.toString(16);
+}
+
+async function consume(stream: ReadableStream<any>): Promise<{
+  bytes: number;
+  chunks: number;
+  digest: string;
+}> {
+  const reader = stream.getReader();
+  let bytes = 0;
+  let chunks = 0;
+  let hash = 2166136261;
+  for (;;) {
+    const result = await reader.read();
+    if (result.done) break;
+    chunks++;
+    const value = result.value as Uint8Array;
+    bytes += value.length;
+    for (let i = 0; i < value.length; i++) {
+      hash = Math.imul(hash ^ value[i], 16777619) >>> 0;
+    }
+  }
+  return { bytes, chunks, digest: hash.toString(16) };
+}
+
+const directory = mkdtempSync(join(tmpdir(), "perry-readable-to-web-"));
+const path = join(directory, "payload.bin");
+const emptyPath = join(directory, "empty.bin");
+const missingPath = join(directory, "missing.bin");
+
+try {
+  const payload = new Uint8Array(150_321);
+  for (let i = 0; i < payload.length; i++) payload[i] = (i * 31 + 7) & 255;
+  writeFileSync(path, payload);
+  writeFileSync(emptyPath, new Uint8Array(0));
+  const expectedDigest = digest(payload);
+
+  const nodeSource = createReadStream(path, { highWaterMark: 4096 });
+  const viaReader = await consume(Readable.toWeb(nodeSource) as ReadableStream<any>);
+  console.log(
+    "reader:",
+    viaReader.bytes,
+    viaReader.digest === expectedDigest,
+    viaReader.chunks > 1,
+    nodeSource.bytesRead,
+  );
+
+  const responseBytes = new Uint8Array(
+    await new Response(
+      Readable.toWeb(
+        createReadStream(path, { highWaterMark: 8192 }),
+      ) as ReadableStream<any>,
+    ).arrayBuffer(),
+  );
+  console.log(
+    "response:",
+    responseBytes.length,
+    digest(responseBytes) === expectedDigest,
+  );
+
+  // Exercise the runtime method-value fallback as well as the compiler's
+  // direct static-method lowering above.
+  const dynamicMethodName = ["to", "Web"].join("");
+  const dynamicToWeb = (Readable as any)[dynamicMethodName];
+  const dynamic = await consume(
+    dynamicToWeb(createReadStream(path, { highWaterMark: 5000 })),
+  );
+  console.log(
+    "dynamic:",
+    dynamic.bytes,
+    dynamic.digest === expectedDigest,
+    dynamic.chunks > 1,
+  );
+
+  const rangeStart = 123;
+  const rangeEnd = 8122;
+  const range = await consume(
+    Readable.toWeb(
+      createReadStream(path, {
+        start: rangeStart,
+        end: rangeEnd,
+        highWaterMark: 777,
+      }),
+    ) as ReadableStream<any>,
+  );
+  const expectedRange = payload.slice(rangeStart, rangeEnd + 1);
+  console.log(
+    "range:",
+    range.bytes,
+    range.digest === digest(expectedRange),
+    range.chunks > 1,
+  );
+
+  const empty = await (
+    Readable.toWeb(createReadStream(emptyPath)) as ReadableStream<any>
+  ).getReader().read();
+  console.log("empty:", empty.done, empty.value === undefined);
+
+  let rejected = false;
+  try {
+    await (
+      Readable.toWeb(createReadStream(missingPath)) as ReadableStream<any>
+    ).getReader().read();
+  } catch {
+    rejected = true;
+  }
+  console.log("missing rejects:", rejected);
+
+  const canceledSource = createReadStream(path, { highWaterMark: 1024 });
+  const canceledReader = (
+    Readable.toWeb(canceledSource) as ReadableStream<any>
+  ).getReader();
+  const first = await canceledReader.read();
+  const stoppedBeforeWholeFile = canceledSource.bytesRead < payload.length;
+  await canceledReader.cancel("stop");
+  await new Promise<void>((resolve) => canceledSource.once("close", resolve));
+  console.log(
+    "cancel:",
+    !first.done && first.value.length === 1024,
+    stoppedBeforeWholeFile,
+    canceledSource.destroyed,
+    canceledSource.closed,
+  );
+
+  // Keep coverage for the existing private-buffer path: foreign-stream support
+  // must not regress Readable.from()/custom Readables.
+  const classic = await consume(
+    Readable.toWeb(Readable.from(["alpha", "beta"])) as ReadableStream<any>,
+  );
+  console.log("classic:", classic.bytes, classic.chunks);
+} finally {
+  rmSync(directory, { recursive: true, force: true });
+}


### PR DESCRIPTION
Lands #9660 — event-backed Node readables (including `fs.ReadStream`) are bridged through their async iterator when converted to Web Streams, with bounded pause/resume backpressure, deferred file-open errors propagated, and the source destroyed on cancellation (#9616).

One gate fix carried: the new `node_stream_constructors/web_adapter.rs` took four bare `get_raw_mut_ptr()` reads out of rooted handles, which the raw-handle ratchet exists to catch. All four are scoped arguments to non-allocating calls, so they now go through `with_mut_ptr` (not `across_*`, which re-reads after a call that can collect — not the shape here).

Validation: `run_lint_gates.sh` **all 62 gates pass**; release build green; RUST_TEST_THREADS=1 perry-runtime **3064/0**; `test_gap_9616_readable_to_web_fs` byte-identical to node.

Rebase-merge preserving authorship.
