### PR TITLE
Merge train: #9665 (GC store-site detector sees method-form stores)

### DIFF
--- a/changelog.d/9665-method-pointer-store-inventory.md
+++ b/changelog.d/9665-method-pointer-store-inventory.md
@@ -1,0 +1,7 @@
+Fixed a green blind spot in the GC store-site inventory: raw-pointer method
+calls such as `slot.write(value)` and `src.copy_to(dst, count)` are now audited
+alongside their `ptr::write` and `ptr::copy` free-function equivalents. The
+checker distinguishes pointer-producing receivers from ordinary I/O, lock,
+builder, and `MaybeUninit` writes, exercises every supported spelling in its
+self-test, and records explicit safety rationales for the method-form stores
+already present in the runtime.

--- a/crates/perry-runtime/src/arena/quarantine.rs
+++ b/crates/perry-runtime/src/arena/quarantine.rs
@@ -359,10 +359,14 @@ unsafe fn poison(data: *mut u8, used: usize) {
     let words = used / 8;
     let ptr = data as *mut u64;
     for i in 0..words {
+        // GC_STORE_AUDIT(POINTER_FREE): diagnostic poison in a retired arena
+        // span is not a live heap edge.
         ptr.add(i).write(QUARANTINE_POISON_WORD);
     }
     let tail_start = words * 8;
     for i in tail_start..used {
+        // GC_STORE_AUDIT(POINTER_FREE): tail bytes repeat the non-pointer
+        // poison pattern in dead storage.
         data.add(i)
             .write((QUARANTINE_POISON_WORD >> (8 * (i % 8))) as u8);
     }

--- a/crates/perry-runtime/src/arena/reset.rs
+++ b/crates/perry-runtime/src/arena/reset.rs
@@ -66,12 +66,16 @@ fn poison_region_in_place(arena: &mut Arena) {
             let words = block.offset / 8;
             let p = block.data as *mut u64;
             for i in 0..words {
+                // GC_STORE_AUDIT(POINTER_FREE): this dead from-space span
+                // receives non-pointer diagnostic poison.
                 p.add(i)
                     .write(crate::arena::quarantine::QUARANTINE_POISON_WORD);
             }
             let tail = block.offset % 8;
             let base = block.data as *mut u8;
             for i in 0..tail {
+                // GC_STORE_AUDIT(POINTER_FREE): trailing dead bytes repeat
+                // the non-pointer poison pattern.
                 base.add(words * 8 + i).write(
                     (crate::arena::quarantine::QUARANTINE_POISON_WORD >> (8 * (i % 8))) as u8,
                 );

--- a/crates/perry-runtime/src/array/subclass.rs
+++ b/crates/perry-runtime/src/array/subclass.rs
@@ -923,6 +923,8 @@ pub(crate) fn array_subclass_fast_length_with_ic(value: f64, cache: *mut u64) ->
             0
         };
         unsafe {
+            // GC_STORE_AUDIT(POINTER_FREE): this IC contains scalar
+            // shape/layout identities, never managed pointers.
             cache.add(1).write(layout.length_slot as u64);
             cache.add(2).write(layout.live_inline_slots as u64);
             cache.write(if family_token != 0 {
@@ -1589,6 +1591,8 @@ pub extern "C" fn js_packed_arraylike_index_get(receiver: f64, index: f64, cache
                                 )
                             };
                             unsafe {
+                                // GC_STORE_AUDIT(POINTER_FREE): generated IC
+                                // words are scalar layout facts, not heap edges.
                                 cache.add(1).write(layout.length_slot as u64);
                                 cache.add(2).write(layout.element_base as u64);
                                 cache.add(3).write(layout.dense_prefix_len as u64);

--- a/crates/perry-runtime/src/array/subclass_loop_guard.rs
+++ b/crates/perry-runtime/src/array/subclass_loop_guard.rs
@@ -82,9 +82,9 @@ fn elements_backed_loop_guard(
         out.add(0).write(3);
         out.add(1).write(gc_word);
         out.add(2).write(array_word);
-        // Word 3 is the payload address the generated loop reads through; the
-        // revalidation entry refreshes it after every iteration that can move
-        // or re-allocate the store.
+        // GC_STORE_AUDIT(STACK): caller-owned generated descriptor; the rooted
+        // receiver owns word 3's derived payload, which revalidation refreshes
+        // after every iteration that can move or re-allocate the store.
         out.add(3).write(elements as u64);
         out.add(4).write(0);
         out.add(5).write(0);
@@ -200,6 +200,8 @@ fn packed_arraylike_loop_guard(
             out.add(0).write(1);
             out.add(1).write(gc_word);
             out.add(2).write(array_word);
+            // GC_STORE_AUDIT(STACK): caller-owned generated descriptor holds
+            // scalar array facts, not roots.
             out.add(3).write(0);
             out.add(4).write(0);
             out.add(5).write(0);
@@ -252,6 +254,8 @@ fn packed_arraylike_loop_guard(
         out.add(1).write(gc_word);
         out.add(2).write(receiver_word);
         out.add(3).write(u64::from(layout.length_slot));
+        // GC_STORE_AUDIT(STACK): caller-owned generated descriptor stores only
+        // revalidated scalar layout facts.
         out.add(4).write(u64::from(layout.element_base));
         out.add(5).write(
             (u64::from(layout.live_inline_slots) << 32) | u64::from(layout.dense_prefix_len),
@@ -344,6 +348,8 @@ pub extern "C" fn js_packed_ecs_u32_loop_guard(
             .take(column_count as usize)
             .enumerate()
         {
+            // GC_STORE_AUDIT(STACK): rooted column operands keep these
+            // call-free generated-loop addresses live.
             out.add(7 + index).write(address as u64);
         }
     }
@@ -572,6 +578,8 @@ fn revalidate_admitted_elements_live(
     // Republish the payload address: the store itself may have been evacuated
     // even though its contents and header word are unchanged.
     unsafe {
+        // GC_STORE_AUDIT(STACK): generated descriptor is not a root; the
+        // rooted receiver supplies this refreshed address.
         (facts as *mut u64).add(3).write(elements as u64);
         (facts as *mut u64)
             .add(6)

--- a/crates/perry-runtime/src/box.rs
+++ b/crates/perry-runtime/src/box.rs
@@ -427,6 +427,8 @@ fn push_free_cell(addr: usize, head: &'static crate::tls_hot::HotKey<std::cell::
     head.with(|head| {
         let next = head.get();
         debug_assert_eq!(addr % ALIGN_OF_BOX_CELL, 0);
+        // GC_STORE_AUDIT(POINTER_FREE): an unregistered malloc-side cell
+        // stores a non-GC free-list link.
         unsafe { (addr as *mut usize).write(next) };
         head.set(addr);
     });
@@ -570,6 +572,8 @@ fn publish_released_cells(
         let mut next = h.get();
         for addr in cells.drain(..) {
             debug_assert_eq!(addr % ALIGN_OF_BOX_CELL, 0);
+            // GC_STORE_AUDIT(POINTER_FREE): released malloc-side cells hold
+            // only non-GC free-list links.
             unsafe { (addr as *mut usize).write(next) };
             next = addr;
         }

--- a/crates/perry-runtime/src/exception.rs
+++ b/crates/perry-runtime/src/exception.rs
@@ -518,6 +518,7 @@ pub extern "C-unwind" fn js_throw(value: f64) -> ! {
         // assume (skipped cleanups are replayed manually).
         #[cfg(windows)]
         unsafe {
+            // GC_STORE_AUDIT(STACK): native jmp_buf control word is not GC-managed storage.
             (jb_ptr as *mut u64).write(0);
         }
         unsafe { longjmp(jb_ptr, 1) }

--- a/crates/perry-runtime/src/object/this_binding.rs
+++ b/crates/perry-runtime/src/object/this_binding.rs
@@ -349,6 +349,8 @@ pub extern "C" fn js_derived_super_bind_current() -> f64 {
         if slot.read() != 0 {
             return crate::error::js_throw_reference_error_this_before_super();
         }
+        // GC_STORE_AUDIT(STACK): generated derived-constructor binding cell
+        // stores a pointer-free byte.
         slot.write(1);
     }
     f64::from_bits(crate::value::TAG_UNDEFINED)

--- a/crates/perry-runtime/src/promise/async_step.rs
+++ b/crates/perry-runtime/src/promise/async_step.rs
@@ -1637,6 +1637,8 @@ mod tests {
         fn drop(&mut self) {
             unsafe {
                 for (source, first_word) in self.forwarded_sources {
+                    // GC_STORE_AUDIT(POINTER_FREE): test restores Promise state
+                    // or a native closure function word, never a GC edge.
                     source.cast::<usize>().write(first_word);
                     let header = source.sub(crate::gc::GC_HEADER_SIZE) as *mut crate::gc::GcHeader;
                     (*header).gc_flags &= !crate::gc::GC_FLAG_FORWARDED;

--- a/crates/perry-runtime/src/punycode.rs
+++ b/crates/perry-runtime/src/punycode.rs
@@ -506,6 +506,8 @@ mod ucs2_tests {
         let ptr = crate::string::js_string_from_bytes(source.as_ptr(), source.len() as u32);
 
         let copied = copy_string_bytes(ptr);
+        // GC_STORE_AUDIT(POINTER_FREE): test mutates one raw byte of a String
+        // payload, not a traced slot.
         unsafe { string_data(ptr).cast_mut().write(b'X') };
 
         assert_eq!(copied, source);

--- a/crates/perry-runtime/src/string/concat.rs
+++ b/crates/perry-runtime/src/string/concat.rs
@@ -143,6 +143,8 @@ pub(crate) unsafe fn copy_bytes_small(src: *const u8, dst: *mut u8, len: usize) 
     } else if len >= 4 {
         let head = src.cast::<u32>().read_unaligned();
         let tail = src.add(len - 4).cast::<u32>().read_unaligned();
+        // GC_STORE_AUDIT(POINTER_FREE): all unaligned arms copy raw UTF-8
+        // payload bytes, never traced slots.
         dst.cast::<u32>().write_unaligned(head);
         dst.add(len - 4).cast::<u32>().write_unaligned(tail);
     } else if len >= 2 {

--- a/crates/perry-runtime/src/string/mod.rs
+++ b/crates/perry-runtime/src/string/mod.rs
@@ -714,6 +714,8 @@ fn zero_alignment_padding_tail(raw: *mut u8, requested_payload_size: usize) {
                 // writes it (a byte LOOP here gets idiom-recognized by LLVM
                 // back into the `bzero` PLT call this branch exists to
                 // avoid — a real cost when the padding is 2 bytes).
+                // GC_STORE_AUDIT(INIT): fresh String tail padding is zeroed
+                // before payload/header publication.
                 raw.add(allocated_payload - 8)
                     .cast::<u64>()
                     .write_unaligned(0);

--- a/scripts/gc_store_site_inventory.py
+++ b/scripts/gc_store_site_inventory.py
@@ -56,6 +56,12 @@ RUST_TLS_INDEX_STORE_RE = re.compile(
 
 RUST_PTR_STORE_RE = re.compile(r"\b(?:std::)?ptr::write(?:_unaligned)?\s*\(")
 RUST_COPY_RE = re.compile(r"\b(?:std::)?ptr::copy(?:_nonoverlapping)?\s*\(")
+RUST_PTR_METHOD_WRITE_RE = re.compile(
+    r"\.\s*(?P<operation>write(?:_unaligned)?)\s*\((?!\s*\))"
+)
+RUST_PTR_METHOD_COPY_RE = re.compile(
+    r"\.\s*copy_(?:to|from)(?:_nonoverlapping)?\s*\("
+)
 RUST_DEREF_ASSIGN_RE = re.compile(
     r"\*(?P<target>[A-Za-z_][A-Za-z0-9_]*)(?:\.add\([^)]*\))?\s*=(?!=)"
 )
@@ -153,6 +159,27 @@ RUST_DEREF_RISK_TARGETS = (
     "new_keys_elements",
     "pair_elems",
     "result_elements",
+)
+
+# Unlike `ptr::write(dst, value)`, `dst.write(value)` carries no namespace that
+# proves the receiver is a raw pointer. Admit the unambiguous unaligned method,
+# explicit pointer-producing chains/casts, and conventional pointer/slot names;
+# this keeps ordinary `file.write(bytes)` and `RwLock::write()` calls out of a
+# GC store inventory while covering raw-pointer method syntax.
+RUST_PTR_METHOD_EXACT_TARGETS = {
+    "dest",
+    "dst",
+    "p",
+    "ptr",
+    "raw",
+    "slot",
+}
+RUST_PTR_METHOD_TARGET_SUFFIXES = (
+    "_data",
+    "_elements",
+    "_fields",
+    "_ptr",
+    "_slot",
 )
 
 RUST_ATOMIC_ROOT_TARGET_HINTS = (
@@ -406,12 +433,16 @@ def classify_rust_store(path: Path, lines: list[str], index: int) -> str | None:
     if RUST_FIELD_STORE_RE.search(line):
         return "raw heap pointer field store"
 
-    if RUST_PTR_STORE_RE.search(line):
+    method_write = any(
+        is_raw_pointer_method_write(lines, index, match)
+        for match in RUST_PTR_METHOD_WRITE_RE.finditer(line)
+    )
+    if RUST_PTR_STORE_RE.search(line) or method_write:
         if any(hint in window for hint in STACK_COPY_HINTS):
             return "raw stack/temporary argument store"
         return "raw slot write"
 
-    if RUST_COPY_RE.search(line):
+    if RUST_COPY_RE.search(line) or RUST_PTR_METHOD_COPY_RE.search(line):
         if any(hint in window for hint in STACK_COPY_HINTS):
             return "raw stack/temporary argument copy"
         if is_runtime_module(path, "string") or is_pointer_free_module(path):
@@ -449,6 +480,51 @@ def is_risky_tls_index_store(window: str) -> bool:
     window_lower = window.lower()
     return "cache" in window_lower and any(
         hint in window_lower for hint in RUST_GLOBAL_INDEX_POINTER_HINTS
+    )
+
+
+def is_raw_pointer_method_write(
+    lines: list[str], index: int, match: re.Match[str]
+) -> bool:
+    """Distinguish raw-pointer `.write` from unrelated Rust write methods."""
+
+    if match.group("operation") == "write_unaligned":
+        return True
+
+    receiver = lines[index][: match.start()].strip()
+    if not receiver:
+        # Rustfmt can put a pointer-producing expression on the immediately
+        # preceding line, with `.write(value)` alone on the continuation line.
+        # Do not reach farther back: that can borrow `.add(...)` from a separate
+        # statement and misclassify an ordinary writer's `.write(...)` call.
+        receiver = lines[index - 1].strip() if index else ""
+    if re.search(
+        r"\bas\s+\*mut\b"
+        r"|\.(?:add|byte_add|cast|cast_mut|offset|sub|byte_sub|wrapping_add|wrapping_sub)"
+        r"(?:::<[^>]+>)?\s*\("
+        r"|\.(?:as_mut_ptr|as_ptr)\s*\("
+        r"|\b(?:std::)?ptr::(?:addr_of_mut|null_mut)!?\s*\(",
+        receiver,
+    ):
+        return True
+
+    target = re.search(r"([A-Za-z_][A-Za-z0-9_]*)\s*$", receiver)
+    if target is None:
+        return False
+    name = target.group(1).lower()
+    source_before_store = "\n".join(lines[: index + 1])
+    escaped_name = re.escape(target.group(1))
+    if re.search(rf"\b{escaped_name}\s*:\s*\*mut\b", source_before_store):
+        return True
+    if re.search(
+        rf"\blet\s+(?:mut\s+)?{escaped_name}\b[^;=]*=\s*[^;]*"
+        rf"(?:\bas\s+\*mut\b|\.as_mut_ptr\s*\(|\.cast_mut\s*\(|"
+        rf"\b(?:std::)?ptr::(?:addr_of_mut|null_mut)!?\s*\()",
+        source_before_store,
+    ):
+        return True
+    return name in RUST_PTR_METHOD_EXACT_TARGETS or name.endswith(
+        RUST_PTR_METHOD_TARGET_SUFFIXES
     )
 
 
@@ -1264,6 +1340,99 @@ def run_self_tests() -> int:
         ["std::ptr::write(elements_ptr.add(i), nanboxed);"],
         "raw slot write",
     )
+    check(
+        "crates/perry-runtime/src/regex.rs",
+        ["slot.write(nanboxed);"],
+        "raw slot write",
+    )
+    check(
+        "crates/perry-runtime/src/string/concat.rs",
+        ["dst.cast::<u64>().write_unaligned(head);"],
+        "raw slot write",
+    )
+    check(
+        "crates/perry-runtime/src/array.rs",
+        ["(addr as *mut usize).write(value);"],
+        "raw slot write",
+    )
+    check_at(
+        "crates/perry-runtime/src/array.rs",
+        ["fn store(output: *mut u64) {", "    output.write(value);", "}"],
+        1,
+        "raw slot write",
+    )
+    check(
+        "crates/perry-runtime/src/string.rs",
+        ["string_data(value).cast_mut().write(b'X');"],
+        "raw slot write",
+    )
+    check(
+        "crates/perry-runtime/src/array.rs",
+        ["cell.write(buffer).as_mut_ptr().write(value);"],
+        "raw slot write",
+    )
+    split_method_write = ["dst.add(i)", ".write(value);"]
+    check_at("crates/perry-runtime/src/array.rs", split_method_write, 0, None)
+    check_at(
+        "crates/perry-runtime/src/array.rs",
+        split_method_write,
+        1,
+        "raw slot write",
+    )
+    for method_copy in (
+        "src.copy_to(dst, count);",
+        "src.copy_to_nonoverlapping(dst, count);",
+        "dst.copy_from(src, count);",
+        "dst.copy_from_nonoverlapping(src, count);",
+    ):
+        check(
+            "crates/perry-runtime/src/array.rs",
+            [method_copy],
+            "slot copy",
+        )
+    split_method_copy = [
+        "src.copy_to_nonoverlapping(",
+        "    dst,",
+        "    count,",
+        ");",
+    ]
+    check(
+        "crates/perry-runtime/src/array.rs",
+        split_method_copy,
+        "slot copy",
+    )
+    for below in range(1, len(split_method_copy)):
+        check_at("crates/perry-runtime/src/array.rs", split_method_copy, below, None)
+    check(
+        "crates/perry-runtime/src/buffer.rs",
+        ["src.copy_to_nonoverlapping(dst_data, count);"],
+        None,
+    )
+    for ordinary_write in (
+        "file.write(&bytes);",
+        "decoder.write(&bytes);",
+        "data.write(&bytes);",
+        "cache.write(value);",
+        "GLOBAL_CACHE.write().unwrap();",
+        "num_bufs[i].write([0u8; 32]);",
+    ):
+        check(
+            "crates/perry-runtime/src/fs.rs",
+            [ordinary_write],
+            None,
+        )
+    split_ordinary_write = [
+        "let data = buffer_data(buf).add(offset);",
+        "let result = file",
+        "    .write(std::slice::from_raw_parts(data, n));",
+    ]
+    for index in range(len(split_ordinary_write)):
+        check_at(
+            "crates/perry-runtime/src/fs.rs",
+            split_ordinary_write,
+            index,
+            None,
+        )
     check(
         "crates/perry-runtime/src/plugin.rs",
         ["*fields.add(1) = make_nanboxed_string(&name);"],


### PR DESCRIPTION
Lands #9665 — the GC store-site inventory now recognises raw-pointer METHOD syntax (`ptr.write(…)`, `write_unaligned`, `copy_to`, `copy_from`, both nonoverlapping variants) alongside the free-function spellings it already saw (#9120).

This is the blind-spot class worth taking seriously: an under-counting scanner fails in the GREEN direction — it just silently passes — so the gate looked healthy while a whole spelling of store site was invisible to it.

Two things make it a real fix rather than a wider net:

- The **self-test still passes**, so the widened detector can still fail, and the negatives are tested — ordinary I/O writers, locks, builders and `MaybeUninit::write` stay out of the inventory.
- The newly visible sites got **specific `GC_STORE_AUDIT` rationales at their actual safety boundary**, not blanket suppression. Spot-checked in `string/concat.rs`: `GC_STORE_AUDIT(POINTER_FREE): all unaligned arms copy raw UTF-8 payload bytes, never traced slots.`

Validation: `run_lint_gates.sh` **all 62 gates pass**; `gc_store_site_inventory.py --self-test` green and the inventory itself green; release build green; RUST_TEST_THREADS=1 perry-runtime **3064/0**.

Rebase-merge preserving authorship.
