### PR TITLE
fix(transform): preserve fresh prototype replacements

### DIFF
--- a/changelog.d/9704-fresh-instance-prototype-replacement.md
+++ b/changelog.d/9704-fresh-instance-prototype-replacement.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Fresh instances now observe class prototype methods replaced after class
+  registration. The method inliner keeps runtime dispatch for prototype chains
+  exposed or mutated anywhere in the module, including helper functions and
+  closures. (#9239)

--- a/crates/perry-transform/src/inline/exact_receivers.rs
+++ b/crates/perry-transform/src/inline/exact_receivers.rs
@@ -1,6 +1,6 @@
 use perry_hir::types::LocalId;
 use perry_hir::walker::walk_expr_children;
-use perry_hir::{Expr, Stmt};
+use perry_hir::{Class, Expr, Module, Stmt};
 use std::collections::{HashMap, HashSet};
 
 use super::*;
@@ -33,6 +33,239 @@ pub fn resolve_receiver_class(
         }
         _ => None,
     }
+}
+
+/// Module-wide proof that a declared class's prototype chain keeps the method
+/// table recorded by its class declaration.
+///
+/// Exact-receiver facts only prove that a local came from `new C()`. They do
+/// not make `C.prototype` immutable: after `C.prototype.m = replacement`, a
+/// later fresh `C` is still exact while its `m` lookup no longer resolves to
+/// the declaration-time body. Keep prototype stability separate from receiver
+/// identity so the method inliner needs both proofs (#9239).
+#[derive(Debug, Default)]
+pub(crate) struct ModulePrototypeFacts {
+    touched_classes: HashSet<String>,
+    opaque_prototype_access: bool,
+}
+
+impl ModulePrototypeFacts {
+    /// True when neither this class nor a known parent has a prototype that is
+    /// named or replaced anywhere in the module.
+    pub(crate) fn method_table_is_stable(&self, classes: &[Class], class_name: &str) -> bool {
+        if self.opaque_prototype_access {
+            return false;
+        }
+
+        let mut current = Some(class_name);
+        let mut seen = HashSet::new();
+        while let Some(name) = current {
+            if !seen.insert(name) || self.touched_classes.contains(name) {
+                return false;
+            }
+
+            let Some(class) = classes.iter().find(|class| class.name == name) else {
+                // Cross-module candidates do not carry their source module's
+                // class table. A destination-side named touch was checked
+                // above; otherwise preserve their existing eligibility.
+                return true;
+            };
+            if class.extends_expr.is_some() || class.native_extends.is_some() {
+                return false;
+            }
+            current = class.extends_name.as_deref();
+        }
+        true
+    }
+}
+
+/// Collect every module site that can expose or replace a declared class
+/// prototype. Naming a prototype is conservatively a touch because it can be
+/// retained in an alias and mutated by a later statement or closure.
+pub(crate) fn collect_module_prototype_facts(module: &Module) -> ModulePrototypeFacts {
+    fn note_holder(object: &Expr, facts: &mut ModulePrototypeFacts) {
+        match object {
+            Expr::ClassRef(name) => {
+                facts.touched_classes.insert(name.clone());
+            }
+            // Function-classic prototypes use runtime synthetic class ids and
+            // cannot replace a declared class's method table.
+            Expr::FuncRef(_) => {}
+            _ => facts.opaque_prototype_access = true,
+        }
+    }
+
+    fn visit_expr(expr: &Expr, facts: &mut ModulePrototypeFacts) {
+        match expr {
+            Expr::RegisterPrototypeMethod { class_name, .. }
+            | Expr::RegisterClassParentDynamic { class_name, .. } => {
+                facts.touched_classes.insert(class_name.clone());
+            }
+            Expr::SetFunctionPrototype { func, .. } => {
+                if let Expr::ClassRef(name) = func.as_ref() {
+                    facts.touched_classes.insert(name.clone());
+                }
+            }
+            Expr::PropertyGet {
+                object, property, ..
+            }
+            | Expr::PropertySet {
+                object, property, ..
+            }
+            | Expr::PropertyUpdate {
+                object, property, ..
+            } if property == "prototype" || property == "__proto__" => {
+                note_holder(object, facts);
+            }
+            Expr::IndexGet { object, index } | Expr::IndexSet { object, index, .. } if matches!(index.as_ref(), Expr::String(key) if key == "prototype" || key == "__proto__") =>
+            {
+                note_holder(object, facts);
+            }
+            Expr::PutValueSet { target, key, .. } if matches!(key.as_ref(), Expr::String(name) if name == "prototype" || name == "__proto__") =>
+            {
+                note_holder(target, facts);
+            }
+            _ => {}
+        }
+
+        // The ordinary expression walker deliberately treats a closure body
+        // as non-executing. Prototype stability is module-wide, so a mutation
+        // in that body still has to participate in this proof.
+        if let Expr::Closure { body, .. } = expr {
+            visit_stmts(body, facts);
+        }
+        walk_expr_children(expr, &mut |child| visit_expr(child, facts));
+    }
+
+    fn visit_stmt(stmt: &Stmt, facts: &mut ModulePrototypeFacts) {
+        match stmt {
+            Stmt::Let { init, .. } => {
+                if let Some(init) = init {
+                    visit_expr(init, facts);
+                }
+            }
+            Stmt::Expr(expr) | Stmt::Throw(expr) | Stmt::Return(Some(expr)) => {
+                visit_expr(expr, facts);
+            }
+            Stmt::If {
+                condition,
+                then_branch,
+                else_branch,
+            } => {
+                visit_expr(condition, facts);
+                visit_stmts(then_branch, facts);
+                if let Some(else_branch) = else_branch {
+                    visit_stmts(else_branch, facts);
+                }
+            }
+            Stmt::While { condition, body } | Stmt::DoWhile { body, condition } => {
+                visit_expr(condition, facts);
+                visit_stmts(body, facts);
+            }
+            Stmt::For {
+                init,
+                condition,
+                update,
+                body,
+            } => {
+                if let Some(init) = init {
+                    visit_stmt(init, facts);
+                }
+                if let Some(condition) = condition {
+                    visit_expr(condition, facts);
+                }
+                if let Some(update) = update {
+                    visit_expr(update, facts);
+                }
+                visit_stmts(body, facts);
+            }
+            Stmt::Try {
+                body,
+                catch,
+                finally,
+            } => {
+                visit_stmts(body, facts);
+                if let Some(catch) = catch {
+                    visit_stmts(&catch.body, facts);
+                }
+                if let Some(finally) = finally {
+                    visit_stmts(finally, facts);
+                }
+            }
+            Stmt::Switch {
+                discriminant,
+                cases,
+            } => {
+                visit_expr(discriminant, facts);
+                for case in cases {
+                    if let Some(test) = &case.test {
+                        visit_expr(test, facts);
+                    }
+                    visit_stmts(&case.body, facts);
+                }
+            }
+            Stmt::Labeled { body, .. } => visit_stmt(body, facts),
+            Stmt::Return(None)
+            | Stmt::Break
+            | Stmt::Continue
+            | Stmt::LabeledBreak(_)
+            | Stmt::LabeledContinue(_)
+            | Stmt::PreallocateBoxes(_)
+            | Stmt::PreallocateTdzBoxes(_)
+            | Stmt::ReleaseBoxes(_) => {}
+        }
+    }
+
+    fn visit_stmts(stmts: &[Stmt], facts: &mut ModulePrototypeFacts) {
+        for stmt in stmts {
+            visit_stmt(stmt, facts);
+        }
+    }
+
+    fn visit_function(function: &perry_hir::Function, facts: &mut ModulePrototypeFacts) {
+        for param in &function.params {
+            if let Some(default) = &param.default {
+                visit_expr(default, facts);
+            }
+        }
+        visit_stmts(&function.body, facts);
+    }
+
+    let mut facts = ModulePrototypeFacts::default();
+    visit_stmts(&module.init, &mut facts);
+    for function in &module.functions {
+        visit_function(function, &mut facts);
+    }
+    for class in &module.classes {
+        if let Some(extends) = &class.extends_expr {
+            visit_expr(extends, &mut facts);
+        }
+        if let Some(constructor) = &class.constructor {
+            visit_function(constructor, &mut facts);
+        }
+        for method in class
+            .methods
+            .iter()
+            .chain(class.static_methods.iter())
+            .chain(class.getters.iter().map(|(_, function)| function))
+            .chain(class.setters.iter().map(|(_, function)| function))
+            .chain(class.computed_members.iter().map(|member| &member.function))
+        {
+            visit_function(method, &mut facts);
+        }
+        for field in class.fields.iter().chain(class.static_fields.iter()) {
+            if let Some(init) = &field.init {
+                visit_expr(init, &mut facts);
+            }
+            if let Some(key) = &field.key_expr {
+                visit_expr(key, &mut facts);
+            }
+        }
+        for member in &class.computed_members {
+            visit_expr(&member.key_expr, &mut facts);
+        }
+    }
+    facts
 }
 
 pub fn intersect_exact_receiver_facts(

--- a/crates/perry-transform/src/inline/mod.rs
+++ b/crates/perry-transform/src/inline/mod.rs
@@ -40,8 +40,8 @@ pub(crate) use closure_analysis::{
 };
 pub(crate) use exact_receivers::{
     apply_exact_receiver_stmt_effect, apply_exact_receiver_stmt_effects,
-    intersect_exact_receiver_facts, invalidate_exact_receivers_for_expr,
-    kill_referenced_exact_receivers,
+    collect_module_prototype_facts, intersect_exact_receiver_facts,
+    invalidate_exact_receivers_for_expr, kill_referenced_exact_receivers,
 };
 pub(crate) use factory_specialize::specialize_captured_class_factories;
 pub(crate) use imul::{detect_math_imul_polyfill, rewrite_imul_calls_in_stmts};
@@ -557,6 +557,10 @@ fn inline_functions_inner(
     // class regardless of native_extends), so it lives at the top of
     // the loop body before the native_extends short-circuit for method
     // collection.
+    // A fresh exact receiver still observes later prototype replacement. The
+    // receiver proof used by the call inliner therefore needs an independent,
+    // module-wide stable-method-table proof (#9239).
+    let prototype_facts = collect_module_prototype_facts(module);
     let mut method_candidates: HashMap<(String, String), MethodCandidate> = HashMap::new();
     let mut class_names: HashMap<String, String> = HashMap::new();
     // (class_name, field_name) → field's class type (when the field is
@@ -604,6 +608,9 @@ fn inline_functions_inner(
     // `import_function_prefixes`.
     let mut needed_imports: BTreeMap<String, Vec<String>> = BTreeMap::new();
     method_candidates.extend(extra_methods.iter().filter_map(|(k, v)| {
+        if !prototype_facts.method_table_is_stable(&module.classes, &k.0) {
+            return None;
+        }
         // If any required (name, path) is missing from dest, queue an import.
         // We always admit when the path is reachable from the destination —
         // if dest has no import that resolves to that path, we synthesize
@@ -681,7 +688,9 @@ fn inline_functions_inner(
         // EventEmitter) — the `this` reference needs special handling
         // in those contexts. The class_name lookup above still records
         // the type so other passes can reference it.
-        if class.native_extends.is_some() {
+        if class.native_extends.is_some()
+            || !prototype_facts.method_table_is_stable(&module.classes, &class.name)
+        {
             continue;
         }
         for method in &class.methods {
@@ -912,6 +921,30 @@ mod tests {
             byte_offset: 0,
             cap_args_appended: 0,
         })
+    }
+
+    #[test]
+    fn prototype_mutation_facts_are_module_wide_and_class_specific() {
+        let base = anon_class(1, "Base");
+        let mut derived = anon_class(2, "Derived");
+        derived.extends_name = Some("Base".to_string());
+        let unrelated = anon_class(3, "Unrelated");
+
+        let mut module = Module::new("prototype-facts");
+        module.classes = vec![base, derived, unrelated];
+        module.functions.push(function(
+            10,
+            vec![Stmt::Expr(Expr::RegisterPrototypeMethod {
+                class_name: "Base".to_string(),
+                method_name: "m".to_string(),
+                value: Box::new(Expr::Integer(1)),
+            })],
+        ));
+
+        let facts = collect_module_prototype_facts(&module);
+        assert!(!facts.method_table_is_stable(&module.classes, "Base"));
+        assert!(!facts.method_table_is_stable(&module.classes, "Derived"));
+        assert!(facts.method_table_is_stable(&module.classes, "Unrelated"));
     }
 
     #[test]

--- a/crates/perry/tests/issue_9131_prototype_method_replacement.rs
+++ b/crates/perry/tests/issue_9131_prototype_method_replacement.rs
@@ -102,6 +102,49 @@ console.log("swap-after:", readA(a));
     );
 }
 
+/// #9239: constructing another exact receiver after replacing a prototype
+/// method must not let the HIR inliner substitute the declaration-time body.
+/// Keep both a stored fresh receiver and a dynamic-constructor call here: the
+/// direct `new C().m()` shape already stays on runtime dispatch and would not
+/// catch a stale exact-receiver optimization fact.
+#[test]
+fn fresh_instances_observe_replaced_prototype_methods() {
+    let stdout = compile_and_run(
+        r#"
+class C {
+  m() { return "orig"; }
+}
+
+const old = new C();
+console.log("before:", old.m());
+(C.prototype as any).m = function () { return "replaced"; };
+console.log("old:", old.m());
+
+const fresh = new C();
+console.log("fresh:", fresh.m());
+console.log("direct:", new C().m());
+
+const DynamicC: any = C;
+console.log("dynamic:", new DynamicC().m());
+
+class HelperC {
+  m() { return "helper-orig"; }
+}
+function replaceThroughHelper() {
+  (HelperC.prototype as any).m = function () { return "helper-replaced"; };
+}
+replaceThroughHelper();
+const helperFresh = new HelperC();
+console.log("helper:", helperFresh.m());
+"#,
+    );
+
+    assert_eq!(
+        stdout,
+        "before: orig\nold: replaced\nfresh: replaced\ndirect: replaced\ndynamic: replaced\nhelper: helper-replaced\n"
+    );
+}
+
 /// #9244: the per-instance prototype-override fast path in
 /// `js_native_call_method` resolves the method by ordinary property lookup.
 /// Before #9251, a runtime-wired generator carried the shared override flag but

--- a/test-files/test_gap_9239_fresh_instance_prototype_replacement.ts
+++ b/test-files/test_gap_9239_fresh_instance_prototype_replacement.ts
@@ -1,0 +1,28 @@
+// #9239: a class prototype replacement applies to existing and fresh
+// instances. The stored fresh receiver is important: it exercises Perry's
+// exact-receiver method inliner instead of only the runtime dispatch path.
+class C {
+  m() { return "orig"; }
+}
+
+const old = new C();
+console.log("before:", old.m());
+(C.prototype as any).m = function () { return "replaced"; };
+console.log("old:", old.m());
+
+const fresh = new C();
+console.log("fresh:", fresh.m());
+console.log("direct:", new C().m());
+
+const DynamicC: any = C;
+console.log("dynamic:", new DynamicC().m());
+
+class HelperC {
+  m() { return "helper-orig"; }
+}
+function replaceThroughHelper() {
+  (HelperC.prototype as any).m = function () { return "helper-replaced"; };
+}
+replaceThroughHelper();
+const helperFresh = new HelperC();
+console.log("helper:", helperFresh.m());


### PR DESCRIPTION
Fixes #9239.

## Summary

- require a module-wide stable prototype-chain proof before the exact-receiver inliner substitutes a declared method body
- scan init code, functions, closures, class bodies, fields, and computed members for direct, aliased, or opaque prototype access
- keep unrelated classes eligible while conservatively disabling inlining for touched classes and their descendants
- cover stored fresh receivers, direct and dynamic construction, and mutation hidden in a helper function

## Testing

- `cargo test -p perry-transform` (124 passed)
- `cargo test -p perry --test issue_9131_prototype_method_replacement -- --nocapture` (3 passed)
- pinned Node 26.5.1: `PERRY_SKIP_BUILD=1 ... ./run_parity_tests.sh --filter test_gap_9239_fresh_instance_prototype_replacement` (1/1 parity pass)
- `cargo clippy -p perry-transform --all-targets`
- `./scripts/pre-tag-check.sh --quick`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed prototype method replacement behavior so existing and newly created instances consistently use the replacement method.
  * Preserved runtime method dispatch when prototypes are modified directly, dynamically, or through helper functions and closures.
  * Prevented optimization from substituting outdated method implementations after prototype changes.

* **Tests**
  * Added regression coverage for direct, fresh, dynamic, and helper-created instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->