### PR TITLE
fix(runtime): register extension keepalive contributors

### DIFF
--- a/crates/perry-ext-fastify/src/lib.rs
+++ b/crates/perry-ext-fastify/src/lib.rs
@@ -59,7 +59,10 @@
 
 use std::sync::Once;
 
-use perry_ffi::{gc_register_mutable_root_scanner_named, iter_handles_of_mut, GcRootVisitor};
+use perry_ffi::{
+    gc_register_mutable_root_scanner_named, iter_handles_of_mut, register_aux_event_pump,
+    GcRootVisitor,
+};
 
 mod app;
 mod cluster_bind;
@@ -85,9 +88,15 @@ static GC_REGISTERED: Once = Once::new();
 /// Without this scanner, a malloc-triggered GC between registration
 /// and incoming-request dispatch would sweep the handler closures —
 /// same root cause as issue #35 for net.Socket listeners.
+/// The same one-time hook registers Fastify's event pump and keepalive
+/// contributor directly with the runtime.
 pub(crate) fn ensure_gc_scanner_registered() {
     GC_REGISTERED.call_once(|| {
         gc_register_mutable_root_scanner_named("perry-ext-fastify", scan_fastify_roots);
+        register_aux_event_pump(
+            server::js_fastify_process_pending,
+            server::js_fastify_has_active,
+        );
     });
 }
 

--- a/crates/perry-ext-fastify/src/server.rs
+++ b/crates/perry-ext-fastify/src/server.rs
@@ -548,9 +548,9 @@ fn drain_server_upgrades(server_handle: Handle) -> i32 {
 
 /// Pump entrypoint — drain pending requests from every registered
 /// `FastifyServerHandle` and dispatch each on the main TS thread.
-/// Wired into perry-stdlib's `js_stdlib_process_pending` via the
-/// `external-fastify-pump` feature so the runtime's outer event loop
-/// drives us each tick.
+/// Registered with perry-runtime when the first Fastify app initializes, so
+/// the runtime's outer event loop drives it without a named reference from
+/// stdlib.
 ///
 /// Re-entrancy: dispatching a request runs user TS, which may `await`;
 /// `wait_for_promise` then drives `js_run_stdlib_pump`, which calls back into
@@ -681,10 +681,10 @@ fn try_recv_fastify_upgrade(server_handle: Handle) -> Option<FastifyPendingUpgra
 }
 
 /// Reports whether any registered fastify server is currently in the
-/// "listening" state OR has a non-empty upgrade queue. Wired into
-/// perry-stdlib's `js_stdlib_has_active_handles` so the runtime's main
-/// event loop keeps running until the user explicitly closes every
-/// server and every queued upgrade has been drained.
+/// "listening" state OR has a non-empty upgrade queue. Registered as a
+/// runtime keepalive contributor so the main event loop keeps running until
+/// the user explicitly closes every server and every queued upgrade has been
+/// drained.
 #[no_mangle]
 pub extern "C" fn js_fastify_has_active() -> i32 {
     let mut active = 0i32;

--- a/crates/perry-ext-http/src/lib.rs
+++ b/crates/perry-ext-http/src/lib.rs
@@ -109,7 +109,7 @@ use bytes::Bytes;
 use lazy_static::lazy_static;
 use perry_ffi::{
     alloc_string, gc_register_mutable_root_scanner_named, get_handle_mut, iter_handles_of_mut,
-    json_stringify, notify_main_thread, register_handle,
+    json_stringify, notify_main_thread, register_aux_event_pump, register_handle,
     spawn_blocking_with_reactor as spawn_blocking, with_handle_mut, ArrayHeader, GcRootVisitor,
     Handle, JsClosure, JsString, JsValue, ObjectHeader, RawClosureHeader, StringHeader,
 };
@@ -216,15 +216,11 @@ pub(crate) enum PendingHttpEvent {
 /// reqwest task spawned per `http.request`/`http.get`, from dispatch until the
 /// response fully streams or errors).
 ///
-/// `EXT_BLOCKING_TASKS_INFLIGHT` (perry-stdlib's idle-kick / active-handle gate)
+/// `EXT_BLOCKING_TASKS_INFLIGHT` (perry-stdlib's blocking-task gate)
 /// only stays up for the SHORT outer `spawn_blocking` closure that *launches* the
 /// reqwest task and returns; it drops to 0 while the actual fetch is still in
-/// flight. So the runtime's idle-kick never fires during a fetch, and a lost
-/// tokio worker-unpark for the reqwest task (the canonical failure under a
-/// `Promise.all` burst of fetches) is never recovered — the main thread parks
-/// forever with the responses received but undelivered. This counter, exposed via
-/// [`js_ext_http_client_inflight`], lets the idle-kick + active-handle gate honor
-/// a fetch's TRUE lifetime so a stranded reqwest task gets roused.
+/// flight. Registering this counter as a keepalive contributor lets the runtime
+/// gate and fast wait-driver honor the request's true lifetime.
 static CLIENT_REQUESTS_INFLIGHT: std::sync::LazyLock<
     std::sync::Mutex<std::collections::HashSet<Handle>>,
 > = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashSet::new()));
@@ -256,7 +252,7 @@ impl Drop for ClientInflightGuard {
     }
 }
 
-/// Exposed for perry-stdlib's idle-kick + active-handle gate (#5779 follow-up):
+/// Registered with the runtime's extension keepalive gate (#5779 follow-up):
 /// returns nonzero while any HTTP client fetch is outstanding.
 #[no_mangle]
 pub extern "C" fn js_ext_http_client_inflight() -> i32 {
@@ -385,31 +381,32 @@ lazy_static! {
 
 static HTTP_GC_REGISTERED: Once = Once::new();
 
+extern "C" fn client_pump() -> i32 {
+    unsafe { js_http_process_pending() }
+}
+
+extern "C" fn client_has_active() -> i32 {
+    let pending = HTTP_PENDING_EVENTS
+        .lock()
+        .map(|queue| !queue.is_empty())
+        .unwrap_or(false);
+    i32::from(pending || js_ext_http_client_inflight() != 0)
+}
+
 pub(crate) fn ensure_gc_scanner_registered() {
     HTTP_GC_REGISTERED.call_once(|| {
         gc_register_mutable_root_scanner_named("perry-ext-http", scan_http_roots);
-        // #2532 — register the client response/error pump with perry-runtime
-        // directly so `http.request` / `http.get` callbacks fire in an
-        // out-of-tree install (prebuilt full stdlib has the
-        // `external-http-client-pump` arm compiled out). No separate
-        // has-active is needed: the in-flight request is a perry-ffi async
-        // op, which `js_native_async_has_active` already keeps the loop alive
-        // for. Idempotent on the runtime side.
+        // Register both halves directly with perry-runtime. The stdlib bridge
+        // intentionally does not name extension symbols: a client contributes
+        // only after this crate is linked and one of its entry points runs.
+        register_aux_event_pump(client_pump, client_has_active);
         extern "C" {
-            fn js_register_aux_pump(f: extern "C" fn() -> i32);
             fn js_register_http_agent_handle_probe(f: unsafe extern "C" fn(i64) -> bool);
         }
         unsafe extern "C" fn http_agent_probe(handle: i64) -> bool {
             agent::js_ext_http_agent_is_handle(handle) != 0
         }
-        // `js_http_process_pending` is an `unsafe extern "C" fn`; the
-        // registry takes a safe `extern "C" fn`, so route through a thin
-        // safe shim.
-        extern "C" fn client_pump() -> i32 {
-            unsafe { js_http_process_pending() }
-        }
         unsafe {
-            js_register_aux_pump(client_pump);
             js_register_http_agent_handle_probe(http_agent_probe);
         }
     });

--- a/crates/perry-ext-http/src/server/mod.rs
+++ b/crates/perry-ext-http/src/server/mod.rs
@@ -93,8 +93,8 @@ static GC_REGISTERED: Once = Once::new();
 pub(crate) fn ensure_gc_scanner_registered() {
     GC_REGISTERED.call_once(|| {
         gc_register_mutable_root_scanner_named("perry-ext-http", scan_http_server_roots);
-        // Register the extension pump for out-of-tree links where stdlib does
-        // not compile its HTTP pump arm. Runtime registration is idempotent.
+        // Register the extension's pump and keepalive contributor with runtime;
+        // stdlib intentionally does not name either HTTP symbol (#9696).
         perry_ffi::register_aux_event_pump(
             crate::server::server::js_node_http_server_process_pending,
             crate::server::server::js_node_http_server_has_active,

--- a/crates/perry-ext-http/src/server/server.rs
+++ b/crates/perry-ext-http/src/server/server.rs
@@ -1409,7 +1409,7 @@ async fn handle_websocket_upgrade(
 }
 
 // ============================================================================
-// Issue #604 — main-thread pump exposed to perry-stdlib's stdlib pump.
+// Issue #604/#9696 — main-thread pump registered with perry-runtime.
 //
 // Pre-#604, `js_node_http_server_listen` ended in `event_loop(...)` —
 // an infinite blocking loop on the main TS thread that drained pending
@@ -1421,12 +1421,10 @@ async fn handle_websocket_upgrade(
 // Replacement: `listen()` returns immediately after spawning the
 // accept loop on the tokio runtime. The new
 // `js_node_http_server_has_active` and `js_node_http_server_process_pending`
-// externs are wired into perry-stdlib's `js_stdlib_has_active_handles` /
-// `js_stdlib_process_pending` (gated on the `external-http-server-pump`
-// feature). The codegen-emitted main loop calls those each tick, so
-// requests + upgrades are dispatched on the same main thread as
-// before — just driven from the outer event loop instead of an inner
-// blocking one.
+// callbacks are registered with the runtime when this extension initializes.
+// The codegen-emitted main loop invokes the registry each tick, so requests +
+// upgrades are dispatched on the same main thread as before — just driven
+// from the outer event loop instead of an inner blocking one.
 //
 // Both externs walk the global handle registry via `iter_handles_of`
 // (covers HTTP/1, HTTPS, and HTTP/2 — HTTPS / HTTP/2 wrap an
@@ -1436,10 +1434,9 @@ async fn handle_websocket_upgrade(
 
 /// Returns 1 if any registered HTTP/HTTPS/HTTP/2 server is currently
 /// listening, has pending requests, or has pending upgrade events.
-/// Wired into perry-stdlib's `js_stdlib_has_active_handles` via the
-/// `external-http-server-pump` feature. Without this gate, the
-/// codegen-emitted main loop would exit before the accept loop has
-/// a chance to push the first request through the channel.
+/// Registered as a runtime keepalive contributor so the codegen-emitted main
+/// loop cannot exit before the accept loop has a chance to push the first
+/// request through the channel.
 #[no_mangle]
 pub extern "C" fn js_node_http_server_has_active() -> i32 {
     let mut active = 0i32;

--- a/crates/perry-ext-net/src/dispatch.rs
+++ b/crates/perry-ext-net/src/dispatch.rs
@@ -7,8 +7,9 @@
 //! handle family.
 
 use perry_ffi::{
-    build_object_shape, js_object_alloc_with_shape, js_object_set_field, ArrayHeader, JsClosure,
-    JsPromise, JsValue, ObjectHeader, Promise, RawClosureHeader, StringHeader,
+    build_object_shape, js_object_alloc_with_shape, js_object_set_field, register_aux_event_pump,
+    ArrayHeader, JsClosure, JsPromise, JsValue, ObjectHeader, Promise, RawClosureHeader,
+    StringHeader,
 };
 use std::sync::Once;
 
@@ -27,8 +28,6 @@ extern "C" {
     ) -> f64;
     fn js_json_parse_or_null(text_ptr: *const StringHeader) -> JsValue;
     fn js_promise_resolve(promise: *mut Promise, value: f64);
-    fn js_register_aux_has_active(f: extern "C" fn() -> i32);
-    fn js_register_aux_pump(f: extern "C" fn() -> i32);
     fn js_register_handle_method_dispatch_extension(
         f: unsafe extern "C" fn(i64, *const u8, usize, *const f64, usize, *mut f64) -> i32,
     );
@@ -54,13 +53,16 @@ extern "C" fn process_pending_aux() -> i32 {
 
 pub(crate) fn ensure_runtime_dispatch_registered() {
     static REGISTER: Once = Once::new();
-    REGISTER.call_once(|| unsafe {
-        js_register_aux_pump(process_pending_aux);
-        js_register_aux_has_active(crate::js_ext_net_has_active_handles);
-        js_register_handle_method_dispatch_extension(js_ext_net_handle_method_dispatch);
-        js_register_handle_property_dispatch_extension(js_ext_net_handle_property_dispatch);
-        js_register_handle_property_set_dispatch_extension(js_ext_net_handle_property_set_dispatch);
-        js_set_native_bun_tcp_dispatch(crate::bun_tcp::js_bun_tcp_native_dispatch);
+    REGISTER.call_once(|| {
+        register_aux_event_pump(process_pending_aux, crate::js_ext_net_has_active_handles);
+        unsafe {
+            js_register_handle_method_dispatch_extension(js_ext_net_handle_method_dispatch);
+            js_register_handle_property_dispatch_extension(js_ext_net_handle_property_dispatch);
+            js_register_handle_property_set_dispatch_extension(
+                js_ext_net_handle_property_set_dispatch,
+            );
+            js_set_native_bun_tcp_dispatch(crate::bun_tcp::js_bun_tcp_native_dispatch);
+        }
     });
 }
 

--- a/crates/perry-ext-ws/src/lib.rs
+++ b/crates/perry-ext-ws/src/lib.rs
@@ -40,9 +40,10 @@ use futures_util::{SinkExt, StreamExt};
 use lazy_static::lazy_static;
 use perry_ffi::{
     alloc_set, alloc_string, gc_register_mutable_root_scanner_named, get_handle_mut,
-    iter_handles_of_mut, notify_main_thread, register_handle, set_add, set_delete, spawn_async,
-    spawn_blocking_with_reactor as spawn_blocking, take_handle, GcRootVisitor, Handle, JsClosure,
-    JsString, JsValue, ObjectHeader, RawClosureHeader, StringHeader,
+    iter_handles_of_mut, notify_main_thread, register_aux_event_pump, register_handle, set_add,
+    set_delete, spawn_async, spawn_blocking_with_reactor as spawn_blocking, take_handle,
+    GcRootVisitor, Handle, JsClosure, JsString, JsValue, ObjectHeader, RawClosureHeader,
+    StringHeader,
 };
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicI32, Ordering};
@@ -141,12 +142,13 @@ extern "C" {
     );
 }
 
-/// Install the crate's runtime hooks once: the mutable-root scanner, and the
-/// handle-property dispatch extension that answers dynamic reads on ws
-/// handles (#9324).
+/// Install the crate's runtime hooks once: event-pump and keepalive
+/// contributors, the mutable-root scanner, and the handle-property dispatch
+/// extension that answers dynamic reads on ws handles (#9324).
 fn ensure_runtime_hooks_registered() {
     WS_RUNTIME_HOOKS_REGISTERED.call_once(|| {
         gc_register_mutable_root_scanner_named("perry-ext-ws", scan_ws_roots);
+        register_aux_event_pump(js_ws_process_pending, js_ws_has_pending);
         unsafe {
             js_register_handle_property_dispatch_extension(js_ext_ws_handle_property_dispatch)
         };

--- a/crates/perry-ext-zlib/src/stream.rs
+++ b/crates/perry-ext-zlib/src/stream.rs
@@ -19,8 +19,8 @@
 
 use perry_ffi::{
     alloc_buffer, alloc_string, gc_register_mutable_root_scanner_named, notify_main_thread,
-    BufferHeader, ErrorKind, GcRootVisitor, JsClosure, JsValue, RawClosureHeader, StringHeader,
-    TransientRootScope, TransientRootedAddr,
+    register_aux_event_pump, BufferHeader, ErrorKind, GcRootVisitor, JsClosure, JsValue,
+    RawClosureHeader, StringHeader, TransientRootScope, TransientRootedAddr,
 };
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::ffi::c_void;
@@ -41,8 +41,6 @@ const TRUE_BITS: u64 = 0x7FFC_0000_0000_0004;
 // perry-runtime `#[no_mangle]` symbols, resolved at final link (perry-runtime
 // is always linked). Mirrors perry-ext-net's extern usage.
 extern "C" {
-    fn js_register_aux_has_active(f: extern "C" fn() -> i32);
-    fn js_register_aux_pump(f: extern "C" fn() -> i32);
     fn js_buffer_is_buffer(ptr: i64) -> i32;
     fn js_get_string_pointer_unified(value: f64) -> i64;
     // #2935: resolve + validate a `{ level }` option to a flate2 level
@@ -100,9 +98,8 @@ extern "C" fn process_pending_aux() -> i32 {
 
 fn ensure_aux_pump_registered() {
     static REGISTER: std::sync::Once = std::sync::Once::new();
-    REGISTER.call_once(|| unsafe {
-        js_register_aux_pump(process_pending_aux);
-        js_register_aux_has_active(js_ext_zlib_has_active_handles);
+    REGISTER.call_once(|| {
+        register_aux_event_pump(process_pending_aux, js_ext_zlib_has_active_handles);
     });
 }
 
@@ -1170,7 +1167,7 @@ fn enforce_global_output_cap(g: &mut Statics, total_cap: usize) {
     }
 }
 
-// ── dispatch (called from perry-stdlib's external-zlib-pump arm) ───────────────
+// ── dynamic method dispatch for external zlib handles ─────────────────────────
 
 /// True iff `handle` indexes a live zlib stream.
 #[no_mangle]
@@ -1557,8 +1554,8 @@ pub unsafe extern "C" fn js_ext_zlib_process_pending() -> i32 {
     count
 }
 
-/// Keep the event loop alive while zlib stream events are queued. Wired into
-/// perry-stdlib's `js_stdlib_has_active_handles`.
+/// Keep the event loop alive while zlib stream events are queued. Registered
+/// directly with perry-runtime alongside the extension pump.
 #[no_mangle]
 pub extern "C" fn js_ext_zlib_has_active_handles() -> i32 {
     if statics().lock().unwrap().pending.is_empty() {

--- a/crates/perry-ffi/src/event_pump.rs
+++ b/crates/perry-ffi/src/event_pump.rs
@@ -23,19 +23,13 @@
 //! ```
 //!
 //! Wrappers manage their own per-module pending-events queue
-//! (`Mutex<Vec<MyEvent>>` typical). They expose a
-//! `js_<name>_process_pending() -> i32` extern that perry-codegen's
-//! event-loop pump calls every tick to drain. The queue's producer
-//! side calls `notify_main_thread()` after pushing so the main loop
-//! wakes promptly instead of waiting on the 1-second heartbeat cap.
-//!
-//! # Today's surface (v0.5.x)
-//!
-//! Just `notify_main_thread`. The dispatch — `js_<name>_process_pending`
-//! / `js_<name>_has_pending` — is wrapper-specific and doesn't need a
-//! perry-ffi entry; codegen knows about each wrapper's tick symbols by
-//! name, the same way it does for perry-stdlib's pumps (cron, http, ws,
-//! readline, …).
+//! (`Mutex<Vec<MyEvent>>` typical). At initialization they pass their
+//! `process_pending` and `has_active` callbacks to
+//! [`register_aux_event_pump`]. The runtime invokes those callbacks through
+//! its registry, so neither codegen nor stdlib hard-references extension
+//! symbols. The queue's producer side calls [`notify_main_thread`] after
+//! pushing so the main loop wakes promptly instead of waiting on the
+//! heartbeat cap.
 
 extern "C" {
     /// Wake the main thread from `js_wait_for_event`.

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -442,29 +442,14 @@ pub(crate) mod stdlib_pump {
         })
     }
 
-    // #2532 — auxiliary pump / has-active registries.
+    // #2532/#9696 — extension pump / keepalive registries.
     //
-    // perry-stdlib owns the single `STDLIB_PUMP_FN` slot above and drains
-    // every in-tree module's pending queue from there. But the
-    // `perry-ext-*` wrapper crates (perry-ext-http's request queue,
-    // perry-ext-http's client response queue, …) are normally drained by
-    // `js_stdlib_process_pending`'s `#[cfg(feature = "external-*-pump")]`
-    // arms — which are only compiled in when the *workspace* auto-optimize
-    // rebuilds perry-stdlib with that feature.
-    //
-    // In an out-of-tree install there is no workspace to rebuild from, so
-    // the link uses the prebuilt full `libperry_stdlib.a` with those pump
-    // arms compiled OUT. The ext lib would then link but its queue would
-    // never be drained — a `node:http` server accepts connections that
-    // nobody dispatches and the program hangs.
-    //
-    // These registries let each linked ext crate register its own
-    // `*_process_pending` / `*_has_active` directly with the runtime, which
-    // drains them on every tick regardless of which perry-stdlib features
-    // are present. Registration is idempotent (a given fn pointer is only
-    // stored once), so the in-tree path's compile-time arm calling the same
-    // function is harmless — the second drain of an already-empty queue is
-    // a no-op.
+    // A prebuilt stdlib cannot know which `perry-ext-*` archives a program
+    // will link. Each extension therefore registers its own pending-work pump
+    // and activity contributor when its first entry point runs. The runtime
+    // drains and queries them without either side naming the other's symbols,
+    // which also lets out-of-tree extensions participate. Registration is
+    // idempotent for each function pointer.
     static AUX_PUMPS: Mutex<Vec<extern "C" fn() -> i32>> = Mutex::new(Vec::new());
     static AUX_HAS_ACTIVE: Mutex<Vec<extern "C" fn() -> i32>> = Mutex::new(Vec::new());
 
@@ -513,6 +498,15 @@ pub(crate) mod stdlib_pump {
             Err(_) => return false,
         };
         fns.iter().any(|f| f() != 0)
+    }
+
+    /// Query the registered extension keepalive contributors.
+    ///
+    /// Exported so the stdlib wait driver's fast path can decide whether to
+    /// advance native I/O without naming any extension crate or symbol.
+    #[no_mangle]
+    pub extern "C" fn js_aux_has_active() -> i32 {
+        i32::from(aux_has_active())
     }
 
     /// Register the stdlib's process_pending function pointer.
@@ -575,9 +569,8 @@ pub(crate) mod stdlib_pump {
                 func();
             }
         }
-        // #2532 — drain any `perry-ext-*` pumps registered directly with
-        // the runtime (out-of-tree installs where perry-stdlib's
-        // compile-time `external-*-pump` arms aren't present).
+        // #2532/#9696 — drain every initialized extension through the
+        // registry; stdlib deliberately has no per-extension pump arms.
         run_aux_pumps();
         let _ = crate::gc::gc_runtime_safepoint();
     }
@@ -655,7 +648,7 @@ pub(crate) mod stdlib_pump {
         // #2532 — a live `perry-ext-*` handle (e.g. a listening HTTP
         // server registered out-of-tree) keeps the loop alive even when
         // perry-stdlib reports none.
-        if aux_has_active() {
+        if js_aux_has_active() != 0 {
             return 1;
         }
         let f = STDLIB_HAS_ACTIVE_FN.load(Ordering::Acquire);
@@ -762,6 +755,35 @@ pub(crate) mod stdlib_pump {
                 after - before,
                 1,
                 "counting_pump must be invoked exactly once per run_aux_pumps despite triple registration"
+            );
+        }
+
+        static AUX_ACTIVE_FLAG: AtomicI32 = AtomicI32::new(0);
+        extern "C" fn aux_flag_has_active() -> i32 {
+            AUX_ACTIVE_FLAG.load(AtomicOrdering::SeqCst)
+        }
+
+        #[test]
+        fn aux_has_active_registration_is_idempotent_and_queryable() {
+            js_register_aux_has_active(aux_flag_has_active);
+            js_register_aux_has_active(aux_flag_has_active);
+            AUX_ACTIVE_FLAG.store(0, AtomicOrdering::SeqCst);
+            assert_eq!(
+                js_aux_has_active(),
+                0,
+                "an idle registered extension must not pin the event loop"
+            );
+            AUX_ACTIVE_FLAG.store(1, AtomicOrdering::SeqCst);
+            assert_eq!(
+                js_aux_has_active(),
+                1,
+                "a live registered extension must keep the event loop alive"
+            );
+            AUX_ACTIVE_FLAG.store(0, AtomicOrdering::SeqCst);
+            assert_eq!(
+                js_aux_has_active(),
+                0,
+                "the contributor must release the loop when it becomes idle"
             );
         }
     }

--- a/crates/perry-stdlib/Cargo.toml
+++ b/crates/perry-stdlib/Cargo.toml
@@ -110,14 +110,9 @@ bundled-ws = ["dep:tokio-tungstenite", "dep:futures-util", "dep:rustls", "async-
 
 # Activated by `optimized_libs::build_optimized_libs` when the
 # well-known flip strips `bundled-ws` and routes `import 'ws'` to
-# perry-ext-ws. Tells perry-stdlib's `js_stdlib_process_pending`
-# to call `js_ws_process_pending` even though `pub mod ws` isn't
-# compiled in — the symbol is provided by perry-ext-ws at link
-# time. Mirrors `external-net-pump` (v0.5.579). Closes #606's
-# follow-up: without this, perry-ext-ws's accept-loop tokio task
-# pushes `Listening` / `Connection` / `Message` events to its
-# event queue but the main thread never drains them, so handlers
-# never fire and the program hangs after the SIGABRT fix.
+# perry-ext-ws. Retains the shared async runtime needed by that extension;
+# the extension registers its pump and keepalive contributor directly with
+# perry-runtime (#9696).
 external-ws-pump = ["async-runtime"]
 
 # Raw TCP sockets (`net.Socket` — Postgres wire driver, custom protocols).
@@ -129,61 +124,35 @@ bundled-net = ["async-runtime"]
 
 # Activated by `optimized_libs::build_optimized_libs` (v0.5.579) when
 # the well-known flip strips `bundled-net` and routes `import 'net'`
-# to perry-ext-net. Tells perry-stdlib's `js_stdlib_process_pending`
-# to call `js_net_process_pending` even though `pub mod net` isn't
-# compiled in — the symbol is provided by perry-ext-net at link
-# time. No fallback no-op stub: gating on this feature ensures
-# perry-stdlib only emits the call site (and thus the undefined
-# extern reference) when perry-ext-net is guaranteed to be linked.
+# to perry-ext-net. Selects ext-net dispatch adapters and the shared async
+# runtime. The extension itself registers its pump and keepalive contributor.
 external-net-pump = ["async-runtime"]
 
 # Activated by `optimized_libs::build_optimized_libs` (#1843) when the
 # well-known flip routes `node:zlib` to perry-ext-zlib and strips
-# `compression`. Tells perry-stdlib's `js_stdlib_process_pending` /
-# `js_stdlib_has_active_handles` to drain perry-ext-zlib's deferred
-# stream-event queue (`js_ext_zlib_process_pending` /
-# `js_ext_zlib_has_active_handles`), and routes lost-static-type
-# `gz.write()` / `.on()` / `.pipe()` calls through
-# `js_ext_zlib_dispatch_method`. It also registers
+# `compression`. Routes lost-static-type `gz.write()` / `.on()` /
+# `.pipe()` calls through `js_ext_zlib_dispatch_method`. It also registers
 # `js_ext_zlib_native_dispatch` for captured module exports such as
-# `util.promisify(zlib.gzip)`. Mirrors `external-net-pump`. No async runtime
-# needed (zlib compression is synchronous), but the pump call sites live in
-# the async-bridge module which is `async-runtime`-gated.
+# `util.promisify(zlib.gzip)`; pump and keepalive registration is owned by
+# perry-ext-zlib.
 external-zlib-pump = ["async-runtime"]
 
 # Activated by `optimized_libs::build_optimized_libs` (v0.5.714) when
 # the well-known flip routes `node:http` / `node:https` / `node:http2`
-# to perry-ext-http (which contains the server implementation). Tells
-# perry-stdlib's `js_stdlib_process_pending` and
-# `js_stdlib_has_active_handles` to call into perry-ext-http's
-# `js_node_http_server_process_pending` / `js_node_http_server_has_active`
-# externs each tick. Without this, the http server's accept-loop
-# tokio task pushes pending requests that nobody drains and the
-# program either hangs (pre-fix listen() blocked the main thread)
-# or exits before the listener task can dispatch any request.
-# Mirrors `external-net-pump` and `external-ws-pump`. Closes #604.
+# to perry-ext-http. Selects the HTTP server dispatch adapters and shared async
+# runtime; perry-ext-http registers its pump and keepalive contributor.
 external-http-server-pump = ["async-runtime"]
 
 # Activated by `optimized_libs::build_optimized_libs` when the well-known
 # flip routes `node:http` / `node:https` to perry-ext-http and the user
-# code calls `http.request` / `http.get` (client side). Tells
-# perry-stdlib's `js_stdlib_process_pending` and
-# `js_stdlib_has_active_handles` to call into perry-ext-http's
-# `js_http_process_pending` / `js_http_has_pending` externs each tick.
-# Without this the client-side response/error events stay queued and
-# the program exits before any callback fires. Issue #769.
+# code calls `http.request` / `http.get`. Selects client dispatch adapters
+# and the shared async runtime; perry-ext-http registers its own callbacks.
 external-http-client-pump = ["async-runtime"]
 
 # Activated by `optimized_libs::build_optimized_libs` whenever the well-known
 # flip routes `import 'fastify'` to perry-ext-fastify (the only fastify path —
-# the in-stdlib adapter was removed). Tells perry-stdlib's
-# `js_stdlib_process_pending` / `js_stdlib_has_active_handles` to call
-# into perry-ext-fastify's `js_fastify_process_pending` /
-# `js_fastify_has_active` externs each tick. Without this, the
-# (now non-blocking) `listen()` returns but no main-thread code ever
-# drains pending requests — programs that combine fastify with an
-# in-process `fetch` against itself, lifecycle hooks, or async route
-# handlers hang. Mirrors `external-http-server-pump`.
+# the in-stdlib adapter was removed). Selects Fastify dispatch adapters and the
+# shared async runtime. perry-ext-fastify owns pump/keepalive registration.
 external-fastify-pump = ["async-runtime"]
 
 # Activated by `optimized_libs::build_optimized_libs` when the well-known

--- a/crates/perry-stdlib/src/common/async_bridge.rs
+++ b/crates/perry-stdlib/src/common/async_bridge.rs
@@ -368,12 +368,12 @@ extern "C" fn stdlib_wait_wake() {
 /// if a native result is queued. No-op when nothing native is in flight, so
 /// pure-JS-async pays only atomic loads.
 extern "C" fn stdlib_fast_drive() {
+    extern "C" {
+        fn js_aux_has_active() -> i32;
+    }
     let n = EXT_BLOCKING_TASKS_INFLIGHT.load(Ordering::Acquire);
-    let native = native_fast_drive_needed(
-        n,
-        ext_http_client_inflight_fast(),
-        ext_http_server_active_fast(),
-    );
+    let registered_extension_active = unsafe { js_aux_has_active() != 0 };
+    let native = native_fast_drive_needed(n, registered_extension_active);
     if !native {
         return;
     }
@@ -385,37 +385,9 @@ extern "C" fn stdlib_fast_drive() {
     });
 }
 
-#[cfg(feature = "external-http-client-pump")]
-fn ext_http_client_inflight_fast() -> bool {
-    extern "C" {
-        fn js_ext_http_client_inflight() -> i32;
-    }
-    unsafe { js_ext_http_client_inflight() != 0 }
-}
-#[cfg(not(feature = "external-http-client-pump"))]
-fn ext_http_client_inflight_fast() -> bool {
-    false
-}
-
-#[cfg(feature = "external-http-server-pump")]
-fn ext_http_server_active_fast() -> bool {
-    extern "C" {
-        fn js_node_http_server_has_active() -> i32;
-    }
-    unsafe { js_node_http_server_has_active() != 0 }
-}
-#[cfg(not(feature = "external-http-server-pump"))]
-fn ext_http_server_active_fast() -> bool {
-    false
-}
-
 #[inline]
-fn native_fast_drive_needed(
-    blocking_tasks_inflight: usize,
-    http_client_inflight: bool,
-    http_server_active: bool,
-) -> bool {
-    blocking_tasks_inflight > 0 || http_client_inflight || http_server_active
+fn native_fast_drive_needed(blocking_tasks_inflight: usize, extension_active: bool) -> bool {
+    blocking_tasks_inflight > 0 || extension_active
 }
 
 /// Queue a promise resolution to be processed later
@@ -607,43 +579,21 @@ pub extern "C" fn js_stdlib_process_pending() -> i32 {
     }
 
     // Process pending WebSocket events (server/client listener callbacks).
-    // Gate fires for either `bundled-ws` (perry-stdlib's own impl) or
-    // `external-ws-pump` (well-known flip → perry-ext-ws provides the
-    // symbol). Mirrors net's gate above. Closes #606 follow-up.
-    #[cfg(any(feature = "websocket", feature = "external-ws-pump"))]
+    // External WebSocket implementations register their own pump with runtime.
+    #[cfg(feature = "websocket")]
     {
-        extern "C" {
-            fn js_ws_process_pending() -> i32;
-        }
-        let ws_count = unsafe { js_ws_process_pending() };
-        count += ws_count;
+        count += unsafe { crate::ws::js_ws_process_pending() };
     }
 
-    // Process pending raw TCP socket events (net.Socket).
-    // v0.5.579 — gate now fires for `bundled-net` (perry-stdlib's
-    // own implementation) AND `external-net-pump` (which the
-    // well-known flip in `optimized_libs.rs` enables when routing
-    // `import 'net'` to perry-ext-net). The fallback no-op stub
-    // pattern (e.g. cron's) doesn't work for net because the
-    // perry-ext-net wrapper's symbol can't be reliably preferred
-    // over perry-stdlib's stub on Mach-O.
-    // v0.5.579: gate on `bundled-net` (perry-stdlib has its own net
-    // module compiled in) OR `external-net-pump` (well-known flip
-    // activated → perry-ext-net is linked, provides the symbol).
-    // Without this gate, the cfg `feature = "net"` from v0.5.572's
-    // umbrella renaming was always FALSE under the well-known flip,
-    // and tokio events queued by perry-ext-net never got drained.
+    // Process pending bundled raw TCP socket events (net.Socket).
+    // External net implementations register their own pump with runtime.
     #[cfg(all(
-        any(feature = "bundled-net", feature = "external-net-pump"),
+        feature = "bundled-net",
         not(target_os = "ios"),
         not(target_os = "android")
     ))]
     {
-        extern "C" {
-            fn js_net_process_pending() -> i32;
-        }
-        let net_count = unsafe { js_net_process_pending() };
-        count += net_count;
+        count += unsafe { crate::net::js_net_process_pending() };
     }
 
     #[cfg(all(
@@ -653,35 +603,6 @@ pub extern "C" fn js_stdlib_process_pending() -> i32 {
     ))]
     {
         count += unsafe { crate::tls::js_tls_process_pending() };
-    }
-
-    // Process pending HTTP server requests + WS upgrades (perry-ext-http).
-    // Closes #604 — pre-fix `js_node_http_server_listen` blocked the
-    // main TS thread inside an inner event_loop, so axios.get/etc.
-    // after a `server.listen(port, () => resolve())` callback never
-    // ran. Now `listen()` returns immediately and pending requests
-    // are drained from the unified pump on every tick. Mirrors the
-    // `external-net-pump` / `external-ws-pump` patterns above.
-    #[cfg(feature = "external-http-server-pump")]
-    {
-        extern "C" {
-            fn js_node_http_server_process_pending() -> i32;
-        }
-        let n = unsafe { js_node_http_server_process_pending() };
-        count += n;
-    }
-
-    // Issue #769 — when the well-known flip routes `node:http` /
-    // `node:https` client (`http.request` / `http.get`) to
-    // perry-ext-http, drain its response/error queue on every tick.
-    // Mirrors the server-side `external-http-server-pump` arm above.
-    #[cfg(feature = "external-http-client-pump")]
-    {
-        extern "C" {
-            fn js_http_process_pending() -> i32;
-        }
-        let n = unsafe { js_http_process_pending() };
-        count += n;
     }
 
     // Process pending worker_threads messages (stdin reader)
@@ -709,30 +630,6 @@ pub extern "C" fn js_stdlib_process_pending() -> i32 {
     #[cfg(feature = "compression-gzip")]
     {
         count += unsafe { crate::zlib::js_zlib_process_pending() };
-    }
-    // External path: the well-known flip routed `node:zlib` to perry-ext-zlib
-    // and stripped `compression`. Drain perry-ext-zlib's queue via its extern.
-    #[cfg(feature = "external-zlib-pump")]
-    {
-        extern "C" {
-            fn js_ext_zlib_process_pending() -> i32;
-        }
-        count += unsafe { js_ext_zlib_process_pending() };
-    }
-
-    // Process pending fastify requests. `listen()` returns immediately and the
-    // per-server mpsc is drained here each tick (#604), so an `await
-    // app.listen(...)` resumes and subsequent user code (in-process `fetch`,
-    // `app.close()`, async route handlers) runs. fastify is served exclusively by
-    // the external perry-ext-fastify crate (the in-stdlib adapter was removed);
-    // the well-known flip enables `external-fastify-pump` and the symbol is
-    // provided by that crate. Mirrors `external-net-pump` / `external-ws-pump`.
-    #[cfg(feature = "external-fastify-pump")]
-    {
-        extern "C" {
-            fn js_fastify_process_pending() -> i32;
-        }
-        count += unsafe { js_fastify_process_pending() };
     }
 
     count
@@ -777,37 +674,8 @@ pub extern "C" fn js_stdlib_has_active_handles() -> i32 {
             return 1;
         }
     }
-    // External (perry-ext-ws) path — when the well-known flip strips
-    // `bundled-ws` and routes `import 'ws'` to perry-ext-ws, the
-    // wrapper's `js_ws_has_pending` reports active servers / open
-    // connections / queued events. Without this gate, a TS program
-    // running an in-process WebSocketServer would have its event loop
-    // exit before the listener task can dispatch any event. Closes
-    // #606 follow-up. Mirrors the `external-net-pump` arm above.
-    #[cfg(all(feature = "external-ws-pump", not(feature = "websocket")))]
-    {
-        extern "C" {
-            fn js_ws_has_pending() -> i32;
-        }
-        if unsafe { js_ws_has_pending() } != 0 {
-            return 1;
-        }
-    }
-    // Check for active raw TCP sockets (net.Socket / tls.connect / upgrade).
-    // Without this, an `await net.connect(...)` returns a Promise that the
-    // runtime can't see is pending, so the event loop exits before the
-    // socket's 'connect' event ever fires through the pump.
-    //
-    // Two paths: `bundled-net` (perry-stdlib's own net implementation
-    // is compiled in) calls `crate::net::js_net_has_active_handles`
-    // directly; `external-net-pump` (the well-known flip routes
-    // `import 'net'` to perry-ext-net) calls perry-ext-net's
-    // `js_ext_net_has_active_handles` extern. Pre-fix only the
-    // bundled-net gate fired, so programs using TS-source drivers
-    // like `@perryts/mysql` that route through perry-ext-net saw
-    // `await new Promise(r => sock.on('connect', r))` exit early
-    // because perry-stdlib's empty NET_SOCKETS map reported no
-    // active handles. Issue #536.
+    // Check bundled raw TCP sockets. External net implementations register
+    // their own keepalive contributor with runtime and remain invisible here.
     #[cfg(all(
         feature = "bundled-net",
         not(target_os = "ios"),
@@ -826,56 +694,6 @@ pub extern "C" fn js_stdlib_has_active_handles() -> i32 {
     ))]
     {
         if crate::tls::js_tls_has_active_handles() != 0 {
-            return 1;
-        }
-    }
-    #[cfg(all(
-        feature = "external-net-pump",
-        not(feature = "bundled-net"),
-        not(target_os = "ios"),
-        not(target_os = "android")
-    ))]
-    {
-        extern "C" {
-            fn js_ext_net_has_active_handles() -> i32;
-        }
-        if unsafe { js_ext_net_has_active_handles() } != 0 {
-            return 1;
-        }
-    }
-    // Active HTTP/HTTPS/HTTP2 servers — keep the event loop alive
-    // for the lifetime of any listening server (until the user calls
-    // `server.close()`). Without this gate, the codegen-emitted main
-    // loop sees no active sources and exits before the first request
-    // ever arrives. Closes #604 — paired with the
-    // `js_node_http_server_process_pending` arm in
-    // `js_stdlib_process_pending` above.
-    #[cfg(feature = "external-http-server-pump")]
-    {
-        extern "C" {
-            fn js_node_http_server_has_active() -> i32;
-        }
-        if unsafe { js_node_http_server_has_active() } != 0 {
-            return 1;
-        }
-    }
-    // Issue #769 — keep the event loop alive while an in-flight
-    // `http.request` / `http.get` (perry-ext-http) hasn't received its
-    // response or error event yet.
-    #[cfg(feature = "external-http-client-pump")]
-    {
-        extern "C" {
-            fn js_http_has_pending() -> i32;
-            fn js_ext_http_client_inflight() -> i32;
-        }
-        if unsafe { js_http_has_pending() } != 0 {
-            return 1;
-        }
-        // #5779 follow-up — also stay alive for the in-flight window BEFORE the
-        // reqwest task has pushed any event (response received but not yet
-        // delivered), so a single outstanding fetch can't let the loop exit
-        // early and so the idle-kick has a live loop to recover it on.
-        if unsafe { js_ext_http_client_inflight() } != 0 {
             return 1;
         }
     }
@@ -907,22 +725,6 @@ pub extern "C" fn js_stdlib_has_active_handles() -> i32 {
             return 1;
         }
     }
-    // External fastify (perry-ext-fastify) — keep the loop alive while any
-    // FastifyServerHandle is "listening". Paired with `js_fastify_process_pending`
-    // in `js_stdlib_process_pending` above (closes the compat-sweep timeout for
-    // `await app.listen(...)` + in-process `fetch`). The in-stdlib adapter was
-    // removed; the well-known flip enables `external-fastify-pump` and the symbol
-    // is provided by perry-ext-fastify at link time. Mirrors the
-    // `external-{net,ws,http-server}-pump` arms above.
-    #[cfg(feature = "external-fastify-pump")]
-    {
-        extern "C" {
-            fn js_fastify_has_active() -> i32;
-        }
-        if unsafe { js_fastify_has_active() } != 0 {
-            return 1;
-        }
-    }
     // zlib streams (#1843) — keep the loop alive while `.end()`-queued
     // 'data'/'end' events are still waiting to be drained, so a purely-
     // synchronous `createGzip().write(x).end()` program doesn't exit before
@@ -930,16 +732,6 @@ pub extern "C" fn js_stdlib_has_active_handles() -> i32 {
     #[cfg(feature = "compression-gzip")]
     {
         if crate::zlib::js_zlib_has_active_handles() != 0 {
-            return 1;
-        }
-    }
-    // External (perry-ext-zlib) path:
-    #[cfg(feature = "external-zlib-pump")]
-    {
-        extern "C" {
-            fn js_ext_zlib_has_active_handles() -> i32;
-        }
-        if unsafe { js_ext_zlib_has_active_handles() } != 0 {
             return 1;
         }
     }
@@ -1119,11 +911,38 @@ mod tests {
     }
 
     #[test]
-    fn active_http_server_keeps_the_fast_wait_path_driving_native_tasks() {
-        assert!(!native_fast_drive_needed(0, false, false));
-        assert!(native_fast_drive_needed(0, false, true));
-        assert!(native_fast_drive_needed(0, true, false));
-        assert!(native_fast_drive_needed(1, false, false));
+    fn active_extension_keeps_the_fast_wait_path_driving_native_tasks() {
+        assert!(!native_fast_drive_needed(0, false));
+        assert!(native_fast_drive_needed(0, true));
+        assert!(native_fast_drive_needed(1, false));
+        assert!(native_fast_drive_needed(1, true));
+    }
+
+    #[test]
+    fn stdlib_bridge_does_not_hard_reference_extension_pumps() {
+        let source = include_str!("async_bridge.rs");
+        let extension_symbols = [
+            "js_ws_process_pending",
+            "js_ws_has_pending",
+            "js_net_process_pending",
+            "js_ext_net_has_active_handles",
+            "js_node_http_server_process_pending",
+            "js_node_http_server_has_active",
+            "js_http_process_pending",
+            "js_http_has_pending",
+            "js_ext_http_client_inflight",
+            "js_ext_zlib_process_pending",
+            "js_ext_zlib_has_active_handles",
+            "js_fastify_process_pending",
+            "js_fastify_has_active",
+        ];
+
+        for symbol in extension_symbols {
+            assert!(
+                !source.contains(&format!("fn {symbol}(")),
+                "stdlib must discover {symbol} through the runtime registry, not an extern declaration"
+            );
+        }
     }
 
     #[test]

--- a/crates/perry/src/commands/compile/optimized_libs/driver.rs
+++ b/crates/perry/src/commands/compile/optimized_libs/driver.rs
@@ -382,10 +382,9 @@ pub(crate) fn build_optimized_libs(
                 features.insert("web-fetch");
             }
             // v0.5.579 — when the flip strips `bundled-net`, activate
-            // `external-net-pump` so perry-stdlib's
-            // `js_stdlib_process_pending` knows to call into
-            // perry-ext-net's queue. Without this the call site is
-            // `#[cfg]`-gated off and tokio events stay queued forever.
+            // `external-net-pump` to retain the shared runtime and external
+            // net dispatch adapters. perry-ext-net registers its pump and
+            // keepalive contributor directly with runtime.
             if original_features.contains(&"bundled-net") {
                 features.insert("external-net-pump");
             }
@@ -398,15 +397,14 @@ pub(crate) fn build_optimized_libs(
             }
             // #1843 — when the flip strips the compression base feature and
             // routes `node:zlib` to perry-ext-zlib, activate
-            // `external-zlib-pump` so perry-stdlib's main-thread pump +
-            // active-handles gate drain perry-ext-zlib's deferred
-            // stream-event queue and route `gz.write()`/`.on()`/`.pipe()`
-            // (lost-static-type) calls into its `js_ext_zlib_dispatch_method`.
-            // Without this the events stay queued forever
-            // (`createGzip().on('data')` never fires). `module_to_features`
-            // maps `zlib` to `compression-gzip` since the per-codec split;
+            // `external-zlib-pump` to retain lost-static-type dispatch
+            // (`gz.write()`/`.on()`/`.pipe()`) into
+            // `js_ext_zlib_dispatch_method`. perry-ext-zlib registers its
+            // own deferred-event pump and keepalive contributor.
+            // `module_to_features` maps `zlib` to `compression-gzip` since
+            // the per-codec split;
             // keep matching the legacy `compression` umbrella too so a
-            // future mapping change can't silently drop the pump.
+            // future mapping change cannot silently drop the adapter.
             if original_features.contains(&"compression-gzip")
                 || original_features.contains(&"compression")
             {
@@ -420,23 +418,18 @@ pub(crate) fn build_optimized_libs(
                 features.remove("compression-zstd");
             }
             // Closes #606 — same shape for ws. When the well-known flip
-            // strips `bundled-ws` and routes to perry-ext-ws, activate
-            // `external-ws-pump` so perry-stdlib's main-thread pump and
-            // active-handles gate know to call into perry-ext-ws's
-            // queue. Without this, perry-ext-ws's accept loop pushes
-            // events that nobody drains, and the program exits or hangs
-            // before any handler fires.
+            // strips `bundled-ws` and routes to perry-ext-ws, retain
+            // `external-ws-pump` for the shared async runtime. perry-ext-ws
+            // registers its event queue and active handles when it initializes.
             if original_features.contains(&"bundled-ws") {
                 features.insert("external-ws-pump");
             }
             // `node:http` / `node:https` / `node:http2` can also create
             // WebSocket client handles through `server.on("upgrade", ...)`.
             // The HTTP wrapper registers those upgraded streams in
-            // perry-ext-ws, so stdlib must pump the external WS queue even
-            // when user code does not import `ws` directly. Without this,
-            // `ws.send(...)` from the upgrade callback works for the greeting,
-            // but later browser/client frames remain queued forever and
-            // `ws.on("message", ...)` never fires.
+            // perry-ext-ws, whose initialization registers its pump and
+            // keepalive callback even without a direct `ws` import. Retain
+            // `external-ws-pump` here for the shared async runtime.
             if matches!(module_normalized, "http" | "https" | "http2") {
                 features.insert("external-ws-pump");
             }
@@ -444,29 +437,20 @@ pub(crate) fn build_optimized_libs(
             // perry-ext-fastify (the in-stdlib adapter was removed), so this
             // fires whenever `import 'fastify'` is routed here — not off a
             // (now-gone) `bundled-fastify` feature. `external-fastify-pump`
-            // wires perry-ext-fastify's `js_fastify_process_pending` /
-            // `js_fastify_has_active` into perry-stdlib's
-            // `js_stdlib_process_pending` / `_has_active_handles` so requests
-            // flow on the main TS thread; it pulls `async-runtime` (shared
-            // tokio) transitively via its Cargo feature deps.
+            // retains Fastify's dispatch adapters and shared async runtime;
+            // perry-ext-fastify self-registers its pump and keepalive callback.
             if module_normalized == "fastify" {
                 features.insert("external-fastify-pump");
             }
             // Closes #604 — when the well-known flip routes `node:http` /
             // `node:https` / `node:http2` to perry-ext-http, activate
-            // `external-http-server-pump`
-            // so perry-stdlib's main-thread pump and active-handles gate
-            // call into perry-ext-http's queue each tick. Without
-            // this, the http server's accept-loop tokio task pushes
-            // requests that nobody drains, and the program hangs (pre-#604
-            // listen() blocked the main thread; post-#604 listen() is
-            // non-blocking but needs the pump to fire).
+            // `external-http-server-pump` to retain its dispatch adapters and
+            // shared async runtime. perry-ext-http self-registers the server
+            // pump and keepalive callback.
             //
             // Gate strictly on the MODULE name (not on `http-client`
-            // feature, which axios / node-fetch also map to) — those
-            // bring perry-ext-axios / perry-ext-fetch which don't define
-            // `js_node_http_server_*` symbols. Activating the pump for
-            // them would drop unresolved externs at link time.
+            // feature, which axios / node-fetch also map to), because those
+            // packages do not need the server dispatch adapters.
             if matches!(module_normalized, "http" | "https" | "http2") {
                 features.insert("external-http-server-pump");
                 // perry-ext-http depends on perry-ext-net, whose TLS client
@@ -478,11 +462,8 @@ pub(crate) fn build_optimized_libs(
                 features.insert("external-tls-server");
             }
             // Issue #769 — when `node:http` / `node:https` routes to
-            // perry-ext-http, also activate the client-side pump so the
-            // response/error queue produced by `http.request` /
-            // `http.get` (perry-ext-http's `js_http_request`,
-            // `js_http_get`) actually gets drained. Without this the
-            // request fires but the user callback never runs.
+            // perry-ext-http, retain its client dispatch adapters and shared
+            // runtime. The client queue and in-flight predicate self-register.
             if matches!(module_normalized, "http" | "https") {
                 features.insert("external-http-client-pump");
             }


### PR DESCRIPTION
## Summary

- make the runtime auxiliary callback registry the single seam for extension event pumps and keepalive contributors
- have HTTP client, WebSocket, and Fastify initialize their own registrations, while routing the existing net and zlib registrations through the public FFI helper
- remove named extension externs from the stdlib pump, active-handle gate, and fast wait-driver
- retain the external pump feature flags for dispatch-adapter and shared-runtime selection only
- add registry/idempotence coverage and an invariant test preventing stdlib from regaining named extension pump references

No package versions or lockfiles are changed.

## Testing

- `cargo check -p perry-runtime -p perry-stdlib -p perry-ffi -p perry-ext-http -p perry-ext-ws -p perry-ext-fastify -p perry-ext-net -p perry-ext-zlib`
- `cargo test -p perry-runtime aux_has_active_registration_is_idempotent_and_queryable -- --nocapture`
- `cargo test -p perry-stdlib stdlib_bridge_does_not_hard_reference_extension_pumps -- --nocapture`
- `cargo test -p perry-stdlib active_extension_keeps_the_fast_wait_path_driving_native_tasks -- --nocapture`
- `cargo test -p perry --test issue_8907_ext_http_cgu_link -- --nocapture`
- `cargo test -p perry --test issue_5174_headers_http_pump_hang headers_in_http_handler_does_not_hang_response_pump -- --nocapture`
- built runtime + stdlib static archives with every external pump feature enabled and verified with `nm` that the bridge object has no undefined extension symbols

Closes #9696


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extension modules now register their event processing and activity checks directly with the runtime.
  * Runtime activity detection now includes registered extension work, helping asynchronous operations remain responsive.
* **Refactor**
  * Consolidated event-pump registration across networking, HTTP, WebSocket, Fastify, and zlib extensions.
* **Documentation**
  * Updated technical documentation to reflect the unified runtime registration model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->