### PR TITLE
fix(runtime): support proxy-wrapped array callbacks

### DIFF
--- a/changelog.d/9688-proxy-array-callbacks.md
+++ b/changelog.d/9688-proxy-array-callbacks.md
@@ -1,0 +1,6 @@
+Array iteration methods and sorting now accept callable `Proxy` callbacks,
+matching Node for proxy-wrapped functions and bound functions.
+
+Comparator validation no longer treats a Proxy registry handle as a closure
+pointer, preventing a user-triggerable crash. Non-callable callbacks and
+comparators continue to throw Node-compatible `TypeError`s.

--- a/crates/perry-runtime/src/array/iter_methods.rs
+++ b/crates/perry-runtime/src/array/iter_methods.rs
@@ -1429,15 +1429,22 @@ fn typeof_owned_string(v: f64) -> String {
 
 /// Resolve a higher-order callback argument to its `ClosureHeader*` (as
 /// `i64`). Returns `Some(ptr)` only for values the runtime can actually
-/// invoke (real closures, bound methods/functions); `None` for any
-/// non-callable so the caller can throw the spec `TypeError`.
+/// invoke (real closures, bound methods/functions, callable Proxies); `None`
+/// for any non-callable so the caller can throw the spec `TypeError`.
 #[inline]
 fn resolve_callback_ptr(cb_boxed: f64) -> Option<i64> {
     use crate::value::JSValue;
     let jv = JSValue::from_bits(cb_boxed.to_bits());
     if jv.is_pointer() {
         let ptr = jv.as_pointer::<ClosureHeader>();
-        if !crate::closure::get_valid_func_ptr(ptr).is_null() {
+        // #9681: a callable Proxy is a small registry id, so the hardened
+        // closure validator correctly rejects it as a ClosureHeader. Return
+        // that bare id anyway: DirectCallN falls back to js_closure_callN,
+        // whose proxy-callee path performs the Proxy [[Call]].
+        if !crate::closure::get_valid_func_ptr(ptr).is_null()
+            || (crate::proxy::js_proxy_is_proxy(cb_boxed) == 1
+                && crate::proxy::proxy_wraps_callable(cb_boxed))
+        {
             return Some(ptr as i64);
         }
     }

--- a/crates/perry-runtime/src/array/sort.rs
+++ b/crates/perry-runtime/src/array/sort.rs
@@ -601,10 +601,21 @@ pub extern "C" fn js_validate_array_comparator(cmp_boxed: f64) -> i64 {
     if jv.is_undefined() {
         return 0;
     }
-    // Callable function -> comparator path.
+    // Callable closure or callable Proxy -> comparator path. Use the shared
+    // validator rather than probing CLOSURE_MAGIC directly: Proxy values are
+    // small registry ids, not dereferenceable ClosureHeader pointers.
     if jv.is_pointer() {
         let ptr = jv.as_pointer::<ClosureHeader>();
-        if !ptr.is_null() && unsafe { (*ptr).type_tag == crate::closure::CLOSURE_MAGIC } {
+        if !crate::closure::get_valid_func_ptr(ptr).is_null() {
+            return ptr as i64;
+        }
+        // #9681: DirectCall2 deliberately falls back to js_closure_call2 for
+        // this bare proxy id, which then performs the Proxy [[Call]]. Check
+        // callability here so a Proxy of a non-callable still throws before
+        // sorting starts.
+        if crate::proxy::js_proxy_is_proxy(cmp_boxed) == 1
+            && crate::proxy::proxy_wraps_callable(cmp_boxed)
+        {
             return ptr as i64;
         }
     }
@@ -633,6 +644,15 @@ fn throw_invalid_comparator(cmp_boxed: f64) -> ! {
                 std::str::from_utf8(slice).unwrap_or("").to_string()
             }
         }
+    };
+    // V8's diagnostic renderer uses #<Object> for an ordinary object (and a
+    // transparent Proxy of one), while JavaScript ToString yields
+    // [object Object]. Keep the existing ToString spellings for arrays,
+    // symbols, primitives, and other object kinds.
+    let value_str = if value_str == "[object Object]" {
+        "#<Object>".to_string()
+    } else {
+        value_str
     };
     let message = format!(
         "The comparison function must be either a function or undefined: {}",

--- a/test-files/test_gap_9681_proxy_array_callbacks.ts
+++ b/test-files/test_gap_9681_proxy_array_callbacks.ts
@@ -1,0 +1,83 @@
+// #9681: Array callback validation must recognize callable Proxy values
+// without dereferencing their small registry ids as ClosureHeader pointers.
+//
+// Exercise every Array.prototype higher-order method plus sort with a plain
+// function, an empty-handler Proxy of that function, a bound function, and a
+// genuine non-callable. A Proxy of that non-callable pins the callability
+// boundary too. Both invalid forms also pin Node's TypeError text.
+
+const source = [3, 1, 2];
+
+function render(value: any): string {
+  const json = JSON.stringify(value);
+  return json === undefined ? "undefined" : json;
+}
+
+function exercise(label: string, callback: any, invoke: any): void {
+  const names = ["plain", "proxy", "bound", "non-callable", "non-callable proxy"];
+  const callbacks = [
+    callback,
+    new Proxy(callback, {}),
+    callback.bind(null),
+    {},
+    new Proxy({}, {}),
+  ];
+
+  for (let i = 0; i < callbacks.length; i++) {
+    try {
+      console.log(label + "/" + names[i] + ": " + render(invoke(callbacks[i])));
+    } catch (e: any) {
+      console.log(label + "/" + names[i] + ": " + e.name + ": " + e.message);
+    }
+  }
+}
+
+let forEachTotal = 0;
+exercise(
+  "forEach",
+  (value: number) => {
+    forEachTotal += value;
+  },
+  (callback: any) => {
+    forEachTotal = 0;
+    source.forEach(callback);
+    return forEachTotal;
+  },
+);
+
+exercise("map", (value: number, index: number) => value + index, (callback: any) =>
+  source.map(callback),
+);
+exercise("filter", (value: number) => value > 1, (callback: any) =>
+  source.filter(callback),
+);
+exercise("some", (value: number) => value === 1, (callback: any) =>
+  source.some(callback),
+);
+exercise("every", (value: number) => value > 0, (callback: any) =>
+  source.every(callback),
+);
+exercise("find", (value: number) => value < 3, (callback: any) =>
+  source.find(callback),
+);
+exercise("findIndex", (value: number) => value < 3, (callback: any) =>
+  source.findIndex(callback),
+);
+exercise("findLast", (value: number) => value < 3, (callback: any) =>
+  source.findLast(callback),
+);
+exercise("findLastIndex", (value: number) => value < 3, (callback: any) =>
+  source.findLastIndex(callback),
+);
+exercise("flatMap", (value: number) => [value, value * 10], (callback: any) =>
+  source.flatMap(callback),
+);
+exercise("reduce", (acc: number, value: number) => acc + value, (callback: any) =>
+  source.reduce(callback, 10),
+);
+exercise("reduceRight", (acc: number, value: number) => acc + value, (callback: any) =>
+  source.reduceRight(callback, 10),
+);
+exercise("sort", (a: number, b: number) => a - b, (callback: any) =>
+  [3, 1, 2].sort(callback),
+);


### PR DESCRIPTION
## Summary

Accept callable Proxy values in Array callback and comparator validation, while preventing proxy registry handles from being dereferenced as closure pointers.

## Changes

- Route proxy-wrapped callbacks through the existing `js_closure_callN` Proxy call path.
- Harden `sort` comparator validation and preserve TypeErrors for non-callable proxies.
- Add Node-parity coverage for all Array higher-order methods plus `sort`, across plain, proxy-wrapped, bound, and non-callable callbacks.

## Related issue

Fixes #9681

## Test plan

- [x] `cargo build --release -p perry -p perry-runtime -p perry-stdlib -p perry-runtime-static -p perry-stdlib-static`
- [x] `./run_parity_tests.sh --filter 9681` (1/1 passed, byte-for-byte Node parity)
- [x] `python3 scripts/check_test_registration.py`
- [x] `./scripts/pre-tag-check.sh --quick`
- [x] `perry-runtime` affected-crate suite (3,068 passed, 4 ignored)
- [ ] Full affected-crate run: the downstream `perry` suite reaches a pre-existing `origin/main` policy failure for `PERRY_CONCAT_SITE_CACHE`; this branch does not touch that code.
- [x] Added `test-files/test_gap_9681_proxy_array_callbacks.ts`
- [x] Documentation update not applicable; no public API changed.
- [x] Platform UI build not applicable.

## Checklist

- [x] No workspace version, CLAUDE.md, or CHANGELOG.md changes
- [x] Commits follow the repository prefix convention
- [x] Read CONTRIBUTING.md and CODE_OF_CONDUCT.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Array iteration methods and sorting now support callable Proxy-wrapped and bound callbacks, matching Node.js behavior.
  * Non-callable callbacks and comparators continue to produce compatible `TypeError` messages.
  * Prevented a crash when invalid Proxy values are supplied as sorting comparators.
  * Improved error formatting for invalid object comparators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->