### PR TITLE
docs: keep README links on released pages

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -3,6 +3,7 @@ name: Docs checks
 on:
   pull_request:
     paths:
+      - "README.md"
       - "docs/**"
       - "scripts/check_docs.py"
       - "crates/perry-doc-tests/**"
@@ -11,6 +12,7 @@ on:
   push:
     branches: [main]
     paths:
+      - "README.md"
       - "docs/**"
       - "scripts/check_docs.py"
       - "crates/perry-doc-tests/**"
@@ -31,6 +33,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Fetch the docs deployed by the latest release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          release_tag="$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName)"
+          git fetch --depth=1 origin "refs/tags/${release_tag}:refs/tags/${release_tag}"
+          echo "PERRY_DOCS_RELEASE_TAG=${release_tag}" >> "$GITHUB_ENV"
       - name: Install mdBook and gettext tooling
         run: |
           sudo apt-get update
@@ -38,8 +47,10 @@ jobs:
           mkdir -p "$HOME/.cargo/bin"
           curl -sSL "https://github.com/rust-lang/mdBook/releases/download/${MDBOOK_VERSION}/mdbook-${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz" | tar -xz -C "$HOME/.cargo/bin"
           cargo install mdbook-i18n-helpers --locked --version 0.4.0
-      - name: Check navigation, local links, anchors, and includes
-        run: python3 scripts/check_docs.py
+      - name: Check navigation, README release links, local links, anchors, and includes
+        run: |
+          python3 scripts/check_docs.py --self-test
+          python3 scripts/check_docs.py
       - name: Check TypeScript fences
         run: cargo run --release --quiet -p perry-doc-tests -- --lint docs/src
       - name: Check gettext catalogs are current
@@ -68,5 +79,6 @@ jobs:
           --accept 200..=399,403,429
           --exclude 'https://www.npmjs.com/'
           --exclude 'https://xtermjs.org/'
+          'README.md'
           'docs/src/**/*.md'
           'docs/*.md'

--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ Everything else lives in the [docs](https://perryts.github.io/perry/):
 - [Language support](https://perryts.github.io/perry/language/supported-features.html) — supported TypeScript features and [limitations](https://perryts.github.io/perry/language/limitations.html)
 - [Native UI](https://perryts.github.io/perry/ui/overview.html) · [Multi-threading](https://perryts.github.io/perry/threading/overview.html) · [Standard library](https://perryts.github.io/perry/stdlib/overview.html)
 - [Platforms](https://perryts.github.io/perry/platforms/overview.html) — per-platform guides from macOS to watchOS to WASM
-- [CLI reference](https://perryts.github.io/perry/cli/commands.html) — commands, flags, `perry.toml`, [privacy & telemetry](https://perryts.github.io/perry/cli/telemetry.html)
-- [Contributing](https://perryts.github.io/perry/contributing/architecture.html) — architecture, [building from source](https://perryts.github.io/perry/contributing/building.html), and the [release process](https://perryts.github.io/perry/contributing/releasing.html)
+- [CLI reference](https://perryts.github.io/perry/cli/commands.html) — commands, flags, `perry.toml`, [privacy & telemetry](docs/src/cli/telemetry.md)
+- [Contributing](docs/src/contributing/architecture.md) — architecture, [building from source](docs/src/contributing/building.md), and the [release process](docs/src/contributing/releasing.md)
 
 ## Community
 
@@ -151,7 +151,7 @@ Perry is built in the open — come say hi:
 
 ## Privacy
 
-Telemetry is **opt-in**: nothing leaves your machine unless you explicitly enable it in `~/.perry/config.toml`, and `PERRY_NO_TELEMETRY=1` (or `CI=true`) always wins. What can be sent is anonymous and redacted — never your source, paths, or project names. Inspect it any time with `perry doctor`, and see exactly what's in the payload in the [privacy & telemetry docs](https://perryts.github.io/perry/cli/telemetry.html).
+Telemetry is **opt-in**: nothing leaves your machine unless you explicitly enable it in `~/.perry/config.toml`, and `PERRY_NO_TELEMETRY=1` (or `CI=true`) always wins. What can be sent is anonymous and redacted — never your source, paths, or project names. Inspect it any time with `perry doctor`, and see exactly what's in the payload in the [privacy & telemetry docs](docs/src/cli/telemetry.md).
 
 ## Sponsors
 

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Check mdBook navigation, local links/anchors, and include targets.
+"""Check mdBook navigation, local links/anchors, and README release links.
 
 This intentionally avoids network access. The scheduled docs workflow runs a
 separate external-link checker so transient remote failures do not block every
@@ -8,17 +8,20 @@ documentation pull request.
 
 from __future__ import annotations
 
+import os
 import re
+import subprocess
 import sys
 from collections import Counter
 from pathlib import Path
-from urllib.parse import unquote
+from urllib.parse import unquote, urlparse
 
 
 ROOT = Path(__file__).resolve().parents[1]
 DOCS = ROOT / "docs"
 SRC = DOCS / "src"
 SUMMARY = SRC / "SUMMARY.md"
+README = ROOT / "README.md"
 
 FENCE_RE = re.compile(r"^\s*(```+|~~~+)")
 INLINE_LINK_RE = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
@@ -26,6 +29,7 @@ REFERENCE_LINK_RE = re.compile(r"^\s*\[[^\]]+\]:\s*(\S+)", re.MULTILINE)
 INCLUDE_RE = re.compile(r"\{\{#(?:rustdoc_)?include\s+([^}\s]+)")
 HEADING_RE = re.compile(r"^\s{0,3}(#{1,6})\s+(.+?)\s*#*\s*$")
 HTML_ID_RE = re.compile(r"\bid=[\"']([^\"']+)[\"']")
+RELEASE_TAG_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
 
 FORBIDDEN_TEXT = {
     "https://github.com/skelpo/perry": "https://github.com/PerryTS/perry",
@@ -35,6 +39,117 @@ FORBIDDEN_TEXT = {
     "@perry/dotenv": "@perryts/dotenv",
     "perryts/mysql2-bindings": "@perryts/tursodb",
 }
+
+
+def latest_release_tag() -> str | None:
+    """Return the highest stable vX.Y.Z tag available in this checkout."""
+    configured = os.environ.get("PERRY_DOCS_RELEASE_TAG")
+    if configured is not None:
+        return configured if RELEASE_TAG_RE.fullmatch(configured) else None
+
+    try:
+        result = subprocess.run(
+            ["git", "tag", "--list", "v*"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+    releases: list[tuple[tuple[int, int, int], str]] = []
+    for tag in result.stdout.splitlines():
+        match = RELEASE_TAG_RE.fullmatch(tag)
+        if match:
+            releases.append((tuple(map(int, match.groups())), tag))
+    return max(releases)[1] if releases else None
+
+
+def published_docs_at(tag: str) -> set[str] | None:
+    """List mdBook chapters published by a release tag's SUMMARY."""
+    try:
+        result = subprocess.run(
+            ["git", "show", f"{tag}:docs/src/SUMMARY.md"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+    published: set[str] = set()
+    for raw in local_destinations(result.stdout):
+        rel, _ = split_destination(raw)
+        if rel and not rel.startswith(("http://", "https://", "mailto:")):
+            published.add((Path("docs/src") / rel).as_posix())
+    return published
+
+
+def public_docs_path(destination: str) -> str | None:
+    """Map either public docs hostname to its mdBook-relative URL path."""
+    parsed = urlparse(destination)
+    path = unquote(parsed.path)
+    if parsed.hostname == "perryts.github.io":
+        if path.rstrip("/") == "/perry":
+            return ""
+        prefix = "/perry/"
+        if not path.startswith(prefix):
+            return None
+        return path[len(prefix) :]
+    if parsed.hostname == "docs.perryts.com":
+        return path.lstrip("/")
+    return None
+
+
+def readme_release_link_errors(
+    text: str, released_docs: set[str], release_tag: str
+) -> list[str]:
+    """Reject public README pages that the deployed release cannot contain."""
+    errors: list[str] = []
+    for raw in local_destinations(text):
+        destination, _ = split_destination(raw)
+        web_path = public_docs_path(destination)
+        if web_path is None or web_path in {"", "index.html"}:
+            continue
+        if not web_path.endswith(".html"):
+            errors.append(
+                f"README.md: public docs link is not an mdBook page: {destination}"
+            )
+            continue
+        source = f"docs/src/{web_path.removesuffix('.html')}.md"
+        if source not in released_docs:
+            errors.append(
+                f"README.md: public docs link is absent from {release_tag}: "
+                f"{destination}; link to {source} until it ships in a release"
+            )
+    return errors
+
+
+def self_test() -> int:
+    released = {"docs/src/guide/released.md"}
+    fixture = """
+[home](https://perryts.github.io/perry/)
+[released](https://perryts.github.io/perry/guide/released.html#section)
+[canonical](https://docs.perryts.com/guide/released.html)
+[external](https://example.com/guide/unreleased.html)
+"""
+    if readme_release_link_errors(fixture, released, "v1.2.3"):
+        print("check_docs --self-test FAILED: accepted fixture was rejected")
+        return 1
+
+    planted = (
+        fixture
+        + "\n[unreleased](https://perryts.github.io/perry/guide/unreleased.html)\n"
+    )
+    errors = readme_release_link_errors(planted, released, "v1.2.3")
+    if len(errors) != 1 or "docs/src/guide/unreleased.md" not in errors[0]:
+        print("check_docs --self-test FAILED: planted unreleased page was not caught")
+        return 1
+
+    print("check_docs --self-test passed: released aliases pass and an unreleased page fails")
+    return 0
 
 
 def without_fenced_code(text: str) -> str:
@@ -108,6 +223,36 @@ def include_file(raw: str) -> str:
 def main() -> int:
     errors: list[str] = []
     markdown = sorted(SRC.rglob("*.md"))
+
+    readme_text = README.read_text(encoding="utf-8")
+    release_tag = latest_release_tag()
+    if release_tag is None:
+        errors.append(
+            "README.md: cannot find a stable release tag; fetch tags before checking docs"
+        )
+    else:
+        released_docs = published_docs_at(release_tag)
+        if released_docs is None:
+            errors.append(f"README.md: cannot inspect documentation at {release_tag}")
+        else:
+            errors.extend(
+                readme_release_link_errors(readme_text, released_docs, release_tag)
+            )
+
+    for raw in local_destinations(readme_text):
+        rel, anchor = split_destination(raw)
+        if not rel or rel.startswith(("http://", "https://", "mailto:")):
+            continue
+        target = (README.parent / rel).resolve()
+        if not target.is_file():
+            errors.append(f"README.md: local link target does not exist: {raw}")
+            continue
+        if anchor and target.suffix.lower() == ".md":
+            anchors = anchors_for(target)
+            if anchor not in anchors:
+                errors.append(
+                    f"README.md: anchor #{anchor} not found in {target.relative_to(ROOT)}"
+                )
 
     summary_text = SUMMARY.read_text(encoding="utf-8")
     listed: set[Path] = set()
@@ -190,10 +335,11 @@ def main() -> int:
 
     print(
         f"documentation checks passed: {len(markdown) - 1} chapters, "
-        "all listed with valid local links, anchors, and include targets"
+        f"all listed with valid local links, anchors, and include targets; "
+        f"README public pages present in {release_tag}"
     )
     return 0
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(self_test() if sys.argv[1:] == ["--self-test"] else main())


### PR DESCRIPTION
## Summary

- point contributing and unreleased telemetry links in the README at their repository source files instead of public pages that do not exist in the latest release
- validate README local targets and ensure public docs links correspond to chapters shipped by the latest GitHub release
- run the docs workflow for README changes and include README in scheduled external-link checks

Closes #9222

## Testing

- `python3 scripts/check_docs.py --self-test`
- `PERRY_DOCS_RELEASE_TAG=v0.5.1220 python3 scripts/check_docs.py` (139 chapters)
- checker rejects all three unreleased public-page occurrences in the pre-fix README
- `actionlint .github/workflows/docs-check.yml`
- `cargo run --release --quiet -p perry-doc-tests -- --lint docs/src`
- `./docs/i18n.sh build-all` (English and all translations)
- remaining README public docs deep links return HTTP 200
- `./scripts/pre-tag-check.sh --quick`

No crate or version files are changed, so no changelog fragment or version bump is needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated README documentation and privacy links to point to maintained in-repository Markdown sources.
  - Improved validation of README links, anchors, and release-specific documentation links to help keep published references accurate.

- **Chores**
  - Documentation checks now run automatically when README content changes.
  - Added validation coverage for external links and release documentation, including self-tests for the checking process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->