### PR TITLE
fix(promise): root the promise and its resolving functions across the executor (#9587)

### DIFF
--- a/changelog.d/promise-executor-evacuation-9587.md
+++ b/changelog.d/promise-executor-evacuation-9587.md
@@ -1,0 +1,48 @@
+**`new Promise(executor)` no longer returns a dead promise when the executor
+allocates.** Claude Code's first-run setup screen wedged on a fresh `HOME`
+100% of the time (#9587); onboarding therefore never wrote `theme` /
+`hasCompletedOnboarding` (#9674).
+
+The executor is arbitrary user JS and it runs while
+`js_promise_new_with_executor` still owns the promise it is about to return.
+cc's dialog helper is the shape that exposed it —
+`new Promise((res) => { let z = (y) => void res(y); root.render(ui(z)) })` runs
+a whole ink/React render, megabytes of allocation, inside the executor. The
+evacuating young collection that lands there MOVES the Promise. The resolving
+closures survive correctly (their capture slots are GC slots, so the collector
+rewrites them), but `promise`, `resolve_closure` and `reject_closure` lived in
+bare Rust locals across `js_closure_call2`, so the function handed the caller
+the PRE-COLLECTION address. From-space is reset and handed back to the mutator
+at the end of the same cycle, so that pointer names recycled memory, and
+`await`ing it goes one of two ways:
+
+* the recycled header decodes as `Fulfilled`, so the `await` never suspends and
+  resumes immediately with a garbage value — cc advanced past the onboarding
+  dialog nobody had answered; or
+* it still decodes as `Pending`, so the async step parks its continuation on the
+  dead copy. `resolve()` then settles the LIVE promise, which has no reaction,
+  and nothing ever resumes — a silent permanent hang with **no throw and no
+  rejection**.
+
+Neither failure raises anything a probe can see: `PERRY_REJECTION_DIAG` is
+silent and the whole-heap `PERRY_GC_FROMSPACE_SCAN` reports CLEAN, because at
+the moment of the collection the stale address exists only in a Rust register,
+and by the time it reaches JS from-space has already been flipped. The
+instrument that does catch it is `PERRY_GC_PROTECT_FROMSPACE=1`, which faults on
+the stale read with `obj_type=5` (`GC_TYPE_PROMISE`).
+
+All three values are now rooted in a `RuntimeHandleScope` for the duration of
+the executor and re-read from their handles afterwards — the discipline
+`js_promise_subclass_init` and `new_promise_capability` already follow. Two
+smaller holes on the same path close with it: `executor` itself was live across
+those allocations (rooted now, and only when it really is a closure, so
+`new Promise(42)` still cannot hand the collector a non-pointer), and
+`make_resolving_functions` rooted `promise` *after*
+`ensure_native_resolving_arity_registered`, which allocates on its first call
+per thread.
+
+Regression: `crates/perry/tests/issue_9587_promise_executor_evacuation.rs`
+(node-oracle output under a nursery-cap sweep, a
+`PERRY_GC_SCHEDULE_RATE=1` forced-collection arm, and a `PERRY_GEN_GC=0`
+never-relocates control) plus the parity fixture
+`test-files/test_issue_9587_promise_executor_evacuation.ts`.

--- a/crates/perry-runtime/src/promise/combinators.rs
+++ b/crates/perry-runtime/src/promise/combinators.rs
@@ -613,12 +613,66 @@ pub extern "C" fn js_promise_new_with_executor(
 ) -> *mut Promise {
     use crate::closure::js_closure_call2;
 
-    let promise = js_promise_new();
+    // #9587: the executor is ARBITRARY USER JS and it runs while this function
+    // still owns the promise it is about to return. Claude Code's dialog helper
+    // is the shape that exposed it:
+    //
+    //     new Promise((res) => { let z = (y) => void res(y); root.render(ui(z)) })
+    //
+    // — a whole ink/React render (megabytes of allocation) inside the executor.
+    // The evacuating young collection that lands there MOVES the Promise. The
+    // resolving closures survive it correctly (their capture slots are GC
+    // slots, so the collector rewrites them), but pre-fix `promise`,
+    // `resolve_closure` and `reject_closure` lived in bare Rust locals across
+    // `js_closure_call2`, so this function handed the caller the
+    // PRE-COLLECTION address. From-space is reset and reused at the end of the
+    // same cycle, so the returned pointer names recycled memory, and `await`ing
+    // it goes one of two ways — both observed on cc 2.1.112:
+    //
+    //   * the recycled header decodes as `Fulfilled`, so the `await` never
+    //     suspends and resumes immediately with a garbage value (cc's setup
+    //     screen advanced past the onboarding dialog nobody had answered); or
+    //   * it still decodes as `Pending`, so the async step parks its
+    //     continuation on the dead copy. `resolve()` then settles the LIVE
+    //     promise — which has no reaction — and nothing ever resumes: a silent,
+    //     permanent hang with no throw and no rejection (cc's trust dialog
+    //     wedged 100% of the time on a fresh HOME).
+    //
+    // Root all three for the duration of the call and take every address back
+    // out of a handle afterwards.
+    // `executor` arrives as a bare pointer and is first USED after two
+    // allocating steps (`js_promise_new`, `make_resolving_functions`), so it
+    // needs the same treatment — `js_promise_subclass_init` already roots its
+    // own executor for exactly this reason. Classify it BEFORE the first
+    // allocation and root it only when it really is a closure: a non-callable
+    // executor (`new Promise(42)`) is not a heap pointer at all, and handing
+    // that to the root set would have the collector trace an address that was
+    // never an object.
+    let executor_is_closure = crate::closure::is_closure_ptr(executor as usize);
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let ptr_of = |h: &crate::gc::RuntimeHandle<'_>| -> i64 {
+        crate::value::js_nanbox_get_pointer(h.get_nanbox_f64())
+    };
+    let executor_h = if executor_is_closure {
+        Some(scope.root_nanbox_f64(crate::value::js_nanbox_pointer(executor as i64)))
+    } else {
+        None
+    };
+    let rooted_executor = || -> *const crate::closure::ClosureHeader {
+        match &executor_h {
+            Some(h) => ptr_of(h) as *const crate::closure::ClosureHeader,
+            None => executor,
+        }
+    };
+    let promise_h = scope.root_nanbox_f64(crate::value::js_nanbox_pointer(js_promise_new() as i64));
 
     // Create the resolve/reject pair sharing a [[AlreadyResolved]] guard, so
     // calling one disables the other (27.2.1.3 CreateResolvingFunctions). The
     // resolve fn also assimilates thenables/promises and rejects self-resolution.
-    let (resolve_closure, reject_closure) = make_resolving_functions(promise);
+    let (resolve_closure, reject_closure) =
+        make_resolving_functions(ptr_of(&promise_h) as *mut Promise);
+    let resolve_h = scope.root_nanbox_f64(crate::value::js_nanbox_pointer(resolve_closure as i64));
+    let reject_h = scope.root_nanbox_f64(crate::value::js_nanbox_pointer(reject_closure as i64));
 
     // Call the executor with (resolve_closure, reject_closure) as proper
     // NaN-boxed POINTER_TAG closure values — so user code that *reflects* on
@@ -627,28 +681,37 @@ pub extern "C" fn js_promise_new_with_executor(
     // object, not a bare number. The call path already accepts POINTER_TAG
     // closures (this mirrors `NewPromiseCapability`'s fast path, which has
     // always boxed them). test262 `resolve-function-*` / `reject-function-*`.
-    let resolve_f64: f64 = crate::value::js_nanbox_pointer(resolve_closure as i64);
-    let reject_f64: f64 = crate::value::js_nanbox_pointer(reject_closure as i64);
     // 27.2.3.1: a non-callable executor throws a TypeError SYNCHRONOUSLY at
     // step 2 (before/instead of being run) — that throw must propagate out of
     // `new Promise(...)`, not be converted into a rejection. Only a genuinely
     // callable executor's abrupt completion (step 10) is caught and rejected.
-    if crate::closure::is_closure_ptr(executor as usize) {
+    if executor_is_closure {
         // Callable executor: catch a throw from its body and reject the promise
         // with the thrown value via the resolving `reject` function (so the
         // shared [[AlreadyResolved]] guard makes a throw AFTER a resolve/reject a
         // no-op). test262 reject-via-abrupt / exception-after-resolve-in-executor.
-        if let Err(reason) =
-            combinator_catch_js(|| js_closure_call2(executor, resolve_f64, reject_f64))
-        {
-            crate::closure::js_closure_call1(reject_closure, reason);
+        if let Err(reason) = combinator_catch_js(|| {
+            js_closure_call2(
+                rooted_executor(),
+                resolve_h.get_nanbox_f64(),
+                reject_h.get_nanbox_f64(),
+            )
+        }) {
+            crate::closure::js_closure_call1(
+                ptr_of(&reject_h) as *mut crate::closure::ClosureHeader,
+                reason,
+            );
         }
     } else {
         // Non-callable: preserve the prior synchronous TypeError (uncaught).
-        js_closure_call2(executor, resolve_f64, reject_f64);
+        js_closure_call2(
+            rooted_executor(),
+            resolve_h.get_nanbox_f64(),
+            reject_h.get_nanbox_f64(),
+        );
     }
 
-    promise
+    ptr_of(&promise_h) as *mut Promise
 }
 
 /// A resolving function's shared `[[AlreadyResolved]]` record. Per ECMA-262
@@ -727,13 +790,18 @@ pub(super) fn make_resolving_functions(
     *mut crate::closure::ClosureHeader,
 ) {
     use crate::closure::{js_closure_alloc, js_closure_set_capture_ptr};
-    ensure_native_resolving_arity_registered();
     // #7497: four allocations follow, and `promise` / `guard` are STORED into
     // capture slots after them. Pre-fix all three lived in bare Rust locals, so
     // a copying minor here wrote pre-collection addresses into the two closures
     // — the from-space-publishing shape, not merely a stale read.
+    //
+    // #9587: `ensure_native_resolving_arity_registered` registers four closure
+    // arities and so can allocate on its first call per thread — root `promise`
+    // BEFORE it, not after, or the very first `new Promise(executor)` on a
+    // thread can publish a pre-collection address into the capture slots.
     let scope = crate::gc::RuntimeHandleScope::new();
     let promise_h = scope.root_nanbox_f64(crate::value::js_nanbox_pointer(promise as i64));
+    ensure_native_resolving_arity_registered();
     let guard_h = scope.root_nanbox_f64(crate::value::js_nanbox_pointer(
         alloc_already_resolved_guard() as i64,
     ));

--- a/crates/perry/tests/issue_9587_promise_executor_evacuation.rs
+++ b/crates/perry/tests/issue_9587_promise_executor_evacuation.rs
@@ -1,0 +1,196 @@
+//! #9587 — `new Promise(executor)` must return the LIVE promise when the
+//! executor allocates.
+//!
+//! The executor is arbitrary user JS and it runs while `js_promise_new_with_executor`
+//! still owns the promise it is about to return. Claude Code's dialog helper is
+//! the shape that exposed it:
+//!
+//! ```js
+//! function qA8(root, ui) {
+//!   return new Promise((res) => { let z = (y) => void res(y); root.render(ui(z)) })
+//! }
+//! ```
+//!
+//! — a whole ink/React render (megabytes of allocation) inside the executor. The
+//! evacuating young collection that lands there MOVES the Promise. The resolving
+//! closures survive correctly (their capture slots are GC slots, so the collector
+//! rewrites them), but pre-fix `promise` lived in a bare Rust local across
+//! `js_closure_call2`, so the function returned the PRE-COLLECTION address.
+//! From-space is reset and handed back to the mutator at the end of the same
+//! cycle, so that pointer names recycled memory. `await`ing it goes one of two
+//! ways, both observed on the compiled cc 2.1.112 binary:
+//!
+//! * the recycled header decodes as `Fulfilled`, so the `await` never suspends
+//!   and resumes immediately with a garbage value — cc advanced past an
+//!   onboarding dialog nobody had answered; or
+//! * it still decodes as `Pending`, so the async step parks its continuation on
+//!   the dead copy. `resolve()` then settles the LIVE promise, which has no
+//!   reaction, and nothing ever resumes — a silent permanent hang with no throw
+//!   and no rejection. That is cc's trust dialog wedging 100% of the time on a
+//!   fresh HOME (#9587), which is also why onboarding never wrote `theme` /
+//!   `hasCompletedOnboarding` (#9674).
+//!
+//! Neither failure raises anything: `PERRY_REJECTION_DIAG` is silent and the
+//! whole-heap `PERRY_GC_FROMSPACE_SCAN` reports CLEAN, because at the moment of
+//! the collection the stale address exists only in a Rust register, and by the
+//! time it reaches JS from-space has already been flipped. The instrument that
+//! does see it is `PERRY_GC_PROTECT_FROMSPACE=1`, which faults on the stale read
+//! with `obj_type=5` (`GC_TYPE_PROMISE`).
+//!
+//! # Why the arms are a nursery-cap sweep
+//!
+//! Whether a *relocating* minor lands inside the executor at all depends on where
+//! the nursery happens to fill, so a single configuration is a coin flip on a
+//! given host. `PERRY_GC_SCAVENGE_NURSERY_MB` is a pacing knob only — it moves
+//! the trigger threshold, it does not change what the collector does — so one
+//! binary under a spread of caps puts a relocating minor at many different points
+//! of the executor. `PERRY_GEN_GC=0` (full mark-sweep, never moves) is the
+//! control: correct before and after the fix, so a green run cannot be inertness.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+/// `test-files/test_issue_9587_promise_executor_evacuation.ts`, inlined so the
+/// test is self-contained.
+const SOURCE: &str = r#"
+let saved: (() => void) | null = null;
+const order: string[] = [];
+
+function dialog(): Promise<string> {
+  return new Promise<string>((resolve) => {
+    saved = () => resolve("resolved");
+    let sink: any = null;
+    for (let i = 0; i < 200000; i++) {
+      sink = { a: i, b: [i, i + 1], c: "row" + i, d: { e: i } };
+    }
+    if (sink === null) console.log("unreachable");
+  });
+}
+
+let settled = false;
+
+async function main(): Promise<void> {
+  const p = dialog();
+  order.push("created");
+  p.then(() => { settled = true; });
+  setTimeout(() => {
+    order.push("resolving");
+    console.log("settled-before-resolve:" + settled);
+    (saved as () => void)();
+  }, 10);
+  const v = await p;
+  let vs = "unreadable";
+  try {
+    vs = (v as unknown) === "resolved" ? "resolved" : "other";
+  } catch {
+    vs = "threw";
+  }
+  order.push("value:" + vs);
+  console.log("order:" + order.join(","));
+}
+
+main();
+"#;
+
+/// node 26.5.0 (`.node-version`) on the program above.
+const NODE_ORACLE: &str = "settled-before-resolve:false\norder:created,resolving,value:resolved\n";
+
+/// The collector kill switches an ambient environment could be carrying. Cleared
+/// per arm so an exported `PERRY_GEN_GC=0` cannot silently turn every arm into
+/// the never-relocates control and pass against the unfixed runtime.
+const GC_ENV_OVERRIDES: &[&str] = &[
+    "PERRY_GEN_GC",
+    "PERRY_GC_SCAVENGE",
+    "PERRY_GC_SCAVENGE_NURSERY_MB",
+    "PERRY_GC_MOVING_SAFEPOINT",
+    "PERRY_GC_MOVING_LOOP_POLLS",
+    "PERRY_GC_FORCE_EVACUATE",
+    "PERRY_GC_SCHEDULE_SEED",
+    "PERRY_GC_SCHEDULE_RATE",
+    "PERRY_CONSERVATIVE_STACK_SCAN",
+    "PERRY_WRITE_BARRIERS",
+    "PERRY_GC_INCREMENTAL",
+    "PERRY_GC_HEAP_LIMIT",
+];
+
+#[test]
+fn promise_returned_from_an_allocating_executor_survives_an_evacuating_minor() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    let output = dir.path().join("main_bin");
+    std::fs::write(&entry, SOURCE).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-cache")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    // One binary, many collector configurations: every knob below is
+    // runtime-only, so all arms run exactly the same generated code.
+    let mut arms: Vec<Vec<(&str, &str)>> = vec![vec![]];
+    for mb in ["1", "2", "3", "4", "8", "16"] {
+        arms.push(vec![("PERRY_GC_SCAVENGE_NURSERY_MB", mb)]);
+    }
+    // Force a collection at (nearly) every handled safepoint, with survivors
+    // moving — the densest placement of a relocating minor inside the executor.
+    arms.push(vec![
+        ("PERRY_GC_SCHEDULE_SEED", "1"),
+        ("PERRY_GC_SCHEDULE_RATE", "1"),
+    ]);
+    // Control: full mark-sweep never relocates, so this arm is green before and
+    // after the fix.
+    arms.push(vec![("PERRY_GEN_GC", "0")]);
+
+    for arm in &arms {
+        let mut cmd = Command::new(&output);
+        cmd.current_dir(dir.path());
+        for key in GC_ENV_OVERRIDES {
+            cmd.env_remove(key);
+        }
+        for (k, v) in arm {
+            cmd.env(k, v);
+        }
+        let run = cmd.output().expect("run compiled binary");
+        let label = if arm.is_empty() {
+            "default".to_string()
+        } else {
+            arm.iter()
+                .map(|(k, v)| format!("{k}={v}"))
+                .collect::<Vec<_>>()
+                .join(" ")
+        };
+        assert!(
+            run.status.success(),
+            "[{label}] compiled binary failed (exit {:?})\nstdout:\n{}\nstderr:\n{}",
+            run.status.code(),
+            String::from_utf8_lossy(&run.stdout),
+            String::from_utf8_lossy(&run.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&run.stdout),
+            NODE_ORACLE,
+            "[{label}] `new Promise(executor)` must return the promise the \
+             collector kept, not the address it had before the executor \
+             allocated. Output missing the `order:` line entirely means the \
+             await parked on the dead copy and never resumed; an `order:` line \
+             printed BEFORE `settled-before-resolve` (or carrying \
+             `value:other`) means the await fell through on a recycled header \
+             that decoded as Fulfilled (#9587)."
+        );
+    }
+}

--- a/test-files/test_issue_9587_promise_executor_evacuation.ts
+++ b/test-files/test_issue_9587_promise_executor_evacuation.ts
@@ -1,0 +1,58 @@
+// #9587 — a `new Promise(executor)` whose executor ALLOCATES must still return
+// the live Promise.
+//
+// The executor is arbitrary user code and it runs before `new Promise` returns.
+// Claude Code's dialog helper is the real-world shape:
+//
+//     new Promise((res) => { const z = (y) => void res(y); root.render(ui(z)) })
+//
+// — an entire ink/React render inside the executor. An evacuating young
+// collection there MOVES the promise. The runtime kept the pre-collection
+// address in a bare local and handed that back, so the `await` either fell
+// through immediately on a recycled header that decoded as `Fulfilled`, or
+// parked its continuation on the dead copy while `resolve()` settled the live
+// one — a silent, permanent hang.
+//
+// Node prints:
+//   order:created,resolving value:resolved
+//   settled-before-resolve:false
+
+let saved: (() => void) | null = null;
+const order: string[] = [];
+
+function dialog(): Promise<string> {
+  return new Promise<string>((resolve) => {
+    saved = () => resolve("resolved");
+    // Stand in for the render: allocate hard enough to trip an evacuating minor
+    // while this promise is young.
+    let sink: any = null;
+    for (let i = 0; i < 200000; i++) {
+      sink = { a: i, b: [i, i + 1], c: "row" + i, d: { e: i } };
+    }
+    if (sink === null) console.log("unreachable");
+  });
+}
+
+let settled = false;
+
+async function main(): Promise<void> {
+  const p = dialog();
+  order.push("created");
+  p.then(() => { settled = true; });
+  setTimeout(() => {
+    order.push("resolving");
+    console.log("settled-before-resolve:" + settled);
+    (saved as () => void)();
+  }, 10);
+  const v = await p;
+  let vs = "unreadable";
+  try {
+    vs = (v as unknown) === "resolved" ? "resolved" : "other";
+  } catch {
+    vs = "threw";
+  }
+  order.push("value:" + vs);
+  console.log("order:" + order.join(","));
+}
+
+main();


### PR DESCRIPTION
Root cause of the TUI dialog wedges. Fourth instance of tonight's recurring family — a GC-managed value in a bare Rust local across a call that can collect (cf. PR #9679's nine array callbacks, #9691's stdin lifecycle, #9684's regex `Arc`s).

## The defect

`js_promise_new_with_executor` (`promise/combinators.rs`) held `promise` — and the `resolve`/`reject` closures — in **bare Rust locals across `js_closure_call2(executor, …)`**, which runs arbitrary user JS. cc's dialog helper is exactly the dangerous shape:

```js
function qA8(root, ui){ return new Promise((res)=>{ let z=(y)=>void res(y); root.render(ui(z)) }) }
```

An entire ink/React render — megabytes of allocation — runs *inside* the executor. The evacuating young collection that lands there **moves the Promise**. The resolving closures survive correctly (their capture slots are GC slots, so the collector rewrites them), but the function returns the **pre-collection address**; from-space is reset and handed back to the mutator at the end of the same cycle, so the returned pointer names recycled memory.

## One bug, two user-visible faces — both observed on cc 2.1.112

- **Recycled header decodes as `Fulfilled`** → the `await` never suspends and resumes with a garbage value. This is why the setup screen "advanced past" a theme dialog nobody had answered, and why `onDone` never ran.
- **Still decodes as `Pending`** → the async step parks its continuation on the dead copy; `resolve()` settles the **live** promise, which has no reaction. Silent permanent hang, **no throw, no rejection** — the trust-dialog wedge (#9587).

Not a swallowed exception and not a paint failure: `PERRY_REJECTION_DIAG` is silent and `PERRY_TRACE_ASYNC=1` shows **zero** settle/suspend events after the Enter that writes the trust config — the resolve reached a different object than the one awaited.

Instrument note for future hunts: whole-heap `PERRY_GC_FROMSPACE_SCAN` reports **CLEAN** here, because at collection time the stale address exists only in a Rust register and from-space has flipped by the time it reaches JS. `PERRY_GC_PROTECT_FROMSPACE=1` is the one that catches it: `[gc-fromspace-protect] FAULT … obj_type=5` (`GC_TYPE_PROMISE`).

## Fix

All three values held in a `RuntimeHandleScope` for the executor's duration, every address re-read from its handle — the discipline `js_promise_subclass_init` and `new_promise_capability` already follow. Two smaller holes on the same path close with it: `executor` itself was live across those allocations (now rooted, and **only when `is_closure_ptr`**, so `new Promise(42)` cannot hand the collector a non-pointer), and `make_resolving_functions` rooted `promise` *after* `ensure_native_resolving_arity_registered`, which allocates on its first call per thread.

## Verification

**Deterministic fixture** (`test-files/test_issue_9587_promise_executor_evacuation.ts` + integration test): nursery-cap sweep, a `PERRY_GC_SCHEDULE_RATE=1` forced-collection arm, and a `PERRY_GEN_GC=0` never-relocates control that proves the test is not inert.

| | output |
|---|---|
| node 26.5.1 oracle | `settled-before-resolve:false` / `order:created,resolving,value:resolved` |
| **unfixed** (default and nursery 1/2/4/8 MB) | `order:created,value:other` printed **before** `settled-before-resolve` — the await fell through |
| unfixed, `PERRY_GEN_GC=0` | correct (control) |
| **fixed** | byte-identical to node |

**cc-level, via the offline harness**: trust-dialog wedge **0/3 → 3/3** advancing to the API-key dialog, with the post-trust continuation log lines (`Stored deep link terminal preference`, `Cleared CA certificates cache`) that never appeared before. Fresh-HOME onboarding now answers the theme step and **persists `theme:'light'` for the first time**.

Suites on the rebased branch (includes #9679, #9691): perry-runtime **3083 passed / 0 failed**; the new integration test 1/1; stdin/readline fixtures `9416`, `9493`, `readline_3698plus` node-identical. `9489_stdin_chunk_boundaries` differs (`983040` vs node's `1000000`) — **pre-existing on current main**, verified by reverting only this change and rebuilding; it belongs to the stdin family, not here.

## Next wall, newly exposed (filed separately)

With the wedge gone, onboarding reaches a step it could never reach before and dies there with `object is not a function` at `WN8.calculateLayout` — so `hasCompletedOnboarding` is still not written on a fresh HOME. Not a regression: the unfixed binary never rendered that step, suites are green, and the fixture is node-identical.

Closes #9587.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where promises created by executors performing heavy allocations could become invalid, return incorrect values, or hang indefinitely.
  * Promise resolution and rejection now remain reliable when garbage collection occurs during executor execution.

* **Tests**
  * Added coverage for allocating promise executors across multiple garbage-collection configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->