### PR TITLE
fix(transform): share async yield-star throw dispatcher

### DIFF
--- a/changelog.d/9686-async-yield-star-dispatch.md
+++ b/changelog.d/9686-async-yield-star-dispatch.md
@@ -1,0 +1,13 @@
+**Async generators with many `yield*` sites no longer make the compiler appear
+to hang while consuming tens of gigabytes.** The `.throw()` lowering cloned the
+entire state dispatcher into every delegation route, making transformed HIR
+quadratic in the number of delegation sites and multiplying LLVM safepoints and
+relocations. Delegation routing now selects one mutually exclusive branch and
+falls through to a single shared dispatcher. On the real-world 32-site function
+that exposed the bug, the generated async-step closure shrank from 33.6 MB to
+2.5 MB of debug-rendered HIR (92.5%).
+
+The fix preserves `.throw()` behavior across multiple delegated generators and
+still routes delegation-protocol failures through the outer generator's
+`try`/`catch`; both paths are covered by a Node-parity fixture. A structural
+transform test also rejects future super-linear dispatcher growth.

--- a/crates/perry-transform/src/generator/dispatch_growth_tests.rs
+++ b/crates/perry-transform/src/generator/dispatch_growth_tests.rs
@@ -1,0 +1,48 @@
+use super::*;
+
+fn async_generator_with_delegations(id: FuncId, delegations: usize) -> Function {
+    Function {
+        id,
+        name: "many_delegations".to_string(),
+        type_params: Vec::new(),
+        params: Vec::new(),
+        return_type: Type::Any,
+        body: (0..delegations)
+            .map(|_| {
+                Stmt::Expr(Expr::Yield {
+                    value: Some(Box::new(Expr::GlobalGet(0))),
+                    delegate: true,
+                })
+            })
+            .collect(),
+        is_async: true,
+        is_generator: true,
+        is_strict: false,
+        is_exported: false,
+        captures: Vec::new(),
+        decorators: Vec::new(),
+        was_plain_async: false,
+        was_unrolled: false,
+    }
+}
+
+fn transformed_body_size(delegations: usize) -> usize {
+    let mut module = Module::new("delegation_growth");
+    module
+        .functions
+        .push(async_generator_with_delegations(1, delegations));
+    transform_generators(&mut module);
+    format!("{:?}", module.functions[0].body).len()
+}
+
+#[test]
+fn async_generator_yield_star_dispatch_growth_is_linear() {
+    let size_16 = transformed_body_size(16);
+    let size_32 = transformed_body_size(32);
+
+    assert!(
+        size_32 < size_16 * 3,
+        "doubling yield* sites grew transformed HIR from {size_16} to {size_32} bytes; \
+         every delegation route must share the state dispatcher instead of cloning it"
+    );
+}

--- a/crates/perry-transform/src/generator/lower.rs
+++ b/crates/perry-transform/src/generator/lower.rs
@@ -1090,10 +1090,10 @@ pub fn transform_generator_function_with_extra_captures(
         // inside a `yield *` and `gen.throw(e)` is called, forward the error into
         // the delegated iterator's `throw` (re-yielding or, on a `done` result,
         // resuming the outer body past the `yield *`) rather than routing it into
-        // the outer generator's own catch handlers. Each route re-drives the
-        // state machine via the `while_body_for_throw` continuation loop, so it
-        // is built BEFORE the loop is moved into `throw_continuation` below.
-        // Empty for sync generators (`delegations` is only recorded for async).
+        // the outer generator's own catch handlers. Delegation routes and the
+        // ordinary catch/throw fallback share one continuation dispatcher below;
+        // copying that full dispatcher into every route makes HIR grow
+        // quadratically for generators with many `yield*` sites.
         // #6709: for async generators `.throw(e)` is the error arm of the
         // shared step closure, so the thrown value arrives through the step's
         // value param (`next_param_id`) rather than a dedicated `.throw`
@@ -1103,41 +1103,14 @@ pub fn transform_generator_function_with_extra_captures(
         } else {
             throw_param_id
         };
-        let yield_star_throw_routes = build_yield_star_throw_routes(
-            &delegations,
-            &catches,
-            &finallys,
-            state_id,
-            throw_val_id,
-            pending_type_id,
-            pending_value_id,
-            &while_body_for_throw,
-            &hoisted_ids,
-            next_local_id,
-        );
-        // #4374: continue the state machine after a catch — run the inlined
-        // finally and reach the next yield/completion within the `.throw()` call.
-        //
-        // Async generators took the legacy deferred-resume path here, which inlines
-        // the catch body into the `.throw()` closure. That only works when the catch
-        // body is still inline; once the `try` contains a `yield` the linearizer has
-        // moved the catch into its own states, so the inlined copy had nothing to run
-        // and `gen.throw(e)` resolved to `{value: undefined, done: false}` instead of
-        // the value the catch yields. Routing to the catch's states (as sync
-        // generators do) is what Node's semantics require.
-        let throw_continuation = Some(while_body_for_throw);
         // #4374: fresh binding for the inner catch that re-runs a try's finally
         // when its catch handler itself throws (catch-rethrow-with-finally).
         let inner_catch_id = alloc_local(next_local_id);
-        let mut throw_resume_body = vec![Stmt::Expr(Expr::LocalSet(
-            executing_id,
-            Box::new(Expr::Bool(true)),
-        ))];
-        // The `yield *` throw routes return/throw from inside their own
-        // continuation loop on a match, so they precede the catch-routing body
-        // and only fall through to it when not suspended in a delegation.
-        throw_resume_body.extend(yield_star_throw_routes);
-        throw_resume_body.extend(build_async_throw_body(
+        // #4374: continue the state machine after a catch — run the inlined
+        // finally and reach the next yield/completion within the `.throw()` call.
+        // The returned routing body deliberately excludes the dispatcher: all
+        // routes below fall through to one shared copy.
+        let ordinary_throw_fallback = build_async_throw_body(
             &catches,
             &finallys,
             state_id,
@@ -1147,8 +1120,31 @@ pub fn transform_generator_function_with_extra_captures(
             pending_type_id,
             pending_value_id,
             &hoisted_ids,
-            throw_continuation,
-        ));
+            true,
+        );
+        let yield_star_throw_routes = build_yield_star_throw_routes(
+            &delegations,
+            &catches,
+            &finallys,
+            state_id,
+            throw_val_id,
+            pending_type_id,
+            pending_value_id,
+            &hoisted_ids,
+            next_local_id,
+            ordinary_throw_fallback,
+        );
+        let mut throw_resume_body = vec![Stmt::Expr(Expr::LocalSet(
+            executing_id,
+            Box::new(Expr::Bool(true)),
+        ))];
+        // Exactly one delegation route or the ordinary catch/throw fallback
+        // runs, then every non-throwing path resumes through this shared loop.
+        throw_resume_body.extend(yield_star_throw_routes);
+        throw_resume_body.push(Stmt::While {
+            condition: Expr::Bool(true),
+            body: while_body_for_throw,
+        });
         // #6709: for async generators, `.next`/`.throw` are thin outer closures
         // driving a shared async-step `__agstep` closure so inner `await`s
         // suspend on the microtask queue; sync generators keep direct closures.

--- a/crates/perry-transform/src/generator/lower/abrupt.rs
+++ b/crates/perry-transform/src/generator/lower/abrupt.rs
@@ -40,14 +40,12 @@ pub(crate) fn build_async_throw_body(
     pending_type_id: LocalId,
     pending_value_id: LocalId,
     hoisted_ids: &std::collections::HashSet<LocalId>,
-    // #4374: for sync generators, the cloned state-dispatch loop. When present,
-    // a matched catch route sets the resume state and *falls through* to this
-    // loop, so the inlined finally runs and the generator continues to the next
-    // yield / completion within the `.throw()` call. When `None` (async
-    // generators) the catch route returns {undefined, false} as before.
-    continuation: Option<Vec<Stmt>>,
+    // #4374: when true, a matched catch route sets the resume state and falls
+    // through to the state dispatcher that the caller appends. When false, use
+    // the legacy inline-catch behavior that returns from this body directly.
+    fall_through_to_dispatch: bool,
 ) -> Vec<Stmt> {
-    let fall_through = continuation.is_some();
+    let fall_through = fall_through_to_dispatch;
     // #4374: when no catch handles the throw, run any pending non-yielding
     // `finally` before propagating the error. A `finally` that `return`s
     // supersedes the thrown value (rewritten to an iter-result return inside
@@ -66,7 +64,7 @@ pub(crate) fn build_async_throw_body(
     fallback.extend(build_finally_run_stmts(finallys, state_id, hoisted_ids));
     fallback.push(Stmt::Throw(Expr::LocalGet(throw_param_id)));
 
-    let mut body = if fall_through {
+    if fall_through {
         // #4438: sync generators route the thrown error to the innermost
         // enclosing catch (jump to its linearized states) or yielding finally
         // (record the pending throw + jump in), then fall through to the
@@ -105,19 +103,7 @@ pub(crate) fn build_async_throw_body(
             }];
         }
         fallback
-    };
-
-    // #4374: append the continuation loop. Only a fallen-through catch/finally
-    // route reaches it (the unhandled branch throws; matched routes set the
-    // resume state and fall through).
-    if let Some(cont) = continuation {
-        body.push(Stmt::While {
-            condition: Expr::Bool(true),
-            body: cont,
-        });
     }
-
-    body
 }
 
 pub(crate) fn catch_route_condition(
@@ -797,11 +783,9 @@ pub(crate) fn build_yield_star_return_routes(
 /// completion). Both the done (resume) and not-done (re-yield) cases are handled
 /// uniformly: the awaited inner result is stored into the delegation's
 /// `result_id`, the state is set to the drive loop's condition state
-/// (`resume_state`), and a clone of the state-dispatch loop (`while_body`) is
-/// re-driven. The condition state reads `result.done` and either exits the loop
-/// (continuing the outer body) or re-yields `result.value`. This continuation
-/// loop is the async-generator abrupt-resume machinery the `.return()` path does
-/// not need (a `return` always completes or re-yields, never resumes the body).
+/// (`resume_state`), and control falls through to the caller's single shared
+/// state dispatcher. The condition state reads `result.done` and either exits
+/// the delegation (continuing the outer body) or re-yields `result.value`.
 ///
 /// An abrupt completion *of the delegation protocol itself* — `iterator.throw`
 /// rejecting, a non-object inner result, or the `throw`-undefined TypeError —
@@ -813,9 +797,11 @@ pub(crate) fn build_yield_star_return_routes(
 /// inside that catch suspends) or, when no catch matches, runs pending
 /// non-yielding finallys and re-throws to reject the generator.
 ///
-/// Each route returns or throws from inside its `while(true)` continuation loop,
-/// so control falls through to the catch-routing fallback only when not
-/// suspended in a delegation. Empty for sync generators (no routes recorded).
+/// The routes form one mutually-exclusive if/else chain around `fallback`.
+/// Successful delegation and catch-routing paths fall through to the one state
+/// dispatcher appended by the caller. Keeping that dispatcher outside the
+/// chain is load-bearing: cloning it into every route makes transformed HIR
+/// quadratic in the number of `yield*` sites.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn build_yield_star_throw_routes(
     delegations: &[DelegationRoute],
@@ -825,11 +811,11 @@ pub(crate) fn build_yield_star_throw_routes(
     throw_param_id: LocalId,
     pending_type_id: LocalId,
     pending_value_id: LocalId,
-    while_body: &[Stmt],
     hoisted_ids: &std::collections::HashSet<LocalId>,
     next_local_id: &mut u32,
+    fallback: Vec<Stmt>,
 ) -> Vec<Stmt> {
-    let mut out = Vec::with_capacity(delegations.len());
+    let mut branches = Vec::with_capacity(delegations.len());
     for route in delegations {
         let m_id = alloc_local(next_local_id); // captured `throw` method
         let ret_m_id = alloc_local(next_local_id); // `return` method (close path)
@@ -1019,19 +1005,16 @@ pub(crate) fn build_yield_star_throw_routes(
             }),
             finally: None,
         };
-        // Both the success path (state = resume_state) and a routed catch (state
-        // = catch_entry_state) fall through to this loop, which dispatches from
-        // the freshly-set state.
-        let drive = Stmt::While {
-            condition: Expr::Bool(true),
-            body: while_body.to_vec(),
-        };
+        branches.push((in_interval, vec![protocol]));
+    }
 
-        out.push(Stmt::If {
-            condition: in_interval,
-            then_branch: vec![protocol, drive],
-            else_branch: None,
-        });
+    let mut out = fallback;
+    for (condition, then_branch) in branches.into_iter().rev() {
+        out = vec![Stmt::If {
+            condition,
+            then_branch,
+            else_branch: Some(out),
+        }];
     }
     out
 }

--- a/crates/perry-transform/src/generator/mod.rs
+++ b/crates/perry-transform/src/generator/mod.rs
@@ -497,3 +497,7 @@ pub fn transform_plain_async_closure_body(
     );
     synth.body
 }
+
+#[cfg(test)]
+#[path = "dispatch_growth_tests.rs"]
+mod dispatch_growth_tests;

--- a/test-files/test_gap_async_generator_yield_star_shared_dispatch.ts
+++ b/test-files/test_gap_async_generator_yield_star_shared_dispatch.ts
@@ -1,0 +1,58 @@
+// Async-generator `yield*` throw routes must select the active delegation and
+// resume through one shared state dispatcher. This checks both separate
+// delegation sites and a delegation-protocol error caught by the outer
+// generator. The transform has a separate structural growth test ensuring the
+// shared dispatcher is not cloned once per route.
+
+async function* inner(label: string) {
+  try {
+    yield label + ":first";
+  } catch (error) {
+    return label + ":caught:" + error;
+  }
+}
+
+async function* outer() {
+  const first = yield* inner("a");
+  yield "after-a:" + first;
+  const second = yield* inner("b");
+  yield "after-b:" + second;
+}
+
+class BrokenDelegate {
+  [Symbol.asyncIterator]() {
+    return this;
+  }
+
+  next() {
+    return Promise.resolve({ value: "broken:first", done: false });
+  }
+
+  throw() {
+    throw new Error("delegate-fail");
+  }
+}
+
+async function* catchesProtocolError() {
+  try {
+    yield* new BrokenDelegate();
+  } catch (error: any) {
+    yield "outer-caught:" + error.message;
+  }
+}
+
+async function main() {
+  const iterator = outer();
+  console.log(JSON.stringify(await iterator.next()));
+  console.log(JSON.stringify(await iterator.throw("boom")));
+  console.log(JSON.stringify(await iterator.next()));
+  console.log(JSON.stringify(await iterator.throw("bang")));
+  console.log(JSON.stringify(await iterator.next()));
+
+  const broken = catchesProtocolError();
+  console.log(JSON.stringify(await broken.next()));
+  console.log(JSON.stringify(await broken.throw("ignored")));
+  console.log(JSON.stringify(await broken.next()));
+}
+
+main();


### PR DESCRIPTION
## Summary

Prevent quadratic HIR growth when lowering `.throw()` for async generators with many `yield*` sites. Each delegation route now falls through to one shared state dispatcher instead of cloning the dispatcher into every route.

## Changes

- Build the ordinary catch/throw fallback once and nest mutually exclusive delegation routes around it.
- Append one shared continuation dispatcher after route selection.
- Add a structural regression test that rejects super-linear transformed-HIR growth when delegation sites double.
- Add a Node-parity fixture covering two delegation sites, `.throw()` resumption, and an outer catch handling a delegation-protocol error.

On the real-world reproducer that exposed this, the generated async-step closure shrank from 33,559,299 to 2,513,475 debug-rendered HIR bytes (92.5%). The module transform then completed normally instead of feeding an estimated multi-gigabyte LLVM IR graph into codegen.

## Related issue

n/a (standalone compiler performance/correctness fix)

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p perry-transform` (123 passed)
- [x] `cargo test --release -p perry --no-default-features --features compile-cli --test issue_6709_async_generator_pending_await -- --nocapture` (2 passed)
- [x] Filtered parity run for `test_gap_async_generator_yield_star_shared_dispatch` against pinned Node 26.5.1 (PASS)
- [x] `python3 scripts/check_test_registration.py`
- [x] `./scripts/pre-tag-check.sh --quick`
- [x] `cargo build --release` clean
- [ ] Full affected-crate/workspace suite (left to CI; the dependency closure is repository-wide)
- [x] Added a user-facing test under `test-files/`
- [x] Docs not needed; no CLI, stdlib, or runtime API changed

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commit follows the loose `fix:` prefix convention used in the log
- [x] I've read CONTRIBUTING.md and agree to the Code of Conduct
