### PR TITLE
fix(readline): root stdin listener snapshots across GC

### DIFF
--- a/changelog.d/9693-readline-listener-snapshot-gc.md
+++ b/changelog.d/9693-readline-listener-snapshot-gc.md
@@ -1,0 +1,9 @@
+Fixed intermittent terminal-input hangs in long-running Claude Code sessions.
+`process.stdin.listeners()` now roots its callback snapshot before allocating
+the returned array, so moving GC cannot leave Ink's stdin suspend/resume path
+with stale `readable` callbacks. Permission dialogs therefore continue to
+receive input after GC pressure.
+
+A forced-evacuation regression test pins the snapshot/allocation boundary that
+previously exposed the stale pointer, and an Ink-style PTY stress fixture
+confirmed input delivery after repeated suspend/remove/restore cycles.

--- a/crates/perry-stdlib/src/readline/mod.rs
+++ b/crates/perry-stdlib/src/readline/mod.rs
@@ -335,6 +335,10 @@ fn scan_readline_roots_mut(visitor: &mut perry_runtime::gc::RuntimeRootVisitor<'
 /// live here. Registered with the runtime at init so the object's `listeners()`
 /// method can see them.
 extern "C" fn stdin_listeners_provider(name_ptr: *const u8, name_len: usize) -> f64 {
+    listener_array_from_snapshot(stdin_listener_snapshot(name_ptr, name_len))
+}
+
+fn stdin_listener_snapshot(name_ptr: *const u8, name_len: usize) -> Vec<i64> {
     let name = if name_ptr.is_null() {
         ""
     } else {
@@ -352,12 +356,44 @@ extern "C" fn stdin_listeners_provider(name_ptr: *const u8, name_len: usize) -> 
             .unwrap_or_default(),
         _ => Vec::new(),
     };
-    let mut arr = perry_runtime::array::js_array_alloc(list.len() as u32);
-    for cb in list {
-        let v = f64::from_bits(JSValue::pointer(cb as *const u8).bits());
-        arr = perry_runtime::array::js_array_push_f64(arr, v);
+    list
+}
+
+fn listener_array_from_snapshot(list: Vec<i64>) -> f64 {
+    listener_array_from_snapshot_impl(list, || {})
+}
+
+fn listener_array_from_snapshot_impl<F>(list: Vec<i64>, before_array_alloc: F) -> f64
+where
+    F: FnOnce(),
+{
+    // `listeners()` is used by Ink to suspend terminal input: it snapshots
+    // every `readable` callback, removes it, then restores that snapshot. The
+    // array allocation below can run a moving collection. The mutable-root
+    // scanner rewrites the callbacks in the authoritative listener list, but
+    // it cannot see raw pointers copied into this local Vec. Root the entire
+    // snapshot before the first Perry allocation so a collection cannot make
+    // Ink remove/re-add stale from-space closures (#9672).
+    let scope = perry_runtime::gc::RuntimeHandleScope::new();
+    let listeners: Vec<_> = list
+        .into_iter()
+        .map(|cb| scope.root_raw_const_ptr(cb as *const ClosureHeader))
+        .collect();
+
+    // The callback makes the collection boundary deterministic in the unit
+    // test and compiles to a no-op at the production call site.
+    before_array_alloc();
+
+    let arr = perry_runtime::array::js_array_alloc(listeners.len() as u32);
+    let arr_handle = scope.root_raw_mut_ptr(arr);
+    for cb in listeners {
+        let v = f64::from_bits(
+            JSValue::pointer(cb.get_raw_const_ptr::<ClosureHeader>() as *const u8).bits(),
+        );
+        let arr = perry_runtime::array::js_array_push_f64(arr_handle.get_raw_mut_ptr(), v);
+        arr_handle.set_raw_mut_ptr(arr);
     }
-    f64::from_bits(JSValue::array_ptr(arr).bits())
+    f64::from_bits(JSValue::array_ptr(arr_handle.get_raw_mut_ptr()).bits())
 }
 
 /// `stdin.addListener/on(event, cb)` reached as an OBJECT method (an aliased

--- a/crates/perry-stdlib/src/readline/mod_tests.rs
+++ b/crates/perry-stdlib/src/readline/mod_tests.rs
@@ -5,6 +5,34 @@
 use super::test_support::*;
 use super::*;
 
+struct ForcedEvacuationGuard {
+    frame: u64,
+    previous_force_evacuation: i32,
+}
+
+impl ForcedEvacuationGuard {
+    fn new() -> Self {
+        // Compiled programs initialize the runtime-handle scanner at startup.
+        // This standalone crate test must do the equivalent before collecting.
+        perry_runtime::gc::gc_init();
+        let previous_force_evacuation = perry_runtime::gc::js_gc_force_evacuation_test_override(1);
+        perry_runtime::gc::js_gc_write_barriers_emitted(1);
+        let frame = perry_runtime::gc::js_shadow_frame_push(0);
+        Self {
+            frame,
+            previous_force_evacuation,
+        }
+    }
+}
+
+impl Drop for ForcedEvacuationGuard {
+    fn drop(&mut self) {
+        perry_runtime::gc::js_shadow_frame_pop(self.frame);
+        perry_runtime::gc::js_gc_write_barriers_emitted(0);
+        perry_runtime::gc::js_gc_force_evacuation_test_override(self.previous_force_evacuation);
+    }
+}
+
 #[test]
 fn close_without_callbacks_is_noop() {
     let _g = reset();
@@ -160,6 +188,38 @@ fn provider_path_removes_end_listeners() {
         STDIN_END_CALLBACKS.lock().map(|v| v.len()).unwrap_or(0),
         0,
         "removing an aliased end listener must clear it"
+    );
+}
+
+#[test]
+fn listeners_provider_roots_readable_snapshot_across_array_allocation() {
+    let _g = reset();
+    let _gc = ForcedEvacuationGuard::new();
+    ensure_gc_scanner_registered();
+
+    let before = readable_counter_callback();
+    stdin_on_op(b"readable".as_ptr(), 8, before, 0);
+    let snapshot = stdin_listener_snapshot(b"readable".as_ptr(), 8);
+    let listeners = listener_array_from_snapshot_impl(snapshot, || {
+        perry_runtime::gc::js_gc_collect();
+    });
+
+    let current = READABLE_CALLBACKS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())[0];
+    assert_ne!(
+        before, current,
+        "the forced collection must relocate the callback to exercise the regression"
+    );
+
+    let array = JSValue::from_bits(listeners.to_bits())
+        .as_pointer::<perry_runtime::array::ArrayHeader>()
+        as *mut perry_runtime::array::ArrayHeader;
+    let returned = perry_runtime::array::js_array_get_f64(array, 0);
+    let returned = JSValue::from_bits(returned.to_bits()).as_pointer::<ClosureHeader>() as i64;
+    assert_eq!(
+        returned, current,
+        "listeners() must return the collector-rewritten callback, not its stale snapshot"
     );
 }
 


### PR DESCRIPTION
## Summary

Keep `process.stdin.listeners()` snapshots valid when Perry's moving collector runs while the returned listener array is being allocated. This prevents Ink's stdin suspend/resume path from restoring stale `readable` callbacks and leaving permission prompts unable to receive input.

## Changes

- Convert snapshotted stdin callbacks to runtime handles before any allocation can trigger GC.
- Reload both the listener array and callbacks from those handles while constructing the result.
- Add a deterministic forced-evacuation regression test at the exact snapshot/allocation boundary.

## Related issue

Fixes #9672

## Test plan

- [x] `cargo test -p perry-stdlib`
- [x] `cargo test -p perry-stdlib --no-default-features readline::mod_tests::listeners_provider_roots_readable_snapshot_across_array_allocation -- --exact --nocapture`
- [x] `cargo check -p perry-stdlib`
- [x] `cargo fmt --all -- --check`
- [x] `./scripts/pre-tag-check.sh --quick`
- [x] Release-build `perry`, runtime/stdlib static libraries, and the standard extension set in one coherent invocation.
- [x] Compiled PTY stress fixture: 64 Ink-style `readable` suspend/remove/restore cycles with forced evacuation, followed by successful input delivery.
- [ ] Full workspace test matrix (the affected crate's complete suite passes: 128 tests).

## Screenshots / output

Not applicable; this is an internal listener-liveness fix.

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)

Docs are unchanged because this corrects GC rooting without changing the CLI, stdlib, or runtime API.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed intermittent terminal-input hangs in long-running sessions, helping keep permission dialogs responsive during garbage collection.
  * Improved input delivery across repeated terminal suspend and restore cycles.

* **Tests**
  * Added regression coverage for callback handling during memory relocation and repeated terminal-input cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->