### PR TITLE
fix(runtime): decide bare managed receivers at the dispatch tower's entry

### DIFF
--- a/changelog.d/9698-bare-receiver-entry-decision.md
+++ b/changelog.d/9698-bare-receiver-entry-decision.md
@@ -1,0 +1,119 @@
+**A dynamic method call on a *bare* managed receiver — a real GC pointer whose
+value was never NaN-boxed — was rooted under a tag the collector ignores, and
+reboxed as an object even when it was a string.** `js_native_call_method` did
+recover the shape, but only in the last few lines of the ~1200-line dispatch
+tower and only ever as `POINTER_TAG`. Three defects followed, and a `.slice`
+on a value that must be a string is what they surface as (#9675).
+
+**1. The receiver was not a root.** The tower parks its receiver in a
+`RuntimeHandleSlot::Nanbox` via `RuntimeHandleScope::root_nanbox_f64`. That slot
+kind is marked by `gc::try_mark_value` and rewritten by
+`gc::try_rewrite_nanboxed_value`, and *both* begin by rejecting any word whose
+tag is not `POINTER_TAG`/`STRING_TAG`/`BIGINT_TAG`. A bare pointer's tag is
+zero, so rooting one there neither **marks** the receiver — a full mark-sweep
+inside dispatch can reap it — nor **rewrites** the slot — an evacuating minor
+leaves it holding a from-space address. This is #6910's hole re-opened in a
+different registry: that issue fixed exactly this mismatch for shadow-stack and
+global-root slots (`gc/tests/root_words.rs` pins it, "bare address" included),
+and the transient-handle registry's nanbox slot kind was never converted.
+#7528's fix — re-read the root slot at every use instead of caching a local —
+is necessary but not sufficient here, because re-reading a slot the collector
+never rewrote returns the same stale address.
+
+**2. Strings and BigInts came back as objects.** `JSValue::pointer` stamps
+`POINTER_TAG` unconditionally. `string_methods::dispatch_string` gates on
+`is_any_string()`, which accepts only `STRING_TAG`/`SHORT_STRING_TAG` — so a
+bare `GC_TYPE_STRING` receiver was reboxed into something that is not a string
+and `.slice` never reached the string arm.
+
+**3. No forwarding walk.** A bare receiver a collection had already moved was
+reboxed at its from-space address.
+
+**4. And the mirror image: an unvouched bare word was still read as a pointer,
+and faulted.** A genuine positive subnormal double has bits that look like an
+address — `1e-310` is `0x1268_8b70_e62b`, above the handle band and inside
+`is_valid_obj_ptr`'s platform window. The tower's probes are magnitude-gated:
+`try_read_gc_header` classifies by address range and then dereferences
+`addr - GC_HEADER_SIZE`, a contract written for a *stale* heap address, where
+the page is still mapped. An arbitrary number is not a stale address; nothing
+was ever mapped there. So `(1e-310 as any).toString()` **SIGSEGV'd** inside
+`url::search_params::shape_is_url_search_params` — a probe that is itself
+careful (it gates on `try_read_gc_header` precisely so a `Date` cell cannot
+fault it) and simply cannot tell a number from an address. Node prints
+`1e-310`. A smaller subnormal aliases the *handle* band instead: `5e-324` is
+`0x1`, so the handle dispatcher answered it and `(5e-324 as any).toString()`
+returned `undefined` where node returns `"5e-324"`. Both were found while
+validating this change, both reproduce on unfixed `main`, and both are fixed
+here — the backtrace was taken rather than assumed, and it named a probe
+nobody would have guessed.
+
+`canonicalize_bare_gc_receiver` now runs as the first statement of
+`js_native_call_method`, before the root and before the first probe. The gate is
+**allocator ownership, not address magnitude**:
+`value::addr_class::try_read_tracked_gc_header` requires arena page membership
+or an exact malloc-registry hit, plus a valid `obj_type`/`size`/arena-flag
+triple, before the first header byte is touched. Forwarding is then followed
+through `value::resolve_forwarding`, and the tag is chosen from the resolved
+header: `STRING_TAG` for `GC_TYPE_STRING`, `BIGINT_TAG` for `GC_TYPE_BIGINT`,
+`POINTER_TAG` otherwise. `GC_TYPE_STRING` is also what `alloc_symbol`
+gc_mallocs, so the string arm carries the same `SYMBOL_MAGIC` content screen
+`gc_pointer_and_type_from_value` uses — a fresh `Symbol()` keeps `POINTER_TAG`,
+which is how symbols are boxed.
+
+The allocator is not the only owner that can answer without touching memory, so
+the gate also asks the address-keyed registries that own **headerless**
+allocations — a `Symbol.for` symbol, an `ArrayBuffer`/`Uint8Array` backing
+store, a typed array. Those have no `GcHeader` for the allocator gate to find,
+are boxed as POINTERs, and are exactly the case the old tail recovery
+legitimately served. Each is a table lookup behind an idle latch, and each is
+already consulted by `gc_pointer_and_type_from_value` for the same reason.
+
+Once every owner has been asked and declined, the word is *definitively not a
+managed pointer*, so it is the number its bits spell and
+`dispatch_unvouched_bare_as_number` answers it there and then — it never reaches
+a pointer-shaped probe. Fixing only the probe that happened to fault would have
+been whack-a-mole; every magnitude-gated probe in the tower has the same
+exposure, and CLAUDE.md's "Known-weak areas" records this codebase paying for
+that pattern three times over. Deciding once, at the chokepoint, makes the class
+unreachable instead of fixing its current instance.
+
+That also makes the tower's magnitude-only **tail recovery unreachable**, and it
+is deleted here: it was the last place that treated address magnitude as proof,
+it did neither of the two things the entry now does (correct tag, and a root the
+collector traces), and its one legitimate constituency — headerless registry
+allocations — is served by the vouch set above.
+
+Every NaN-boxed receiver returns from one `bits >> 48` compare, so the ordinary
+dispatch path is unchanged. `+0.0` is deliberately left on the ordinary path: it
+is not address-shaped, so no probe can mistake it for a pointer.
+
+**What the pre-fix path actually did**, measured by flipping the new guard off
+and re-running the tests: `.slice(1)` on a bare managed string receiver did not
+throw — it returned a `POINTER_TAG` value whose payload
+`try_read_tracked_gc_header` does not recognise at all, at a *different address
+on every run*. A wild pointer handed back to codegen, which NaN-unboxes and
+dereferences it. Seven of the eleven new tests fail on that arm; all eleven pass
+with the fix.
+
+`native_call_method/bare_receiver/tests.rs` covers both directions, because the
+second is what keeps a gate like this honest. Reclassification: string →
+`STRING_TAG` (and satisfying the exact `is_any_string()` predicate
+`dispatch_string` gates on), BigInt → `BIGINT_TAG`, plain object/array →
+`POINTER_TAG`, a hand-forwarded receiver → its *current* address, and an
+end-to-end `js_native_call_method(bare, "slice", [1])` returning `"bcdef"`.
+Non-reclassification: genuine positive subnormal doubles whose bits sit squarely
+inside the platform heap window the old tail recovery accepted, a `Box`
+allocation carrying a hand-built `GcHeader`, headerless registry handle ids
+across every band, a fresh `Symbol()`, and twelve NaN-boxed forms returned
+bit-for-bit. Routing: the two subnormals that actually bit (`1e-310`, `5e-324`)
+must reach number dispatch; a `Symbol.for` symbol — asserted in the test to be
+registered *and* not allocator-tracked, so the registry arm is load-bearing
+rather than incidental — must not; neither must any allocator-vouched receiver;
+and `+0.0` must stay on the ordinary path.
+
+Rejected alternative: root the receiver with `root_heap_word_u64` instead, whose
+`HeapWord` slot kind *does* accept bare addresses (that is #6910's fix). One
+line, but it closes only defect 1 — strings would still dispatch as objects and
+a forwarded receiver would still be used at its old address — and it would move
+every ordinary receiver onto the more conservative `try_mark_value_or_raw`
+interior-pointer path on the hot dispatch route.

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -8,6 +8,7 @@
 
 use super::*;
 
+mod bare_receiver;
 mod collection_methods;
 mod common_methods;
 mod disposal;
@@ -26,6 +27,9 @@ mod probe_dispatch_tests;
 mod to_locale_string_tests;
 mod typed_array;
 
+use bare_receiver::{
+    canonicalize_bare_gc_receiver, dispatch_unvouched_bare_as_number, is_unvouched_bare_word,
+};
 use disposal::{
     js_using_check_disposable, try_disposable_stack_method_dispatch, try_symbol_dispose_dispatch,
 };
@@ -1188,6 +1192,27 @@ pub unsafe extern "C-unwind" fn js_native_call_method(
     args_ptr: *const f64,
     args_len: usize,
 ) -> f64 {
+    // #9675: a LEGACY BARE managed receiver — a real GC pointer that was never
+    // NaN-boxed — must be reboxed under its true tag HERE, before the root
+    // below and before the first probe. See `bare_receiver` for why the tail
+    // recovery was too late (an unrooted receiver goes stale mid-dispatch) and
+    // too coarse (its unconditional POINTER_TAG hid strings from
+    // `dispatch_string`). Every NaN-boxed receiver returns from one compare.
+    let object = canonicalize_bare_gc_receiver(object);
+    // #9675: no owner claimed it, so it is not a managed pointer — it is the
+    // number its bits spell. Answer it here rather than letting ~1200 lines of
+    // magnitude-gated probes dereference it: `1e-310` is `0x1268_8b70_e62b`,
+    // address-shaped enough for `try_read_gc_header` to deref `addr - 8` and
+    // SIGSEGV, and `5e-324` is `0x1`, which the handle dispatcher answered.
+    if is_unvouched_bare_word(object) {
+        return dispatch_unvouched_bare_as_number(
+            object,
+            method_name_ptr,
+            method_name_len,
+            args_ptr,
+            args_len,
+        );
+    }
     if !method_name_ptr.is_null() && method_name_len > 0 {
         let method_name_bytes =
             std::slice::from_raw_parts(method_name_ptr as *const u8, method_name_len);
@@ -2388,30 +2413,14 @@ pub unsafe extern "C-unwind" fn js_native_call_method(
             }
         }
     }
-    // A BARE heap pointer — a real object whose value was never NaN-boxed, so its
-    // top 16 bits are zero and it decodes as a denormal double. Classifying it as a
-    // "number" here throws `<method> is not a function` on a perfectly good object.
-    // Validate deref-free (above the handle band + a genuinely tracked allocation),
-    // rebox as a POINTER_TAG value and dispatch on the object it actually is.
-    // Perry already recovers bare pointers on other dispatch paths; this one threw
-    // before it ever got the chance.
-    if jsval().is_number() && (jsval().bits() >> 48) == 0 {
-        let raw = jsval().bits() as usize;
-        if crate::value::addr_class::is_above_handle_band(raw)
-            && crate::value::addr_class::is_valid_obj_ptr(raw as *const u8)
-        {
-            let reboxed = crate::value::JSValue::pointer(raw as *const u8);
-            if reboxed.bits() != jsval().bits() {
-                return js_native_call_method(
-                    f64::from_bits(reboxed.bits()),
-                    method_name_ptr,
-                    method_name_len,
-                    args_ptr,
-                    args_len,
-                );
-            }
-        }
-    }
+    // #9675: the BARE-heap-pointer recovery that used to sit here is gone. It
+    // reboxed any word whose magnitude looked like a heap address, which is what
+    // let a genuine subnormal double be dispatched as an object. Both halves of
+    // that decision now live at this function's ENTRY, where an owner is asked
+    // before the first probe runs: a vouched bare pointer is reboxed under its
+    // true tag AND rooted (this recovery did neither), and an unvouched one is
+    // dispatched as the number it is. Nothing address-shaped reaches this point
+    // any more. See `bare_receiver`.
     let primitive_kind: Option<&'static str> = if jsval().is_any_string() {
         Some("string")
     } else if jsval().is_int32() || jsval().is_number() {

--- a/crates/perry-runtime/src/object/native_call_method/bare_receiver.rs
+++ b/crates/perry-runtime/src/object/native_call_method/bare_receiver.rs
@@ -1,0 +1,233 @@
+//! #9675: canonicalizing a LEGACY BARE managed receiver at the dispatch
+//! tower's entry, before it is rooted and before the first probe.
+//!
+//! A "bare" receiver is a real GC pointer whose value was never NaN-boxed, so
+//! its top 16 bits are zero and it decodes as a positive subnormal double.
+//! Perry still produces this shape — `gc_pointer_and_type_from_value` accepts
+//! it explicitly — and `js_native_call_method` recovered it, but only in the
+//! last few lines of the tower and only ever as `POINTER_TAG`. Three separate
+//! defects followed from that, and this module closes all three by rewriting
+//! the receiver into the tag it actually deserves *at the entry*.
+//!
+//! ## 1. The receiver was rooted under a tag the collector ignores
+//!
+//! The tower roots its receiver with
+//! [`RuntimeHandleScope::root_nanbox_f64`](crate::gc::RuntimeHandleScope::root_nanbox_f64),
+//! which parks it in a `RuntimeHandleSlot::Nanbox`. That slot kind is marked by
+//! `gc::try_mark_value` and rewritten by `gc::try_rewrite_nanboxed_value`, and
+//! **both begin by rejecting any word whose tag is not
+//! `POINTER_TAG`/`STRING_TAG`/`BIGINT_TAG`**. A bare pointer's tag is zero, so
+//! rooting one as a nanbox
+//!
+//! * does not MARK the receiver — a full mark-sweep inside dispatch can reap
+//!   it, and
+//! * does not REWRITE the slot — an evacuating minor inside dispatch leaves it
+//!   holding a from-space address.
+//!
+//! #7528 already established that the tower runs "~1160 more lines across a
+//! dozen probes that allocate" after that root, and made every use re-read the
+//! root slot rather than a local copy. That fix is necessary but not
+//! sufficient: re-reading a slot the collector never rewrote returns the same
+//! stale address. The tail recovery then validates it with magnitude-only
+//! predicates (`is_above_handle_band` + `is_valid_obj_ptr`), which cannot tell
+//! a live address from a stale one, and dispatches on whatever now occupies
+//! those bytes.
+//!
+//! Canonicalizing here means the value the tower roots carries a tag the
+//! collector traces AND rewrites, so the receiver is kept alive and every
+//! `object()` re-read below yields its current address. This is the runtime-side
+//! form of the root-dominance invariant in
+//! `docs/src/internals/gc-rooting-invariant.md`: the static checker reads
+//! emitted LLVM IR and cannot see a mis-tagged runtime root at all.
+//!
+//! ## 2. Strings and BigInts came back as objects
+//!
+//! `JSValue::pointer` stamps `POINTER_TAG` unconditionally. `is_any_string()`
+//! accepts only `STRING_TAG`/`SHORT_STRING_TAG`, and `string_methods::
+//! dispatch_string` gates on exactly that predicate — so a bare `GC_TYPE_STRING`
+//! receiver was reboxed into something that is not a string, `.slice` never
+//! reached the string arm, and the call fell through to the `<m> is not a
+//! function` catch-all on a perfectly good string. `.slice` on a value that
+//! must be a string is the reported symptom of #9675. BigInt had the same
+//! shape via `BIGINT_TAG`.
+//!
+//! ## 3. An already-forwarded receiver was dispatched at its old address
+//!
+//! The tail recovery did no forwarding walk, so a bare receiver that a
+//! collection had already moved was reboxed at its from-space address.
+//!
+//! ## What the gate is, and what it deliberately leaves alone
+//!
+//! Ownership, not address magnitude.
+//! [`try_read_tracked_gc_header`](crate::value::addr_class::try_read_tracked_gc_header)
+//! requires arena page membership or an exact malloc-registry hit, plus a valid
+//! `obj_type`/`size`/arena-flag triple, before the first header byte is
+//! touched. So this path does not reclassify
+//!
+//! * genuine subnormal numbers (including pointer-magnitude bit patterns),
+//! * unrelated non-Perry allocations, even ones carrying synthetic GC headers,
+//! * headerless registry handles and every other handle-band id, or
+//! * any NaN-boxed value at all — one `bits >> 48` compare returns those
+//!   untouched, so the ordinary receiver pays nothing.
+//!
+//! ## 4. An unvouched bare word was still read as a pointer, and faulted
+//!
+//! The mirror image of the above, and the reason this module owns the decision
+//! rather than reboxing opportunistically. A genuine positive subnormal double
+//! has bits that *look* like an address: `1e-310` is `0x1268_8b70_e62b`, which
+//! is above the handle band and inside `is_valid_obj_ptr`'s platform window. The
+//! tower's probes are magnitude-gated — `try_read_gc_header` classifies by
+//! address range and then dereferences `addr - GC_HEADER_SIZE` — and that
+//! contract is written for a STALE heap address, where the page is still
+//! mapped. An arbitrary number is not a stale address; nothing was ever mapped
+//! there. `(1e-310 as any).toString()` therefore SIGSEGV'd inside
+//! `url::search_params::shape_is_url_search_params`, a probe that is itself
+//! careful (it gates on `try_read_gc_header` precisely so a Date cell cannot
+//! fault it) and simply cannot tell a number from an address. Node prints
+//! `1e-310`. A smaller subnormal aliases the *handle* band instead — `5e-324`
+//! is `0x1`, so the handle dispatcher answered it and
+//! `(5e-324 as any).toString()` returned `undefined` where node returns
+//! `"5e-324"`.
+//!
+//! Fixing the one probe that happened to fault would be whack-a-mole: every
+//! magnitude-gated probe in the tower has the same exposure, and this codebase
+//! has paid for that pattern three times over (CLAUDE.md, "Known-weak areas").
+//! The chokepoint is here. Once an owner has been asked and declined, the word
+//! is *definitively not a managed pointer*, so it is the number its bits spell
+//! and [`dispatch_unvouched_bare_as_number`] dispatches it as one — it never
+//! reaches a pointer-shaped probe at all. That makes the whole class
+//! unreachable rather than fixing its current instance.
+//!
+//! Because of that, the tower's magnitude-only tail recovery is now
+//! unreachable for bare words and is deleted with this change: it was the last
+//! place that treated address magnitude as proof.
+
+/// Rebox an allocator-proven bare managed receiver into a properly tagged
+/// NaN-box, following forwarding. Returns `object` unchanged for everything
+/// else. See the module docs for why this must happen before the root.
+#[inline]
+pub(super) unsafe fn canonicalize_bare_gc_receiver(object: f64) -> f64 {
+    let bits = object.to_bits();
+    // Every NaN-boxed value — `INT32_TAG` and `SHORT_STRING_TAG` included — has
+    // non-zero top 16 bits, and 0 is not an address. One compare returns every
+    // ordinary receiver before any probe runs.
+    if bits == 0 || (bits >> 48) != 0 {
+        return object;
+    }
+    let addr = bits as usize;
+    if !bare_word_has_an_owner(addr) {
+        return object;
+    }
+    if crate::value::addr_class::try_read_tracked_gc_header(addr).is_none() {
+        // Vouched for by a header-free registry rather than by the allocator:
+        // there is no `GcHeader` to read a kind out of, and every such
+        // allocation (a `Symbol.for` symbol, a registered buffer, a typed
+        // array) is boxed as a POINTER.
+        return f64::from_bits(
+            crate::value::POINTER_TAG | (addr as u64 & crate::value::POINTER_MASK),
+        );
+    }
+    // A collection may already have moved it; the root taken by the caller is
+    // only useful once it holds the CURRENT address.
+    let resolved = crate::value::resolve_forwarding(addr);
+    let Some(header) = crate::value::addr_class::try_read_tracked_gc_header(resolved) else {
+        // A forwarding target that is no longer a tracked allocation is not
+        // something to dispatch on. Leave the value alone rather than
+        // manufacture a pointer to it.
+        return object;
+    };
+    let tag = match (*header.as_ptr()).obj_type {
+        // `alloc_symbol` gc_mallocs a `SymbolHeader` as `GC_TYPE_STRING`, so the
+        // header alone cannot separate a string from a fresh `Symbol()`. Screen
+        // on the object's own first word the way
+        // `gc_pointer_and_type_from_value` does — `may_be_symbol_header` is
+        // exact in the `false` direction, so a string pays one content load and
+        // a symbol keeps `POINTER_TAG`, which is how symbols are boxed.
+        crate::gc::GC_TYPE_STRING
+            if !(crate::symbol::may_be_symbol_header(resolved as *const u8)
+                && crate::symbol::is_registered_symbol(resolved)) =>
+        {
+            crate::value::STRING_TAG
+        }
+        crate::gc::GC_TYPE_BIGINT => crate::value::BIGINT_TAG,
+        _ => crate::value::POINTER_TAG,
+    };
+    f64::from_bits(tag | (resolved as u64 & crate::value::POINTER_MASK))
+}
+
+/// Can any owner answer for `addr` **without dereferencing it**?
+///
+/// The allocator is the strongest answer (`try_read_tracked_gc_header` proves
+/// arena page membership or an exact malloc-registry hit). The rest are the
+/// address-keyed registries that own allocations carrying no `GcHeader` at all —
+/// a `Symbol.for` symbol, an `ArrayBuffer`/`Uint8Array` backing store, a typed
+/// array. Every one of these is a table lookup behind an idle latch, so a
+/// program that never made one pays a single atomic load; and every one of them
+/// is consulted by `gc_pointer_and_type_from_value` for the same reason.
+///
+/// Nothing here reads memory at `addr`, which is the whole point: this runs on
+/// words that may not be addresses.
+#[inline]
+fn bare_word_has_an_owner(addr: usize) -> bool {
+    let allocator_owns = unsafe { crate::value::addr_class::try_read_tracked_gc_header(addr) };
+    allocator_owns.is_some()
+        || crate::symbol::is_registered_symbol(addr)
+        || crate::buffer::is_registered_buffer(addr)
+        || crate::buffer::is_any_array_buffer(addr)
+        || crate::buffer::is_uint8array_buffer(addr)
+        || crate::typedarray::lookup_typed_array_kind(addr).is_some()
+}
+
+/// True when `object` is still a bare word after
+/// [`canonicalize_bare_gc_receiver`] has run — i.e. no owner claimed it, so it
+/// cannot be a managed pointer.
+///
+/// `+0.0` (all-zero bits) is deliberately excluded: it is not address-shaped,
+/// no probe can mistake it for one, and leaving it on the ordinary path keeps
+/// this change to the words that actually alias addresses.
+#[inline]
+pub(super) fn is_unvouched_bare_word(object: f64) -> bool {
+    let bits = object.to_bits();
+    bits != 0 && (bits >> 48) == 0
+}
+
+/// Dispatch an unvouched bare word as the number its bits spell.
+///
+/// This is what the tower's `primitive_kind` arm would have done for it, minus
+/// the ~1200 lines of pointer-shaped probes in between — any one of which may
+/// dereference the word on nothing more than its magnitude. Reaching the same
+/// answer without them is the fix for defect 4 above.
+#[inline]
+pub(super) unsafe fn dispatch_unvouched_bare_as_number(
+    object: f64,
+    method_name_ptr: *const i8,
+    method_name_len: usize,
+    args_ptr: *const f64,
+    args_len: usize,
+) -> f64 {
+    let method_name_cow = if method_name_ptr.is_null() || method_name_len == 0 {
+        std::borrow::Cow::Borrowed("")
+    } else {
+        let bytes = std::slice::from_raw_parts(method_name_ptr as *const u8, method_name_len);
+        String::from_utf8_lossy(bytes)
+    };
+    let method_name: &str = &method_name_cow;
+    if let Some(result) = super::call_primitive_builtin_prototype_method(
+        object,
+        b"Number",
+        method_name,
+        args_ptr,
+        args_len,
+    ) {
+        return result;
+    }
+    crate::error::js_throw_type_error_not_a_function(
+        b"number".as_ptr(),
+        b"number".len(),
+        method_name.as_ptr(),
+        method_name.len(),
+    )
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/perry-runtime/src/object/native_call_method/bare_receiver/tests.rs
+++ b/crates/perry-runtime/src/object/native_call_method/bare_receiver/tests.rs
@@ -1,0 +1,517 @@
+//! #9675 regression coverage for [`canonicalize_bare_gc_receiver`].
+//!
+//! Two claims, and the second is the one that keeps a fix like this honest:
+//!
+//! * **the reclassification happens** — a bare `GC_TYPE_STRING` receiver comes
+//!   back a STRING, a bare `GC_TYPE_BIGINT` receiver a BIGINT, an ordinary
+//!   managed object a POINTER, an already-forwarded receiver at its CURRENT
+//!   address, and a bare string receiver's dynamic `.slice` returns the sliced
+//!   string instead of throwing;
+//! * **nothing else is reclassified** — genuine subnormal doubles whose bits sit
+//!   squarely in the heap-address range, unrelated allocations carrying
+//!   synthetic GC headers, headerless registry handles, a fresh `Symbol()`
+//!   (which is itself a `GC_TYPE_STRING` allocation), and every NaN-boxed value
+//!   are returned bit-for-bit unchanged — and a word nothing vouched for is
+//!   routed to NUMBER dispatch, so no magnitude-gated probe can dereference it.
+//!
+//! Without the second half this file would pass with the gate widened to "any
+//! address-shaped word", which is exactly the mistake the magnitude-only tail
+//! recovery makes.
+
+use super::*;
+use crate::gc::{GcHeader, GC_FLAG_FORWARDED, GC_HEADER_SIZE};
+use crate::value::{JSValue, BIGINT_TAG, POINTER_MASK, POINTER_TAG, STRING_TAG, TAG_MASK};
+
+/// Encode `addr` the way a managed pointer looks when it was never NaN-boxed:
+/// the raw address, top 16 bits zero. This is the shape
+/// `gc_pointer_and_type_from_value` already accepts and the shape
+/// `js_native_call_method` classified as a "number".
+fn bare(addr: usize) -> f64 {
+    f64::from_bits(addr as u64)
+}
+
+/// Every test below is vacuous unless the receiver really is bare-encodable on
+/// this host, and unless a bare word really does carry the zero tag that both
+/// `try_mark_value` and `try_rewrite_nanboxed_value` reject (see
+/// `gc/tests/root_words.rs`, #6910 — the same hole, in the shadow/global
+/// registries).
+fn assert_bare_premise(addr: usize, what: &str) {
+    assert!(addr != 0, "test premise: {what} allocated");
+    assert_eq!(
+        (addr as u64) >> 48,
+        0,
+        "test premise: {what} must be representable as a bare receiver on this \
+         host (top 16 bits zero)"
+    );
+    assert_eq!(
+        bare(addr).to_bits() & TAG_MASK,
+        0,
+        "test premise: a bare receiver's tag is zero, which is why a `Nanbox` \
+         root slot holding one is neither marked nor rewritten"
+    );
+}
+
+fn tag_of(value: f64) -> u64 {
+    value.to_bits() & TAG_MASK
+}
+
+fn payload_of(value: f64) -> usize {
+    (value.to_bits() & POINTER_MASK) as usize
+}
+
+unsafe fn rust_string(header: *const crate::StringHeader) -> String {
+    let bytes = std::slice::from_raw_parts(
+        crate::string::string_data(header),
+        (*header).byte_len as usize,
+    );
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+unsafe fn header_of(addr: usize) -> *mut GcHeader {
+    (addr - GC_HEADER_SIZE) as *mut GcHeader
+}
+
+// ---------------------------------------------------------------------------
+// The reclassification happens.
+// ---------------------------------------------------------------------------
+
+/// The #9675 shape. `string_methods::dispatch_string` gates on
+/// `is_any_string()`, which accepts only `STRING_TAG`/`SHORT_STRING_TAG` — so
+/// the tail recovery's unconditional `JSValue::pointer` rebox produced a
+/// receiver that is not a string, `.slice` never reached the string arm, and
+/// the call fell through to the `<m> is not a function` catch-all.
+#[test]
+fn bare_gc_string_receiver_is_canonicalized_to_string_tag() {
+    let header = crate::string::js_string_from_str("abcdef");
+    let addr = header as usize;
+    assert_bare_premise(addr, "a GC string");
+
+    let canonical = unsafe { canonicalize_bare_gc_receiver(bare(addr)) };
+    assert_eq!(
+        tag_of(canonical),
+        STRING_TAG,
+        "a bare GC_TYPE_STRING receiver must be reboxed with STRING_TAG"
+    );
+    assert_eq!(
+        payload_of(canonical),
+        addr,
+        "payload must be the same object"
+    );
+    assert!(
+        JSValue::from_bits(canonical.to_bits()).is_any_string(),
+        "the canonical receiver must satisfy the exact predicate \
+         `string_methods::dispatch_string` gates on"
+    );
+
+    // What the tail recovery produced instead, stated so the reason this test
+    // exists cannot be lost: same object, wrong kind.
+    let as_the_tail_reboxed_it = f64::from_bits(JSValue::pointer(addr as *const u8).bits());
+    assert!(
+        !JSValue::from_bits(as_the_tail_reboxed_it.to_bits()).is_any_string(),
+        "premise of the bug: an unconditional POINTER_TAG rebox of a GC string \
+         is not a string, so `.slice` cannot dispatch"
+    );
+}
+
+/// The user-visible statement: a dynamic `.slice` on a bare managed string
+/// receiver returns the sliced string.
+#[test]
+fn bare_gc_string_receiver_dispatches_slice_as_a_string() {
+    let header = crate::string::js_string_from_str("abcdef");
+    let addr = header as usize;
+    assert_bare_premise(addr, "a GC string");
+
+    let args = [1.0f64];
+    let result = unsafe {
+        crate::object::js_native_call_method(
+            bare(addr),
+            b"slice".as_ptr() as *const i8,
+            5,
+            args.as_ptr(),
+            args.len(),
+        )
+    };
+    assert!(
+        JSValue::from_bits(result.to_bits()).is_any_string(),
+        "`.slice(1)` on a bare managed string receiver must return a string"
+    );
+    let out = crate::value::js_get_string_pointer_unified(result) as *const crate::StringHeader;
+    assert!(!out.is_null(), "the returned string must be readable");
+    assert_eq!(unsafe { rust_string(out) }, "bcdef");
+}
+
+#[test]
+fn bare_gc_bigint_receiver_is_canonicalized_to_bigint_tag() {
+    let mut limbs = [0u64; crate::bigint::BIGINT_LIMBS];
+    limbs[0] = 42;
+    let addr = crate::bigint::bigint_alloc_with_limbs(limbs) as usize;
+    assert_bare_premise(addr, "a GC BigInt");
+
+    let canonical = unsafe { canonicalize_bare_gc_receiver(bare(addr)) };
+    assert_eq!(
+        tag_of(canonical),
+        BIGINT_TAG,
+        "a bare GC_TYPE_BIGINT receiver must be reboxed with BIGINT_TAG"
+    );
+    assert_eq!(payload_of(canonical), addr);
+    assert!(JSValue::from_bits(canonical.to_bits()).is_bigint());
+}
+
+#[test]
+fn bare_gc_object_receiver_is_canonicalized_to_pointer_tag() {
+    let addr = crate::object::js_object_alloc(0, 4) as usize;
+    assert_bare_premise(addr, "a plain managed object");
+
+    let canonical = unsafe { canonicalize_bare_gc_receiver(bare(addr)) };
+    assert_eq!(
+        tag_of(canonical),
+        POINTER_TAG,
+        "an ordinary managed receiver keeps POINTER_TAG — the tag it always had"
+    );
+    assert_eq!(payload_of(canonical), addr);
+}
+
+/// The tail recovery did no forwarding walk, so a receiver a collection had
+/// already moved was reboxed at its from-space address and dispatched there.
+#[test]
+fn bare_receiver_canonicalization_follows_forwarding() {
+    let from = crate::string::js_string_from_str("abcdef") as usize;
+    let to = crate::string::js_string_from_str("uvwxyz") as usize;
+    assert_bare_premise(from, "the from-space GC string");
+    assert_bare_premise(to, "the to-space GC string");
+    assert_ne!(from, to, "test premise: two distinct allocations");
+
+    unsafe {
+        let header = header_of(from);
+        crate::gc::set_forwarding_address(header, to as *mut u8);
+        (*header).gc_flags |= GC_FLAG_FORWARDED;
+    }
+
+    let canonical = unsafe { canonicalize_bare_gc_receiver(bare(from)) };
+    assert_eq!(
+        payload_of(canonical),
+        to,
+        "a forwarded bare receiver must canonicalize to its CURRENT address, \
+         not the from-space one the tail recovery used"
+    );
+    assert_eq!(tag_of(canonical), STRING_TAG);
+
+    unsafe {
+        (*header_of(from)).gc_flags &= !GC_FLAG_FORWARDED;
+    }
+}
+
+/// The canonical receiver's whole purpose is to be rootable: the tower parks it
+/// in a `RuntimeHandleSlot::Nanbox`, and that slot kind is marked by
+/// `try_mark_value` and rewritten by `try_rewrite_nanboxed_value`, both of
+/// which accept exactly `POINTER_TAG`/`STRING_TAG`/`BIGINT_TAG` and reject
+/// everything else.
+#[test]
+fn every_canonical_receiver_carries_a_tag_the_collector_traces() {
+    let mut limbs = [0u64; crate::bigint::BIGINT_LIMBS];
+    limbs[0] = 7;
+    let candidates = [
+        (
+            "string",
+            crate::string::js_string_from_str("abcdef") as usize,
+        ),
+        (
+            "bigint",
+            crate::bigint::bigint_alloc_with_limbs(limbs) as usize,
+        ),
+        ("object", crate::object::js_object_alloc(0, 4) as usize),
+        ("array", crate::array::js_array_alloc(4) as usize),
+    ];
+    for (what, addr) in candidates {
+        assert_bare_premise(addr, what);
+        let canonical = unsafe { canonicalize_bare_gc_receiver(bare(addr)) };
+        assert!(
+            matches!(tag_of(canonical), POINTER_TAG | STRING_TAG | BIGINT_TAG),
+            "{what}: a bare receiver must be reboxed under a tag a `Nanbox` root \
+             slot is marked and rewritten through; a zero tag is dropped by both \
+             passes (#6910's hole, re-opened in the transient-handle registry)"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Nothing else is reclassified.
+// ---------------------------------------------------------------------------
+
+/// Address magnitude is not evidence of anything. These are genuine positive
+/// subnormal doubles whose bit patterns sit squarely inside the platform heap
+/// window the tail recovery's `is_valid_obj_ptr` accepts.
+#[test]
+fn pointer_magnitude_subnormal_numbers_are_not_reclassified() {
+    for bits in [
+        0x1000u64,
+        0x0010_0000,
+        0x0000_5555_5555_5555,
+        0x0000_7fff_ffff_f000,
+        0x0000_0001_0000_0008,
+        1,
+        0,
+    ] {
+        let value = f64::from_bits(bits);
+        assert!(
+            JSValue::from_bits(bits).is_number(),
+            "test premise: {bits:#x} decodes as a number, so the tower would \
+             report it as `(number)`"
+        );
+        let out = unsafe { canonicalize_bare_gc_receiver(value) };
+        assert_eq!(
+            out.to_bits(),
+            bits,
+            "{bits:#x} is owned by nothing and must be returned bit-for-bit \
+             unchanged"
+        );
+    }
+}
+
+/// An unrelated allocation with a hand-built `GcHeader` in front of it passes
+/// every magnitude test and every header-content test. Only allocator
+/// ownership rejects it.
+#[test]
+fn unrelated_allocations_with_synthetic_headers_are_not_reclassified() {
+    #[repr(C)]
+    struct Synthetic {
+        header: GcHeader,
+        payload: [u64; 4],
+    }
+
+    let synthetic = Box::new(Synthetic {
+        header: GcHeader {
+            obj_type: crate::gc::GC_TYPE_STRING,
+            gc_flags: 0,
+            _reserved: 0,
+            size: std::mem::size_of::<Synthetic>() as u32,
+        },
+        payload: [0; 4],
+    });
+    let user = &synthetic.payload as *const [u64; 4] as usize;
+    assert_bare_premise(user, "a non-Perry allocation");
+
+    let out = unsafe { canonicalize_bare_gc_receiver(bare(user)) };
+    assert_eq!(
+        out.to_bits(),
+        user as u64,
+        "a `Box` allocation is owned by neither the arena nor the GC malloc \
+         registry, so it must not be reboxed as a managed receiver"
+    );
+}
+
+/// Registry handles (timers, sockets, zlib streams, proxies, …) are small ids
+/// with no header at all. Dereferencing one is the #4665/#4800 SIGSEGV.
+#[test]
+fn headerless_registry_handles_are_not_reclassified() {
+    for id in [1u64, 0x1008, 0x1_0000, 0x4_0000, 0xF_0000, 0xF_FFF8] {
+        let out = unsafe { canonicalize_bare_gc_receiver(f64::from_bits(id)) };
+        assert_eq!(
+            out.to_bits(),
+            id,
+            "handle id {id:#x} must be returned unchanged, without a header read"
+        );
+    }
+}
+
+/// `alloc_symbol` gc_mallocs a `SymbolHeader` as `GC_TYPE_STRING`, so the
+/// header alone would call a fresh `Symbol()` a string. Tagging one STRING_TAG
+/// would hand `js_get_string_pointer_unified` a `SymbolHeader` to read as text.
+#[test]
+fn a_fresh_symbol_receiver_keeps_pointer_tag() {
+    let addr = unsafe { crate::value::js_nanbox_get_pointer(crate::symbol::js_symbol_new_empty()) }
+        as usize;
+    assert_bare_premise(addr, "a fresh Symbol()");
+    assert!(
+        unsafe { crate::symbol::may_be_symbol_header(addr as *const u8) },
+        "test premise: a symbol carries SYMBOL_MAGIC in its first word; without \
+         it this test cannot distinguish the symbol screen from its absence"
+    );
+
+    let canonical = unsafe { canonicalize_bare_gc_receiver(bare(addr)) };
+    assert_eq!(
+        tag_of(canonical),
+        POINTER_TAG,
+        "a fresh Symbol() is a GC_TYPE_STRING allocation but is boxed as a \
+         POINTER; the SYMBOL_MAGIC screen is what keeps it out of the string arm"
+    );
+    assert_eq!(payload_of(canonical), addr);
+}
+
+/// Defect 4. A word no owner claims is not a pointer, so the tower must answer
+/// it as a number instead of handing it to probes that classify by address
+/// magnitude and then dereference `addr - GC_HEADER_SIZE`.
+///
+/// These are the two shapes that actually bit. `1e-310` is `0x1268_8b70_e62b`:
+/// above the handle band, inside `is_valid_obj_ptr`'s window, and unmapped —
+/// `(1e-310 as any).toString()` SIGSEGV'd in
+/// `url::search_params::shape_is_url_search_params`. `5e-324` is `0x1`, which
+/// aliases the handle band instead, and the handle dispatcher answered it with
+/// `undefined`. Node prints `1e-310` and `5e-324`.
+#[test]
+fn address_shaped_subnormals_route_to_number_dispatch() {
+    for (label, bits) in [
+        ("1e-310 (heap-magnitude alias)", 1e-310f64.to_bits()),
+        ("5e-324 (handle-band alias)", 5e-324f64.to_bits()),
+        ("the largest bare-shaped word", 0x0000_FFFF_FFFF_FFFFu64),
+        ("mid-range bare-shaped word", 0x0000_5555_5555_5555u64),
+    ] {
+        let value = f64::from_bits(bits);
+        assert_eq!(
+            (bits >> 48),
+            0,
+            "test premise: {label} is a bare-shaped word, or it cannot alias an \
+             address at all"
+        );
+        assert!(
+            is_unvouched_bare_word(unsafe { canonicalize_bare_gc_receiver(value) }),
+            "{label}: no owner may claim a genuine subnormal double — if one \
+             does, it is about to be dereferenced as an object"
+        );
+    }
+}
+
+/// The boundary, and why the routing arm can be this narrow. Only a word whose
+/// bits are BELOW 2^48 is address-shaped, so only those reach a bare-pointer
+/// arm. A subnormal near the top of its range — `2.2e-308` is
+/// `bits >> 48 == 15` — is not bare-shaped, and
+/// `as_pointer()` masking cannot expose it either: every probe that masks is
+/// gated on `is_pointer()`, and its tag is not `POINTER_TAG`. It therefore stays
+/// on the ordinary path, which is where it already behaved correctly.
+///
+/// This test exists because the first version of the routing test above asserted
+/// `2.2e-308` WAS bare-shaped and went red on its own premise.
+#[test]
+fn subnormals_above_the_bare_shaped_range_stay_on_the_ordinary_path() {
+    for (label, value) in [
+        ("2.2e-308", 2.2e-308f64),
+        ("f64::MIN_POSITIVE", f64::MIN_POSITIVE),
+        ("1e-300", 1e-300f64),
+    ] {
+        let bits = value.to_bits();
+        assert_ne!(
+            bits >> 48,
+            0,
+            "test premise: {label} must NOT be bare-shaped, or this test is \
+             asserting the wrong side of the boundary"
+        );
+        assert!(
+            !JSValue::from_bits(bits).is_pointer(),
+            "{label}: not POINTER_TAG, so no `as_pointer()`-masking probe can \
+             reach it as an address"
+        );
+        let out = unsafe { canonicalize_bare_gc_receiver(value) };
+        assert_eq!(out.to_bits(), bits, "{label} must be returned unchanged");
+        assert!(
+            !is_unvouched_bare_word(out),
+            "{label} must not be routed to number dispatch — it was never \
+             address-shaped"
+        );
+    }
+}
+
+/// The other direction of the same predicate: a real managed allocation must
+/// NOT be routed to number dispatch, or every bare receiver starts throwing.
+#[test]
+fn vouched_bare_receivers_are_not_routed_to_number_dispatch() {
+    let mut limbs = [0u64; crate::bigint::BIGINT_LIMBS];
+    limbs[0] = 3;
+    let candidates = [
+        (
+            "string",
+            crate::string::js_string_from_str("abcdef") as usize,
+        ),
+        (
+            "bigint",
+            crate::bigint::bigint_alloc_with_limbs(limbs) as usize,
+        ),
+        ("object", crate::object::js_object_alloc(0, 4) as usize),
+        ("array", crate::array::js_array_alloc(4) as usize),
+    ];
+    for (what, addr) in candidates {
+        assert_bare_premise(addr, what);
+        let canonical = unsafe { canonicalize_bare_gc_receiver(bare(addr)) };
+        assert!(
+            !is_unvouched_bare_word(canonical),
+            "{what}: the allocator vouched for this address, so it must reach \
+             the dispatch tower, not the number arm"
+        );
+    }
+}
+
+/// `+0.0` is not address-shaped and no probe can mistake it for a pointer, so it
+/// deliberately stays on the ordinary path — this change is scoped to the words
+/// that actually alias addresses.
+#[test]
+fn positive_zero_is_not_routed_to_number_dispatch() {
+    assert!(!is_unvouched_bare_word(0.0f64));
+}
+
+/// A headerless registry allocation has no `GcHeader` for the allocator gate to
+/// find, but its owning registry can answer for the address without touching
+/// memory. Such a receiver must be reboxed as a POINTER, not sent to the number
+/// arm — that is the case the deleted tail recovery legitimately served.
+#[test]
+fn headerless_registry_allocations_are_vouched_as_pointers() {
+    // `Symbol.for` leaks a `Box` with no GcHeader; a unique key guarantees this
+    // thread allocates and registers it (see `probe_dispatch_tests`).
+    let key = crate::string::js_string_from_str("perry-9675-vouch");
+    let key_f64 = f64::from_bits(crate::value::js_nanbox_string(key as i64).to_bits());
+    let addr = unsafe { crate::value::js_nanbox_get_pointer(crate::symbol::js_symbol_for(key_f64)) }
+        as usize;
+    assert_bare_premise(addr, "a Symbol.for symbol");
+    assert!(
+        crate::symbol::is_registered_symbol(addr),
+        "test premise: Symbol.for registered on this thread; otherwise no owner \
+         can vouch and this test proves nothing"
+    );
+    assert!(
+        unsafe { crate::value::addr_class::try_read_tracked_gc_header(addr) }.is_none(),
+        "test premise: a Box-leaked symbol is NOT an allocator-tracked \
+         allocation — that is what makes the registry arm load-bearing"
+    );
+
+    let canonical = unsafe { canonicalize_bare_gc_receiver(bare(addr)) };
+    assert!(
+        !is_unvouched_bare_word(canonical),
+        "a registered symbol must be vouched for, not dispatched as a number"
+    );
+    assert_eq!(
+        tag_of(canonical),
+        POINTER_TAG,
+        "a headerless registry allocation has no GcHeader to read a kind from \
+         and is boxed as a POINTER"
+    );
+    assert_eq!(payload_of(canonical), addr);
+}
+
+/// The ordinary path pays one compare. Every NaN-boxed receiver — including
+/// `INT32_TAG`, which shares its high half with nothing else, and a real
+/// pointer, which is already canonical — comes back untouched.
+#[test]
+fn nanboxed_receivers_are_returned_unchanged() {
+    let object = crate::object::js_object_alloc(0, 4) as usize;
+    let string = crate::string::js_string_from_str("hello") as usize;
+    let probes = [
+        ("undefined", crate::value::TAG_UNDEFINED),
+        ("null", crate::value::TAG_NULL),
+        ("true", crate::value::TAG_TRUE),
+        ("false", crate::value::TAG_FALSE),
+        ("int32 0", crate::value::INT32_TAG),
+        ("int32 42", crate::value::INT32_TAG | 42),
+        ("double 3.5", 3.5f64.to_bits()),
+        ("double -1.0", (-1.0f64).to_bits()),
+        ("double 1e300", 1e300f64.to_bits()),
+        ("nan", f64::NAN.to_bits()),
+        ("pointer", POINTER_TAG | object as u64),
+        ("string", STRING_TAG | string as u64),
+    ];
+    for (what, bits) in probes {
+        let out = unsafe { canonicalize_bare_gc_receiver(f64::from_bits(bits)) };
+        assert_eq!(
+            out.to_bits(),
+            bits,
+            "{what} is already NaN-boxed and must be returned unchanged"
+        );
+    }
+}


### PR DESCRIPTION
Closes #9675.

## What this is, and what it is not

#9675 reports `(number).slice is not a function` from a "Yes, and save this"
permission dialog in a large minified CLI compiled with Perry. That message is
emitted from exactly one place — the *dynamic* dispatch tower in
`native_call_method.rs` — and the issue's own follow-up comment narrowed it to
"a genuine number, or a stale/unrecoverable bare pointer", having cleared 45
receiver shapes and every rule-persisting dialog empirically.

This PR fixes the second half of that disjunction, and it does not claim to have
replayed the reporter's session. What it does claim, with an A/B on this
machine, is that the tower's handling of a *bare* receiver was broken in four
independent ways, one of which is a plain SIGSEGV reachable from one line of
TypeScript. All four are closed by moving one decision to one place.

A "bare" receiver is a real GC pointer whose value was never NaN-boxed, so its
top 16 bits are zero and it decodes as a positive subnormal double. Perry still
produces the shape — `gc_pointer_and_type_from_value` accepts it explicitly —
and the tower recovered it, but only in its last few lines and only ever as
`POINTER_TAG`.

## The four defects

**1. The receiver was not a root.** The tower parks it in a
`RuntimeHandleSlot::Nanbox` via `root_nanbox_f64`. That slot kind is marked by
`gc::try_mark_value` and rewritten by `gc::try_rewrite_nanboxed_value`, and
*both* begin by rejecting any word whose tag is not
`POINTER_TAG`/`STRING_TAG`/`BIGINT_TAG`. A bare pointer's tag is zero, so
rooting one there neither **marks** the receiver (a mark-sweep inside dispatch
can reap it) nor **rewrites** the slot (an evacuating minor leaves it on a
from-space address).

This is #6910's hole re-opened in a different registry. That issue fixed exactly
this mark/rewrite mismatch for shadow-stack and global-root slots —
`gc/tests/root_words.rs` still pins it, "bare address" included — and the
transient-handle registry's nanbox slot kind was never converted. #7528's fix
(re-read the root slot at every use rather than caching a local, because the
collector rewrites the slot and not the copy) is necessary but not sufficient
here: re-reading a slot the collector never rewrote returns the same stale
address.

**2. Strings and BigInts came back as objects.** `JSValue::pointer` stamps
`POINTER_TAG` unconditionally. `string_methods::dispatch_string` gates on
`is_any_string()`, which accepts only `STRING_TAG`/`SHORT_STRING_TAG` — so a
bare `GC_TYPE_STRING` receiver was reboxed into something that is not a string,
and `.slice` never reached the string arm.

**3. No forwarding walk.** A bare receiver a collection had already moved was
reboxed at its from-space address.

**4. The mirror image: an unvouched word was still read as a pointer, and
faulted.** A genuine positive subnormal double has bits that look like an
address. `1e-310` is `0x1268_8b70_e62b` — above the handle band, inside
`is_valid_obj_ptr`'s platform window, and unmapped. The tower's probes are
magnitude-gated: `try_read_gc_header` classifies by address *range* and then
dereferences `addr - GC_HEADER_SIZE`, a contract written for a **stale** heap
address, where the page is still mapped. An arbitrary number is not a stale
address; nothing was ever mapped there.

```ts
const n: number = 1e-310;
console.log((n as any).toString());   // node: "1e-310"   perry: SIGSEGV
```

```
Program received signal SIGSEGV, Segmentation fault.
#0  perry_runtime::url::search_params::shape_is_url_search_params ()
#1  js_native_call_method ()
rdi  0x12688b70e62b        <- the double's bits, as an address
```

`shape_is_url_search_params` is itself careful — it gates on
`try_read_gc_header` precisely so a `Date` cell cannot fault it — and simply
cannot tell a number from an address. A smaller subnormal aliases the *handle*
band instead: `5e-324` is `0x1`, so the handle dispatcher answered it and
`(5e-324 as any).toString()` returned `undefined` where node returns
`"5e-324"`.

I took that backtrace rather than assuming one, and it named a probe I would not
have guessed — the fix I had written first was aimed at the wrong block.

## The fix

`canonicalize_bare_gc_receiver` runs as the **first statement** of
`js_native_call_method`, before the root and before any probe. It asks whether
an owner can answer for the word **without dereferencing it**:

- the allocator answers strongest — `try_read_tracked_gc_header` requires arena
  page membership or an exact malloc-registry hit, plus a valid
  `obj_type`/`size`/arena-flag triple, before the first header byte is touched;
- the address-keyed registries answer for **headerless** allocations — a
  `Symbol.for` symbol, an `ArrayBuffer`/`Uint8Array` backing store, a typed
  array. These have no `GcHeader` at all, are boxed as POINTERs, and are exactly
  the constituency the old tail recovery legitimately served. Each is a table
  lookup behind an idle latch, and each is already consulted by
  `gc_pointer_and_type_from_value` for the same reason.

A **vouched** receiver is reboxed under its true tag, through
`resolve_forwarding`, with the tag taken from the resolved header:
`STRING_TAG` for `GC_TYPE_STRING`, `BIGINT_TAG` for `GC_TYPE_BIGINT`,
`POINTER_TAG` otherwise. `alloc_symbol` gc_mallocs a `SymbolHeader` as
`GC_TYPE_STRING`, so the string arm carries the same `SYMBOL_MAGIC` content
screen `gc_pointer_and_type_from_value` uses — a fresh `Symbol()` keeps
`POINTER_TAG`. That canonical value is what the tower then roots, which is what
closes defects 1–3.

An **unvouched** word is definitively not a managed pointer, so it is the number
its bits spell, and `dispatch_unvouched_bare_as_number` answers it there and
then — it never reaches a pointer-shaped probe. Fixing only the probe that
happened to fault would have been whack-a-mole: every magnitude-gated probe in
the tower has the same exposure, and CLAUDE.md's "Known-weak areas" records this
codebase paying for that pattern three times over. Deciding once, at the
chokepoint, makes the class unreachable instead of fixing its current instance.

That also makes the tower's magnitude-only **tail recovery unreachable**, so it
is deleted: it was the last place treating address magnitude as proof, it did
neither of the two things the entry now does, and its one legitimate
constituency is in the vouch set above.

Every NaN-boxed receiver returns from a single `bits >> 48` compare, so the
ordinary dispatch path is unchanged. `+0.0` deliberately stays on the ordinary
path — it is not address-shaped, so no probe can mistake it for a pointer.

## Evidence

**A/B by flipping the entry guard off** (`if true { return object; }`), same
build, same target dir:

| | with the fix | guard flipped off |
|---|---|---|
| `bare_receiver` tests | 17 passed | **8 failed** |
| `(1e-310 as any).toString()` | `1e-310`, matches node | **SIGSEGV** |
| `.slice(1)` on a bare managed string | `"bcdef"` | a `POINTER_TAG` value `try_read_tracked_gc_header` does not recognise, **at a different address every run** — a wild pointer handed back to codegen, not a throw |

**Full `perry-runtime` suite**: 3082 passed, 0 failed, 4 ignored
(`RUST_TEST_THREADS=1`, as the crate requires). The one failure during
development was my own test premise — the first version of the routing test
asserted `2.2e-308` was bare-shaped when its `bits >> 48` is 15; there is now a
boundary test pinning which side of 2^48 each shape falls on, and why the arm
can be this narrow.

**Gates**: `scripts/run_lint_gates.sh` — 62/62 script gates, including
`addr_class_inventory.py`, both `raw_handle_debt.py` invocations,
`unrooted_local_shape.py` and `gc_runtime_root_holders.py`. `cargo clippy
--workspace` clean.

Two pre-existing conditions I hit and did **not** touch: the `warnings` job's
`-D warnings` fails on Linux over `pthread_getattr_np`/`pthread_attr_getstack`/
`pthread_attr_destroy` being declared with different signatures in
`gc/roots.rs` and `error_stack_frames.rs` — both declarations are verbatim on
`main` in files this PR does not modify.

## Test coverage

`native_call_method/bare_receiver/tests.rs`, in both directions, because the
second is what keeps a gate like this honest — this file would pass with the
gate widened to "any address-shaped word", which is precisely the mistake the
deleted tail recovery made.

*Reclassification*: string → `STRING_TAG` (and satisfying the exact
`is_any_string()` predicate `dispatch_string` gates on), BigInt →
`BIGINT_TAG`, plain object/array → `POINTER_TAG`, a hand-forwarded receiver →
its **current** address, an end-to-end
`js_native_call_method(bare, "slice", [1])` returning `"bcdef"`, and every
canonical receiver carrying a tag the collector actually traces.

*Non-reclassification*: genuine positive subnormals whose bits sit squarely
inside the window the old recovery accepted, a `Box` allocation carrying a
hand-built `GcHeader`, headerless registry handle ids across every band, a
fresh `Symbol()`, and twelve NaN-boxed forms returned bit-for-bit.

*Routing*: the two subnormals that actually bit must reach number dispatch; a
`Symbol.for` symbol — asserted in the test to be registered **and** not
allocator-tracked, so the registry arm is load-bearing rather than incidental —
must not; nor must any allocator-vouched receiver; and `+0.0` must stay on the
ordinary path.

## Rejected alternative

Root the receiver with `root_heap_word_u64`, whose `HeapWord` slot kind *does*
accept bare addresses (that is #6910's fix). One line, but it closes only defect
1 — strings would still dispatch as objects, a forwarded receiver would still be
used at its old address, subnormals would still be dereferenced — and it would
move every ordinary receiver onto the more conservative `try_mark_value_or_raw`
interior-pointer path on the hot dispatch route.

No version bump (maintainer bumps at merge).

https://claude.ai/code/session_01AqKj15vbuTWf2KZb4Xc4Zi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved method calls on internally managed values by preserving the correct value type, including strings, BigInts, symbols, and objects.
  * Corrected method dispatch for moved or forwarded managed values.
  * Prevented unrecognized numeric values from being treated as object references; they now follow numeric dispatch behavior.
  * Preserved existing behavior for standard boxed values and ordinary floating-point numbers.

* **Tests**
  * Added regression coverage for receiver classification, forwarding, numeric dispatch, symbols, and dynamic string operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->