### PR TITLE
fix(transform): handle labeled for-of across await

### DIFF
--- a/changelog.d/9702-labeled-for-of-await.md
+++ b/changelog.d/9702-labeled-for-of-await.md
@@ -1,0 +1,2 @@
+Fixed async functions hanging when an awaited `switch` inside a labeled
+`for...of` loop executes a labeled `break` or `continue`.

--- a/crates/perry-transform/src/generator/linearize.rs
+++ b/crates/perry-transform/src/generator/linearize.rs
@@ -1597,6 +1597,21 @@ pub fn linearize_body(
                     | Stmt::DoWhile { body, .. } => {
                         rewrite_labeled_bc_in_stmts(body, label, next_local_id);
                     }
+                    // A statically-typed array `for...of` lowers to a runtime
+                    // `ArrayIterationPatched` guard whose two branches contain
+                    // the iterator-protocol and indexed loops, respectively.
+                    // The source label still targets either generated loop,
+                    // but wrapping the guard means neither loop sees the label
+                    // directly. Rewrite the completions in both loop bodies
+                    // before the guard is split into generator states (#9198).
+                    Stmt::If {
+                        condition: Expr::ArrayIterationPatched,
+                        then_branch,
+                        else_branch: Some(else_branch),
+                    } => {
+                        rewrite_labeled_bc_in_lowered_for_of_arm(then_branch, label, next_local_id);
+                        rewrite_labeled_bc_in_lowered_for_of_arm(else_branch, label, next_local_id);
+                    }
                     // A labeled yielding SWITCH: `break label` at case-body
                     // level is the switch's own break — rewrite it to plain
                     // `break` so the yielding-switch desugar below folds it
@@ -1663,6 +1678,25 @@ pub fn linearize_body(
             other => {
                 current.push(other.clone());
             }
+        }
+    }
+}
+
+/// Rewrite completions targeting a source label in one branch of the
+/// `ArrayIterationPatched` for-of guard. Each branch consists of setup
+/// statements followed by the generated loop; nested loops in the user's body
+/// remain boundaries inside [`rewrite_labeled_bc_in_stmts`].
+fn rewrite_labeled_bc_in_lowered_for_of_arm(
+    stmts: &mut [Stmt],
+    label: &str,
+    next_local_id: &mut u32,
+) {
+    for stmt in stmts.iter_mut() {
+        match stmt {
+            Stmt::For { body, .. } | Stmt::While { body, .. } | Stmt::DoWhile { body, .. } => {
+                rewrite_labeled_bc_in_stmts(body, label, next_local_id);
+            }
+            _ => {}
         }
     }
 }

--- a/crates/perry/tests/issue_5868_switch_state_machine.rs
+++ b/crates/perry/tests/issue_5868_switch_state_machine.rs
@@ -311,3 +311,33 @@ run();
     );
     assert_eq!(stdout, "in-case\nafter\n");
 }
+
+/// Issue #9198: labeled loop completions from an awaited switch must target
+/// the enclosing for-of loop instead of becoming dispatch-loop completions.
+#[test]
+fn awaited_switch_inside_labeled_for_of() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+async function run(xs: number[]) {
+  const out: string[] = [];
+  outer: for (const x of xs) {
+    switch (x % 4) {
+      case 0: out.push("z" + x); break;
+      case 1: await Promise.resolve(); out.push("a" + x); break;
+      case 2: if (x > 5) break outer; out.push("b" + x); break;
+      default: await Promise.resolve(); if (x > 10) continue outer; out.push("d" + x);
+    }
+    out.push("|");
+  }
+  return out.join("");
+}
+(async () => {
+  console.log(await run([0, 1, 2, 3, 4, 5, 6, 7, 11, 12]));
+  console.log(await run([7, 11, 3]));
+})();
+"#,
+    );
+    assert_eq!(stdout, "z0|a1|b2|d3|z4|a5|\nd7|d3|\n");
+}


### PR DESCRIPTION
## Summary

- recognize the runtime-guarded array for-of lowering when its source loop has a label
- rewrite matching labeled break and continue completions in both generated loop arms before awaited switch state splitting
- add a bounded regression for the reported hang and an executed continue-outer path

## Testing

- cargo test -p perry --test issue_5868_switch_state_machine -- --test-threads=1 (10 passed)
- cargo test --lib --bins -p perry-transform (123 passed)
- ./scripts/pre-tag-check.sh --quick
- ./scripts/test_affected_crates.sh --base upstream/main (the perry suite reaches 1073 passing tests, then stops at the existing PERRY_CONCAT_SITE_CACHE build-cache audit; the same targeted audit fails on pristine upstream/main)

Closes #9198

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed async functions hanging when an awaited `switch` inside a labeled `for...of` loop uses a labeled `break` or `continue`.
  - Ensured labeled loop controls continue to target the enclosing loop correctly after awaiting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->