### PR TITLE
Merge train: #9679 (nine unrooted Array.prototype callbacks)

### DIFF
--- a/changelog.d/9673-array-callback-rooting.md
+++ b/changelog.d/9673-array-callback-rooting.md
@@ -1,0 +1,33 @@
+**Nine `Array.prototype` higher-order methods kept the raw callback pointer
+they were handed and re-used it after the callback had allocated** — a
+collection landing inside the loop retired the closure, and the next dispatch
+read recycled memory. When that memory had been reissued as an ordinary object
+the validator reported its `typeof` instead: `TypeError: object is not a
+function`. That is the error claude-code's OAuth login died with (#9673).
+
+A callback born at the call site — the inline arrow in `xs.forEach(x => …)` —
+is reachable only through the raw parameter and the native stack, and an
+evacuating minor does not scan the native stack. `js_array_map` learned this in
+#6081/#6206, `js_array_filter` alongside it, and `js_array_map_discard` again in
+#7533 when an unrelated allocation change moved a collection into its window.
+The remaining arms — `forEach`, `some`, `every`, `find`, `findIndex`,
+`findLast`, `findLastIndex`, `flatMap` and `reduce` — were never converted and
+still bound the pre-collection address. Each now roots the callback for the loop
+and re-reads it at every dispatch, NaN-boxed so the read-back stays out of
+`scripts/raw_handle_debt.py`'s ledger (the shape `map_discard` already used).
+
+The defect was latent in exactly the way the earlier three were: a stale
+address only bites when a collection lands in its window, and nothing put one
+there in the suites. `PERRY_GC_PROTECT_FROMSPACE=1` — which mprotects retired
+from-space so a stale use faults at the instruction that makes it — puts the
+question beyond timing. On unfixed `main`,
+`test-files/test_gap_9673_array_callback_rooting.ts forEach` dies there with
+`obj_type=4 size=32` (a `GC_TYPE_CLOSURE`) and a backtrace naming
+`js_array_forEach + 4072`; with the fix the whole fixture runs, byte-identical
+to `node --experimental-strip-types`, with and without the instrument.
+
+Three separate one-arm fixes across three issues is a pattern, so the invariant
+is now checked rather than remembered: `array/callback_rooting_tests.rs` reads
+this module's own source and fails if any arm dispatches the raw parameter, or
+resolves a direct-call site for a callback it never roots. A new arm has to
+root, or the test names it.

--- a/crates/perry-runtime/src/array/callback_rooting_tests.rs
+++ b/crates/perry-runtime/src/array/callback_rooting_tests.rs
@@ -1,0 +1,147 @@
+//! #9673 ratchet: every `Array.prototype` higher-order arm must dispatch a
+//! callback it re-read from a GC root, never the raw pointer it was handed.
+//!
+//! The defect this pins: a callback born at the call site (the inline arrow in
+//! `xs.forEach(x => …)`) is reachable ONLY through that raw parameter plus the
+//! native stack, which an evacuating minor does not scan. Every dispatch in the
+//! loop allocates, so binding the address once and reusing it dereferences a
+//! closure the collector has already retired — the read lands on recycled
+//! memory whose header is no longer `CLOSURE_MAGIC`, and the next validation
+//! reports the recycled object's `typeof`: `TypeError: object is not a
+//! function`.
+//!
+//! `js_array_map` (#6081/#6206), `js_array_filter` and `js_array_map_discard`
+//! (#7533) each learned this one arm at a time, three separate times, because
+//! nothing checked the others. This is the check: it reads the module's own
+//! source, so a new arm — or a refactor that drops a re-read — fails here
+//! instead of waiting for a collection to land in its window.
+
+const SRC: &str = include_str!("iter_methods.rs");
+
+fn lines() -> Vec<&'static str> {
+    SRC.lines().collect()
+}
+
+/// Indices (0-based) of every line that hands a callback to a resolved
+/// direct-call site.
+fn dispatch_indices(lines: &[&str]) -> Vec<usize> {
+    lines
+        .iter()
+        .enumerate()
+        .filter(|(_, l)| l.contains("cb_site.call("))
+        .map(|(i, _)| i)
+        .collect()
+}
+
+/// The argument a dispatch actually passes: normally on the same line, but the
+/// `reduce` arm wraps, so a bare `cb_site.call(` takes the line below.
+fn callee_argument<'a>(lines: &[&'a str], idx: usize) -> &'a str {
+    let line = lines[idx];
+    if line.trim_end().ends_with("cb_site.call(") {
+        lines.get(idx + 1).copied().unwrap_or("")
+    } else {
+        line
+    }
+}
+
+/// A dispatch is rooted when its callee argument is a re-read of the loop's
+/// root: the `current_callback()` closure over a NaN-boxed handle
+/// (`js_array_map_discard` and the #9673 arms), or a `callback` shadowed from
+/// the raw handle immediately above (`js_array_map`, `js_array_filter`).
+fn is_rooted_dispatch(lines: &[&str], idx: usize) -> bool {
+    let arg = callee_argument(lines, idx);
+    if arg.contains("current_callback()") {
+        return true;
+    }
+    if arg.contains("callback") {
+        let start = idx.saturating_sub(4);
+        return lines[start..idx]
+            .iter()
+            .any(|l| l.contains("let callback = cb_handle."));
+    }
+    false
+}
+
+#[test]
+fn every_dispatch_reads_the_callback_from_its_root() {
+    let lines = lines();
+    let offenders: Vec<String> = dispatch_indices(&lines)
+        .into_iter()
+        .filter(|idx| !is_rooted_dispatch(&lines, *idx))
+        .map(|idx| format!("iter_methods.rs:{}: {}", idx + 1, lines[idx].trim()))
+        .collect();
+    assert!(
+        offenders.is_empty(),
+        "#9673: these Array.prototype arms dispatch the raw callback parameter \
+         instead of re-reading it from the loop's root — a collection inside the \
+         loop retires the closure and the next validation throws \
+         `object is not a function`:\n  {}",
+        offenders.join("\n  ")
+    );
+}
+
+/// The dispatch check is only meaningful if the arms actually root the
+/// callback. Every `DirectCallN::resolve(callback)` must be followed, inside
+/// its own function, by a root of that same callback.
+#[test]
+fn every_resolved_call_site_roots_its_callback() {
+    let lines = lines();
+    let mut offenders = Vec::new();
+    for (i, line) in lines.iter().enumerate() {
+        if !line.contains("::resolve(callback)") {
+            continue;
+        }
+        let mut rooted = false;
+        for probe in lines.iter().skip(i + 1) {
+            if probe.starts_with("pub extern") || probe.starts_with("fn ") {
+                break;
+            }
+            if probe.contains("root_raw_const_ptr(callback)")
+                || probe.contains("js_nanbox_pointer(callback as i64)")
+            {
+                rooted = true;
+                break;
+            }
+        }
+        if !rooted {
+            offenders.push(format!("iter_methods.rs:{}: {}", i + 1, line.trim()));
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "#9673: these loops resolve a direct-call site for a callback they never \
+         root — the closure can be retired mid-loop:\n  {}",
+        offenders.join("\n  ")
+    );
+}
+
+/// Non-vacuity: the scan must see every arm, and it must reject the shape the
+/// fix removed.
+#[test]
+fn the_ratchet_sees_every_arm_and_rejects_the_old_shape() {
+    let lines = lines();
+    assert!(
+        dispatch_indices(&lines).len() >= 12,
+        "expected every Array.prototype higher-order arm to be scanned, saw {}",
+        dispatch_indices(&lines).len()
+    );
+    for arm in [
+        "js_array_forEach",
+        "js_array_map",
+        "js_array_filter",
+        "js_array_find",
+        "js_array_some",
+        "js_array_every",
+        "js_array_flatMap",
+        "js_array_reduce",
+    ] {
+        assert!(SRC.contains(arm), "{arm} is no longer in iter_methods.rs");
+    }
+    // The pre-fix shape — a bare `cb_site.call(callback, …)` with no rebind
+    // above it — must be rejected, or the scan above proves nothing.
+    let pre_fix = ["    let cb_site = X::resolve(callback);", "    cb_site.call(callback, a, b, c);"];
+    assert!(
+        !is_rooted_dispatch(&pre_fix, 1),
+        "the ratchet accepts the shape #9673 removed"
+    );
+}

--- a/crates/perry-runtime/src/array/callback_rooting_tests.rs
+++ b/crates/perry-runtime/src/array/callback_rooting_tests.rs
@@ -139,7 +139,10 @@ fn the_ratchet_sees_every_arm_and_rejects_the_old_shape() {
     }
     // The pre-fix shape — a bare `cb_site.call(callback, …)` with no rebind
     // above it — must be rejected, or the scan above proves nothing.
-    let pre_fix = ["    let cb_site = X::resolve(callback);", "    cb_site.call(callback, a, b, c);"];
+    let pre_fix = [
+        "    let cb_site = X::resolve(callback);",
+        "    cb_site.call(callback, a, b, c);",
+    ];
     assert!(
         !is_rooted_dispatch(&pre_fix, 1),
         "the ratchet accepts the shape #9673 removed"

--- a/crates/perry-runtime/src/array/iter_methods.rs
+++ b/crates/perry-runtime/src/array/iter_methods.rs
@@ -271,6 +271,14 @@ pub extern "C" fn js_array_forEach(arr: *const ArrayHeader, callback: *const Clo
         // fixed closure (see closure/dispatch/direct.rs), and this loop calls
         // exactly one.
         let cb_site = crate::closure::DirectCall3::resolve(callback);
+        // #9673: root the callback for the loop and re-read it at every
+        // dispatch — an inline-arrow callback is reachable only through this
+        // raw parameter, every dispatch allocates, and an evacuating minor
+        // retires the closure out from under the loop (see `js_array_map`).
+        let cb_handle = scope.root_nanbox_f64(crate::value::js_nanbox_pointer(callback as i64));
+        let current_callback = || {
+            crate::value::js_nanbox_get_pointer(cb_handle.get_nanbox_f64()) as *const ClosureHeader
+        };
         // The override is a movable `ObjectHeader` held across user callbacks
         // that allocate — root it for the duration of the loop.
         let self_handle = self_override.map(|recv| scope.root_nanbox_f64(recv));
@@ -286,7 +294,7 @@ pub extern "C" fn js_array_forEach(arr: *const ArrayHeader, callback: *const Clo
                     continue;
                 }
                 let element = crate::array::array_spec_get(arr, i as u32);
-                cb_site.call(callback, element, i as f64, self_value(&rooted));
+                cb_site.call(current_callback(), element, i as f64, self_value(&rooted));
             }
             return;
         }
@@ -298,7 +306,7 @@ pub extern "C" fn js_array_forEach(arr: *const ArrayHeader, callback: *const Clo
             // dispatch path supports call3 safely, so bound native
             // methods like `array.forEach(console.log)` can observe the
             // source array just like Node.
-            cb_site.call(callback, element, i as f64, self_value(&rooted));
+            cb_site.call(current_callback(), element, i as f64, self_value(&rooted));
         }
     }
 }
@@ -625,6 +633,14 @@ pub extern "C" fn js_array_find(arr: *const ArrayHeader, callback: *const Closur
         // fixed closure (see closure/dispatch/direct.rs), and this loop calls
         // exactly one.
         let cb_site = crate::closure::DirectCall3::resolve(callback);
+        // #9673: root the callback for the loop and re-read it at every
+        // dispatch — an inline-arrow callback is reachable only through this
+        // raw parameter, every dispatch allocates, and an evacuating minor
+        // retires the closure out from under the loop (see `js_array_map`).
+        let cb_handle = scope.root_nanbox_f64(crate::value::js_nanbox_pointer(callback as i64));
+        let current_callback = || {
+            crate::value::js_nanbox_get_pointer(cb_handle.get_nanbox_f64()) as *const ClosureHeader
+        };
         let _tg = DenseThisGuard::bind_undefined();
         let exotic = crate::array::array_iteration_is_exotic(arr);
 
@@ -634,7 +650,7 @@ pub extern "C" fn js_array_find(arr: *const ArrayHeader, callback: *const Closur
             } else {
                 rooted.get_or_undefined(i)
             };
-            let result = cb_site.call(callback, element, i as f64, rooted.receiver());
+            let result = cb_site.call(current_callback(), element, i as f64, rooted.receiver());
             // Proper truthy check: handles NaN-boxed booleans
             if crate::value::js_is_truthy(result) != 0 {
                 return element;
@@ -687,6 +703,14 @@ pub extern "C" fn js_array_findIndex(
         // fixed closure (see closure/dispatch/direct.rs), and this loop calls
         // exactly one.
         let cb_site = crate::closure::DirectCall3::resolve(callback);
+        // #9673: root the callback for the loop and re-read it at every
+        // dispatch — an inline-arrow callback is reachable only through this
+        // raw parameter, every dispatch allocates, and an evacuating minor
+        // retires the closure out from under the loop (see `js_array_map`).
+        let cb_handle = scope.root_nanbox_f64(crate::value::js_nanbox_pointer(callback as i64));
+        let current_callback = || {
+            crate::value::js_nanbox_get_pointer(cb_handle.get_nanbox_f64()) as *const ClosureHeader
+        };
         let _tg = DenseThisGuard::bind_undefined();
         let exotic = crate::array::array_iteration_is_exotic(arr);
 
@@ -696,7 +720,7 @@ pub extern "C" fn js_array_findIndex(
             } else {
                 rooted.get_or_undefined(i)
             };
-            let result = cb_site.call(callback, element, i as f64, rooted.receiver());
+            let result = cb_site.call(current_callback(), element, i as f64, rooted.receiver());
             // Proper truthy check: handles NaN-boxed booleans
             if crate::value::js_is_truthy(result) != 0 {
                 return i as i32;
@@ -734,6 +758,14 @@ pub extern "C" fn js_array_find_last(
         // fixed closure (see closure/dispatch/direct.rs), and this loop calls
         // exactly one.
         let cb_site = crate::closure::DirectCall3::resolve(callback);
+        // #9673: root the callback for the loop and re-read it at every
+        // dispatch — an inline-arrow callback is reachable only through this
+        // raw parameter, every dispatch allocates, and an evacuating minor
+        // retires the closure out from under the loop (see `js_array_map`).
+        let cb_handle = scope.root_nanbox_f64(crate::value::js_nanbox_pointer(callback as i64));
+        let current_callback = || {
+            crate::value::js_nanbox_get_pointer(cb_handle.get_nanbox_f64()) as *const ClosureHeader
+        };
         let _tg = DenseThisGuard::bind_undefined();
         let exotic = crate::array::array_iteration_is_exotic(arr);
         for i in (0..length).rev() {
@@ -742,7 +774,7 @@ pub extern "C" fn js_array_find_last(
             } else {
                 rooted.get_or_undefined(i)
             };
-            let result = cb_site.call(callback, element, i as f64, rooted.receiver());
+            let result = cb_site.call(current_callback(), element, i as f64, rooted.receiver());
             if crate::value::js_is_truthy(result) != 0 {
                 return element;
             }
@@ -778,6 +810,14 @@ pub extern "C" fn js_array_find_last_index(
         // fixed closure (see closure/dispatch/direct.rs), and this loop calls
         // exactly one.
         let cb_site = crate::closure::DirectCall3::resolve(callback);
+        // #9673: root the callback for the loop and re-read it at every
+        // dispatch — an inline-arrow callback is reachable only through this
+        // raw parameter, every dispatch allocates, and an evacuating minor
+        // retires the closure out from under the loop (see `js_array_map`).
+        let cb_handle = scope.root_nanbox_f64(crate::value::js_nanbox_pointer(callback as i64));
+        let current_callback = || {
+            crate::value::js_nanbox_get_pointer(cb_handle.get_nanbox_f64()) as *const ClosureHeader
+        };
         let _tg = DenseThisGuard::bind_undefined();
         let exotic = crate::array::array_iteration_is_exotic(arr);
         for i in (0..length).rev() {
@@ -786,7 +826,7 @@ pub extern "C" fn js_array_find_last_index(
             } else {
                 rooted.get_or_undefined(i)
             };
-            let result = cb_site.call(callback, element, i as f64, rooted.receiver());
+            let result = cb_site.call(current_callback(), element, i as f64, rooted.receiver());
             if crate::value::js_is_truthy(result) != 0 {
                 return i as i32;
             }
@@ -879,6 +919,14 @@ pub extern "C" fn js_array_some(arr: *const ArrayHeader, callback: *const Closur
         // fixed closure (see closure/dispatch/direct.rs), and this loop calls
         // exactly one.
         let cb_site = crate::closure::DirectCall3::resolve(callback);
+        // #9673: root the callback for the loop and re-read it at every
+        // dispatch — an inline-arrow callback is reachable only through this
+        // raw parameter, every dispatch allocates, and an evacuating minor
+        // retires the closure out from under the loop (see `js_array_map`).
+        let cb_handle = scope.root_nanbox_f64(crate::value::js_nanbox_pointer(callback as i64));
+        let current_callback = || {
+            crate::value::js_nanbox_get_pointer(cb_handle.get_nanbox_f64()) as *const ClosureHeader
+        };
         let _tg = DenseThisGuard::bind_undefined();
         let exotic = crate::array::array_iteration_is_exotic(arr);
 
@@ -895,7 +943,7 @@ pub extern "C" fn js_array_some(arr: *const ArrayHeader, callback: *const Closur
                     None => continue,
                 }
             };
-            let result = cb_site.call(callback, element, i as f64, rooted.receiver());
+            let result = cb_site.call(current_callback(), element, i as f64, rooted.receiver());
             if crate::value::js_is_truthy(result) != 0 {
                 return f64::from_bits(TAG_TRUE);
             }
@@ -1032,6 +1080,14 @@ pub extern "C" fn js_array_every(arr: *const ArrayHeader, callback: *const Closu
         // fixed closure (see closure/dispatch/direct.rs), and this loop calls
         // exactly one.
         let cb_site = crate::closure::DirectCall3::resolve(callback);
+        // #9673: root the callback for the loop and re-read it at every
+        // dispatch — an inline-arrow callback is reachable only through this
+        // raw parameter, every dispatch allocates, and an evacuating minor
+        // retires the closure out from under the loop (see `js_array_map`).
+        let cb_handle = scope.root_nanbox_f64(crate::value::js_nanbox_pointer(callback as i64));
+        let current_callback = || {
+            crate::value::js_nanbox_get_pointer(cb_handle.get_nanbox_f64()) as *const ClosureHeader
+        };
         let _tg = DenseThisGuard::bind_undefined();
         let exotic = crate::array::array_iteration_is_exotic(arr);
 
@@ -1048,7 +1104,7 @@ pub extern "C" fn js_array_every(arr: *const ArrayHeader, callback: *const Closu
                     None => continue,
                 }
             };
-            let result = cb_site.call(callback, element, i as f64, rooted.receiver());
+            let result = cb_site.call(current_callback(), element, i as f64, rooted.receiver());
             if crate::value::js_is_truthy(result) == 0 {
                 return f64::from_bits(TAG_FALSE);
             }
@@ -1077,6 +1133,14 @@ pub extern "C" fn js_array_flatMap(
         // fixed closure (see closure/dispatch/direct.rs), and this loop calls
         // exactly one.
         let cb_site = crate::closure::DirectCall3::resolve(callback);
+        // #9673: root the callback for the loop and re-read it at every
+        // dispatch — an inline-arrow callback is reachable only through this
+        // raw parameter, every dispatch allocates, and an evacuating minor
+        // retires the closure out from under the loop (see `js_array_map`).
+        let cb_handle = scope.root_nanbox_f64(crate::value::js_nanbox_pointer(callback as i64));
+        let current_callback = || {
+            crate::value::js_nanbox_get_pointer(cb_handle.get_nanbox_f64()) as *const ClosureHeader
+        };
         // Root the result across callbacks and pushes (a push both allocates
         // — possibly triggering a moving GC — and may reallocate the array).
         let result_rooted = scope.root_nanbox_f64(f64::from_bits(
@@ -1099,7 +1163,7 @@ pub extern "C" fn js_array_flatMap(
             let Some(element) = rooted.present(i) else {
                 continue;
             };
-            let mapped = cb_site.call(callback, element, i as f64, rooted.receiver());
+            let mapped = cb_site.call(current_callback(), element, i as f64, rooted.receiver());
             // Root first: detecting a lazy array may materialize it, and a
             // push in the inner loop can move the callback result's target.
             sub_rooted.set_nanbox_f64(mapped);
@@ -1194,6 +1258,14 @@ pub extern "C" fn js_array_reduce(
             throw_reduce_of_empty();
         }
 
+        // #9673: root the callback for the loop and re-read it at every
+        // dispatch — an inline-arrow callback is reachable only through this
+        // raw parameter, every dispatch allocates, and an evacuating minor
+        // retires the closure out from under the loop (see `js_array_map`).
+        let cb_handle = scope.root_nanbox_f64(crate::value::js_nanbox_pointer(callback as i64));
+        let current_callback = || {
+            crate::value::js_nanbox_get_pointer(cb_handle.get_nanbox_f64()) as *const ClosureHeader
+        };
         let exotic = crate::array::array_iteration_is_exotic(arr);
         let present = |i: usize| -> Option<f64> {
             if exotic {
@@ -1232,7 +1304,7 @@ pub extern "C" fn js_array_reduce(
             };
             // Spec callback is `(accumulator, currentValue, currentIndex, array)`.
             let next = cb_site.call(
-                callback,
+                current_callback(),
                 acc_rooted.get_nanbox_f64(),
                 element,
                 i as f64,

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -45,6 +45,8 @@ mod subclass;
 pub(crate) mod subclass_elements;
 
 #[cfg(test)]
+mod callback_rooting_tests;
+#[cfg(test)]
 mod collection_tag_tests;
 #[cfg(test)]
 mod forwarding_tests;

--- a/test-files/test_gap_9673_array_callback_rooting.ts
+++ b/test-files/test_gap_9673_array_callback_rooting.ts
@@ -1,0 +1,73 @@
+// #9673: an `Array.prototype` higher-order method that binds the RAW callback
+// pointer it was handed and keeps using it after the callback has allocated.
+//
+// A callback born at the call site — the inline arrow in `xs.forEach(x => …)` —
+// is reachable ONLY through that raw parameter plus the native stack, which an
+// evacuating minor does not scan. Every dispatch inside the loop allocates, so
+// from some element on the loop dereferences a closure the collector has
+// already retired. The read lands on recycled memory whose header is no longer
+// `CLOSURE_MAGIC`; the next validation reports the recycled object's `typeof`
+// instead — `TypeError: object is not a function`, which is what claude-code's
+// OAuth login died with.
+//
+// `js_array_map` (#6081/#6206) and `js_array_filter` root the callback and
+// re-read it at every dispatch, and `js_array_map_discard` got the same
+// treatment when #7533's allocation change moved a collection into its window.
+// forEach / some / every / find / findIndex / findLast / findLastIndex /
+// flatMap / reduce were never converted and still bind the pre-collection
+// address.
+//
+// PROOF INSTRUMENT: `PERRY_GC_PROTECT_FROMSPACE=1` mprotects retired
+// from-space, so a stale use faults at the instruction that makes it — the same
+// instrument that pinned the `map_discard` arm. On unfixed `origin/main` the
+// `forEach` arm dies with
+//
+//   [gc-fromspace-protect] FAULT: signal 10 at 0x…
+//     last-known object: user_ptr=0x… obj_type=4 size=32     (GC_TYPE_CLOSURE)
+//   2  js_array_forEach + 4072
+//
+// and prints nothing. Node prints the arm's value; so must perry, with and
+// without the instrument.
+//
+// One arm per process (argv[2]) so a fault attributes to exactly one method.
+function junk(n: number): number {
+  const a: any[] = [];
+  for (let j = 0; j < n; j++) a.push({ k: j, s: "x" + j, arr: [j, j + 1, j + 2] });
+  return a.length;
+}
+const src: number[] = [];
+for (let i = 0; i < 4000; i++) src.push(i);
+const which = process.argv[2] || "forEach";
+let out: unknown;
+switch (which) {
+  case "forEach": { let n = 0; src.forEach((v) => { n += v + junk(60); }); out = n > 0; break; }
+  case "some": out = src.some((v) => { junk(60); return v === 3999; }); break;
+  case "every": out = src.every((v) => { junk(60); return v >= 0; }); break;
+  case "find": out = src.find((v) => { junk(60); return v === 3999; }); break;
+  case "findIndex": out = src.findIndex((v) => { junk(60); return v === 3999; }); break;
+  case "findLast": out = src.findLast((v) => { junk(60); return v === 0; }); break;
+  case "findLastIndex": out = src.findLastIndex((v) => { junk(60); return v === 0; }); break;
+  case "flatMap": out = src.flatMap((v) => { junk(60); return v; }).length; break;
+  case "reduce": out = src.reduce((a, v) => { junk(60); return a + v; }, 0); break;
+  case "reduceRight": out = src.reduceRight((a, v) => { junk(60); return a + v; }, 0); break;
+  case "map": out = src.map((v) => { junk(60); return v; }).length; break;
+  case "filter": out = src.filter((v) => { junk(60); return v % 2 === 0; }).length; break;
+  case "sort": out = src.slice(0, 800).sort((a, b) => { junk(60); return a - b; })[0]; break;
+  // Controls: a genuine non-callable must still raise Node's exact message —
+  // rooting the callback must not turn the TypeError into a silent no-op.
+  case "bad": {
+    const msgs: string[] = [];
+    for (const bad of [{}, null, 5, "x"] as any[]) {
+      try {
+        src.map(bad);
+        msgs.push("no throw");
+      } catch (e: any) {
+        msgs.push(e.message);
+      }
+    }
+    out = msgs;
+    break;
+  }
+  default: out = "unknown arm";
+}
+console.log(which + " -> " + JSON.stringify(out));


### PR DESCRIPTION
Lands #9679 — nine `Array.prototype` higher-order methods dispatched an unrooted callback, so a collection mid-loop could sweep it and the next iteration threw `object is not a function` (#9673).

Two things make this write-up worth reading beyond the fix:

**It disproves the issue's own hypothesis.** `node:crypto` was the prime suspect; the author shows it is *correctly* absent from `CJS_DEFAULT_NAMESPACE_MODULES` (its CJS and ESM namespaces are the same object), that all three formerly hand-maintained copies now derive from one table, and that cc's login path uses spellings perry handles. The reasoning runs from the error string to its single producer — `throw_not_a_function(render_callback_typeof(cb))` at `array/iter_methods.rs:1423` — rather than from the plausible-sounding story.

**The misleading evidence has a known source.** Both named frames that pointed at crypto (`getPublicKeyThumbprint` from `@azure/msal-node`'s stub, `encrypt` from node-forge's RSA) were **#9521 name-borrowing artifacts** — from the Error.stack naming that landed earlier today. Neither can be on cc's OAuth path. Worth knowing that a borrowed frame name can actively mislead a debugging session.

It also *lowers* the raw-handle ratchet (959 against a 963 baseline).

Validation: `run_lint_gates.sh` **all 64 gates pass**; release build green; RUST_TEST_THREADS=1 perry-runtime **3082/0** including the three new `callback_rooting` tests; `test_gap_9673_array_callback_rooting` byte-identical to node.

Rebase-merge preserving authorship.
