### PR TITLE
fix(stream): root Web adapter values across moving GC

### DIFF
--- a/changelog.d/9662-web-adapter-gc-roots.md
+++ b/changelog.d/9662-web-adapter-gc-roots.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Web Stream adapters now keep controllers, iterators, promises, and callbacks
+  rooted across allocations, preventing stale references when the moving
+  garbage collector runs during stream conversion.

--- a/crates/perry-runtime/src/node_stream/async_iterator.rs
+++ b/crates/perry-runtime/src/node_stream/async_iterator.rs
@@ -704,44 +704,70 @@ pub(super) extern "C" fn ns_iterator1(closure: *const ClosureHeader, opts: f64) 
 }
 
 fn install_async_iterator_symbol(target: f64, func: extern "C" fn(*const ClosureHeader) -> f64) {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let target = scope.root_nanbox_f64(target);
     let async_iterator = crate::symbol::well_known_symbol("asyncIterator");
     if async_iterator.is_null() {
         return;
     }
-    let closure = js_closure_alloc(func as *const u8, 1);
-    js_closure_set_capture_ptr(closure, 0, target.to_bits() as i64);
-    let closure_value = box_pointer(closure as *const u8);
+    let closure = scope.root_raw_mut_ptr(js_closure_alloc(func as *const u8, 1));
+    closure.with_mut_ptr(|closure| {
+        js_closure_set_capture_ptr(closure, 0, target.get_nanbox_f64().to_bits() as i64)
+    });
     let symbol_value = box_pointer(async_iterator as *const u8);
-    unsafe {
-        crate::symbol::js_object_set_symbol_property(target, symbol_value, closure_value);
-    }
+    closure.with_const_ptr(|closure| unsafe {
+        crate::symbol::js_object_set_symbol_property(
+            target.get_nanbox_f64(),
+            symbol_value,
+            box_pointer(closure),
+        );
+    });
+}
+
+fn set_rooted_iterator_value(
+    iterator: &crate::gc::RuntimeHandle<'_>,
+    key_bytes: &[u8],
+    value: f64,
+) {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let value = scope.root_nanbox_f64(value);
+    let key = scope.root_string_ptr(hidden_key(key_bytes));
+    key.with_mut_ptr(|key| {
+        set_hidden_value(iterator.get_nanbox_f64(), key, value.get_nanbox_f64())
+    });
 }
 
 pub(super) fn build_readable_async_iterator(stream: f64, destroy_on_return: bool) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let stream = scope.root_nanbox_f64(stream);
     let methods = [
         ("next", cast0(ns_readable_iterator_next)),
         ("return", cast0(ns_readable_iterator_return)),
     ];
     let obj = build_object(&methods, READABLE_ITERATOR_SHAPE_ID + methods.len() as u32);
-    let iterator = box_pointer(obj as *const u8);
-    set_hidden_value(iterator, hidden_key(READABLE_ITERATOR_STREAM_KEY), stream);
-    set_hidden_value(iterator, hidden_key(READABLE_ITERATOR_INDEX_KEY), 0.0);
-    set_hidden_value(
-        iterator,
-        hidden_key(READABLE_ITERATOR_DONE_KEY),
+    let iterator = scope.root_nanbox_f64(box_pointer(obj as *const u8));
+    set_rooted_iterator_value(
+        &iterator,
+        READABLE_ITERATOR_STREAM_KEY,
+        stream.get_nanbox_f64(),
+    );
+    set_rooted_iterator_value(&iterator, READABLE_ITERATOR_INDEX_KEY, 0.0);
+    set_rooted_iterator_value(
+        &iterator,
+        READABLE_ITERATOR_DONE_KEY,
         f64::from_bits(TAG_FALSE),
     );
-    set_hidden_value(
-        iterator,
-        hidden_key(READABLE_ITERATOR_DESTROY_ON_RETURN_KEY),
+    set_rooted_iterator_value(
+        &iterator,
+        READABLE_ITERATOR_DESTROY_ON_RETURN_KEY,
         f64::from_bits(if destroy_on_return {
             TAG_TRUE
         } else {
             TAG_FALSE
         }),
     );
-    install_async_iterator_symbol(iterator, ns_readable_iterator_self);
-    iterator
+    install_async_iterator_symbol(iterator.get_nanbox_f64(), ns_readable_iterator_self);
+    iterator.get_nanbox_f64()
 }
 
 /// Build an async iterator that yields `value` exactly once, then completes.

--- a/crates/perry-runtime/src/node_stream_constructors/web_adapter.rs
+++ b/crates/perry-runtime/src/node_stream_constructors/web_adapter.rs
@@ -130,20 +130,36 @@ fn closure_value(closure: *mut ClosureHeader) -> f64 {
 }
 
 fn closure_with_stream(func: *const u8, node_stream: f64) -> f64 {
-    let closure = js_closure_alloc(func, 1);
-    js_closure_set_capture_f64(closure, 0, node_stream);
-    closure_value(closure)
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let node_stream = scope.root_nanbox_f64(node_stream);
+    let closure = scope.root_raw_mut_ptr(js_closure_alloc(func, 1));
+    closure.with_mut_ptr(|closure| {
+        js_closure_set_capture_f64(closure, 0, node_stream.get_nanbox_f64())
+    });
+    closure.with_mut_ptr(closure_value)
 }
 
 fn build_enumerable_object(fields: &[(&[u8], f64)]) -> f64 {
-    let obj = js_object_alloc(0, fields.len() as u32);
-    let mut keys = crate::array::js_array_alloc(fields.len() as u32);
-    for (idx, (name, value)) in fields.iter().enumerate() {
-        keys = crate::array::js_array_push_f64(keys, string_value(name));
-        js_object_set_field(obj, idx as u32, JSValue::from_bits(value.to_bits()));
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let values = fields.iter().map(|(_, value)| *value).collect::<Vec<_>>();
+    let values = scope.root_nanbox_f64_slice(&values);
+    let obj = scope.root_raw_mut_ptr(js_object_alloc(0, fields.len() as u32));
+    let keys = scope.root_raw_mut_ptr(crate::array::js_array_alloc(fields.len() as u32));
+    for (idx, (name, _)) in fields.iter().enumerate() {
+        let key = scope.root_nanbox_f64(string_value(name));
+        keys.set_raw_mut_ptr(
+            keys.with_mut_ptr(|keys| crate::array::js_array_push_f64(keys, key.get_nanbox_f64())),
+        );
+        obj.with_mut_ptr(|obj| {
+            js_object_set_field(
+                obj,
+                idx as u32,
+                JSValue::from_bits(values[idx].get_nanbox_u64()),
+            )
+        });
     }
-    crate::object::js_object_set_keys(obj, keys);
-    box_pointer(obj as *const u8)
+    obj.with_mut_ptr(|obj| keys.with_mut_ptr(|keys| crate::object::js_object_set_keys(obj, keys)));
+    obj.with_const_ptr(|obj: *const u8| box_pointer(obj))
 }
 
 fn build_web_read_result(value: f64, done: bool) -> f64 {
@@ -155,9 +171,11 @@ fn property_value(value: f64, name: &[u8]) -> f64 {
 }
 
 fn call_method_no_args(receiver: f64, name: &[u8]) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let receiver = scope.root_nanbox_f64(receiver);
     unsafe {
         crate::object::js_native_call_method(
-            receiver,
+            receiver.get_nanbox_f64(),
             name.as_ptr() as *const i8,
             name.len(),
             std::ptr::null(),
@@ -167,10 +185,13 @@ fn call_method_no_args(receiver: f64, name: &[u8]) -> f64 {
 }
 
 fn destroy_foreign_readable(stream: f64, reason: f64) {
-    let args = [reason];
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let stream = scope.root_nanbox_f64(stream);
+    let reason = scope.root_nanbox_f64(reason);
+    let args = [reason.get_nanbox_f64()];
     unsafe {
         let _ = crate::object::js_native_call_method(
-            stream,
+            stream.get_nanbox_f64(),
             b"destroy".as_ptr() as *const i8,
             7,
             args.as_ptr(),
@@ -221,17 +242,22 @@ extern "C" fn node_to_web_readable_pull(closure: *const ClosureHeader, controlle
 }
 
 fn settle_foreign_readable_pull(controller: f64, result: f64) {
-    if crate::value::js_is_truthy(property_value(result, b"done")) != 0 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let controller = scope.root_nanbox_f64(controller);
+    let result = scope.root_nanbox_f64(result);
+    let done = scope.root_nanbox_f64(property_value(result.get_nanbox_f64(), b"done"));
+    if crate::value::js_is_truthy(done.get_nanbox_f64()) != 0 {
         if let Some(close) = web_readable_close() {
             unsafe {
-                close(controller);
+                close(controller.get_nanbox_f64());
             }
         }
         return;
     }
     if let Some(enqueue) = web_readable_enqueue() {
+        let value = scope.root_nanbox_f64(property_value(result.get_nanbox_f64(), b"value"));
         unsafe {
-            enqueue(controller, property_value(result, b"value"));
+            enqueue(controller.get_nanbox_f64(), value.get_nanbox_f64());
         }
     }
 }
@@ -246,8 +272,11 @@ extern "C" fn foreign_readable_pull_fulfilled(closure: *const ClosureHeader, res
 extern "C" fn foreign_readable_pull_rejected(closure: *const ClosureHeader, reason: f64) -> f64 {
     if !closure.is_null() {
         if let Some(error) = web_readable_error() {
+            let scope = crate::gc::RuntimeHandleScope::new();
+            let controller = scope.root_nanbox_f64(js_closure_get_capture_f64(closure, 0));
+            let reason = scope.root_nanbox_f64(reason);
             unsafe {
-                error(js_closure_get_capture_f64(closure, 0), reason);
+                error(controller.get_nanbox_f64(), reason.get_nanbox_f64());
             }
         }
     }
@@ -264,10 +293,11 @@ extern "C" fn foreign_readable_to_web_pull(closure: *const ClosureHeader, contro
         return f64::from_bits(TAG_UNDEFINED);
     }
     let scope = crate::gc::RuntimeHandleScope::new();
+    let controller = scope.root_nanbox_f64(controller);
     let iterator = scope.root_nanbox_f64(js_closure_get_capture_f64(closure, 0));
     let next = scope.root_nanbox_f64(call_method_no_args(iterator.get_nanbox_f64(), b"next"));
     if crate::promise::js_value_is_promise(next.get_nanbox_f64()) == 0 {
-        settle_foreign_readable_pull(controller, next.get_nanbox_f64());
+        settle_foreign_readable_pull(controller.get_nanbox_f64(), next.get_nanbox_f64());
         return f64::from_bits(TAG_UNDEFINED);
     }
 
@@ -279,26 +309,36 @@ extern "C" fn foreign_readable_to_web_pull(closure: *const ClosureHeader, contro
         foreign_readable_pull_rejected as *const u8,
         1,
     ));
-    fulfilled.with_mut_ptr(|f| js_closure_set_capture_f64(f, 0, controller));
-    rejected.with_mut_ptr(|r| js_closure_set_capture_f64(r, 0, controller));
-    let promise =
-        crate::value::js_nanbox_get_pointer(next.get_nanbox_f64()) as *mut crate::promise::Promise;
-    box_pointer(
-        fulfilled.with_mut_ptr(|f| {
-            rejected.with_mut_ptr(|r| crate::promise::js_promise_then(promise, f, r))
-        }) as *const u8,
-    )
+    fulfilled.with_mut_ptr(|fulfilled| {
+        js_closure_set_capture_f64(fulfilled, 0, controller.get_nanbox_f64())
+    });
+    rejected.with_mut_ptr(|rejected| {
+        js_closure_set_capture_f64(rejected, 0, controller.get_nanbox_f64())
+    });
+    let promise = scope
+        .root_raw_mut_ptr(crate::value::js_nanbox_get_pointer(next.get_nanbox_f64())
+            as *mut crate::promise::Promise);
+    let chained = promise.with_mut_ptr(|promise| {
+        fulfilled.with_const_ptr(|fulfilled| {
+            rejected.with_const_ptr(|rejected| {
+                crate::promise::js_promise_then(promise, fulfilled, rejected)
+            })
+        })
+    });
+    box_pointer(chained as *const u8)
 }
 
 extern "C" fn foreign_readable_to_web_cancel(closure: *const ClosureHeader, reason: f64) -> f64 {
     if closure.is_null() {
         return resolved_promise(f64::from_bits(TAG_UNDEFINED));
     }
-    let iterator = js_closure_get_capture_f64(closure, 0);
-    let stream = js_closure_get_capture_f64(closure, 1);
-    let returned = call_method_no_args(iterator, b"return");
-    destroy_foreign_readable(stream, reason);
-    returned
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let iterator = scope.root_nanbox_f64(js_closure_get_capture_f64(closure, 0));
+    let stream = scope.root_nanbox_f64(js_closure_get_capture_f64(closure, 1));
+    let reason = scope.root_nanbox_f64(reason);
+    let returned = scope.root_nanbox_f64(call_method_no_args(iterator.get_nanbox_f64(), b"return"));
+    destroy_foreign_readable(stream.get_nanbox_f64(), reason.get_nanbox_f64());
+    returned.get_nanbox_f64()
 }
 
 extern "C" fn node_to_web_readable_cancel(closure: *const ClosureHeader, reason: f64) -> f64 {
@@ -310,41 +350,62 @@ extern "C" fn node_to_web_readable_cancel(closure: *const ClosureHeader, reason:
 
 fn node_readable_to_web(node_stream: f64) -> Option<f64> {
     let readable_new = web_readable_new()?;
-    if async_iterator::is_foreign_readable(node_stream) {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let node_stream = scope.root_nanbox_f64(node_stream);
+    if async_iterator::is_foreign_readable(node_stream.get_nanbox_f64()) {
         crate::closure::js_register_closure_arity(foreign_readable_to_web_pull as *const u8, 1);
         crate::closure::js_register_closure_arity(foreign_readable_to_web_cancel as *const u8, 1);
         crate::closure::js_register_closure_arity(foreign_readable_pull_fulfilled as *const u8, 1);
         crate::closure::js_register_closure_arity(foreign_readable_pull_rejected as *const u8, 1);
 
-        let iterator = async_iterator::build_readable_async_iterator(node_stream, true);
-        let pull = js_closure_alloc(foreign_readable_to_web_pull as *const u8, 1);
-        js_closure_set_capture_f64(pull, 0, iterator);
-        let cancel = js_closure_alloc(foreign_readable_to_web_cancel as *const u8, 2);
-        js_closure_set_capture_f64(cancel, 0, iterator);
-        js_closure_set_capture_f64(cancel, 1, node_stream);
-        return Some(unsafe {
+        let iterator = scope.root_nanbox_f64(async_iterator::build_readable_async_iterator(
+            node_stream.get_nanbox_f64(),
+            true,
+        ));
+        let pull = scope.root_raw_mut_ptr(js_closure_alloc(
+            foreign_readable_to_web_pull as *const u8,
+            1,
+        ));
+        pull.with_mut_ptr(|pull| js_closure_set_capture_f64(pull, 0, iterator.get_nanbox_f64()));
+        let cancel = scope.root_raw_mut_ptr(js_closure_alloc(
+            foreign_readable_to_web_cancel as *const u8,
+            2,
+        ));
+        cancel.with_mut_ptr(|cancel| {
+            js_closure_set_capture_f64(cancel, 0, iterator.get_nanbox_f64());
+            js_closure_set_capture_f64(cancel, 1, node_stream.get_nanbox_f64());
+        });
+        return Some(pull.with_mut_ptr(|pull| {
+            cancel.with_mut_ptr(|cancel| unsafe {
+                readable_new(
+                    f64::from_bits(TAG_UNDEFINED),
+                    closure_value(pull),
+                    closure_value(cancel),
+                    1.0,
+                )
+            })
+        }));
+    }
+    crate::closure::js_register_closure_arity(node_to_web_readable_pull as *const u8, 1);
+    crate::closure::js_register_closure_arity(node_to_web_readable_cancel as *const u8, 1);
+    let pull = scope.root_raw_mut_ptr(js_closure_alloc(node_to_web_readable_pull as *const u8, 1));
+    pull.with_mut_ptr(|pull| js_closure_set_capture_f64(pull, 0, node_stream.get_nanbox_f64()));
+    let cancel = scope.root_raw_mut_ptr(js_closure_alloc(
+        node_to_web_readable_cancel as *const u8,
+        1,
+    ));
+    cancel
+        .with_mut_ptr(|cancel| js_closure_set_capture_f64(cancel, 0, node_stream.get_nanbox_f64()));
+    Some(pull.with_mut_ptr(|pull| {
+        cancel.with_mut_ptr(|cancel| unsafe {
             readable_new(
                 f64::from_bits(TAG_UNDEFINED),
                 closure_value(pull),
                 closure_value(cancel),
                 1.0,
             )
-        });
-    }
-    crate::closure::js_register_closure_arity(node_to_web_readable_pull as *const u8, 1);
-    crate::closure::js_register_closure_arity(node_to_web_readable_cancel as *const u8, 1);
-    let pull = js_closure_alloc(node_to_web_readable_pull as *const u8, 1);
-    js_closure_set_capture_f64(pull, 0, node_stream);
-    let cancel = js_closure_alloc(node_to_web_readable_cancel as *const u8, 1);
-    js_closure_set_capture_f64(cancel, 0, node_stream);
-    Some(unsafe {
-        readable_new(
-            f64::from_bits(TAG_UNDEFINED),
-            closure_value(pull),
-            closure_value(cancel),
-            1.0,
-        )
-    })
+        })
+    }))
 }
 
 extern "C" fn fallback_web_reader_read(closure: *const ClosureHeader) -> f64 {
@@ -393,7 +454,9 @@ extern "C" fn fallback_foreign_reader_read(closure: *const ClosureHeader) -> f64
     if closure.is_null() {
         return resolved_promise(build_web_read_result(f64::from_bits(TAG_UNDEFINED), true));
     }
-    call_method_no_args(js_closure_get_capture_f64(closure, 0), b"next")
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let iterator = scope.root_nanbox_f64(js_closure_get_capture_f64(closure, 0));
+    call_method_no_args(iterator.get_nanbox_f64(), b"next")
 }
 
 extern "C" fn fallback_foreign_reader_cancel(closure: *const ClosureHeader, reason: f64) -> f64 {
@@ -404,35 +467,67 @@ extern "C" fn fallback_foreign_get_reader(closure: *const ClosureHeader) -> f64 
     if closure.is_null() {
         return f64::from_bits(TAG_UNDEFINED);
     }
-    let iterator = js_closure_get_capture_f64(closure, 0);
-    let stream = js_closure_get_capture_f64(closure, 1);
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let iterator = scope.root_nanbox_f64(js_closure_get_capture_f64(closure, 0));
+    let stream = scope.root_nanbox_f64(js_closure_get_capture_f64(closure, 1));
     crate::closure::js_register_closure_arity(fallback_foreign_reader_read as *const u8, 0);
     crate::closure::js_register_closure_arity(fallback_foreign_reader_cancel as *const u8, 1);
-    let read = js_closure_alloc(fallback_foreign_reader_read as *const u8, 1);
-    js_closure_set_capture_f64(read, 0, iterator);
-    let cancel = js_closure_alloc(fallback_foreign_reader_cancel as *const u8, 2);
-    js_closure_set_capture_f64(cancel, 0, iterator);
-    js_closure_set_capture_f64(cancel, 1, stream);
-    build_enumerable_object(&[
-        (b"read", closure_value(read)),
-        (b"cancel", closure_value(cancel)),
-    ])
+    let read = scope.root_raw_mut_ptr(js_closure_alloc(
+        fallback_foreign_reader_read as *const u8,
+        1,
+    ));
+    read.with_mut_ptr(|read| js_closure_set_capture_f64(read, 0, iterator.get_nanbox_f64()));
+    let cancel = scope.root_raw_mut_ptr(js_closure_alloc(
+        fallback_foreign_reader_cancel as *const u8,
+        2,
+    ));
+    cancel.with_mut_ptr(|cancel| {
+        js_closure_set_capture_f64(cancel, 0, iterator.get_nanbox_f64());
+        js_closure_set_capture_f64(cancel, 1, stream.get_nanbox_f64());
+    });
+    read.with_mut_ptr(|read| {
+        cancel.with_mut_ptr(|cancel| {
+            build_enumerable_object(&[
+                (b"read", closure_value(read)),
+                (b"cancel", closure_value(cancel)),
+            ])
+        })
+    })
 }
 
 fn fallback_foreign_readable_to_web(node_stream: f64) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let node_stream = scope.root_nanbox_f64(node_stream);
     crate::closure::js_register_closure_arity(fallback_foreign_get_reader as *const u8, 0);
     crate::closure::js_register_closure_arity(fallback_foreign_reader_cancel as *const u8, 1);
-    let iterator = async_iterator::build_readable_async_iterator(node_stream, true);
-    let get_reader = js_closure_alloc(fallback_foreign_get_reader as *const u8, 2);
-    js_closure_set_capture_f64(get_reader, 0, iterator);
-    js_closure_set_capture_f64(get_reader, 1, node_stream);
-    let cancel = js_closure_alloc(fallback_foreign_reader_cancel as *const u8, 2);
-    js_closure_set_capture_f64(cancel, 0, iterator);
-    js_closure_set_capture_f64(cancel, 1, node_stream);
-    build_enumerable_object(&[
-        (b"getReader", closure_value(get_reader)),
-        (b"cancel", closure_value(cancel)),
-    ])
+    let iterator = scope.root_nanbox_f64(async_iterator::build_readable_async_iterator(
+        node_stream.get_nanbox_f64(),
+        true,
+    ));
+    let get_reader = scope.root_raw_mut_ptr(js_closure_alloc(
+        fallback_foreign_get_reader as *const u8,
+        2,
+    ));
+    get_reader.with_mut_ptr(|get_reader| {
+        js_closure_set_capture_f64(get_reader, 0, iterator.get_nanbox_f64());
+        js_closure_set_capture_f64(get_reader, 1, node_stream.get_nanbox_f64());
+    });
+    let cancel = scope.root_raw_mut_ptr(js_closure_alloc(
+        fallback_foreign_reader_cancel as *const u8,
+        2,
+    ));
+    cancel.with_mut_ptr(|cancel| {
+        js_closure_set_capture_f64(cancel, 0, iterator.get_nanbox_f64());
+        js_closure_set_capture_f64(cancel, 1, node_stream.get_nanbox_f64());
+    });
+    get_reader.with_mut_ptr(|get_reader| {
+        cancel.with_mut_ptr(|cancel| {
+            build_enumerable_object(&[
+                (b"getReader", closure_value(get_reader)),
+                (b"cancel", closure_value(cancel)),
+            ])
+        })
+    })
 }
 
 fn fallback_node_readable_to_web(node_stream: f64) -> f64 {

--- a/crates/perry-runtime/src/node_stream_dispatch.rs
+++ b/crates/perry-runtime/src/node_stream_dispatch.rs
@@ -45,33 +45,43 @@ pub(super) fn build_object(methods: &[(&str, StubFn)], shape_id: u32) -> *mut Ob
         packed.push(0);
     }
     let field_count = methods.len() as u32;
-    let obj =
-        js_object_alloc_with_shape(shape_id, field_count, packed.as_ptr(), packed.len() as u32);
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let obj = scope.root_raw_mut_ptr(js_object_alloc_with_shape(
+        shape_id,
+        field_count,
+        packed.as_ptr(),
+        packed.len() as u32,
+    ));
 
-    // NaN-box the object pointer — we'll capture it (as raw bits) in each
-    // closure's slot 0 so the stub `this_value` helper can reconstruct
-    // the f64 form for `return this` semantics.
-    let this_bits = JSValue::pointer(obj as *const u8).bits();
-
-    let mut on_method: Option<JSValue> = None;
+    let mut on_method: Option<crate::gc::RuntimeHandle<'_>> = None;
     for (i, (name, func)) in methods.iter().enumerate() {
         if *name == "addListener" {
-            if let Some(val) = on_method {
-                js_object_set_field(obj, i as u32, val);
+            if let Some(on_method) = on_method {
+                obj.with_mut_ptr(|obj| {
+                    on_method.with_const_ptr(|closure| {
+                        js_object_set_field(obj, i as u32, JSValue::pointer(closure))
+                    })
+                });
                 continue;
             }
         }
-        let closure = js_closure_alloc(*func as *const u8, 1);
+        let closure = scope.root_raw_mut_ptr(js_closure_alloc(*func as *const u8, 1));
         // Reuse `set_capture_ptr` (i64 payload). We only need 64 bits
         // and the NaN-boxed pattern fits cleanly when reinterpreted.
-        crate::closure::js_closure_set_capture_ptr(closure, 0, this_bits as i64);
-        let val = JSValue::pointer(closure as *const u8);
+        closure.with_mut_ptr(|closure| {
+            let this_bits = obj.with_const_ptr(|obj| JSValue::pointer(obj).bits());
+            crate::closure::js_closure_set_capture_ptr(closure, 0, this_bits as i64);
+        });
         if *name == "on" {
-            on_method = Some(val);
+            on_method = Some(closure);
         }
-        js_object_set_field(obj, i as u32, val);
+        obj.with_mut_ptr(|obj| {
+            closure.with_const_ptr(|closure| {
+                js_object_set_field(obj, i as u32, JSValue::pointer(closure))
+            })
+        });
     }
-    obj
+    obj.with_mut_ptr(|obj| obj)
 }
 
 /// #6316 — reserved own-key prefix for a native base method DISPLACED by a


### PR DESCRIPTION
## Summary

- root Web-stream adapter controllers, iterator results, source streams, promises, and closures across allocating and user-code-invoking calls
- refresh handles while constructing readable async iterators and native stream method objects
- preserve the file-backed `Readable.toWeb()` behavior landed in #9661 under moving GC

Follow-up to #9660 and #9661.

## Testing

- `cargo check -p perry-runtime`
- `cargo test -p perry-runtime node_stream -- --test-threads=1` (85 passed)
- `cargo test -p perry-runtime fs:: -- --test-threads=1` (10 passed)
- `PERRY_SKIP_BUILD=1 ./run_parity_tests.sh --filter test_gap_9616_readable_to_web_fs` (1/1 passed)
- seeded forced-evacuation parity at rate 0.05 (30,791 copying collections; 20,633 moved objects; 1/1 passed)
- `python3 scripts/raw_handle_debt.py` (959 sites vs baseline 963)
- `./scripts/pre-tag-check.sh --quick`

The rate-1 stress arm was non-vacuous but exceeded the 120-second fixture timeout because it scheduled collections at nearly every poll in the 150,321-byte test loop; the rate-0.05 arm completed with 30,791 copying collections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Web Stream adapter reliability during garbage collection.
  * Prevented stale references while converting and processing streams.
  * Improved stability for async iterators, controllers, callbacks, and stream-related operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->