### PR TITLE
fix(runtime): release compiled regex programs during GC

### DIFF
--- a/changelog.d/9684-regex-program-finalization.md
+++ b/changelog.d/9684-regex-program-finalization.md
@@ -1,0 +1,6 @@
+**Compiled RegExp programs no longer remain allocated after their JavaScript
+owner is collected.** RegExp headers held raw `Arc` references for the standard,
+fancy, and RepeatMatcher programs, but their GC finalizer cleared only metadata
+side tables. The finalizer now releases all three owned references while
+preserving ownership across live arena moves, preventing the permanent
+per-pattern memory growth reported in #9678.

--- a/crates/perry-runtime/src/gc/types.rs
+++ b/crates/perry-runtime/src/gc/types.rs
@@ -270,10 +270,10 @@ pub(crate) enum GcFinalizeHookKind {
     /// #7539: free a dead lazy JSON array's tape bytes, which
     /// `json_tape_store` owns outside the GC heap.
     LazyArrayTape,
-    /// Drop a dead RegExp cell's entries from every payload-address-keyed
-    /// registry. Arena reclamation reaches the equivalent cleanup through the
-    /// move-hook dead-owner fan-out; malloc-tracked cells use this finalize
-    /// hook instead.
+    /// Release a dead RegExp cell's header-owned compiled programs and drop
+    /// its entries from every payload-address-keyed registry. Moved arena
+    /// stubs use only the move-hook dead-owner fan-out so ownership transfers
+    /// to the relocated header instead of being released with the old copy.
     RegExpSideTables,
 }
 
@@ -879,7 +879,7 @@ pub(crate) unsafe fn gc_type_finalize_unmarked_payload(obj_type: u8, user_ptr: *
             crate::json_tape_store::release(user_ptr as usize);
         }
         GcFinalizeHookKind::RegExpSideTables => {
-            crate::regex::regex_header_clear_dead_for_gc(user_ptr as usize);
+            crate::regex::regex_header_finalize_for_gc(user_ptr as *mut crate::regex::RegExpHeader);
         }
     }
 }

--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -196,6 +196,41 @@ pub(crate) fn regex_header_clear_dead_for_gc(addr: usize) {
     crate::object::exotic_expando::exotic_expando_owner_clear_dead(addr);
 }
 
+/// Release the compiled programs owned by a dead `RegExpHeader`, then remove
+/// its address-owned metadata.
+///
+/// The program pointers are raw `Arc` references installed by
+/// `lazy::build_and_install_programs` or `RegExp.prototype.compile`. Null them
+/// before reconstructing the `Arc`s because arena cleanup can visit the
+/// metadata and finalizer paths for the same dead cell.
+pub(crate) unsafe fn regex_header_finalize_for_gc(re: *mut RegExpHeader) {
+    if re.is_null() {
+        return;
+    }
+    #[cfg(feature = "regex-engine")]
+    {
+        let regex_ptr = (*re).regex_ptr;
+        let fancy_ptr = (*re).fancy_ptr;
+        let repeat_matcher_ptr = (*re).repeat_matcher_ptr;
+        (*re).regex_ptr = ptr::null_mut();
+        (*re).fancy_ptr = ptr::null();
+        (*re).repeat_matcher_ptr = ptr::null();
+
+        if !regex_ptr.is_null() {
+            drop(Arc::from_raw(regex_ptr as *const Regex));
+        }
+        if !fancy_ptr.is_null() {
+            drop(Arc::from_raw(fancy_ptr as *const fancy_regex::Regex));
+        }
+        if !repeat_matcher_ptr.is_null() {
+            drop(Arc::from_raw(
+                repeat_matcher_ptr as *const repeat_matcher::RepeatMatcherRegex,
+            ));
+        }
+    }
+    regex_header_clear_dead_for_gc(re as usize);
+}
+
 #[cfg(test)]
 pub(crate) fn test_regex_pointer_entry_exists(addr: usize) -> bool {
     REGEX_POINTERS.with(|table| table.borrow().contains(&addr))
@@ -416,8 +451,8 @@ pub(crate) fn build_fancy_regex(pattern: &str) -> Result<fancy_regex::Regex, fan
 /// up to [`REGEX_SIZE_LIMIT`] — `new RegExp(userInput)` was an attacker-driven
 /// OOM). When an insert would exceed the cap the whole map is cleared — the
 /// `PARSE_KEY_CACHE` precedent: cheap, no LRU bookkeeping, recompilation is
-/// the fallback. Live `RegExpHeader`s are unaffected: each header OWNS a
-/// leaked `Arc` reference to its compiled program(s),
+/// the fallback. Live `RegExpHeader`s are unaffected: each header OWNS a raw
+/// `Arc` reference to its compiled program(s), released by its GC finalizer,
 /// so dropping the cache's references cannot free a program still in use.
 #[cfg(feature = "regex-engine")]
 const REGEX_CACHE_MAX_ENTRIES: usize = 512;

--- a/crates/perry-runtime/src/regex/compile.rs
+++ b/crates/perry-runtime/src/regex/compile.rs
@@ -145,7 +145,7 @@ pub extern "C" fn js_regexp_compile_value(
         ));
     }
 
-    // The header OWNS leaked `Arc` references to its compiled program(s)
+    // The header OWNS raw `Arc` references to its compiled program(s)
     // (mirrors `js_regexp_new`), so the capped `REGEX_CACHE`/`FANCY_CACHE`
     // (see `REGEX_CACHE_MAX_ENTRIES`) can evict without invalidating this
     // receiver. Refresh `fancy_ptr` too — it must track the NEW pattern, not

--- a/crates/perry-runtime/src/regex/lazy.rs
+++ b/crates/perry-runtime/src/regex/lazy.rs
@@ -259,8 +259,8 @@ fn build_and_install_programs(re: *const RegExpHeader) {
 ///
 /// # Safety
 /// `re` must be a live `RegExpHeader` (all callers gate on
-/// `is_valid_regex_ptr`); the returned reference borrows a leaked `Arc` the
-/// header owns for its lifetime.
+/// `is_valid_regex_ptr`); the returned reference borrows a raw `Arc` the
+/// header owns until its GC finalizer runs.
 pub(crate) unsafe fn header_std_regex<'a>(re: *const RegExpHeader) -> &'a Regex {
     ensure_regex_compiled(re);
     &*(*re).regex_ptr

--- a/crates/perry-runtime/src/regex/tests.rs
+++ b/crates/perry-runtime/src/regex/tests.rs
@@ -59,6 +59,85 @@ fn malloc_finalize_clears_regexp_address_owned_tables() {
     assert!(!crate::object::exotic_expando::test_exotic_expando_entry_exists(addr));
 }
 
+fn clone_raw_arc<T>(raw: *const T) -> std::sync::Arc<T> {
+    unsafe {
+        let arc = std::sync::Arc::from_raw(raw);
+        let observer = arc.clone();
+        let _ = std::sync::Arc::into_raw(arc);
+        observer
+    }
+}
+
+#[test]
+fn regexp_finalize_releases_all_header_owned_programs() {
+    let _lock = crate::gc::global_side_table_test_lock();
+
+    fn compile(pattern: &str, subject: &str) -> *mut RegExpHeader {
+        let re = js_regexp_new(make_string(pattern), make_string(""));
+        assert!(js_regexp_test(re, make_string(subject)) != 0);
+        re
+    }
+
+    // Every compiled header owns the standard-engine program, including the
+    // never-match placeholder used by fancy-regex patterns.
+    let standard = compile(r"needle\d+", "needle42");
+    let standard_raw = unsafe { (*standard).regex_ptr as *const Regex };
+    assert!(!standard_raw.is_null());
+    let standard_observer = clone_raw_arc(standard_raw);
+    let standard_before = std::sync::Arc::strong_count(&standard_observer);
+    unsafe {
+        crate::gc::gc_type_finalize_unmarked_payload(
+            crate::gc::GC_TYPE_REGEXP,
+            standard.cast::<u8>(),
+        );
+    }
+    assert_eq!(
+        std::sync::Arc::strong_count(&standard_observer) + 1,
+        standard_before
+    );
+    assert!(unsafe { (*standard).regex_ptr.is_null() });
+
+    let fancy = compile(r"(?<=pre)\d+", "pre77");
+    let fancy_raw = unsafe { (*fancy).fancy_ptr as *const fancy_regex::Regex };
+    assert!(!fancy_raw.is_null());
+    let fancy_observer = clone_raw_arc(fancy_raw);
+    let fancy_before = std::sync::Arc::strong_count(&fancy_observer);
+    unsafe {
+        crate::gc::gc_type_finalize_unmarked_payload(crate::gc::GC_TYPE_REGEXP, fancy.cast::<u8>());
+    }
+    assert_eq!(
+        std::sync::Arc::strong_count(&fancy_observer) + 1,
+        fancy_before
+    );
+    assert!(unsafe { (*fancy).fancy_ptr.is_null() });
+
+    let repeat = compile(r"(a?b??)*", "ab");
+    let repeat_raw =
+        unsafe { (*repeat).repeat_matcher_ptr as *const repeat_matcher::RepeatMatcherRegex };
+    assert!(!repeat_raw.is_null());
+    let repeat_observer = clone_raw_arc(repeat_raw);
+    let repeat_before = std::sync::Arc::strong_count(&repeat_observer);
+    unsafe {
+        crate::gc::gc_type_finalize_unmarked_payload(
+            crate::gc::GC_TYPE_REGEXP,
+            repeat.cast::<u8>(),
+        );
+    }
+    let repeat_after = std::sync::Arc::strong_count(&repeat_observer);
+    assert_eq!(repeat_after + 1, repeat_before);
+    assert!(unsafe { (*repeat).repeat_matcher_ptr.is_null() });
+
+    // Arena overflow cleanup and finalization can overlap. A second finalizer
+    // must observe null pointers rather than release an owned reference twice.
+    unsafe {
+        crate::gc::gc_type_finalize_unmarked_payload(
+            crate::gc::GC_TYPE_REGEXP,
+            repeat.cast::<u8>(),
+        );
+    }
+    assert_eq!(std::sync::Arc::strong_count(&repeat_observer), repeat_after);
+}
+
 #[test]
 fn js_replacement_expands_special_patterns() {
     let re = regex::Regex::new(r"(\w+)\s(\w+)").unwrap();


### PR DESCRIPTION
## Summary

Release the compiled regex programs owned by a `RegExpHeader` when the GC finalizes that header. This closes the permanent per-pattern leak reported in #9678.

## Changes

- Reconstruct and drop the header-owned standard, fancy, and RepeatMatcher `Arc` references during true GC finalization.
- Null the raw program pointers before dropping them so overlapping cleanup remains idempotent.
- Keep moved arena-stub cleanup metadata-only, transferring ownership to the relocated live header instead of freeing its programs.
- Add a regression test that verifies all three owned references lose exactly one strong count and repeated finalization does not double-release them.

## Related issue

Fixes #9678

## Test plan

- [ ] `cargo build --release` clean
- [ ] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` passes
- [x] `CARGO_BUILD_JOBS=1 RUST_TEST_THREADS=1 cargo test --lib -p perry-runtime` (3,069 passed, 4 ignored)
- [x] `cargo test -p perry-runtime regex::tests::` (60 passed)
- [x] `cargo test -p perry-runtime gc::tests::` (930 passed, 1 ignored)
- [x] `cargo check -p perry-runtime --no-default-features`
- [x] `./scripts/pre-tag-check.sh --quick`
- [x] Added a `#[test]` in the affected crate
- [ ] Docs updated (not applicable: no user-facing API change)
- [ ] Platform UI backend built (not applicable)

`./scripts/test_affected_crates.sh --base origin/main` completed the entire single-threaded runtime phase successfully, then encountered an existing failure in the unchanged `perry` crate: `PERRY_CONCAT_SITE_CACHE` is missing from the build-cache environment-variable inventory. The same focused test fails on `origin/main`, and this branch has no diff under `crates/perry`.

## Screenshots / output

Not applicable.

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Regular expression programs are now properly released when their JavaScript owners are collected by garbage collection.
  * Improved cleanup across standard, fallback, and RepeatMatcher regular expression engines.
  * Preserved regular expression program ownership during live memory moves.

* **Tests**
  * Added coverage verifying complete cleanup and safe repeated finalization of regular expression programs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->