### PR TITLE
Merge train: #9662 #9663 (web-adapter GC roots, README release links)

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -3,6 +3,7 @@ name: Docs checks
 on:
   pull_request:
     paths:
+      - "README.md"
       - "docs/**"
       - "scripts/check_docs.py"
       - "crates/perry-doc-tests/**"
@@ -11,6 +12,7 @@ on:
   push:
     branches: [main]
     paths:
+      - "README.md"
       - "docs/**"
       - "scripts/check_docs.py"
       - "crates/perry-doc-tests/**"
@@ -31,6 +33,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Fetch the docs deployed by the latest release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          release_tag="$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName)"
+          git fetch --depth=1 origin "refs/tags/${release_tag}:refs/tags/${release_tag}"
+          echo "PERRY_DOCS_RELEASE_TAG=${release_tag}" >> "$GITHUB_ENV"
       - name: Install mdBook and gettext tooling
         run: |
           sudo apt-get update
@@ -38,8 +47,10 @@ jobs:
           mkdir -p "$HOME/.cargo/bin"
           curl -sSL "https://github.com/rust-lang/mdBook/releases/download/${MDBOOK_VERSION}/mdbook-${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz" | tar -xz -C "$HOME/.cargo/bin"
           cargo install mdbook-i18n-helpers --locked --version 0.4.0
-      - name: Check navigation, local links, anchors, and includes
-        run: python3 scripts/check_docs.py
+      - name: Check navigation, README release links, local links, anchors, and includes
+        run: |
+          python3 scripts/check_docs.py --self-test
+          python3 scripts/check_docs.py
       - name: Check TypeScript fences
         run: cargo run --release --quiet -p perry-doc-tests -- --lint docs/src
       - name: Check gettext catalogs are current
@@ -68,5 +79,6 @@ jobs:
           --accept 200..=399,403,429
           --exclude 'https://www.npmjs.com/'
           --exclude 'https://xtermjs.org/'
+          'README.md'
           'docs/src/**/*.md'
           'docs/*.md'

--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ Everything else lives in the [docs](https://perryts.github.io/perry/):
 - [Language support](https://perryts.github.io/perry/language/supported-features.html) — supported TypeScript features and [limitations](https://perryts.github.io/perry/language/limitations.html)
 - [Native UI](https://perryts.github.io/perry/ui/overview.html) · [Multi-threading](https://perryts.github.io/perry/threading/overview.html) · [Standard library](https://perryts.github.io/perry/stdlib/overview.html)
 - [Platforms](https://perryts.github.io/perry/platforms/overview.html) — per-platform guides from macOS to watchOS to WASM
-- [CLI reference](https://perryts.github.io/perry/cli/commands.html) — commands, flags, `perry.toml`, [privacy & telemetry](https://perryts.github.io/perry/cli/telemetry.html)
-- [Contributing](https://perryts.github.io/perry/contributing/architecture.html) — architecture, [building from source](https://perryts.github.io/perry/contributing/building.html), and the [release process](https://perryts.github.io/perry/contributing/releasing.html)
+- [CLI reference](https://perryts.github.io/perry/cli/commands.html) — commands, flags, `perry.toml`, [privacy & telemetry](docs/src/cli/telemetry.md)
+- [Contributing](docs/src/contributing/architecture.md) — architecture, [building from source](docs/src/contributing/building.md), and the [release process](docs/src/contributing/releasing.md)
 
 ## Community
 
@@ -151,7 +151,7 @@ Perry is built in the open — come say hi:
 
 ## Privacy
 
-Telemetry is **opt-in**: nothing leaves your machine unless you explicitly enable it in `~/.perry/config.toml`, and `PERRY_NO_TELEMETRY=1` (or `CI=true`) always wins. What can be sent is anonymous and redacted — never your source, paths, or project names. Inspect it any time with `perry doctor`, and see exactly what's in the payload in the [privacy & telemetry docs](https://perryts.github.io/perry/cli/telemetry.html).
+Telemetry is **opt-in**: nothing leaves your machine unless you explicitly enable it in `~/.perry/config.toml`, and `PERRY_NO_TELEMETRY=1` (or `CI=true`) always wins. What can be sent is anonymous and redacted — never your source, paths, or project names. Inspect it any time with `perry doctor`, and see exactly what's in the payload in the [privacy & telemetry docs](docs/src/cli/telemetry.md).
 
 ## Sponsors
 

--- a/changelog.d/9662-web-adapter-gc-roots.md
+++ b/changelog.d/9662-web-adapter-gc-roots.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Web Stream adapters now keep controllers, iterators, promises, and callbacks
+  rooted across allocations, preventing stale references when the moving
+  garbage collector runs during stream conversion.

--- a/crates/perry-runtime/src/node_stream/async_iterator.rs
+++ b/crates/perry-runtime/src/node_stream/async_iterator.rs
@@ -704,44 +704,70 @@ pub(super) extern "C" fn ns_iterator1(closure: *const ClosureHeader, opts: f64) 
 }
 
 fn install_async_iterator_symbol(target: f64, func: extern "C" fn(*const ClosureHeader) -> f64) {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let target = scope.root_nanbox_f64(target);
     let async_iterator = crate::symbol::well_known_symbol("asyncIterator");
     if async_iterator.is_null() {
         return;
     }
-    let closure = js_closure_alloc(func as *const u8, 1);
-    js_closure_set_capture_ptr(closure, 0, target.to_bits() as i64);
-    let closure_value = box_pointer(closure as *const u8);
+    let closure = scope.root_raw_mut_ptr(js_closure_alloc(func as *const u8, 1));
+    closure.with_mut_ptr(|closure| {
+        js_closure_set_capture_ptr(closure, 0, target.get_nanbox_f64().to_bits() as i64)
+    });
     let symbol_value = box_pointer(async_iterator as *const u8);
-    unsafe {
-        crate::symbol::js_object_set_symbol_property(target, symbol_value, closure_value);
-    }
+    closure.with_const_ptr(|closure| unsafe {
+        crate::symbol::js_object_set_symbol_property(
+            target.get_nanbox_f64(),
+            symbol_value,
+            box_pointer(closure),
+        );
+    });
+}
+
+fn set_rooted_iterator_value(
+    iterator: &crate::gc::RuntimeHandle<'_>,
+    key_bytes: &[u8],
+    value: f64,
+) {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let value = scope.root_nanbox_f64(value);
+    let key = scope.root_string_ptr(hidden_key(key_bytes));
+    key.with_mut_ptr(|key| {
+        set_hidden_value(iterator.get_nanbox_f64(), key, value.get_nanbox_f64())
+    });
 }
 
 pub(super) fn build_readable_async_iterator(stream: f64, destroy_on_return: bool) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let stream = scope.root_nanbox_f64(stream);
     let methods = [
         ("next", cast0(ns_readable_iterator_next)),
         ("return", cast0(ns_readable_iterator_return)),
     ];
     let obj = build_object(&methods, READABLE_ITERATOR_SHAPE_ID + methods.len() as u32);
-    let iterator = box_pointer(obj as *const u8);
-    set_hidden_value(iterator, hidden_key(READABLE_ITERATOR_STREAM_KEY), stream);
-    set_hidden_value(iterator, hidden_key(READABLE_ITERATOR_INDEX_KEY), 0.0);
-    set_hidden_value(
-        iterator,
-        hidden_key(READABLE_ITERATOR_DONE_KEY),
+    let iterator = scope.root_nanbox_f64(box_pointer(obj as *const u8));
+    set_rooted_iterator_value(
+        &iterator,
+        READABLE_ITERATOR_STREAM_KEY,
+        stream.get_nanbox_f64(),
+    );
+    set_rooted_iterator_value(&iterator, READABLE_ITERATOR_INDEX_KEY, 0.0);
+    set_rooted_iterator_value(
+        &iterator,
+        READABLE_ITERATOR_DONE_KEY,
         f64::from_bits(TAG_FALSE),
     );
-    set_hidden_value(
-        iterator,
-        hidden_key(READABLE_ITERATOR_DESTROY_ON_RETURN_KEY),
+    set_rooted_iterator_value(
+        &iterator,
+        READABLE_ITERATOR_DESTROY_ON_RETURN_KEY,
         f64::from_bits(if destroy_on_return {
             TAG_TRUE
         } else {
             TAG_FALSE
         }),
     );
-    install_async_iterator_symbol(iterator, ns_readable_iterator_self);
-    iterator
+    install_async_iterator_symbol(iterator.get_nanbox_f64(), ns_readable_iterator_self);
+    iterator.get_nanbox_f64()
 }
 
 /// Build an async iterator that yields `value` exactly once, then completes.

--- a/crates/perry-runtime/src/node_stream_constructors/web_adapter.rs
+++ b/crates/perry-runtime/src/node_stream_constructors/web_adapter.rs
@@ -130,20 +130,36 @@ fn closure_value(closure: *mut ClosureHeader) -> f64 {
 }
 
 fn closure_with_stream(func: *const u8, node_stream: f64) -> f64 {
-    let closure = js_closure_alloc(func, 1);
-    js_closure_set_capture_f64(closure, 0, node_stream);
-    closure_value(closure)
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let node_stream = scope.root_nanbox_f64(node_stream);
+    let closure = scope.root_raw_mut_ptr(js_closure_alloc(func, 1));
+    closure.with_mut_ptr(|closure| {
+        js_closure_set_capture_f64(closure, 0, node_stream.get_nanbox_f64())
+    });
+    closure.with_mut_ptr(closure_value)
 }
 
 fn build_enumerable_object(fields: &[(&[u8], f64)]) -> f64 {
-    let obj = js_object_alloc(0, fields.len() as u32);
-    let mut keys = crate::array::js_array_alloc(fields.len() as u32);
-    for (idx, (name, value)) in fields.iter().enumerate() {
-        keys = crate::array::js_array_push_f64(keys, string_value(name));
-        js_object_set_field(obj, idx as u32, JSValue::from_bits(value.to_bits()));
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let values = fields.iter().map(|(_, value)| *value).collect::<Vec<_>>();
+    let values = scope.root_nanbox_f64_slice(&values);
+    let obj = scope.root_raw_mut_ptr(js_object_alloc(0, fields.len() as u32));
+    let keys = scope.root_raw_mut_ptr(crate::array::js_array_alloc(fields.len() as u32));
+    for (idx, (name, _)) in fields.iter().enumerate() {
+        let key = scope.root_nanbox_f64(string_value(name));
+        keys.set_raw_mut_ptr(
+            keys.with_mut_ptr(|keys| crate::array::js_array_push_f64(keys, key.get_nanbox_f64())),
+        );
+        obj.with_mut_ptr(|obj| {
+            js_object_set_field(
+                obj,
+                idx as u32,
+                JSValue::from_bits(values[idx].get_nanbox_u64()),
+            )
+        });
     }
-    crate::object::js_object_set_keys(obj, keys);
-    box_pointer(obj as *const u8)
+    obj.with_mut_ptr(|obj| keys.with_mut_ptr(|keys| crate::object::js_object_set_keys(obj, keys)));
+    obj.with_const_ptr(|obj: *const u8| box_pointer(obj))
 }
 
 fn build_web_read_result(value: f64, done: bool) -> f64 {
@@ -155,9 +171,11 @@ fn property_value(value: f64, name: &[u8]) -> f64 {
 }
 
 fn call_method_no_args(receiver: f64, name: &[u8]) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let receiver = scope.root_nanbox_f64(receiver);
     unsafe {
         crate::object::js_native_call_method(
-            receiver,
+            receiver.get_nanbox_f64(),
             name.as_ptr() as *const i8,
             name.len(),
             std::ptr::null(),
@@ -167,10 +185,13 @@ fn call_method_no_args(receiver: f64, name: &[u8]) -> f64 {
 }
 
 fn destroy_foreign_readable(stream: f64, reason: f64) {
-    let args = [reason];
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let stream = scope.root_nanbox_f64(stream);
+    let reason = scope.root_nanbox_f64(reason);
+    let args = [reason.get_nanbox_f64()];
     unsafe {
         let _ = crate::object::js_native_call_method(
-            stream,
+            stream.get_nanbox_f64(),
             b"destroy".as_ptr() as *const i8,
             7,
             args.as_ptr(),
@@ -221,17 +242,22 @@ extern "C" fn node_to_web_readable_pull(closure: *const ClosureHeader, controlle
 }
 
 fn settle_foreign_readable_pull(controller: f64, result: f64) {
-    if crate::value::js_is_truthy(property_value(result, b"done")) != 0 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let controller = scope.root_nanbox_f64(controller);
+    let result = scope.root_nanbox_f64(result);
+    let done = scope.root_nanbox_f64(property_value(result.get_nanbox_f64(), b"done"));
+    if crate::value::js_is_truthy(done.get_nanbox_f64()) != 0 {
         if let Some(close) = web_readable_close() {
             unsafe {
-                close(controller);
+                close(controller.get_nanbox_f64());
             }
         }
         return;
     }
     if let Some(enqueue) = web_readable_enqueue() {
+        let value = scope.root_nanbox_f64(property_value(result.get_nanbox_f64(), b"value"));
         unsafe {
-            enqueue(controller, property_value(result, b"value"));
+            enqueue(controller.get_nanbox_f64(), value.get_nanbox_f64());
         }
     }
 }
@@ -246,8 +272,11 @@ extern "C" fn foreign_readable_pull_fulfilled(closure: *const ClosureHeader, res
 extern "C" fn foreign_readable_pull_rejected(closure: *const ClosureHeader, reason: f64) -> f64 {
     if !closure.is_null() {
         if let Some(error) = web_readable_error() {
+            let scope = crate::gc::RuntimeHandleScope::new();
+            let controller = scope.root_nanbox_f64(js_closure_get_capture_f64(closure, 0));
+            let reason = scope.root_nanbox_f64(reason);
             unsafe {
-                error(js_closure_get_capture_f64(closure, 0), reason);
+                error(controller.get_nanbox_f64(), reason.get_nanbox_f64());
             }
         }
     }
@@ -264,10 +293,11 @@ extern "C" fn foreign_readable_to_web_pull(closure: *const ClosureHeader, contro
         return f64::from_bits(TAG_UNDEFINED);
     }
     let scope = crate::gc::RuntimeHandleScope::new();
+    let controller = scope.root_nanbox_f64(controller);
     let iterator = scope.root_nanbox_f64(js_closure_get_capture_f64(closure, 0));
     let next = scope.root_nanbox_f64(call_method_no_args(iterator.get_nanbox_f64(), b"next"));
     if crate::promise::js_value_is_promise(next.get_nanbox_f64()) == 0 {
-        settle_foreign_readable_pull(controller, next.get_nanbox_f64());
+        settle_foreign_readable_pull(controller.get_nanbox_f64(), next.get_nanbox_f64());
         return f64::from_bits(TAG_UNDEFINED);
     }
 
@@ -279,26 +309,36 @@ extern "C" fn foreign_readable_to_web_pull(closure: *const ClosureHeader, contro
         foreign_readable_pull_rejected as *const u8,
         1,
     ));
-    fulfilled.with_mut_ptr(|f| js_closure_set_capture_f64(f, 0, controller));
-    rejected.with_mut_ptr(|r| js_closure_set_capture_f64(r, 0, controller));
-    let promise =
-        crate::value::js_nanbox_get_pointer(next.get_nanbox_f64()) as *mut crate::promise::Promise;
-    box_pointer(
-        fulfilled.with_mut_ptr(|f| {
-            rejected.with_mut_ptr(|r| crate::promise::js_promise_then(promise, f, r))
-        }) as *const u8,
-    )
+    fulfilled.with_mut_ptr(|fulfilled| {
+        js_closure_set_capture_f64(fulfilled, 0, controller.get_nanbox_f64())
+    });
+    rejected.with_mut_ptr(|rejected| {
+        js_closure_set_capture_f64(rejected, 0, controller.get_nanbox_f64())
+    });
+    let promise = scope
+        .root_raw_mut_ptr(crate::value::js_nanbox_get_pointer(next.get_nanbox_f64())
+            as *mut crate::promise::Promise);
+    let chained = promise.with_mut_ptr(|promise| {
+        fulfilled.with_const_ptr(|fulfilled| {
+            rejected.with_const_ptr(|rejected| {
+                crate::promise::js_promise_then(promise, fulfilled, rejected)
+            })
+        })
+    });
+    box_pointer(chained as *const u8)
 }
 
 extern "C" fn foreign_readable_to_web_cancel(closure: *const ClosureHeader, reason: f64) -> f64 {
     if closure.is_null() {
         return resolved_promise(f64::from_bits(TAG_UNDEFINED));
     }
-    let iterator = js_closure_get_capture_f64(closure, 0);
-    let stream = js_closure_get_capture_f64(closure, 1);
-    let returned = call_method_no_args(iterator, b"return");
-    destroy_foreign_readable(stream, reason);
-    returned
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let iterator = scope.root_nanbox_f64(js_closure_get_capture_f64(closure, 0));
+    let stream = scope.root_nanbox_f64(js_closure_get_capture_f64(closure, 1));
+    let reason = scope.root_nanbox_f64(reason);
+    let returned = scope.root_nanbox_f64(call_method_no_args(iterator.get_nanbox_f64(), b"return"));
+    destroy_foreign_readable(stream.get_nanbox_f64(), reason.get_nanbox_f64());
+    returned.get_nanbox_f64()
 }
 
 extern "C" fn node_to_web_readable_cancel(closure: *const ClosureHeader, reason: f64) -> f64 {
@@ -310,41 +350,62 @@ extern "C" fn node_to_web_readable_cancel(closure: *const ClosureHeader, reason:
 
 fn node_readable_to_web(node_stream: f64) -> Option<f64> {
     let readable_new = web_readable_new()?;
-    if async_iterator::is_foreign_readable(node_stream) {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let node_stream = scope.root_nanbox_f64(node_stream);
+    if async_iterator::is_foreign_readable(node_stream.get_nanbox_f64()) {
         crate::closure::js_register_closure_arity(foreign_readable_to_web_pull as *const u8, 1);
         crate::closure::js_register_closure_arity(foreign_readable_to_web_cancel as *const u8, 1);
         crate::closure::js_register_closure_arity(foreign_readable_pull_fulfilled as *const u8, 1);
         crate::closure::js_register_closure_arity(foreign_readable_pull_rejected as *const u8, 1);
 
-        let iterator = async_iterator::build_readable_async_iterator(node_stream, true);
-        let pull = js_closure_alloc(foreign_readable_to_web_pull as *const u8, 1);
-        js_closure_set_capture_f64(pull, 0, iterator);
-        let cancel = js_closure_alloc(foreign_readable_to_web_cancel as *const u8, 2);
-        js_closure_set_capture_f64(cancel, 0, iterator);
-        js_closure_set_capture_f64(cancel, 1, node_stream);
-        return Some(unsafe {
+        let iterator = scope.root_nanbox_f64(async_iterator::build_readable_async_iterator(
+            node_stream.get_nanbox_f64(),
+            true,
+        ));
+        let pull = scope.root_raw_mut_ptr(js_closure_alloc(
+            foreign_readable_to_web_pull as *const u8,
+            1,
+        ));
+        pull.with_mut_ptr(|pull| js_closure_set_capture_f64(pull, 0, iterator.get_nanbox_f64()));
+        let cancel = scope.root_raw_mut_ptr(js_closure_alloc(
+            foreign_readable_to_web_cancel as *const u8,
+            2,
+        ));
+        cancel.with_mut_ptr(|cancel| {
+            js_closure_set_capture_f64(cancel, 0, iterator.get_nanbox_f64());
+            js_closure_set_capture_f64(cancel, 1, node_stream.get_nanbox_f64());
+        });
+        return Some(pull.with_mut_ptr(|pull| {
+            cancel.with_mut_ptr(|cancel| unsafe {
+                readable_new(
+                    f64::from_bits(TAG_UNDEFINED),
+                    closure_value(pull),
+                    closure_value(cancel),
+                    1.0,
+                )
+            })
+        }));
+    }
+    crate::closure::js_register_closure_arity(node_to_web_readable_pull as *const u8, 1);
+    crate::closure::js_register_closure_arity(node_to_web_readable_cancel as *const u8, 1);
+    let pull = scope.root_raw_mut_ptr(js_closure_alloc(node_to_web_readable_pull as *const u8, 1));
+    pull.with_mut_ptr(|pull| js_closure_set_capture_f64(pull, 0, node_stream.get_nanbox_f64()));
+    let cancel = scope.root_raw_mut_ptr(js_closure_alloc(
+        node_to_web_readable_cancel as *const u8,
+        1,
+    ));
+    cancel
+        .with_mut_ptr(|cancel| js_closure_set_capture_f64(cancel, 0, node_stream.get_nanbox_f64()));
+    Some(pull.with_mut_ptr(|pull| {
+        cancel.with_mut_ptr(|cancel| unsafe {
             readable_new(
                 f64::from_bits(TAG_UNDEFINED),
                 closure_value(pull),
                 closure_value(cancel),
                 1.0,
             )
-        });
-    }
-    crate::closure::js_register_closure_arity(node_to_web_readable_pull as *const u8, 1);
-    crate::closure::js_register_closure_arity(node_to_web_readable_cancel as *const u8, 1);
-    let pull = js_closure_alloc(node_to_web_readable_pull as *const u8, 1);
-    js_closure_set_capture_f64(pull, 0, node_stream);
-    let cancel = js_closure_alloc(node_to_web_readable_cancel as *const u8, 1);
-    js_closure_set_capture_f64(cancel, 0, node_stream);
-    Some(unsafe {
-        readable_new(
-            f64::from_bits(TAG_UNDEFINED),
-            closure_value(pull),
-            closure_value(cancel),
-            1.0,
-        )
-    })
+        })
+    }))
 }
 
 extern "C" fn fallback_web_reader_read(closure: *const ClosureHeader) -> f64 {
@@ -393,7 +454,9 @@ extern "C" fn fallback_foreign_reader_read(closure: *const ClosureHeader) -> f64
     if closure.is_null() {
         return resolved_promise(build_web_read_result(f64::from_bits(TAG_UNDEFINED), true));
     }
-    call_method_no_args(js_closure_get_capture_f64(closure, 0), b"next")
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let iterator = scope.root_nanbox_f64(js_closure_get_capture_f64(closure, 0));
+    call_method_no_args(iterator.get_nanbox_f64(), b"next")
 }
 
 extern "C" fn fallback_foreign_reader_cancel(closure: *const ClosureHeader, reason: f64) -> f64 {
@@ -404,35 +467,67 @@ extern "C" fn fallback_foreign_get_reader(closure: *const ClosureHeader) -> f64 
     if closure.is_null() {
         return f64::from_bits(TAG_UNDEFINED);
     }
-    let iterator = js_closure_get_capture_f64(closure, 0);
-    let stream = js_closure_get_capture_f64(closure, 1);
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let iterator = scope.root_nanbox_f64(js_closure_get_capture_f64(closure, 0));
+    let stream = scope.root_nanbox_f64(js_closure_get_capture_f64(closure, 1));
     crate::closure::js_register_closure_arity(fallback_foreign_reader_read as *const u8, 0);
     crate::closure::js_register_closure_arity(fallback_foreign_reader_cancel as *const u8, 1);
-    let read = js_closure_alloc(fallback_foreign_reader_read as *const u8, 1);
-    js_closure_set_capture_f64(read, 0, iterator);
-    let cancel = js_closure_alloc(fallback_foreign_reader_cancel as *const u8, 2);
-    js_closure_set_capture_f64(cancel, 0, iterator);
-    js_closure_set_capture_f64(cancel, 1, stream);
-    build_enumerable_object(&[
-        (b"read", closure_value(read)),
-        (b"cancel", closure_value(cancel)),
-    ])
+    let read = scope.root_raw_mut_ptr(js_closure_alloc(
+        fallback_foreign_reader_read as *const u8,
+        1,
+    ));
+    read.with_mut_ptr(|read| js_closure_set_capture_f64(read, 0, iterator.get_nanbox_f64()));
+    let cancel = scope.root_raw_mut_ptr(js_closure_alloc(
+        fallback_foreign_reader_cancel as *const u8,
+        2,
+    ));
+    cancel.with_mut_ptr(|cancel| {
+        js_closure_set_capture_f64(cancel, 0, iterator.get_nanbox_f64());
+        js_closure_set_capture_f64(cancel, 1, stream.get_nanbox_f64());
+    });
+    read.with_mut_ptr(|read| {
+        cancel.with_mut_ptr(|cancel| {
+            build_enumerable_object(&[
+                (b"read", closure_value(read)),
+                (b"cancel", closure_value(cancel)),
+            ])
+        })
+    })
 }
 
 fn fallback_foreign_readable_to_web(node_stream: f64) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let node_stream = scope.root_nanbox_f64(node_stream);
     crate::closure::js_register_closure_arity(fallback_foreign_get_reader as *const u8, 0);
     crate::closure::js_register_closure_arity(fallback_foreign_reader_cancel as *const u8, 1);
-    let iterator = async_iterator::build_readable_async_iterator(node_stream, true);
-    let get_reader = js_closure_alloc(fallback_foreign_get_reader as *const u8, 2);
-    js_closure_set_capture_f64(get_reader, 0, iterator);
-    js_closure_set_capture_f64(get_reader, 1, node_stream);
-    let cancel = js_closure_alloc(fallback_foreign_reader_cancel as *const u8, 2);
-    js_closure_set_capture_f64(cancel, 0, iterator);
-    js_closure_set_capture_f64(cancel, 1, node_stream);
-    build_enumerable_object(&[
-        (b"getReader", closure_value(get_reader)),
-        (b"cancel", closure_value(cancel)),
-    ])
+    let iterator = scope.root_nanbox_f64(async_iterator::build_readable_async_iterator(
+        node_stream.get_nanbox_f64(),
+        true,
+    ));
+    let get_reader = scope.root_raw_mut_ptr(js_closure_alloc(
+        fallback_foreign_get_reader as *const u8,
+        2,
+    ));
+    get_reader.with_mut_ptr(|get_reader| {
+        js_closure_set_capture_f64(get_reader, 0, iterator.get_nanbox_f64());
+        js_closure_set_capture_f64(get_reader, 1, node_stream.get_nanbox_f64());
+    });
+    let cancel = scope.root_raw_mut_ptr(js_closure_alloc(
+        fallback_foreign_reader_cancel as *const u8,
+        2,
+    ));
+    cancel.with_mut_ptr(|cancel| {
+        js_closure_set_capture_f64(cancel, 0, iterator.get_nanbox_f64());
+        js_closure_set_capture_f64(cancel, 1, node_stream.get_nanbox_f64());
+    });
+    get_reader.with_mut_ptr(|get_reader| {
+        cancel.with_mut_ptr(|cancel| {
+            build_enumerable_object(&[
+                (b"getReader", closure_value(get_reader)),
+                (b"cancel", closure_value(cancel)),
+            ])
+        })
+    })
 }
 
 fn fallback_node_readable_to_web(node_stream: f64) -> f64 {

--- a/crates/perry-runtime/src/node_stream_dispatch.rs
+++ b/crates/perry-runtime/src/node_stream_dispatch.rs
@@ -45,33 +45,43 @@ pub(super) fn build_object(methods: &[(&str, StubFn)], shape_id: u32) -> *mut Ob
         packed.push(0);
     }
     let field_count = methods.len() as u32;
-    let obj =
-        js_object_alloc_with_shape(shape_id, field_count, packed.as_ptr(), packed.len() as u32);
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let obj = scope.root_raw_mut_ptr(js_object_alloc_with_shape(
+        shape_id,
+        field_count,
+        packed.as_ptr(),
+        packed.len() as u32,
+    ));
 
-    // NaN-box the object pointer — we'll capture it (as raw bits) in each
-    // closure's slot 0 so the stub `this_value` helper can reconstruct
-    // the f64 form for `return this` semantics.
-    let this_bits = JSValue::pointer(obj as *const u8).bits();
-
-    let mut on_method: Option<JSValue> = None;
+    let mut on_method: Option<crate::gc::RuntimeHandle<'_>> = None;
     for (i, (name, func)) in methods.iter().enumerate() {
         if *name == "addListener" {
-            if let Some(val) = on_method {
-                js_object_set_field(obj, i as u32, val);
+            if let Some(on_method) = on_method {
+                obj.with_mut_ptr(|obj| {
+                    on_method.with_const_ptr(|closure| {
+                        js_object_set_field(obj, i as u32, JSValue::pointer(closure))
+                    })
+                });
                 continue;
             }
         }
-        let closure = js_closure_alloc(*func as *const u8, 1);
+        let closure = scope.root_raw_mut_ptr(js_closure_alloc(*func as *const u8, 1));
         // Reuse `set_capture_ptr` (i64 payload). We only need 64 bits
         // and the NaN-boxed pattern fits cleanly when reinterpreted.
-        crate::closure::js_closure_set_capture_ptr(closure, 0, this_bits as i64);
-        let val = JSValue::pointer(closure as *const u8);
+        closure.with_mut_ptr(|closure| {
+            let this_bits = obj.with_const_ptr(|obj| JSValue::pointer(obj).bits());
+            crate::closure::js_closure_set_capture_ptr(closure, 0, this_bits as i64);
+        });
         if *name == "on" {
-            on_method = Some(val);
+            on_method = Some(closure);
         }
-        js_object_set_field(obj, i as u32, val);
+        obj.with_mut_ptr(|obj| {
+            closure.with_const_ptr(|closure| {
+                js_object_set_field(obj, i as u32, JSValue::pointer(closure))
+            })
+        });
     }
-    obj
+    obj.with_mut_ptr(|obj| obj)
 }
 
 /// #6316 — reserved own-key prefix for a native base method DISPLACED by a

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Check mdBook navigation, local links/anchors, and include targets.
+"""Check mdBook navigation, local links/anchors, and README release links.
 
 This intentionally avoids network access. The scheduled docs workflow runs a
 separate external-link checker so transient remote failures do not block every
@@ -8,17 +8,20 @@ documentation pull request.
 
 from __future__ import annotations
 
+import os
 import re
+import subprocess
 import sys
 from collections import Counter
 from pathlib import Path
-from urllib.parse import unquote
+from urllib.parse import unquote, urlparse
 
 
 ROOT = Path(__file__).resolve().parents[1]
 DOCS = ROOT / "docs"
 SRC = DOCS / "src"
 SUMMARY = SRC / "SUMMARY.md"
+README = ROOT / "README.md"
 
 FENCE_RE = re.compile(r"^\s*(```+|~~~+)")
 INLINE_LINK_RE = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
@@ -26,6 +29,7 @@ REFERENCE_LINK_RE = re.compile(r"^\s*\[[^\]]+\]:\s*(\S+)", re.MULTILINE)
 INCLUDE_RE = re.compile(r"\{\{#(?:rustdoc_)?include\s+([^}\s]+)")
 HEADING_RE = re.compile(r"^\s{0,3}(#{1,6})\s+(.+?)\s*#*\s*$")
 HTML_ID_RE = re.compile(r"\bid=[\"']([^\"']+)[\"']")
+RELEASE_TAG_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
 
 FORBIDDEN_TEXT = {
     "https://github.com/skelpo/perry": "https://github.com/PerryTS/perry",
@@ -35,6 +39,117 @@ FORBIDDEN_TEXT = {
     "@perry/dotenv": "@perryts/dotenv",
     "perryts/mysql2-bindings": "@perryts/tursodb",
 }
+
+
+def latest_release_tag() -> str | None:
+    """Return the highest stable vX.Y.Z tag available in this checkout."""
+    configured = os.environ.get("PERRY_DOCS_RELEASE_TAG")
+    if configured is not None:
+        return configured if RELEASE_TAG_RE.fullmatch(configured) else None
+
+    try:
+        result = subprocess.run(
+            ["git", "tag", "--list", "v*"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+    releases: list[tuple[tuple[int, int, int], str]] = []
+    for tag in result.stdout.splitlines():
+        match = RELEASE_TAG_RE.fullmatch(tag)
+        if match:
+            releases.append((tuple(map(int, match.groups())), tag))
+    return max(releases)[1] if releases else None
+
+
+def published_docs_at(tag: str) -> set[str] | None:
+    """List mdBook chapters published by a release tag's SUMMARY."""
+    try:
+        result = subprocess.run(
+            ["git", "show", f"{tag}:docs/src/SUMMARY.md"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+    published: set[str] = set()
+    for raw in local_destinations(result.stdout):
+        rel, _ = split_destination(raw)
+        if rel and not rel.startswith(("http://", "https://", "mailto:")):
+            published.add((Path("docs/src") / rel).as_posix())
+    return published
+
+
+def public_docs_path(destination: str) -> str | None:
+    """Map either public docs hostname to its mdBook-relative URL path."""
+    parsed = urlparse(destination)
+    path = unquote(parsed.path)
+    if parsed.hostname == "perryts.github.io":
+        if path.rstrip("/") == "/perry":
+            return ""
+        prefix = "/perry/"
+        if not path.startswith(prefix):
+            return None
+        return path[len(prefix) :]
+    if parsed.hostname == "docs.perryts.com":
+        return path.lstrip("/")
+    return None
+
+
+def readme_release_link_errors(
+    text: str, released_docs: set[str], release_tag: str
+) -> list[str]:
+    """Reject public README pages that the deployed release cannot contain."""
+    errors: list[str] = []
+    for raw in local_destinations(text):
+        destination, _ = split_destination(raw)
+        web_path = public_docs_path(destination)
+        if web_path is None or web_path in {"", "index.html"}:
+            continue
+        if not web_path.endswith(".html"):
+            errors.append(
+                f"README.md: public docs link is not an mdBook page: {destination}"
+            )
+            continue
+        source = f"docs/src/{web_path.removesuffix('.html')}.md"
+        if source not in released_docs:
+            errors.append(
+                f"README.md: public docs link is absent from {release_tag}: "
+                f"{destination}; link to {source} until it ships in a release"
+            )
+    return errors
+
+
+def self_test() -> int:
+    released = {"docs/src/guide/released.md"}
+    fixture = """
+[home](https://perryts.github.io/perry/)
+[released](https://perryts.github.io/perry/guide/released.html#section)
+[canonical](https://docs.perryts.com/guide/released.html)
+[external](https://example.com/guide/unreleased.html)
+"""
+    if readme_release_link_errors(fixture, released, "v1.2.3"):
+        print("check_docs --self-test FAILED: accepted fixture was rejected")
+        return 1
+
+    planted = (
+        fixture
+        + "\n[unreleased](https://perryts.github.io/perry/guide/unreleased.html)\n"
+    )
+    errors = readme_release_link_errors(planted, released, "v1.2.3")
+    if len(errors) != 1 or "docs/src/guide/unreleased.md" not in errors[0]:
+        print("check_docs --self-test FAILED: planted unreleased page was not caught")
+        return 1
+
+    print("check_docs --self-test passed: released aliases pass and an unreleased page fails")
+    return 0
 
 
 def without_fenced_code(text: str) -> str:
@@ -108,6 +223,36 @@ def include_file(raw: str) -> str:
 def main() -> int:
     errors: list[str] = []
     markdown = sorted(SRC.rglob("*.md"))
+
+    readme_text = README.read_text(encoding="utf-8")
+    release_tag = latest_release_tag()
+    if release_tag is None:
+        errors.append(
+            "README.md: cannot find a stable release tag; fetch tags before checking docs"
+        )
+    else:
+        released_docs = published_docs_at(release_tag)
+        if released_docs is None:
+            errors.append(f"README.md: cannot inspect documentation at {release_tag}")
+        else:
+            errors.extend(
+                readme_release_link_errors(readme_text, released_docs, release_tag)
+            )
+
+    for raw in local_destinations(readme_text):
+        rel, anchor = split_destination(raw)
+        if not rel or rel.startswith(("http://", "https://", "mailto:")):
+            continue
+        target = (README.parent / rel).resolve()
+        if not target.is_file():
+            errors.append(f"README.md: local link target does not exist: {raw}")
+            continue
+        if anchor and target.suffix.lower() == ".md":
+            anchors = anchors_for(target)
+            if anchor not in anchors:
+                errors.append(
+                    f"README.md: anchor #{anchor} not found in {target.relative_to(ROOT)}"
+                )
 
     summary_text = SUMMARY.read_text(encoding="utf-8")
     listed: set[Path] = set()
@@ -190,10 +335,11 @@ def main() -> int:
 
     print(
         f"documentation checks passed: {len(markdown) - 1} chapters, "
-        "all listed with valid local links, anchors, and include targets"
+        f"all listed with valid local links, anchors, and include targets; "
+        f"README public pages present in {release_tag}"
     )
     return 0
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(self_test() if sys.argv[1:] == ["--self-test"] else main())


### PR DESCRIPTION
Lands #9662 and #9663.

**#9662** roots the Web-stream adapter surface across moving GC — controllers, iterator results, source streams, promises and closures rooted across allocating and user-code-invoking calls, with handles refreshed while constructing readable async iterators and native stream method objects. It preserves the file-backed `Readable.toWeb()` behaviour from #9661 under a moving collector, and it *lowers* the raw-handle ratchet (959 against a 963 baseline) rather than holding steady. The author validated it under seeded forced-evacuation — 30,791 copying collections with 20,633 objects actually moved, so the stress arm demonstrably ran rather than passing vacuously.

**#9663** keeps README links pointed at released pages: the docs check now resolves the latest release tag and validates against it. Its workflow runs `check_docs.py --self-test` before the real check, and that self-test is sabotage-based — it plants an unreleased page and asserts the checker catches it, and asserts a valid fixture is not falsely rejected. Verified locally: self-test green, real check green.

Validation: `run_lint_gates.sh` **all 62 gates pass**; release build green; RUST_TEST_THREADS=1 perry-runtime **3064/0**; `test_gap_9616_readable_to_web_fs` byte-identical to node.

Rebase-merge preserving authorship.
