### PR TITLE
fix(runtime): unify process.stdin reader surface

### DIFF
--- a/changelog.d/9697-shared-stdin-reader.md
+++ b/changelog.d/9697-shared-stdin-reader.md
@@ -1,0 +1,5 @@
+Fixed `process.stdin` listener and keypress delivery across runtime and
+`node:readline` APIs. Both surfaces now share one ordered fd-0 reader, so
+`readline.emitKeypressEvents()` works with cooked and piped input and
+`removeAllListeners([event])` reliably clears stdin listeners without racing or
+dropping buffered bytes.

--- a/crates/perry-runtime/src/os.rs
+++ b/crates/perry-runtime/src/os.rs
@@ -842,10 +842,12 @@ mod process_streams;
 #[cfg(test)]
 pub(crate) use process_streams::test_set_stdin_data_listener;
 pub use process_streams::{
-    js_process_stderr, js_process_stdin, js_process_stdout, mark_process_stdin_destroyed,
-    pump_process_stdin, scan_process_stream_singleton_roots_mut, set_process_stdin_raw_state,
-    stdin_chunk_jsvalue, stdin_chunk_jsvalue_opt, stdin_encoding_flush_jsvalue, stdin_has_encoding,
-    stdin_is_detached, stdin_listeners_keep_loop_alive, stdin_push_bytes,
+    disable_process_stdin_keypress_events, enable_process_stdin_keypress_events,
+    ensure_process_stdin_reader, is_process_stdin_handle, js_process_stderr, js_process_stdin,
+    js_process_stdout, mark_process_stdin_destroyed, pump_process_stdin,
+    scan_process_stream_singleton_roots_mut, set_process_stdin_raw_state, stdin_chunk_jsvalue,
+    stdin_chunk_jsvalue_opt, stdin_encoding_flush_jsvalue, stdin_has_encoding, stdin_is_detached,
+    stdin_keypress_events_enabled, stdin_listeners_keep_loop_alive, stdin_push_bytes,
 };
 
 /// Get the operating system name

--- a/crates/perry-runtime/src/os_process_streams.rs
+++ b/crates/perry-runtime/src/os_process_streams.rs
@@ -205,14 +205,9 @@ extern "C" fn process_stdin_unref_stub(
 /// `process.stdin.ref()` — restore the event-loop hold (#9676). Was a no-op
 /// stub, which is what made `unref()` a one-way latch.
 ///
-/// Deliberately does NOT start a reader. `ref` is the inverse of `unref` and
-/// nothing more, exactly as in Node: it does not resume a `pause()`d stream,
-/// and starting one here would be actively harmful — perry-stdlib's readline
-/// runs its own fd-0 reader, both readers take `std::io::stdin()`'s process
-/// lock, and a program whose listeners live in readline's registry would end
-/// up with the runtime's reader parked on that lock (or, worse, consuming
-/// bytes into a buffer those listeners never see). `resume()` remains the one
-/// call that restarts a stopped reader.
+/// Deliberately does NOT start the shared reader. `ref` is the inverse of
+/// `unref` and nothing more, exactly as in Node: it does not resume a paused
+/// stream. `resume()` remains the one call that restarts a stopped reader.
 extern "C" fn process_stdin_ref_stub(
     _closure: *const crate::closure::ClosureHeader,
     _arg: f64,
@@ -250,6 +245,8 @@ pub fn set_process_stdin_raw_state(enabled: bool) {
 }
 
 pub fn mark_process_stdin_destroyed() {
+    STDIN_DETACHED.store(true, std::sync::atomic::Ordering::Release);
+    disable_process_stdin_keypress_events();
     set_stdin_bool_field(b"readable", false);
     set_stdin_bool_field(b"readableEnded", true);
     set_stdin_bool_field(b"destroyed", true);
@@ -263,8 +260,8 @@ pub fn mark_process_stdin_destroyed() {
 // `setRawMode(!0); on("readable", () => { let c = stdin.read(); while (c !==
 // null) { …; c = stdin.read() } })`. Previously `on`/`read`/`resume` were
 // no-op stubs ("encoding-aware reads remain future work"), so input was dead
-// even though `perry/tui` had its own working reader. A dedicated reader
-// thread reads fd 0, buffers the bytes and wakes the event loop; the loop
+// even though `perry/tui` had its own working reader. The runtime-owned reader
+// thread reads fd 0, routes the bytes and wakes the event loop; the loop
 // pump (`pump_process_stdin`, called each tick from `js_callback_timer_tick`)
 // drains the buffer and fires the registered `data`/`readable` listeners.
 static STDIN_BUFFER: std::sync::Mutex<Vec<u8>> = std::sync::Mutex::new(Vec::new());
@@ -286,10 +283,76 @@ static STDIN_END_FIRED: std::sync::atomic::AtomicBool = std::sync::atomic::Atomi
 static STDIN_READER_STARTED: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
+/// Optional consumer installed by perry-stdlib's readline implementation.
+///
+/// fd 0 must have exactly one physical reader. Historically this module and
+/// `perry-stdlib::readline` each spawned a thread that held
+/// `std::io::StdinLock` for its whole lifetime; whichever thread won the lock
+/// consumed every byte and the other parked forever. The runtime now owns the
+/// sole reader and forwards each read (and EOF) through these callbacks when
+/// readline is linked. The callbacks only enqueue Rust-owned bytes/flags; JS
+/// dispatch remains on the main-thread pumps.
+static STDIN_READER_DATA_FN: std::sync::atomic::AtomicPtr<()> =
+    std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());
+static STDIN_READER_EOF_FN: std::sync::atomic::AtomicPtr<()> =
+    std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());
+
+/// Serializes the initial buffered-byte handoff with live reader deliveries.
+/// Without it, a read that arrives just after callback registration could be
+/// forwarded before bytes that the runtime reader had already buffered.
+static STDIN_READER_ROUTE: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn stdin_reader_data_consumer() -> Option<extern "C" fn(*const u8, usize)> {
+    let ptr = STDIN_READER_DATA_FN.load(std::sync::atomic::Ordering::Acquire);
+    if ptr.is_null() {
+        None
+    } else {
+        // SAFETY: `js_register_stdin_reader_consumer` stores this exact ABI.
+        Some(unsafe { std::mem::transmute::<*mut (), extern "C" fn(*const u8, usize)>(ptr) })
+    }
+}
+
+fn stdin_reader_eof_consumer() -> Option<extern "C" fn()> {
+    let ptr = STDIN_READER_EOF_FN.load(std::sync::atomic::Ordering::Acquire);
+    if ptr.is_null() {
+        None
+    } else {
+        // SAFETY: `js_register_stdin_reader_consumer` stores this exact ABI.
+        Some(unsafe { std::mem::transmute::<*mut (), extern "C" fn()>(ptr) })
+    }
+}
+
+/// Register readline as a subscriber to the runtime-owned fd-0 reader.
+///
+/// Bytes read before stdlib initialized are handed over synchronously while
+/// the route lock is held, preserving their order relative to future reads.
+#[no_mangle]
+pub extern "C" fn js_register_stdin_reader_consumer(
+    on_data: extern "C" fn(*const u8, usize),
+    on_eof: extern "C" fn(),
+) {
+    let _route = STDIN_READER_ROUTE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    STDIN_READER_DATA_FN.store(on_data as *mut (), std::sync::atomic::Ordering::Release);
+    STDIN_READER_EOF_FN.store(on_eof as *mut (), std::sync::atomic::Ordering::Release);
+
+    let pending = STDIN_BUFFER
+        .lock()
+        .map(|mut bytes| std::mem::take(&mut *bytes))
+        .unwrap_or_default();
+    if !pending.is_empty() {
+        on_data(pending.as_ptr(), pending.len());
+    }
+    if STDIN_EOF_SEEN.load(std::sync::atomic::Ordering::Acquire) {
+        on_eof();
+    }
+}
+
 fn ensure_stdin_reader() {
     use std::sync::atomic::Ordering;
-    // A previous reader may have exited (EOF, error, or detach via
-    // `pause`/`unref`); its drop guard resets `STDIN_READER_STARTED` to false,
+    // A previous reader may have exited (EOF, error, or explicit detach); its
+    // drop guard resets `STDIN_READER_STARTED` to false,
     // so a later `resume()`/`on(...)` can spin up a fresh reader.
     if STDIN_READER_STARTED
         .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
@@ -315,7 +378,11 @@ fn ensure_stdin_reader() {
             // bytes are available (it does not wait to fill the buffer), so a
             // lone keystroke is unaffected — it returns 1 byte immediately —
             // while a burst collapses into one lock + one notify.
-            let mut buf = [0u8; 4096];
+            // 64 KiB matches Node's pipe read size and the former readline
+            // reader's #9489 chunking contract. With this module now owning
+            // the sole fd-0 read, a smaller buffer would regress a 1 MiB pipe
+            // from ~16 `data` events to hundreds.
+            let mut buf = [0u8; 65536];
             loop {
                 // #9676: `stdin_reader_should_stop`, NOT `stdin_is_detached` —
                 // an `unref()`d stdin still delivers data in Node, and reading
@@ -329,12 +396,23 @@ fn ensure_stdin_reader() {
                         // `'end'`/`'close'` listeners after the buffer drains,
                         // and wake the loop so a final pump runs even when no
                         // more bytes arrive (e.g. `< /dev/null`).
+                        let _route = STDIN_READER_ROUTE
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner());
                         STDIN_EOF_SEEN.store(true, std::sync::atomic::Ordering::Release);
+                        if let Some(on_eof) = stdin_reader_eof_consumer() {
+                            on_eof();
+                        }
                         crate::event_pump::js_notify_main_thread();
                         break;
                     }
                     Ok(n) => {
-                        if let Ok(mut q) = STDIN_BUFFER.lock() {
+                        let _route = STDIN_READER_ROUTE
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner());
+                        if let Some(on_data) = stdin_reader_data_consumer() {
+                            on_data(buf.as_ptr(), n);
+                        } else if let Ok(mut q) = STDIN_BUFFER.lock() {
                             q.extend_from_slice(&buf[..n]);
                         }
                         crate::event_pump::js_notify_main_thread();
@@ -346,15 +424,22 @@ fn ensure_stdin_reader() {
     }
 }
 
+/// Start (or restart) the single runtime-owned fd-0 reader.
+///
+/// Readline calls this after installing its consumer callbacks. Keeping the
+/// compare/exchange in this module makes it impossible for the two surfaces to
+/// race separate `StdinLock`s again.
+pub fn ensure_process_stdin_reader() {
+    ensure_stdin_reader();
+}
+
 /// Append bytes to the buffer that `process.stdin.read()` drains.
 ///
 /// `process.stdin.on(...)` / `.setRawMode(...)` / `.pause()` / `.resume()` do NOT
 /// dispatch on this object — codegen lowers them to direct extern calls into
-/// `perry-stdlib`'s readline, which runs its own fd-0 reader. `read()` has no such
-/// route, so it stays a method here and drains `STDIN_BUFFER`. Paused-mode input
-/// (`on("readable")` + `read()`) therefore needs readline's reader to deposit its
-/// bytes here, or the two halves of that pattern would talk to different buffers
-/// and `read()` would always return null.
+/// `perry-stdlib`'s readline. `read()` has no such route, so it stays a method
+/// here and drains `STDIN_BUFFER`. The shared reader's stdlib consumer deposits
+/// non-flowing bytes here so `on("readable")` and `read()` use the same buffer.
 /// `perry-stdlib`'s readline owns the `process.stdin` listener lists (codegen
 /// lowers `stdin.on(...)` to a direct extern into it), but the stdin *object*
 /// lives here — so `stdin.listeners(event)` cannot see them without a bridge.
@@ -383,6 +468,8 @@ pub extern "C" fn js_register_stdin_listeners_provider(f: extern "C" fn(*const u
 static STDIN_ON_FN: std::sync::atomic::AtomicPtr<()> =
     std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());
 static STDIN_OFF_FN: std::sync::atomic::AtomicPtr<()> =
+    std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());
+static STDIN_REMOVE_ALL_FN: std::sync::atomic::AtomicPtr<()> =
     std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());
 
 /// Encoding set via `process.stdin.setEncoding(enc)`. `None` — Node's default —
@@ -517,9 +604,11 @@ extern "C" fn process_stdin_set_encoding(
 pub extern "C" fn js_register_stdin_listener_ops(
     on: extern "C" fn(*const u8, usize, i64, i32),
     off: extern "C" fn(*const u8, usize, i64),
+    remove_all: extern "C" fn(*const u8, usize, i32),
 ) {
     STDIN_ON_FN.store(on as *mut (), std::sync::atomic::Ordering::Release);
     STDIN_OFF_FN.store(off as *mut (), std::sync::atomic::Ordering::Release);
+    STDIN_REMOVE_ALL_FN.store(remove_all as *mut (), std::sync::atomic::Ordering::Release);
 }
 
 /// #9676: perry-stdlib's readline `pause`/`resume`, so the stdin OBJECT's
@@ -528,8 +617,8 @@ pub extern "C" fn js_register_stdin_listener_ops(
 ///
 /// Without this bridge the two spellings latched DIFFERENT flags. `rl.close()`
 /// and a literal `process.stdin.pause()` both set readline's `STDIN_PAUSED`,
-/// whose pump branch returns without draining `PENDING_DATA` — while readline's
-/// fd-0 reader keeps reading and keeps notifying the main thread. Recovering
+/// whose pump branch returns without draining `PENDING_DATA` — while the shared
+/// fd-0 reader keeps reading and notifying the main thread. Recovering
 /// with an ALIASED `stdin.resume()` (`const s = process.stdin; s.resume()`, and
 /// every TUI that holds stdin in a variable) landed on the runtime object stub,
 /// which cleared only the runtime's own flags and left `STDIN_PAUSED` set for
@@ -561,18 +650,97 @@ fn stdin_flow_op(slot: &std::sync::atomic::AtomicPtr<()>) -> Option<extern "C" f
 fn stdin_ops_provider() -> Option<(
     extern "C" fn(*const u8, usize, i64, i32),
     extern "C" fn(*const u8, usize, i64),
+    extern "C" fn(*const u8, usize, i32),
 )> {
     let on = STDIN_ON_FN.load(std::sync::atomic::Ordering::Acquire);
     let off = STDIN_OFF_FN.load(std::sync::atomic::Ordering::Acquire);
-    if on.is_null() || off.is_null() {
+    let remove_all = STDIN_REMOVE_ALL_FN.load(std::sync::atomic::Ordering::Acquire);
+    if on.is_null() || off.is_null() || remove_all.is_null() {
         return None;
     }
     unsafe {
         Some((
             std::mem::transmute::<*mut (), extern "C" fn(*const u8, usize, i64, i32)>(on),
             std::mem::transmute::<*mut (), extern "C" fn(*const u8, usize, i64)>(off),
+            std::mem::transmute::<*mut (), extern "C" fn(*const u8, usize, i32)>(remove_all),
         ))
     }
+}
+
+/// Move listeners registered on the stdin object before readline initialized
+/// into readline's canonical registry. This is called only after stdlib has
+/// finished installing the provider, and before the reader-buffer handoff, so
+/// no already-read byte can overtake an earlier listener registration.
+#[no_mangle]
+pub extern "C" fn js_migrate_stdin_listeners_to_provider() {
+    let Some((on, _, _)) = stdin_ops_provider() else {
+        return;
+    };
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let take = |list: &std::sync::Mutex<Vec<i64>>| {
+        list.lock()
+            .map(|mut listeners| std::mem::take(&mut *listeners))
+            .unwrap_or_default()
+    };
+    for (name, listeners, once) in [
+        (b"data".as_slice(), take(&STDIN_DATA_LISTENERS), 0),
+        (b"data".as_slice(), take(&STDIN_DATA_ONCE), 1),
+        (b"readable".as_slice(), take(&STDIN_READABLE_LISTENERS), 0),
+        (b"readable".as_slice(), take(&STDIN_READABLE_ONCE), 1),
+        (b"end".as_slice(), take(&STDIN_END_LISTENERS), 0),
+        (b"end".as_slice(), take(&STDIN_END_ONCE), 1),
+    ] {
+        let callbacks: Vec<_> = listeners
+            .into_iter()
+            .map(|callback| {
+                scope.root_raw_const_ptr(callback as *const crate::closure::ClosureHeader)
+            })
+            .collect();
+        for callback in callbacks {
+            on(
+                name.as_ptr(),
+                name.len(),
+                callback.get_raw_const_ptr::<crate::closure::ClosureHeader>() as i64,
+                once,
+            );
+        }
+    }
+}
+
+/// Whether `readline.emitKeypressEvents(process.stdin)` has installed its
+/// data-to-keypress parser. Keypress listeners alone do not make Node emit;
+/// the readline helper is the plumbing that activates them.
+static STDIN_KEYPRESS_EVENTS_ENABLED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+pub fn stdin_keypress_events_enabled() -> bool {
+    STDIN_KEYPRESS_EVENTS_ENABLED.load(std::sync::atomic::Ordering::Acquire)
+}
+
+pub fn disable_process_stdin_keypress_events() {
+    STDIN_KEYPRESS_EVENTS_ENABLED.store(false, std::sync::atomic::Ordering::Release);
+}
+
+/// True when a raw object handle is the process-global stdin singleton.
+pub fn is_process_stdin_handle(handle: i64) -> bool {
+    STDIN_STREAM_SINGLETON.with(|slot| *slot.borrow() == handle as usize)
+}
+
+/// Install the hidden `data` listener used by
+/// `readline.emitKeypressEvents(process.stdin)` into the same registry as
+/// ordinary stdin data listeners. That makes cooked/piped input flow through
+/// the keypress parser too, and lets `removeAllListeners("data")` remove the
+/// plumbing exactly as Node does.
+pub fn enable_process_stdin_keypress_events(callback: i64) {
+    if STDIN_KEYPRESS_EVENTS_ENABLED.swap(true, std::sync::atomic::Ordering::AcqRel) {
+        return;
+    }
+    if let Some((on, _, _)) = stdin_ops_provider() {
+        on(b"data".as_ptr(), 4, callback, 0);
+    } else if let Ok(mut listeners) = STDIN_DATA_LISTENERS.lock() {
+        listeners.push(callback);
+    }
+    ensure_stdin_reader();
 }
 
 /// `process.stdin.addListener(event, cb)` / `.on(...)` reached as an object method.
@@ -581,7 +749,7 @@ extern "C" fn process_stdin_add_listener(
     event: f64,
     callback: f64,
 ) -> f64 {
-    if let Some((on, _)) = stdin_ops_provider() {
+    if let Some((on, _, _)) = stdin_ops_provider() {
         let name = stdin_event_name(event).unwrap_or_default();
         let cb = stdin_callback_ptr(callback);
         if cb != 0 {
@@ -598,7 +766,7 @@ extern "C" fn process_stdin_add_listener_once(
     event: f64,
     callback: f64,
 ) -> f64 {
-    if let Some((on, _)) = stdin_ops_provider() {
+    if let Some((on, _, _)) = stdin_ops_provider() {
         let name = stdin_event_name(event).unwrap_or_default();
         let cb = stdin_callback_ptr(callback);
         if cb != 0 {
@@ -620,7 +788,7 @@ extern "C" fn process_stdin_remove_listener(
         return stdin_this_value();
     }
     let name = stdin_event_name(event).unwrap_or_default();
-    if let Some((_, off)) = stdin_ops_provider() {
+    if let Some((_, off, _)) = stdin_ops_provider() {
         off(name.as_ptr(), name.len(), cb);
     }
     // #9399: ALSO drop it from the runtime-local lists. `on`/`once` on the
@@ -643,7 +811,95 @@ extern "C" fn process_stdin_remove_listener(
             l.retain(|entry| *entry != cb);
         }
     }
+    // A `keypress` listener registered before readline's provider existed is
+    // kept in node:stream's generic emitter registry (the hidden parser emits
+    // there). Removing through the stdin object must reach it too.
+    if name == "keypress" {
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let stream = scope.root_nanbox_f64(stdin_this_value());
+        let event = scope.root_nanbox_f64(event);
+        let callback = scope.root_nanbox_f64(callback);
+        let stream_raw = crate::value::js_nanbox_get_pointer(stream.get_nanbox_f64()) as i64;
+        if stream_raw != 0 {
+            let _ = crate::node_stream::js_node_stream_method_remove_listener(
+                stream_raw,
+                event.get_nanbox_f64(),
+                callback.get_nanbox_f64(),
+            );
+        }
+    }
     stdin_this_value()
+}
+
+fn clear_stdin_listener_list(list: &std::sync::Mutex<Vec<i64>>) {
+    if let Ok(mut listeners) = list.lock() {
+        listeners.clear();
+    }
+}
+
+/// `process.stdin.removeAllListeners([event])` across both stdin registries.
+///
+/// The stdin object has its own native listener surface, while
+/// `emitKeypressEvents` uses node:stream's hidden EventEmitter storage for its
+/// generated `keypress` emission. Both must be cleared or callbacks survive a
+/// call that Node treats as authoritative.
+extern "C" fn process_stdin_remove_all_listeners(
+    _closure: *const crate::closure::ClosureHeader,
+    event: f64,
+) -> f64 {
+    let name = stdin_event_name(event);
+    if let Some((_, _, remove_all)) = stdin_ops_provider() {
+        match name.as_deref() {
+            Some(name) => remove_all(name.as_ptr(), name.len(), 1),
+            None => remove_all(std::ptr::null(), 0, 0),
+        }
+    }
+
+    match name.as_deref() {
+        Some("data") => {
+            clear_stdin_listener_list(&STDIN_DATA_LISTENERS);
+            clear_stdin_listener_list(&STDIN_DATA_ONCE);
+            disable_process_stdin_keypress_events();
+        }
+        Some("readable") => {
+            clear_stdin_listener_list(&STDIN_READABLE_LISTENERS);
+            clear_stdin_listener_list(&STDIN_READABLE_ONCE);
+        }
+        Some("end") | Some("close") => {
+            clear_stdin_listener_list(&STDIN_END_LISTENERS);
+            clear_stdin_listener_list(&STDIN_END_ONCE);
+        }
+        Some(_) => {}
+        None => {
+            for list in [
+                &STDIN_DATA_LISTENERS,
+                &STDIN_DATA_ONCE,
+                &STDIN_READABLE_LISTENERS,
+                &STDIN_READABLE_ONCE,
+                &STDIN_END_LISTENERS,
+                &STDIN_END_ONCE,
+            ] {
+                clear_stdin_listener_list(list);
+            }
+            disable_process_stdin_keypress_events();
+        }
+    }
+
+    // A pre-provider keypress listener lives in node:stream's generic emitter
+    // registry, so clear that registry too. Root both values across the array
+    // allocations performed by remove-all.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let stream = scope.root_nanbox_f64(stdin_this_value());
+    let event = scope.root_nanbox_f64(event);
+    let stream_value = stream.get_nanbox_f64();
+    let stream_raw = crate::value::js_nanbox_get_pointer(stream_value) as i64;
+    if stream_raw != 0 {
+        let _ = crate::node_stream::js_node_stream_method_remove_all_listeners(
+            stream_raw,
+            event.get_nanbox_f64(),
+        );
+    }
+    stream.get_nanbox_f64()
 }
 
 /// `process.stdin.listeners(event)` — the registered listeners for `event`,
@@ -657,6 +913,17 @@ extern "C" fn process_stdin_listeners(
     if !f.is_null() {
         let func: extern "C" fn(*const u8, usize) -> f64 = unsafe { std::mem::transmute(f) };
         return func(name.as_ptr(), name.len());
+    }
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let stream = scope.root_nanbox_f64(stdin_this_value());
+    let event = scope.root_nanbox_f64(event);
+    let stream_raw = crate::value::js_nanbox_get_pointer(stream.get_nanbox_f64()) as i64;
+    if stream_raw != 0 {
+        let listeners =
+            crate::node_stream::js_node_stream_method_listeners(stream_raw, event.get_nanbox_f64());
+        return f64::from_bits(
+            crate::value::JSValue::array_ptr(listeners as *mut crate::array::ArrayHeader).bits(),
+        );
     }
     let arr = crate::array::js_array_alloc(0);
     f64::from_bits(crate::value::JSValue::array_ptr(arr).bits())
@@ -836,6 +1103,13 @@ extern "C" fn process_stdin_on(
                 &STDIN_END_ONCE,
                 false,
             ),
+            Some("keypress") => {
+                let stream_raw = crate::value::js_nanbox_get_pointer(stdin_this_value()) as i64;
+                if stream_raw != 0 {
+                    let _ =
+                        crate::node_stream::js_node_stream_method_on(stream_raw, event, callback);
+                }
+            }
             _ => {}
         }
     }
@@ -872,6 +1146,13 @@ extern "C" fn process_stdin_once(
                 &STDIN_END_ONCE,
                 true,
             ),
+            Some("keypress") => {
+                let stream_raw = crate::value::js_nanbox_get_pointer(stdin_this_value()) as i64;
+                if stream_raw != 0 {
+                    let _ =
+                        crate::node_stream::js_node_stream_method_once(stream_raw, event, callback);
+                }
+            }
             _ => {}
         }
     }
@@ -1316,11 +1597,9 @@ fn build_stream_object_with_write(
             JSValue::from_bits(crate::tty::tty_listener_remove_all_value().to_bits()),
         );
     }
-    // #3962: install the appended listener-removal + lifecycle methods.
-    // `on`/`once` above are no-ops here, so `addListener`/`removeListener`/
-    // `off`/`removeAllListeners`/`resume` are no-ops too. On *stdin* (fd 0),
-    // `pause`/`unref`/`destroy` additionally detach the reader so the loop can
-    // quiesce after TUI teardown; on stdout/stderr they stay no-ops.
+    // #3962: install the appended listener-removal + lifecycle methods. stdin
+    // replaces the stream stubs below with its real listener/flow operations;
+    // stdout and stderr retain the stubs.
     if let Some(start) = teardown_start {
         let set_field_with_stub =
             |idx: u32, stub: extern "C" fn(*const crate::closure::ClosureHeader, f64) -> f64| {
@@ -1354,7 +1633,16 @@ fn build_stream_object_with_write(
             set_field_with_stub(start + 1, process_stream_on_once_stub); // removeListener
             set_field_with_stub(start + 2, process_stream_on_once_stub); // off
         }
-        set_field_with_stub(start + 3, process_stream_on_once_stub); // removeAllListeners
+        if is_stdin {
+            let remove_all = stdin_native_method(
+                process_stdin_remove_all_listeners as *const u8,
+                "removeAllListeners",
+                1,
+            );
+            js_object_set_field(obj, start + 3, JSValue::from_bits(remove_all.to_bits()));
+        } else {
+            set_field_with_stub(start + 3, process_stream_on_once_stub);
+        }
         set_field_with_stub(start + 4, lifecycle); // pause
                                                    // resume: real flowing-mode start on stdin, no-op on stdout/stderr.
         set_field_with_stub(

--- a/crates/perry-runtime/src/os_process_streams.rs
+++ b/crates/perry-runtime/src/os_process_streams.rs
@@ -697,12 +697,9 @@ pub extern "C" fn js_migrate_stdin_listeners_to_provider() {
             })
             .collect();
         for callback in callbacks {
-            on(
-                name.as_ptr(),
-                name.len(),
-                callback.get_raw_const_ptr::<crate::closure::ClosureHeader>() as i64,
-                once,
-            );
+            callback.with_const_ptr::<crate::closure::ClosureHeader, _>(|callback| {
+                on(name.as_ptr(), name.len(), callback as i64, once)
+            });
         }
     }
 }
@@ -1070,6 +1067,30 @@ fn register_stdin_listener(
     }
 }
 
+fn register_generic_stdin_keypress_listener(event: f64, callback: f64, once: bool) {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let stream = scope.root_nanbox_f64(stdin_this_value());
+    let event = scope.root_nanbox_f64(event);
+    let callback = scope.root_nanbox_f64(callback);
+    let stream_raw = crate::value::js_nanbox_get_pointer(stream.get_nanbox_f64()) as i64;
+    if stream_raw == 0 {
+        return;
+    }
+    if once {
+        let _ = crate::node_stream::js_node_stream_method_once(
+            stream_raw,
+            event.get_nanbox_f64(),
+            callback.get_nanbox_f64(),
+        );
+    } else {
+        let _ = crate::node_stream::js_node_stream_method_on(
+            stream_raw,
+            event.get_nanbox_f64(),
+            callback.get_nanbox_f64(),
+        );
+    }
+}
+
 /// `process.stdin.on(event, cb)` — registers a persistent `data`/`readable`
 /// listener and starts the reader. Returns `this` so callers can chain.
 extern "C" fn process_stdin_on(
@@ -1103,13 +1124,7 @@ extern "C" fn process_stdin_on(
                 &STDIN_END_ONCE,
                 false,
             ),
-            Some("keypress") => {
-                let stream_raw = crate::value::js_nanbox_get_pointer(stdin_this_value()) as i64;
-                if stream_raw != 0 {
-                    let _ =
-                        crate::node_stream::js_node_stream_method_on(stream_raw, event, callback);
-                }
-            }
+            Some("keypress") => register_generic_stdin_keypress_listener(event, callback, false),
             _ => {}
         }
     }
@@ -1146,13 +1161,7 @@ extern "C" fn process_stdin_once(
                 &STDIN_END_ONCE,
                 true,
             ),
-            Some("keypress") => {
-                let stream_raw = crate::value::js_nanbox_get_pointer(stdin_this_value()) as i64;
-                if stream_raw != 0 {
-                    let _ =
-                        crate::node_stream::js_node_stream_method_once(stream_raw, event, callback);
-                }
-            }
+            Some("keypress") => register_generic_stdin_keypress_listener(event, callback, true),
             _ => {}
         }
     }

--- a/crates/perry-runtime/src/readline_helpers.rs
+++ b/crates/perry-runtime/src/readline_helpers.rs
@@ -153,16 +153,18 @@ fn build_keypress_object(name: &str, ctrl: bool, shift: bool, meta: bool, seq: &
     let packed = b"name\0ctrl\0shift\0meta\0sequence\0";
     let obj = js_object_alloc_with_shape(0x7FFF_FF48, 5, packed.as_ptr(), packed.len() as u32);
     let obj_handle = scope.root_raw_mut_ptr(obj);
-    let name_str = js_string_from_bytes(name.as_ptr(), name.len() as u32);
-    let obj = obj_handle.get_raw_mut_ptr();
+    let (name_str, obj) = obj_handle.across_mut::<crate::object::ObjectHeader, _>(|| {
+        js_string_from_bytes(name.as_ptr(), name.len() as u32)
+    });
     js_object_set_field(obj, 0, JSValue::string_ptr(name_str));
     js_object_set_field(obj, 1, JSValue::bool(ctrl));
     js_object_set_field(obj, 2, JSValue::bool(shift));
     js_object_set_field(obj, 3, JSValue::bool(meta));
-    let seq_str = js_string_from_bytes(seq.as_ptr(), seq.len() as u32);
-    let obj = obj_handle.get_raw_mut_ptr();
+    let (seq_str, obj) = obj_handle.across_mut::<crate::object::ObjectHeader, _>(|| {
+        js_string_from_bytes(seq.as_ptr(), seq.len() as u32)
+    });
     js_object_set_field(obj, 4, JSValue::string_ptr(seq_str));
-    f64::from_bits(JSValue::pointer(obj as *const u8).bits())
+    obj_handle.with_const_ptr::<u8, _>(|obj| f64::from_bits(JSValue::pointer(obj).bits()))
 }
 
 fn parse_keypress(chunk: &[u8]) -> Option<(Option<String>, String, bool, bool, bool, String)> {
@@ -264,18 +266,24 @@ extern "C" fn emit_keypress_data(closure: *const ClosureHeader, chunk: f64) -> f
         let key = build_keypress_object(&name, ctrl, shift, meta, &seq);
         let key = scope.root_nanbox_f64(key);
         let args = scope.root_raw_mut_ptr(js_array_alloc(0));
-        let pushed = js_array_push_f64(args.get_raw_mut_ptr(), first.get_nanbox_f64());
+        let pushed = args.with_mut_ptr::<crate::array::ArrayHeader, _>(|args| {
+            js_array_push_f64(args, first.get_nanbox_f64())
+        });
         args.set_raw_mut_ptr(pushed);
-        let pushed = js_array_push_f64(args.get_raw_mut_ptr(), key.get_nanbox_f64());
+        let pushed = args.with_mut_ptr::<crate::array::ArrayHeader, _>(|args| {
+            js_array_push_f64(args, key.get_nanbox_f64())
+        });
         args.set_raw_mut_ptr(pushed);
         let Some(raw) = raw_ptr_from_value(stream.get_nanbox_f64()) else {
             return undefined();
         };
-        crate::node_stream::js_node_stream_method_emit_args(
-            raw,
-            event.get_nanbox_f64(),
-            args.get_raw_mut_ptr::<crate::array::ArrayHeader>() as i64,
-        );
+        args.with_mut_ptr::<crate::array::ArrayHeader, _>(|args| {
+            crate::node_stream::js_node_stream_method_emit_args(
+                raw,
+                event.get_nanbox_f64(),
+                args as i64,
+            )
+        });
     }
     undefined()
 }
@@ -296,15 +304,19 @@ pub extern "C" fn js_readline_emit_keypress_events_args(
         return undefined();
     };
     if crate::os::is_process_stdin_handle(raw) {
-        crate::os::enable_process_stdin_keypress_events(
-            listener.get_raw_const_ptr::<ClosureHeader>() as i64,
-        );
+        listener.with_const_ptr::<ClosureHeader, _>(|listener| {
+            crate::os::enable_process_stdin_keypress_events(listener as i64)
+        });
     } else {
         let event = scope.root_nanbox_f64(boxed_str(b"data"));
-        let listener_value = f64::from_bits(
-            JSValue::pointer(listener.get_raw_const_ptr::<ClosureHeader>() as *const u8).bits(),
-        );
-        crate::node_stream::js_node_stream_method_on(raw, event.get_nanbox_f64(), listener_value);
+        listener.with_const_ptr::<ClosureHeader, _>(|listener| {
+            let listener_value = f64::from_bits(JSValue::pointer(listener as *const u8).bits());
+            crate::node_stream::js_node_stream_method_on(
+                raw,
+                event.get_nanbox_f64(),
+                listener_value,
+            )
+        });
     }
     undefined()
 }

--- a/crates/perry-runtime/src/readline_helpers.rs
+++ b/crates/perry-runtime/src/readline_helpers.rs
@@ -8,19 +8,6 @@ use crate::closure::{
 use crate::object::{js_object_alloc_with_shape, js_object_set_field};
 use crate::string::{js_string_from_bytes, StringHeader};
 use crate::value::{js_jsvalue_to_string, JSValue, TAG_FALSE, TAG_UNDEFINED};
-use std::cell::RefCell;
-use std::collections::HashMap;
-
-#[derive(Default)]
-struct KeypressReplayState {
-    emitted: Vec<Vec<u8>>,
-    replay_index: Option<usize>,
-}
-
-thread_local! {
-    static KEYPRESS_REPLAY: RefCell<HashMap<i64, KeypressReplayState>> =
-        RefCell::new(HashMap::new());
-}
 
 fn undefined() -> f64 {
     f64::from_bits(TAG_UNDEFINED)
@@ -162,14 +149,18 @@ fn string_bytes(value: f64) -> Vec<u8> {
 }
 
 fn build_keypress_object(name: &str, ctrl: bool, shift: bool, meta: bool, seq: &str) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
     let packed = b"name\0ctrl\0shift\0meta\0sequence\0";
     let obj = js_object_alloc_with_shape(0x7FFF_FF48, 5, packed.as_ptr(), packed.len() as u32);
+    let obj_handle = scope.root_raw_mut_ptr(obj);
     let name_str = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    let obj = obj_handle.get_raw_mut_ptr();
     js_object_set_field(obj, 0, JSValue::string_ptr(name_str));
     js_object_set_field(obj, 1, JSValue::bool(ctrl));
     js_object_set_field(obj, 2, JSValue::bool(shift));
     js_object_set_field(obj, 3, JSValue::bool(meta));
     let seq_str = js_string_from_bytes(seq.as_ptr(), seq.len() as u32);
+    let obj = obj_handle.get_raw_mut_ptr();
     js_object_set_field(obj, 4, JSValue::string_ptr(seq_str));
     f64::from_bits(JSValue::pointer(obj as *const u8).bits())
 }
@@ -209,52 +200,82 @@ fn parse_keypress(chunk: &[u8]) -> Option<(Option<String>, String, bool, bool, b
     Some((Some(seq.clone()), seq.clone(), false, false, false, seq))
 }
 
-fn is_replayed_keypress_chunk(stream_raw: i64, bytes: &[u8]) -> bool {
-    KEYPRESS_REPLAY.with(|states| {
-        let mut states = states.borrow_mut();
-        let state = states.entry(stream_raw).or_default();
-        if let Some(index) = state.replay_index {
-            if index < state.emitted.len() && state.emitted[index] == bytes {
-                state.replay_index = if index + 1 >= state.emitted.len() {
-                    None
-                } else {
-                    Some(index + 1)
-                };
-                return true;
+/// Split a cooked-mode stream chunk into the logical key units that Node's
+/// `emitKeypressEvents` parser emits. Raw-mode input already arrives one byte
+/// at a time, while a pipe commonly arrives as `"abc\n"` in one read; treating
+/// that whole read as one key was the cooked-input half of #9692.
+pub fn split_keypress_chunks(bytes: &[u8]) -> Vec<Vec<u8>> {
+    let mut chunks = Vec::new();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == 0x1b
+            && index + 2 < bytes.len()
+            && matches!(bytes[index + 1], b'[' | b'O')
+        {
+            let mut end = index + 2;
+            while end < bytes.len() && end - index < 16 {
+                if (0x40..=0x7e).contains(&bytes[end]) {
+                    end += 1;
+                    break;
+                }
+                end += 1;
             }
-            state.replay_index = None;
+            chunks.push(bytes[index..end].to_vec());
+            index = end;
+            continue;
         }
-        if state.emitted.len() > 1 && state.emitted.first().is_some_and(|first| first == bytes) {
-            state.replay_index = Some(1);
-            return true;
+
+        let width = match bytes[index] {
+            0x00..=0x7f => 1,
+            0xc2..=0xdf => 2,
+            0xe0..=0xef => 3,
+            0xf0..=0xf4 => 4,
+            _ => 1,
+        };
+        let end = (index + width).min(bytes.len());
+        if std::str::from_utf8(&bytes[index..end]).is_ok() {
+            chunks.push(bytes[index..end].to_vec());
+            index = end;
+        } else {
+            chunks.push(vec![bytes[index]]);
+            index += 1;
         }
-        state.emitted.push(bytes.to_vec());
-        if state.emitted.len() > 32 {
-            state.emitted.remove(0);
-        }
-        false
-    })
+    }
+    chunks
 }
 
 extern "C" fn emit_keypress_data(closure: *const ClosureHeader, chunk: f64) -> f64 {
-    let stream = js_closure_get_capture_f64(closure, 0);
-    let Some(raw) = raw_ptr_from_value(stream) else {
-        return undefined();
-    };
-    let bytes = string_bytes(chunk);
-    if is_replayed_keypress_chunk(raw, &bytes) {
-        return undefined();
-    }
-    if let Some((str_arg, name, ctrl, shift, meta, seq)) = parse_keypress(&bytes) {
+    let stream_scope = crate::gc::RuntimeHandleScope::new();
+    let stream = stream_scope.root_nanbox_f64(js_closure_get_capture_f64(closure, 0));
+    let chunk = stream_scope.root_nanbox_f64(chunk);
+    let bytes = string_bytes(chunk.get_nanbox_f64());
+    for key_chunk in split_keypress_chunks(&bytes) {
+        let Some((str_arg, name, ctrl, shift, meta, seq)) = parse_keypress(&key_chunk) else {
+            continue;
+        };
+        let scope = crate::gc::RuntimeHandleScope::new();
         let event = boxed_str(b"keypress");
-        let mut args = js_array_alloc(0);
+        let event = scope.root_nanbox_f64(event);
         let first = str_arg
             .as_ref()
             .map(|s| boxed_str(s.as_bytes()))
             .unwrap_or_else(undefined);
-        args = js_array_push_f64(args, first);
-        args = js_array_push_f64(args, build_keypress_object(&name, ctrl, shift, meta, &seq));
-        crate::node_stream::js_node_stream_method_emit_args(raw, event, args as i64);
+        let first = scope.root_nanbox_f64(first);
+        let key = build_keypress_object(&name, ctrl, shift, meta, &seq);
+        let key = scope.root_nanbox_f64(key);
+        let args = scope.root_raw_mut_ptr(js_array_alloc(0));
+        let pushed = js_array_push_f64(args.get_raw_mut_ptr(), first.get_nanbox_f64());
+        args.set_raw_mut_ptr(pushed);
+        let pushed = js_array_push_f64(args.get_raw_mut_ptr(), key.get_nanbox_f64());
+        args.set_raw_mut_ptr(pushed);
+        let Some(raw) = raw_ptr_from_value(stream.get_nanbox_f64()) else {
+            return undefined();
+        };
+        crate::node_stream::js_node_stream_method_emit_args(
+            raw,
+            event.get_nanbox_f64(),
+            args.get_raw_mut_ptr::<crate::array::ArrayHeader>() as i64,
+        );
     }
     undefined()
 }
@@ -263,13 +284,27 @@ extern "C" fn emit_keypress_data(closure: *const ClosureHeader, chunk: f64) -> f
 pub extern "C" fn js_readline_emit_keypress_events_args(
     args: *const crate::array::ArrayHeader,
 ) -> f64 {
-    let stream = arg(args, 0);
-    let Some(raw) = raw_ptr_from_value(stream) else {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let stream = scope.root_nanbox_f64(arg(args, 0));
+    if raw_ptr_from_value(stream.get_nanbox_f64()).is_none() {
+        return undefined();
+    }
+    let listener = js_closure_alloc(emit_keypress_data as *const u8, 1);
+    js_closure_set_capture_f64(listener, 0, stream.get_nanbox_f64());
+    let listener = scope.root_raw_const_ptr(listener as *const ClosureHeader);
+    let Some(raw) = raw_ptr_from_value(stream.get_nanbox_f64()) else {
         return undefined();
     };
-    let listener = js_closure_alloc(emit_keypress_data as *const u8, 1);
-    js_closure_set_capture_f64(listener, 0, stream);
-    let listener_value = f64::from_bits(JSValue::pointer(listener as *const u8).bits());
-    crate::node_stream::js_node_stream_method_on(raw, boxed_str(b"data"), listener_value);
+    if crate::os::is_process_stdin_handle(raw) {
+        crate::os::enable_process_stdin_keypress_events(
+            listener.get_raw_const_ptr::<ClosureHeader>() as i64,
+        );
+    } else {
+        let event = scope.root_nanbox_f64(boxed_str(b"data"));
+        let listener_value = f64::from_bits(
+            JSValue::pointer(listener.get_raw_const_ptr::<ClosureHeader>() as *const u8).bits(),
+        );
+        crate::node_stream::js_node_stream_method_on(raw, event.get_nanbox_f64(), listener_value);
+    }
     undefined()
 }

--- a/crates/perry-stdlib/src/readline/mod.rs
+++ b/crates/perry-stdlib/src/readline/mod.rs
@@ -14,21 +14,17 @@
 //!       // key = { name, ctrl, shift, meta, sequence }
 //!   });
 //!
-//! Architecture: a single background thread reads stdin one byte at a
-//! time. When raw mode is OFF (default), bytes accumulate into a line
-//! buffer and the line is queued on `\n`. When raw mode is ON, byte
-//! chunks are queued immediately for `'data'`/`'keypress'` dispatch.
-//! Mode flips are observed at the start of each byte read, so toggling
-//! mid-stream is supported (the next byte routes to the new mode's
-//! queue). The main event-loop pump drains both queues every tick via
-//! `js_readline_process_pending`.
+//! Architecture: perry-runtime owns the single background fd-0 reader and
+//! forwards each block here. When raw mode is OFF (default), bytes accumulate
+//! into lines or cooked `'data'` chunks. When raw mode is ON, byte chunks are
+//! queued immediately for `'data'`/`'keypress'` dispatch. The main event-loop
+//! pump classifies each ordered block after synchronous listener changes have
+//! settled, then drains both queues via `js_readline_process_pending`.
 //!
 //! Phase 3 (`tty.isatty`, `process.stdout.columns/rows`, SIGWINCH) is
 //! independent of this file.
 
 use std::cell::RefCell;
-#[cfg(not(test))]
-use std::io::Read;
 use std::io::{self, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
@@ -116,6 +112,14 @@ impl ReadlineInterfaceState {
 
 /// Lines waiting for the main thread to dispatch.
 static PENDING_LINES: Mutex<Vec<String>> = Mutex::new(Vec::new());
+/// Ordered blocks received from perry-runtime's sole fd-0 reader. The reader
+/// thread deliberately does not classify them: synchronous JS can remove and
+/// replace listeners before the next event-loop turn, and Node applies the
+/// settled stream mode when it delivers that turn's bytes.
+static PENDING_INPUT: Mutex<Vec<Vec<u8>>> = Mutex::new(Vec::new());
+/// Partial cooked-mode line carried between reads from the runtime-owned fd-0
+/// reader. Classification and line splitting happen on the main thread.
+static PENDING_LINE_BYTES: Mutex<Vec<u8>> = Mutex::new(Vec::new());
 /// Raw byte chunks waiting for the main thread to dispatch as 'data' /
 /// 'keypress' events.
 static PENDING_DATA: Mutex<Vec<Vec<u8>>> = Mutex::new(Vec::new());
@@ -470,8 +474,12 @@ extern "C" fn stdin_on_op(name_ptr: *const u8, name_len: usize, cb: i64, _once: 
         }
         _ => return,
     }
-    try_register_pump();
-    ensure_reader_started();
+    // The provider is already installed before this callback can run. Avoid
+    // re-entering bridge registration while pre-provider listeners are being
+    // migrated; only the pump and shared reader need arming here.
+    #[cfg(all(feature = "async-runtime", not(test)))]
+    crate::common::async_bridge::ensure_pump_registered();
+    start_shared_stdin_reader();
 }
 
 extern "C" fn stdin_off_op(name_ptr: *const u8, name_len: usize, cb: i64) {
@@ -521,6 +529,61 @@ extern "C" fn stdin_off_op(name_ptr: *const u8, name_len: usize, cb: i64) {
     }
 }
 
+/// `stdin.removeAllListeners([event])` reached through the runtime-owned stdin
+/// object. `has_event == 0` distinguishes the no-argument form from an empty
+/// event name.
+extern "C" fn stdin_remove_all_op(name_ptr: *const u8, name_len: usize, has_event: i32) {
+    let name = if has_event == 0 || name_ptr.is_null() {
+        None
+    } else {
+        Some(
+            std::str::from_utf8(unsafe { std::slice::from_raw_parts(name_ptr, name_len) })
+                .unwrap_or(""),
+        )
+    };
+    match name {
+        Some("data") => {
+            if let Ok(mut callbacks) = DATA_CALLBACKS.lock() {
+                callbacks.clear();
+            }
+            STDIN_DATA_FLOWING.store(false, Ordering::Release);
+            perry_runtime::os::disable_process_stdin_keypress_events();
+        }
+        Some("readable") => {
+            if let Ok(mut callbacks) = READABLE_CALLBACKS.lock() {
+                callbacks.clear();
+            }
+            STDIN_PULL_MODE.store(false, Ordering::Release);
+        }
+        Some("keypress") => {
+            if let Ok(mut callbacks) = KEYPRESS_CALLBACKS.lock() {
+                callbacks.clear();
+            }
+        }
+        Some("end") | Some("close") => {
+            if let Ok(mut callbacks) = STDIN_END_CALLBACKS.lock() {
+                callbacks.clear();
+            }
+        }
+        Some(_) => {}
+        None => {
+            for callbacks in [
+                &DATA_CALLBACKS,
+                &READABLE_CALLBACKS,
+                &KEYPRESS_CALLBACKS,
+                &STDIN_END_CALLBACKS,
+            ] {
+                if let Ok(mut callbacks) = callbacks.lock() {
+                    callbacks.clear();
+                }
+            }
+            STDIN_DATA_FLOWING.store(false, Ordering::Release);
+            STDIN_PULL_MODE.store(false, Ordering::Release);
+            perry_runtime::os::disable_process_stdin_keypress_events();
+        }
+    }
+}
+
 /// A `data` chunk as Node would deliver it: a Buffer by default, a decoded
 /// string once an encoding has been set with `setEncoding`. `None` means the
 /// chunk was absorbed into the UTF-8 decoder's held partial and Node would
@@ -548,14 +611,39 @@ fn ensure_stdin_listeners_provider_registered() {
             fn js_register_stdin_listener_ops(
                 on: extern "C" fn(*const u8, usize, i64, i32),
                 off: extern "C" fn(*const u8, usize, i64),
+                remove_all: extern "C" fn(*const u8, usize, i32),
             );
             // #9676: the flow half of the same bridge — see `stdin_pause_op`.
             fn js_register_stdin_flow_ops(pause: extern "C" fn(), resume: extern "C" fn());
         }
         unsafe {
             js_register_stdin_listeners_provider(stdin_listeners_provider);
-            js_register_stdin_listener_ops(stdin_on_op, stdin_off_op);
+            js_register_stdin_listener_ops(stdin_on_op, stdin_off_op, stdin_remove_all_op);
             js_register_stdin_flow_ops(stdin_pause_op, stdin_resume_op);
+        }
+    });
+
+    // Registrations made through an alias before readline initialized live in
+    // the runtime fallback lists. Adopt them before fd-0's already-buffered
+    // bytes are handed to `stdin_reader_data`, preserving both ownership and
+    // event order.
+    extern "C" {
+        fn js_migrate_stdin_listeners_to_provider();
+    }
+    unsafe {
+        js_migrate_stdin_listeners_to_provider();
+    }
+
+    static READER_CONSUMER_ONCE: Once = Once::new();
+    READER_CONSUMER_ONCE.call_once(|| {
+        extern "C" {
+            fn js_register_stdin_reader_consumer(
+                on_data: extern "C" fn(*const u8, usize),
+                on_eof: extern "C" fn(),
+            );
+        }
+        unsafe {
+            js_register_stdin_reader_consumer(stdin_reader_data, stdin_reader_eof);
         }
     });
 }
@@ -1137,164 +1225,40 @@ fn create_interface_from_options(opts: f64) -> i64 {
 }
 
 // ---------------------------------------------------------------------------
-// Background reader
+// Runtime-owned stdin reader consumer
 // ---------------------------------------------------------------------------
 
-/// Spawn the background byte-mode reader if it isn't already running.
-/// Idempotent across threads via `READER_STARTED.compare_exchange`.
-fn ensure_reader_started() {
-    if READER_STARTED
-        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-        .is_err()
-    {
+/// Enqueue one block from perry-runtime's sole fd-0 reader. This callback runs
+/// on the reader thread and must never call JS or touch the GC. In particular,
+/// it leaves mode classification to the main-thread pump so a synchronous
+/// remove/re-add sequence cannot race the producer thread.
+extern "C" fn stdin_reader_data(bytes_ptr: *const u8, bytes_len: usize) {
+    if bytes_ptr.is_null() || bytes_len == 0 || STDIN_DESTROYED.load(Ordering::Acquire) {
         return;
     }
-    // Under `cargo test` never spawn the real reader: it would block on the
-    // test runner's stdin and flip EOF_REACHED / push to the shared queues
-    // at arbitrary points mid-test. The flag still flips so the has-active
-    // logic sees the same state it would in production, and `reset()` can
-    // clear it between tests.
+    let bytes = unsafe { std::slice::from_raw_parts(bytes_ptr, bytes_len) };
+    if let Ok(mut pending) = PENDING_INPUT.lock() {
+        pending.push(bytes.to_vec());
+    }
+}
+
+/// EOF notification from the runtime-owned reader. Queued input is flushed by
+/// `route_pending_stdin_input` on the main thread before EOF events dispatch.
+extern "C" fn stdin_reader_eof() {
+    EOF_REACHED.store(true, Ordering::Release);
+}
+
+/// Connect readline to perry-runtime's reader and ask that single owner to
+/// start. Under unit tests we keep the historical no-I/O behavior.
+fn start_shared_stdin_reader() {
+    READER_STARTED.store(true, Ordering::Release);
     #[cfg(not(test))]
-    std::thread::spawn(move || {
-        let stdin = io::stdin();
-        let mut reader = stdin.lock();
-        // #9489: read a BLOCK per syscall, and cut `'data'` chunks at the
-        // block boundary. This loop used to `read(2)` ONE BYTE at a time and
-        // flush a chunk at every `\n`, so 1 MB of `"line\n"` cost 1,048,576
-        // read syscalls and produced 200,000 `'data'` events in 2.10 s where
-        // Node delivers 16 in 0.04 s.
-        //
-        // 64 KiB is Node's own pipe read size, and `read` still returns as
-        // soon as ANY bytes are available — it does not wait to fill the
-        // buffer — so a lone keystroke is still delivered immediately and
-        // three spaced writes are still three chunks.
-        let mut buf = [0u8; 65536];
-        // Bytes accumulated for the CURRENT read: in cooked flowing / pull
-        // mode this becomes one `'data'` chunk per read; in line mode it is
-        // the partial line carried to the next `\n`.
-        let mut line_buf: Vec<u8> = Vec::with_capacity(65536);
-        // Raw-mode chunks staged for one lock acquisition per read instead of
-        // one per byte. The per-BYTE chunking itself is preserved on purpose:
-        // the keypress path reassembles escape sequences from single-byte
-        // chunks (`pump::coalesce_escape_sequences`), and a paste must still
-        // fire one `'keypress'` per character.
-        let mut raw_chunks: Vec<Vec<u8>> = Vec::new();
-        // #9588: set whenever this read(2) put something the MAIN THREAD has to
-        // dispatch into a shared queue. See the notify below.
-        let mut queued_for_main: bool;
-        loop {
-            let n = match reader.read(&mut buf) {
-                Ok(0) => break, // EOF
-                Ok(n) => n,
-                Err(_) => break,
-            };
-            if STDIN_DESTROYED.load(Ordering::Acquire) {
-                break;
-            }
-            queued_for_main = false;
-            // The mode atomics are still consulted PER BYTE, exactly as
-            // before: a mode flip from the main thread mid-block must land on
-            // the same byte it used to. Only the syscall and the chunk
-            // boundary changed.
-            for &b in &buf[..n] {
-                if RAW_MODE.load(Ordering::Acquire) {
-                    raw_chunks.push(vec![b]);
-                } else if STDIN_DATA_FLOWING.load(Ordering::Acquire)
-                    || STDIN_PULL_MODE.load(Ordering::Acquire)
-                {
-                    // Cooked flowing mode (#5227): a `process.stdin.on('data')`
-                    // listener is attached but raw mode is off. Deliver input
-                    // as 'data' chunks (newline INCLUDED, matching Node's
-                    // piped-stream chunks) rather than routing it to the
-                    // readline 'line' queue. #9489: the chunk is cut at the
-                    // end of this read, NOT at each newline.
-                    line_buf.push(b);
-                } else if b == b'\n' {
-                    // Strip trailing CR for Windows CRLF input.
-                    if line_buf.last() == Some(&b'\r') {
-                        line_buf.pop();
-                    }
-                    let line = String::from_utf8_lossy(&line_buf).into_owned();
-                    line_buf.clear();
-                    if let Ok(mut q) = PENDING_LINES.lock() {
-                        q.push(line);
-                    }
-                    queued_for_main = true;
-                } else {
-                    line_buf.push(b);
-                }
-            }
-            if !raw_chunks.is_empty() {
-                if let Ok(mut q) = PENDING_DATA.lock() {
-                    q.append(&mut raw_chunks);
-                }
-                raw_chunks.clear();
-                queued_for_main = true;
-            }
-            // One `'data'` chunk per read(2) — Node's contract. Line splitting
-            // is the CONSUMER's job (readline does its own, above); imposing
-            // it on the shared `'data'` path is what #9489 fixed.
-            if !line_buf.is_empty()
-                && !RAW_MODE.load(Ordering::Acquire)
-                && (STDIN_DATA_FLOWING.load(Ordering::Acquire)
-                    || STDIN_PULL_MODE.load(Ordering::Acquire))
-            {
-                if let Ok(mut q) = PENDING_DATA.lock() {
-                    q.push(std::mem::take(&mut line_buf));
-                }
-                line_buf = Vec::with_capacity(65536);
-                queued_for_main = true;
-            }
-            // #9588 — WAKE THE PUMP. This reader is a cross-thread producer for
-            // queues only the main thread drains (`js_readline_process_pending`,
-            // reached from `js_run_stdlib_pump`), and it used to push and loop
-            // straight back into `read(2)` without telling anyone. The main loop
-            // therefore learned about a keystroke only when it happened to wake
-            // for some *other* reason, so input latency was the whole
-            // `js_wait_for_event` budget: the next timer deadline, or — for a TUI
-            // sitting idle with no timer armed — the full `IDLE_CAP_MS` (1 s)
-            // safety cap. Measured on the claude-code bundle before this line:
-            // 695-963 ms from keypress to the `'data'` handler, against Node's
-            // sub-millisecond. That is the protocol the event pump documents
-            // ("producer: push_to_queue(); js_notify_main_thread()") and the one
-            // perry-runtime's own stdin reader in `os_process_streams` already
-            // follows; readline's reader was the one producer that skipped it.
-            //
-            // Once per read(2), not per byte: a paste arrives as one syscall and
-            // needs exactly one wake, and the flag keeps a read that queued
-            // nothing (a raw-mode byte absorbed with no listener, a partial line
-            // still accumulating) from waking the loop for no work.
-            if queued_for_main {
-                perry_runtime::event_pump::js_notify_main_thread();
-            }
-        }
-        // Flush any trailing bytes not terminated by a newline. In cooked
-        // flowing mode this is the last 'data' chunk for input like
-        // `printf "abc"` (no final newline); otherwise it's a final 'line'.
-        if !line_buf.is_empty() && !STDIN_DESTROYED.load(Ordering::Acquire) {
-            if (STDIN_DATA_FLOWING.load(Ordering::Acquire)
-                || STDIN_PULL_MODE.load(Ordering::Acquire))
-                && !RAW_MODE.load(Ordering::Acquire)
-            {
-                if let Ok(mut q) = PENDING_DATA.lock() {
-                    q.push(std::mem::take(&mut line_buf));
-                }
-            } else if !RAW_MODE.load(Ordering::Acquire) {
-                if line_buf.last() == Some(&b'\r') {
-                    line_buf.pop();
-                }
-                let line = String::from_utf8_lossy(&line_buf).into_owned();
-                if let Ok(mut q) = PENDING_LINES.lock() {
-                    q.push(line);
-                }
-            }
-        }
-        EOF_REACHED.store(true, Ordering::Release);
-        // #9588: EOF is main-thread-visible work too — the `'end'`/`'close'`
-        // dispatch and the liveness flip that lets the loop exit. Without a wake
-        // here a piped program's exit was delayed by up to `IDLE_CAP_MS`.
-        perry_runtime::event_pump::js_notify_main_thread();
-    });
+    perry_runtime::os::ensure_process_stdin_reader();
+}
+
+fn ensure_reader_started() {
+    ensure_stdin_listeners_provider_registered();
+    start_shared_stdin_reader();
 }
 
 // ---------------------------------------------------------------------------
@@ -1939,6 +1903,12 @@ pub extern "C" fn js_readline_stdin_destroy() -> f64 {
         *deadline = None;
     }
     if let Ok(mut q) = PENDING_LINES.lock() {
+        q.clear();
+    }
+    if let Ok(mut q) = PENDING_INPUT.lock() {
+        q.clear();
+    }
+    if let Ok(mut q) = PENDING_LINE_BYTES.lock() {
         q.clear();
     }
     if let Ok(mut v) = DATA_CALLBACKS.lock() {

--- a/crates/perry-stdlib/src/readline/pump.rs
+++ b/crates/perry-stdlib/src/readline/pump.rs
@@ -241,14 +241,119 @@ fn coalesce_escape_sequences(raw: Vec<Vec<u8>>) -> Vec<Vec<u8>> {
     out
 }
 
+/// Classify reader blocks after synchronous JS for this event-loop turn has
+/// settled the stream mode. This keeps physical I/O single-owned without
+/// exposing producer-thread scheduling as observable listener behavior.
+fn route_pending_stdin_input() {
+    if STDIN_DESTROYED.load(Ordering::Acquire) {
+        if let Ok(mut pending) = PENDING_INPUT.lock() {
+            pending.clear();
+        }
+        if let Ok(mut line) = PENDING_LINE_BYTES.lock() {
+            line.clear();
+        }
+        return;
+    }
+
+    let blocks = PENDING_INPUT
+        .lock()
+        .map(|mut pending| std::mem::take(&mut *pending))
+        .unwrap_or_default();
+    let mut line_buf = PENDING_LINE_BYTES
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let mut raw_chunks: Vec<Vec<u8>> = Vec::new();
+
+    for block in blocks {
+        for byte in block {
+            if RAW_MODE.load(Ordering::Acquire) {
+                // Preserve byte-sized raw chunks so escape sequences can be
+                // reassembled across reads by `coalesce_escape_sequences`.
+                raw_chunks.push(vec![byte]);
+            } else if STDIN_DATA_FLOWING.load(Ordering::Acquire)
+                || STDIN_PULL_MODE.load(Ordering::Acquire)
+            {
+                line_buf.push(byte);
+            } else if byte == b'\n' {
+                if line_buf.last() == Some(&b'\r') {
+                    line_buf.pop();
+                }
+                let line = String::from_utf8_lossy(&line_buf).into_owned();
+                line_buf.clear();
+                if let Ok(mut queue) = PENDING_LINES.lock() {
+                    queue.push(line);
+                }
+            } else {
+                line_buf.push(byte);
+            }
+        }
+
+        if !raw_chunks.is_empty() {
+            if let Ok(mut queue) = PENDING_DATA.lock() {
+                queue.append(&mut raw_chunks);
+            }
+        }
+        // One cooked `'data'` chunk per physical read, preserving #9489's Node
+        // chunking while leaving line splitting to the readline consumer.
+        if !line_buf.is_empty()
+            && !RAW_MODE.load(Ordering::Acquire)
+            && (STDIN_DATA_FLOWING.load(Ordering::Acquire)
+                || STDIN_PULL_MODE.load(Ordering::Acquire))
+        {
+            if let Ok(mut queue) = PENDING_DATA.lock() {
+                queue.push(std::mem::take(&mut *line_buf));
+            }
+            *line_buf = Vec::with_capacity(65536);
+        }
+    }
+
+    // EOF is published after the reader has enqueued its final block. The
+    // producer may publish it while this pump is still classifying an earlier
+    // snapshot, so flush only when no later block remains in PENDING_INPUT.
+    if stdin_eof_input_drained() {
+        if !line_buf.is_empty() {
+            if (STDIN_DATA_FLOWING.load(Ordering::Acquire)
+                || STDIN_PULL_MODE.load(Ordering::Acquire))
+                && !RAW_MODE.load(Ordering::Acquire)
+            {
+                if let Ok(mut queue) = PENDING_DATA.lock() {
+                    queue.push(std::mem::take(&mut *line_buf));
+                }
+            } else if !RAW_MODE.load(Ordering::Acquire) {
+                if line_buf.last() == Some(&b'\r') {
+                    line_buf.pop();
+                }
+                let line = String::from_utf8_lossy(&line_buf).into_owned();
+                line_buf.clear();
+                if let Ok(mut queue) = PENDING_LINES.lock() {
+                    queue.push(line);
+                }
+            }
+        }
+    }
+}
+
+/// Whether physical EOF has been observed and every preceding reader block
+/// has left the handoff queue. The reader enqueues a block before publishing
+/// EOF, so the acquire load followed by the queue lock closes the race where a
+/// pump took an earlier snapshot just before the final blocks arrived.
+fn stdin_eof_input_drained() -> bool {
+    EOF_REACHED.load(Ordering::Acquire)
+        && PENDING_INPUT
+            .lock()
+            .map(|pending| pending.is_empty())
+            .unwrap_or(false)
+}
+
 /// Drain pending lines and byte chunks, dispatching to registered
 /// callbacks. Called from the async-bridge tick on every event-loop
 /// iteration. Returns the number of callbacks fired.
 #[no_mangle]
 pub extern "C" fn js_readline_process_pending() -> i32 {
     let mut fired: i32 = 0;
+    route_pending_stdin_input();
 
-    // Drain raw-mode byte chunks → 'data' / 'keypress' callbacks.
+    // Drain raw- or cooked-mode byte chunks → 'data' / 'keypress' callbacks.
     let chunks: Vec<Vec<u8>> = if STDIN_DESTROYED.load(Ordering::Acquire) {
         if let Ok(mut q) = PENDING_DATA.lock() {
             q.clear();
@@ -302,7 +407,7 @@ pub extern "C" fn js_readline_process_pending() -> i32 {
     // JS busy loop: one registered listener meant a callback invocation on
     // every event-loop iteration forever, and the non-zero `fired` return
     // kept the loop hot.
-    let readable_eof_due = EOF_REACHED.load(Ordering::Acquire)
+    let readable_eof_due = stdin_eof_input_drained()
         && !READABLE_EOF_NOTIFIED.load(Ordering::Acquire)
         && !STDIN_DESTROYED.load(Ordering::Acquire);
     if !chunks.is_empty() || readable_eof_due {
@@ -336,10 +441,14 @@ pub extern "C" fn js_readline_process_pending() -> i32 {
     // drain (not once per chunk) and each chunk is parsed once, not once
     // per callback.
     let data_callbacks = DATA_CALLBACKS.lock().map(|v| v.clone()).unwrap_or_default();
-    let keypress_callbacks = KEYPRESS_CALLBACKS
-        .lock()
-        .map(|v| v.clone())
-        .unwrap_or_default();
+    let keypress_callbacks = if cfg!(test) || perry_runtime::os::stdin_keypress_events_enabled() {
+        KEYPRESS_CALLBACKS
+            .lock()
+            .map(|v| v.clone())
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
     // `stdin_chunk_value`, the sequence string and key-object construction
     // all allocate. Root these cloned callback snapshots because the mutable
     // registry scanner can only rewrite the original listener lists.
@@ -374,10 +483,10 @@ pub extern "C" fn js_readline_process_pending() -> i32 {
                 fired += 1;
             }
         }
-        if keypress_callback_handles.is_empty() {
-            continue;
-        }
-        if let Some((name, ctrl, shift, meta, seq)) = parse_keypress(&chunk) {
+        for key_chunk in perry_runtime::readline_helpers::split_keypress_chunks(&chunk) {
+            let Some((name, ctrl, shift, meta, seq)) = parse_keypress(&key_chunk) else {
+                continue;
+            };
             for callback in &keypress_callback_handles {
                 // Root the sequence string across build_keypress_object's
                 // allocations (a moving minor GC there would leave arg1
@@ -428,7 +537,7 @@ pub extern "C" fn js_readline_process_pending() -> i32 {
     // emits process.stdin's end/close events. `rl.close()` may already have
     // fired the first event without stdin actually ending, so the two
     // one-shot states must not be conflated.
-    if EOF_REACHED.load(Ordering::Acquire) {
+    if stdin_eof_input_drained() {
         let readline_close_already = CLOSE_FIRED.with(|f| {
             let was = *f.borrow();
             *f.borrow_mut() = true;
@@ -503,6 +612,7 @@ pub extern "C" fn js_readline_has_active() -> i32 {
     let paused = STDIN_PAUSED.load(Ordering::Acquire);
     let refed = STDIN_REFED.load(Ordering::Acquire);
     let has_lines = PENDING_LINES.lock().map(|q| !q.is_empty()).unwrap_or(false);
+    let has_input = PENDING_INPUT.lock().map(|q| !q.is_empty()).unwrap_or(false);
     // A held escape prefix counts as pending data: the loop must stay alive
     // until its explicit escapeCodeTimeout deadline can flush it.
     let has_data = PENDING_DATA.lock().map(|q| !q.is_empty()).unwrap_or(false)
@@ -545,7 +655,11 @@ pub extern "C" fn js_readline_has_active() -> i32 {
             || has_close_cb);
     if !destroyed
         && refed
-        && (has_dispatchable_lines || has_dispatchable_data || has_close_cb || reader_keeps_alive)
+        && ((has_input && !paused)
+            || has_dispatchable_lines
+            || has_dispatchable_data
+            || has_close_cb
+            || reader_keeps_alive)
     {
         1
     } else {
@@ -556,6 +670,22 @@ pub extern "C" fn js_readline_has_active() -> i32 {
 #[cfg(test)]
 mod tests {
     use super::parse_keypress;
+
+    #[test]
+    fn eof_waits_for_every_reader_handoff_block() {
+        let _guard = super::super::test_support::reset();
+        super::PENDING_INPUT
+            .lock()
+            .unwrap()
+            .push(b"still pending".to_vec());
+        super::EOF_REACHED.store(true, std::sync::atomic::Ordering::Release);
+
+        assert!(!super::stdin_eof_input_drained());
+        super::PENDING_INPUT.lock().unwrap().clear();
+        assert!(super::stdin_eof_input_drained());
+
+        super::EOF_REACHED.store(false, std::sync::atomic::Ordering::Release);
+    }
 
     #[test]
     fn parse_keypress_arrow_keys() {

--- a/crates/perry-stdlib/src/readline/test_support.rs
+++ b/crates/perry-stdlib/src/readline/test_support.rs
@@ -74,6 +74,8 @@ pub(super) fn reset() -> MutexGuard<'static, ()> {
     }
     STDIN_PULL_MODE.store(false, Ordering::Release);
     PENDING_LINES.lock().unwrap().clear();
+    PENDING_INPUT.lock().unwrap().clear();
+    PENDING_LINE_BYTES.lock().unwrap().clear();
     PENDING_DATA.lock().unwrap().clear();
     PENDING_ESCAPE.lock().unwrap().clear();
     *PENDING_ESCAPE_DEADLINE.lock().unwrap() = None;

--- a/crates/perry/tests/issue_9692_stdin_surface.rs
+++ b/crates/perry/tests/issue_9692_stdin_surface.rs
@@ -1,0 +1,248 @@
+//! Regression coverage for #9692's shared stdin surface.
+//!
+//! Node and Perry run the same fixture with both possible initialization
+//! orders: the runtime object reader requested first through an aliased stream,
+//! or readline requested first through the syntactic `process.stdin` path.
+//! Every scenario is exercised with a pipe, a cooked PTY, and a raw PTY. The
+//! PTY arms are load-bearing: two competing `StdinLock` owners can appear green
+//! under a pipe depending on which reader happens to start first.
+
+#![cfg(unix)]
+
+use std::fs::File;
+use std::io::{BufRead, BufReader, Write};
+use std::os::fd::{FromRawFd, RawFd};
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
+use std::time::{Duration, Instant};
+
+const SOURCE: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../test-files/test_issue_9692_stdin_surface.ts"
+));
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile(dir: &Path) -> (PathBuf, PathBuf) {
+    let source = dir.join("stdin_surface.ts");
+    let binary = dir.join("stdin_surface_bin");
+    std::fs::write(&source, SOURCE).expect("write stdin fixture");
+    let output = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&source)
+        .arg("-o")
+        .arg(&binary)
+        .output()
+        .expect("compile stdin fixture");
+    assert!(
+        output.status.success(),
+        "fixture compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    (source, binary)
+}
+
+fn command_for(program: &Path, is_node: bool) -> Command {
+    if is_node {
+        let mut command = Command::new("node");
+        command.arg("--no-warnings").arg(program);
+        command
+    } else {
+        Command::new(program)
+    }
+}
+
+fn configure(command: &mut Command, scenario: &str, order: &str, raw: bool) {
+    command
+        .env("PERRY_9692_SCENARIO", scenario)
+        .env("PERRY_9692_ORDER", order)
+        .env("PERRY_9692_RAW", if raw { "1" } else { "0" });
+}
+
+fn result_line(output: &str) -> Option<String> {
+    output.lines().find_map(|line| {
+        line.trim_end_matches('\r')
+            .strip_prefix("RESULT:")
+            .map(str::to_owned)
+    })
+}
+
+fn run_pipe(program: &Path, is_node: bool, scenario: &str, order: &str) -> (ExitStatus, String) {
+    let mut command = command_for(program, is_node);
+    configure(&mut command, scenario, order, false);
+    let mut child = command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn pipe fixture");
+    let mut stdin = child.stdin.take().expect("pipe fixture stdin");
+    stdin.write_all(b"ab\n").expect("write pipe input");
+    drop(stdin);
+    let output = child.wait_with_output().expect("wait for pipe fixture");
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let result = result_line(&stdout).unwrap_or_else(|| panic!("missing RESULT line: {stdout:?}"));
+    (output.status, result)
+}
+
+fn open_pty() -> (File, File) {
+    let mut master: RawFd = -1;
+    let mut slave: RawFd = -1;
+    let rc = unsafe {
+        libc::openpty(
+            &mut master,
+            &mut slave,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    };
+    assert_eq!(rc, 0, "openpty failed: {}", std::io::Error::last_os_error());
+    assert!(master >= 0 && slave >= 0);
+    // SAFETY: openpty returned two fresh owned descriptors.
+    unsafe { (File::from_raw_fd(master), File::from_raw_fd(slave)) }
+}
+
+struct PtyChild {
+    child: Child,
+    input: File,
+    lines: Receiver<String>,
+}
+
+impl PtyChild {
+    fn spawn(program: &Path, is_node: bool, scenario: &str, order: &str, raw: bool) -> Self {
+        let (master, slave) = open_pty();
+        let mut command = command_for(program, is_node);
+        configure(&mut command, scenario, order, raw);
+        command
+            .stdin(Stdio::from(slave.try_clone().expect("clone PTY stdin")))
+            .stdout(Stdio::from(slave.try_clone().expect("clone PTY stdout")))
+            .stderr(Stdio::null());
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                if libc::ioctl(0, libc::TIOCSCTTY as _, 0) == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        let child = command.spawn().expect("spawn PTY fixture");
+        drop(slave);
+        let input = master.try_clone().expect("clone PTY master");
+        let (tx, lines) = mpsc::channel();
+        std::thread::spawn(move || {
+            for line in BufReader::new(master).lines() {
+                let Ok(line) = line else { break };
+                if tx.send(line.trim_end_matches('\r').to_string()).is_err() {
+                    break;
+                }
+            }
+        });
+        Self {
+            child,
+            input,
+            lines,
+        }
+    }
+
+    fn recv_until(&self, prefix: &str, timeout: Duration) -> Result<String, RecvTimeoutError> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let line = self.lines.recv_timeout(remaining)?;
+            if line.starts_with(prefix) {
+                return Ok(line);
+            }
+        }
+    }
+}
+
+impl Drop for PtyChild {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn run_pty(
+    program: &Path,
+    is_node: bool,
+    scenario: &str,
+    order: &str,
+    raw: bool,
+) -> (ExitStatus, String) {
+    let mut session = PtyChild::spawn(program, is_node, scenario, order, raw);
+    session
+        .recv_until("READY", Duration::from_secs(20))
+        .unwrap_or_else(|_| panic!("{scenario}/{order}/raw={raw} never became ready"));
+    session
+        .input
+        .write_all(if raw { b"ab\r" } else { b"ab\n" })
+        .expect("write PTY input");
+    session.input.flush().expect("flush PTY input");
+    let line = session
+        .recv_until("RESULT:", Duration::from_secs(5))
+        .unwrap_or_else(|_| panic!("{scenario}/{order}/raw={raw} produced no result"));
+    let result = line.trim_start_matches("RESULT:").to_string();
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let status = loop {
+        if let Some(status) = session.child.try_wait().expect("poll PTY fixture") {
+            break status;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "PTY fixture did not exit: {result}"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    };
+    (status, result)
+}
+
+#[test]
+fn stdin_surface_matches_node_for_pipe_and_cooked_and_raw_ptys() {
+    let dir = tempfile::tempdir().expect("create fixture directory");
+    let (source, binary) = compile(dir.path());
+    let cases = [("pipe", false), ("pty-cooked", false), ("pty-raw", true)];
+
+    for scenario in ["keypress", "remove-data", "remove-all"] {
+        for order in ["runtime-first", "readline-first"] {
+            for (transport, raw) in cases {
+                let run = |program: &Path, is_node: bool| {
+                    if transport == "pipe" {
+                        run_pipe(program, is_node, scenario, order)
+                    } else {
+                        run_pty(program, is_node, scenario, order, raw)
+                    }
+                };
+                let (node_status, node) = run(&source, true);
+                let (perry_status, perry) = run(&binary, false);
+                assert!(
+                    node_status.success(),
+                    "Node oracle failed for {scenario}/{order}/{transport}: {node}"
+                );
+                assert!(
+                    perry_status.success(),
+                    "Perry failed for {scenario}/{order}/{transport}: {perry}"
+                );
+                assert_ne!(
+                    node, "timeout",
+                    "Node oracle timed out for {scenario}/{order}/{transport}"
+                );
+                assert_eq!(
+                    perry, node,
+                    "stdin divergence for {scenario}/{order}/{transport}"
+                );
+            }
+        }
+    }
+}

--- a/test-files/test_issue_9692_stdin_surface.ts
+++ b/test-files/test_issue_9692_stdin_surface.ts
@@ -1,0 +1,62 @@
+import { emitKeypressEvents } from "node:readline";
+
+const input: any = process.stdin;
+const scenario = process.env.PERRY_9692_SCENARIO || "keypress";
+const order = process.env.PERRY_9692_ORDER || "runtime-first";
+const raw = process.env.PERRY_9692_RAW === "1";
+let done = false;
+
+input.setEncoding("utf8");
+
+function primeRuntimeReader(stream: any, callback: (chunk: unknown) => void) {
+  stream.on("data", callback);
+  stream.removeListener("data", callback);
+}
+
+function primeReadlineReader(callback: (chunk: unknown) => void) {
+  process.stdin.on("data", callback);
+  process.stdin.removeListener("data", callback);
+}
+
+function finish(payload: string, status = 0) {
+  if (done) return;
+  done = true;
+  if (raw && typeof input.setRawMode === "function") input.setRawMode(false);
+  input.pause();
+  console.log("RESULT:" + payload);
+  setTimeout(() => process.exit(status), 20);
+}
+
+const timeout = setTimeout(() => finish("timeout", 2), 2500);
+const prime = (_chunk: unknown) => {};
+if (order === "runtime-first") primeRuntimeReader(input, prime);
+else primeReadlineReader(prime);
+
+if (raw && typeof input.setRawMode === "function") input.setRawMode(true);
+
+if (scenario === "keypress") {
+  emitKeypressEvents(input);
+  const codes: number[] = [];
+  process.stdin.on("keypress", (sequence: string | undefined) => {
+    codes.push(sequence === undefined ? -1 : sequence.charCodeAt(0));
+    if (codes.length === 3) {
+      clearTimeout(timeout);
+      finish("keypress:" + codes.join(","));
+    }
+  });
+} else {
+  const removed: string[] = [];
+  emitKeypressEvents(input);
+  process.stdin.on("keypress", () => removed.push("keypress"));
+  process.stdin.on("data", () => removed.push("data"));
+
+  if (scenario === "remove-data") input.removeAllListeners("data");
+  else input.removeAllListeners();
+
+  process.stdin.on("data", () => {
+    clearTimeout(timeout);
+    finish(scenario + ":" + (removed.join(",") || "none"));
+  });
+}
+
+console.log("READY");


### PR DESCRIPTION
## Summary

Fixes the split process.stdin implementation so runtime object methods and node:readline use one ordered fd-0 reader. This restores cooked and piped keypress events and makes removeAllListeners clear stdin listeners like Node.

## Changes

- Make perry-runtime the sole physical fd-0 reader and hand buffered/live input to readline in order.
- Migrate listeners registered before readline initializes into its canonical registry.
- Implement process.stdin.removeAllListeners([event]) across the runtime, readline, and keypress-emitter registries.
- Parse cooked input into logical keypress units while preserving raw escape-sequence behavior.
- Add a Node-compared pipe, cooked PTY, and raw PTY regression matrix for both initialization orders.
- Preserve large-pipe chunking and defer EOF until all handed-off input is dispatched.

## Related issue

Closes #9692

## Test plan

- [ ] cargo build --release clean
- [ ] cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows passes
- [x] (if user-facing) Added or updated a test under test-files/ or a #[test] in the affected crate
- [x] (if CLI / stdlib / runtime API changed) Updated docs/src/ — not needed; this fixes existing Node-compatible APIs
- [x] (if touching a platform UI backend) Built -p perry-ui-<backend> locally on that platform — not applicable

Remote verification on perrymaster.skelpo.net:

- cargo check for perry-runtime, perry-stdlib, and perry
- CI-shaped Clippy checks for the Perry binary and affected libraries
- perry-runtime library tests: 3069 passed, 4 ignored
- perry-stdlib library tests: 128 passed
- issue #9692 Node/Perry parity matrix: all 18 pipe, cooked PTY, and raw PTY combinations passed
- adjacent stdin lifecycle regression tests, including #9676
- #9489 large-pipe and trickle-input regression fixture
- scripts/pre-tag-check.sh --quick
- complete script-only lint mirror: all 62 applicable gates passed; 2 CI-only gates skipped
- test registration and changeset fragment checks

## Screenshots / output

The Node/Perry matrix passes all 18 combinations: three behaviors × two initialization orders × pipe/cooked PTY/raw PTY.

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose feat: / fix: / docs: / chore: prefix convention used in the log
- [x] I've read CONTRIBUTING.md and agree to the Code of Conduct


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coordination between `process.stdin` and `node:readline` input handling.
  * Fixed keypress delivery for cooked and piped input.
  * Improved listener removal reliability, including `removeAllListeners()`.
  * Prevented buffered input from being lost and ensured EOF is processed after pending data.

* **Tests**
  * Added regression coverage across piped, cooked-terminal, and raw-terminal input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->