### PR TITLE
fix(runtime): classify buffer-backed Uint8Array misses (#9347)

### DIFF
--- a/changelog.d/9710-typed-array-buffer-miss-consumers.md
+++ b/changelog.d/9710-typed-array-buffer-miss-consumers.md
@@ -1,0 +1,19 @@
+**Buffer-backed `Uint8Array` values now stay typed arrays when a kind-registry
+lookup misses.** Perry deliberately represents JavaScript `Uint8Array` values
+with `BufferHeader`, outside `lookup_typed_array_kind`; three consumers treated
+that expected miss as a failed brand or receiver check.
+
+The reflected `%TypedArray%.prototype` `length`, `byteLength`, `byteOffset`, and
+`buffer` getters now accept both `Uint8Array` and Node `Buffer` receivers. They
+also report real view offsets and the same stable backing `ArrayBuffer` as the
+direct property path. Node-API's `napi_is_typedarray` and
+`napi_get_typedarray_info` likewise report buffer-backed views and Buffers as
+`napi_uint8_array`, including their backing identity, offset, and canonical data
+span.
+
+Finally, `Object.preventExtensions` and its `Reflect` counterparts record and
+read the Uint8Array's side-table state, so it no longer remains extensible or
+admits a fresh expando after successfully preventing extensions. `Reflect.set`
+now also creates and updates its ordinary properties through the same Buffer
+property table as direct assignment. The buffer sweeper removes the
+address-keyed extensibility and TypedArray-property state on death.

--- a/crates/perry-runtime/src/buffer/header.rs
+++ b/crates/perry-runtime/src/buffer/header.rs
@@ -1178,6 +1178,12 @@ pub(crate) fn finalize_collected_dead_buffer(addr: usize) {
     //    `visit_metadata_usize_slot`, which resolves it against whatever now
     //    occupies those bytes and rewrites the key to the new tenant's address.
     super::own_props::clear_buffer_own_props(addr);
+    // A BufferHeader-backed Uint8Array keeps ordinary expandos and its
+    // non-extensible marker in the TypedArray side tables. Prune those here as
+    // well as in unregister_typed_array: this representation never enters the
+    // typed-array registry, so that unregister path can never see it (#9347).
+    crate::typedarray_props::typed_array_clear_own_props(addr);
+    crate::typedarray_props::typed_array_clear_no_extend(addr);
     super::detach::remove_detached_entry_for_dead_buffer(addr);
     super::view::remove_entries_for_dead_buffer(addr);
     // #9342: drop the dead address from the inline-read admission cache before

--- a/crates/perry-runtime/src/buffer/own_props.rs
+++ b/crates/perry-runtime/src/buffer/own_props.rs
@@ -67,8 +67,18 @@ pub fn buffer_set_own_prop(addr: usize, prop: &str, value: f64) {
         }
         return;
     }
-    if crate::object::get_property_attrs(addr, prop).is_some_and(|attrs| !attrs.writable())
-        && buffer_get_own_prop(addr, prop).is_some()
+    let existing = buffer_get_own_prop(addr, prop).is_some();
+    if existing
+        && crate::object::get_property_attrs(addr, prop).is_some_and(|attrs| !attrs.writable())
+    {
+        return;
+    }
+    // BufferHeader-backed typed arrays have no GcHeader flag. Their
+    // preventExtensions state lives in the TypedArray side table, so ordinary
+    // direct writes must consult it before adding a fresh expando (#9347).
+    if !existing
+        && crate::typedarray_props::is_typed_array_owner(addr)
+        && crate::typedarray_props::typed_array_owner_no_extend(addr)
     {
         return;
     }

--- a/crates/perry-runtime/src/gc/tests/buffer_side_tables.rs
+++ b/crates/perry-runtime/src/gc/tests/buffer_side_tables.rs
@@ -270,6 +270,59 @@ fn test_dead_buffer_own_property_entry_pruned_on_full_gc() {
     );
 }
 
+/// Buffer-backed Uint8Arrays use TypedArray metadata tables even though their
+/// owners are swept through the buffer finalizer. The finalizer must clear the
+/// non-extensible marker before the old-arena address can be reused (#9347).
+#[test]
+fn test_dead_uint8array_extensibility_entry_pruned_on_full_gc() {
+    let _guard = GcTestIsolationGuard::new();
+
+    let addr = crate::buffer::js_uint8array_alloc(32) as usize;
+    assert!(unsafe {
+        crate::typedarray_props::typed_array_set_property_by_name(addr, "existing", 1.0)
+    });
+    assert_eq!(
+        crate::buffer::buffer_get_own_prop(addr, "existing"),
+        Some(1.0),
+        "the typed-array Set path must use the canonical Buffer property table"
+    );
+    crate::typedarray_props::typed_array_mark_no_extend(addr);
+    assert!(
+        crate::typedarray_props::typed_array_owner_no_extend(addr),
+        "test premise: the Uint8Array has a side-table marker"
+    );
+    assert!(unsafe {
+        crate::typedarray_props::typed_array_set_property_by_name(addr, "existing", 2.0)
+    });
+    assert_eq!(
+        crate::buffer::buffer_get_own_prop(addr, "existing"),
+        Some(2.0)
+    );
+    assert!(!unsafe {
+        crate::typedarray_props::typed_array_set_property_by_name(addr, "fresh", 3.0)
+    });
+    crate::buffer::buffer_set_own_prop(addr, "direct_fresh", 4.0);
+    assert!(
+        crate::buffer::buffer_get_own_prop(addr, "fresh").is_none()
+            && crate::buffer::buffer_get_own_prop(addr, "direct_fresh").is_none(),
+        "neither reflected nor direct Set may add a key after preventExtensions"
+    );
+
+    // No roots: dead at the full trace. Buffer-backed Uint8Arrays never enter
+    // unregister_typed_array, so only finalize_collected_dead_buffer can
+    // remove this address-keyed entry.
+    full_gc();
+
+    assert!(
+        !crate::typedarray_props::typed_array_owner_no_extend(addr),
+        "a recycled address must not inherit a dead Uint8Array's integrity state"
+    );
+    assert!(
+        crate::buffer::buffer_get_own_prop(addr, "existing").is_none(),
+        "the canonical property table must be pruned with its dead owner"
+    );
+}
+
 /// A LIVE buffer keeps its own properties across a full collection. Without
 /// this the prune above could pass by dropping everything unconditionally.
 ///

--- a/crates/perry-runtime/src/node_api_host/buffers.rs
+++ b/crates/perry-runtime/src/node_api_host/buffers.rs
@@ -30,6 +30,22 @@ fn pointer_owner(env: NapiEnv, value: NapiValue) -> Result<usize, NapiStatus> {
     super::metadata::owner_from_bits(bits).ok_or(NapiStatus::InvalidArg)
 }
 
+#[derive(Clone, Copy)]
+enum NapiTypedArrayOwner {
+    Registered(usize),
+    Uint8Buffer(usize),
+}
+
+fn classify_typed_array_owner(owner: usize) -> Option<NapiTypedArrayOwner> {
+    if crate::typedarray::lookup_typed_array_kind(owner).is_some() {
+        Some(NapiTypedArrayOwner::Registered(owner))
+    } else if crate::object::typed_array_proto_thunks::is_typed_array_buffer(owner) {
+        Some(NapiTypedArrayOwner::Uint8Buffer(owner))
+    } else {
+        None
+    }
+}
+
 fn write_pointer_handle(env: NapiEnv, pointer: *const u8, result: *mut NapiValue) -> NapiStatus {
     if result.is_null() {
         return set_status(env, NapiStatus::InvalidArg, "result must not be null");
@@ -252,7 +268,7 @@ pub unsafe extern "C" fn napi_get_arraybuffer_info(
     };
     let buffer = owner as *const BufferHeader;
     if !data.is_null() {
-        *data = crate::buffer::buffer_data(buffer) as *mut c_void;
+        *data = crate::buffer::resolve_span_data_ptr(buffer) as *mut c_void;
     }
     if !byte_length.is_null() {
         *byte_length = (*buffer).length as usize;
@@ -326,7 +342,9 @@ pub unsafe extern "C" fn napi_is_typedarray(
         return set_status(env, NapiStatus::InvalidArg, "result must not be null");
     }
     *result = pointer_owner(env, value)
-        .is_ok_and(|owner| crate::typedarray::lookup_typed_array_kind(owner).is_some());
+        .ok()
+        .and_then(classify_typed_array_owner)
+        .is_some();
     ok(env)
 }
 
@@ -340,25 +358,51 @@ pub unsafe extern "C" fn napi_get_typedarray_info(
     arraybuffer: *mut NapiValue,
     byte_offset: *mut usize,
 ) -> NapiStatus {
-    let owner = match pointer_owner(env, typedarray) {
-        Ok(owner) if crate::typedarray::lookup_typed_array_kind(owner).is_some() => owner,
+    let owner = match pointer_owner(env, typedarray)
+        .ok()
+        .and_then(classify_typed_array_owner)
+    {
+        Some(owner) => owner,
         _ => return set_status(env, NapiStatus::InvalidArg, "value must be a TypedArray"),
     };
-    let typed_array = owner as *mut TypedArrayHeader;
-    let backing = crate::typedarray_view::js_typed_array_backing_buffer(typed_array);
-    let refreshed_owner = pointer_owner(env, typedarray).unwrap_or(owner);
-    let refreshed = refreshed_owner as *mut TypedArrayHeader;
+    let (reported_kind, reported_length, reported_data, backing, reported_offset) = match owner {
+        NapiTypedArrayOwner::Registered(owner) => {
+            let typed_array = owner as *mut TypedArrayHeader;
+            let backing = crate::typedarray_view::js_typed_array_backing_buffer(typed_array);
+            let refreshed_owner = pointer_owner(env, typedarray).unwrap_or(owner);
+            let refreshed = refreshed_owner as *mut TypedArrayHeader;
+            (
+                std::mem::transmute::<i32, NapiTypedarrayType>((*refreshed).kind as i32),
+                (*refreshed).length as usize,
+                crate::typedarray::data_ptr_mut(refreshed).cast::<c_void>(),
+                backing,
+                crate::typedarray_view::js_typed_array_byte_offset(refreshed) as usize,
+            )
+        }
+        NapiTypedArrayOwner::Uint8Buffer(owner) => {
+            let backing = crate::buffer::buffer_backing_array_buffer(owner);
+            let refreshed_owner = pointer_owner(env, typedarray).unwrap_or(owner);
+            let refreshed = refreshed_owner as *const BufferHeader;
+            (
+                NapiTypedarrayType::Uint8Array,
+                crate::buffer::js_buffer_length(refreshed).max(0) as usize,
+                crate::buffer::resolve_span_data_ptr(refreshed) as *mut c_void,
+                backing as *mut BufferHeader,
+                crate::buffer::buffer_byte_offset(refreshed_owner) as usize,
+            )
+        }
+    };
     if !kind.is_null() {
-        *kind = std::mem::transmute::<i32, NapiTypedarrayType>((*refreshed).kind as i32);
+        *kind = reported_kind;
     }
     if !length.is_null() {
-        *length = (*refreshed).length as usize;
+        *length = reported_length;
     }
     if !data.is_null() {
-        *data = crate::typedarray::data_ptr_mut(refreshed).cast();
+        *data = reported_data;
     }
     if !byte_offset.is_null() {
-        *byte_offset = crate::typedarray_view::js_typed_array_byte_offset(refreshed) as usize;
+        *byte_offset = reported_offset;
     }
     if !arraybuffer.is_null() {
         *arraybuffer =

--- a/crates/perry-runtime/src/node_api_host/tests.rs
+++ b/crates/perry-runtime/src/node_api_host/tests.rs
@@ -756,6 +756,133 @@ fn buffers_views_detach_and_promises_keep_backing_identity() {
     );
 }
 
+#[test]
+fn buffer_backed_uint8arrays_report_typedarray_info() {
+    let env = test_env();
+
+    let inspect = |value: NapiValue,
+                   expected_length: usize,
+                   expected_offset: usize,
+                   expected_data: *mut c_void,
+                   expected_backing: Option<NapiValue>| {
+        let mut is_typed_array = false;
+        assert_eq!(
+            unsafe { napi_is_typedarray(env, value, &mut is_typed_array) },
+            NapiStatus::Ok
+        );
+        assert!(is_typed_array);
+
+        let mut kind = NapiTypedarrayType::Int8Array;
+        let mut length = 0;
+        let mut data = std::ptr::null_mut();
+        let mut backing = std::ptr::null_mut();
+        let mut offset = usize::MAX;
+        assert_eq!(
+            unsafe {
+                napi_get_typedarray_info(
+                    env,
+                    value,
+                    &mut kind,
+                    &mut length,
+                    &mut data,
+                    &mut backing,
+                    &mut offset,
+                )
+            },
+            NapiStatus::Ok
+        );
+        assert_eq!(kind, NapiTypedarrayType::Uint8Array);
+        assert_eq!((length, offset), (expected_length, expected_offset));
+        assert_eq!(data, expected_data);
+
+        let mut is_array_buffer = false;
+        assert_eq!(
+            unsafe { napi_is_arraybuffer(env, backing, &mut is_array_buffer) },
+            NapiStatus::Ok
+        );
+        assert!(is_array_buffer);
+        if let Some(expected) = expected_backing {
+            let mut same = false;
+            assert_eq!(
+                unsafe { napi_strict_equals(env, backing, expected, &mut same) },
+                NapiStatus::Ok
+            );
+            assert!(same);
+        }
+
+        let mut backing_data = std::ptr::null_mut();
+        let mut backing_length = 0;
+        assert_eq!(
+            unsafe {
+                napi_get_arraybuffer_info(env, backing, &mut backing_data, &mut backing_length)
+            },
+            NapiStatus::Ok
+        );
+        assert!(backing_length >= expected_offset + expected_length);
+        assert_eq!(
+            data,
+            unsafe { (backing_data as *mut u8).add(expected_offset) }.cast()
+        );
+
+        let mut backing_again = std::ptr::null_mut();
+        assert_eq!(
+            unsafe {
+                napi_get_typedarray_info(
+                    env,
+                    value,
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                    &mut backing_again,
+                    std::ptr::null_mut(),
+                )
+            },
+            NapiStatus::Ok
+        );
+        let mut same = false;
+        assert_eq!(
+            unsafe { napi_strict_equals(env, backing, backing_again, &mut same) },
+            NapiStatus::Ok
+        );
+        assert!(
+            same,
+            "the reported backing ArrayBuffer identity must be stable"
+        );
+    };
+
+    let mut arraybuffer = std::ptr::null_mut();
+    let mut arraybuffer_data = std::ptr::null_mut();
+    assert_eq!(
+        unsafe { napi_create_arraybuffer(env, 8, &mut arraybuffer_data, &mut arraybuffer) },
+        NapiStatus::Ok
+    );
+    let arraybuffer_bits = value_bits(env, arraybuffer).unwrap();
+    let view_ptr = crate::buffer::js_uint8array_view(f64::from_bits(arraybuffer_bits), 2.0, 3.0);
+    let view = add_handle(env, crate::value::JSValue::pointer(view_ptr.cast()).bits()).unwrap();
+    inspect(
+        view,
+        3,
+        2,
+        unsafe { (arraybuffer_data as *mut u8).add(2) }.cast(),
+        Some(arraybuffer),
+    );
+
+    let mut node_buffer = std::ptr::null_mut();
+    let mut node_buffer_data = std::ptr::null_mut();
+    assert_eq!(
+        unsafe { napi_create_buffer(env, 4, &mut node_buffer_data, &mut node_buffer) },
+        NapiStatus::Ok
+    );
+    inspect(node_buffer, 4, 0, node_buffer_data, None);
+
+    let mut is_typed_array = true;
+    assert_eq!(
+        unsafe { napi_is_typedarray(env, arraybuffer, &mut is_typed_array) },
+        NapiStatus::Ok
+    );
+    assert!(!is_typed_array, "an ArrayBuffer is not a TypedArray");
+}
+
 static ASYNC_EXECUTED: AtomicUsize = AtomicUsize::new(0);
 static ASYNC_COMPLETED: AtomicUsize = AtomicUsize::new(0);
 static ASYNC_OFF_THREAD_REJECTED: AtomicUsize = AtomicUsize::new(0);

--- a/crates/perry-runtime/src/object/global_this/typed_array.rs
+++ b/crates/perry-runtime/src/object/global_this/typed_array.rs
@@ -256,13 +256,55 @@ fn jsvalue_extends_typed_array(value: f64) -> bool {
     }
 }
 
-/// Resolve the `IMPLICIT_THIS` receiver to a `(typed-array ptr, kind)` if it
-/// is a typed array, else `None`. Backs the `%TypedArray%.prototype` accessor
-/// getters installed for reflection (#2060) — these fire when user code does
-/// `desc.get.call(int8arr)` after pulling the descriptor out via
-/// `Object.getOwnPropertyDescriptor`. Mirrors the receiver-extraction the
-/// `Array.prototype.slice` thunk uses (NaN-boxed pointer or raw-i64 form).
-fn typed_array_receiver() -> Option<(*const crate::typedarray::TypedArrayHeader, u8)> {
+#[derive(Clone, Copy)]
+enum TypedArrayAccessorReceiver {
+    Registered(*const crate::typedarray::TypedArrayHeader, u8),
+    Uint8Buffer(usize),
+}
+
+impl TypedArrayAccessorReceiver {
+    fn length(self) -> u32 {
+        match self {
+            Self::Registered(ta, _) => crate::typedarray::js_typed_array_length(ta).max(0) as u32,
+            Self::Uint8Buffer(addr) => {
+                crate::buffer::js_buffer_length(addr as *const crate::buffer::BufferHeader).max(0)
+                    as u32
+            }
+        }
+    }
+
+    fn byte_length(self) -> usize {
+        match self {
+            Self::Registered(_, kind) => {
+                self.length() as usize * crate::typedarray::elem_size_for_kind(kind)
+            }
+            Self::Uint8Buffer(_) => self.length() as usize,
+        }
+    }
+
+    fn byte_offset(self) -> u32 {
+        match self {
+            Self::Registered(ta, _) => crate::typedarray_view::js_typed_array_byte_offset(ta),
+            Self::Uint8Buffer(addr) => crate::buffer::buffer_byte_offset(addr),
+        }
+    }
+
+    fn backing_buffer(self) -> usize {
+        match self {
+            Self::Registered(ta, _) => {
+                crate::typedarray_view::js_typed_array_backing_buffer(ta) as usize
+            }
+            Self::Uint8Buffer(addr) => crate::buffer::buffer_backing_array_buffer(addr),
+        }
+    }
+}
+
+/// Resolve the `IMPLICIT_THIS` receiver for the reflected
+/// `%TypedArray%.prototype` accessors installed by #2060. A Perry
+/// `Uint8Array` (and Node's `Buffer` subclass) uses `BufferHeader`, so a miss
+/// in `lookup_typed_array_kind` must continue through the strict buffer brand
+/// check instead of becoming a `TypeError` (#9347).
+fn typed_array_receiver() -> Option<TypedArrayAccessorReceiver> {
     use crate::value::JSValue;
     let this_bits = IMPLICIT_THIS.with(|c| c.get());
     let this_jsv = JSValue::from_bits(this_bits);
@@ -273,8 +315,14 @@ fn typed_array_receiver() -> Option<(*const crate::typedarray::TypedArrayHeader,
     } else {
         return None;
     };
-    let kind = crate::typedarray::lookup_typed_array_kind(raw)?;
-    Some((raw as *const crate::typedarray::TypedArrayHeader, kind))
+    if let Some(kind) = crate::typedarray::lookup_typed_array_kind(raw) {
+        return Some(TypedArrayAccessorReceiver::Registered(
+            raw as *const _,
+            kind,
+        ));
+    }
+    crate::object::typed_array_proto_thunks::is_typed_array_buffer(raw)
+        .then_some(TypedArrayAccessorReceiver::Uint8Buffer(raw))
 }
 
 fn typed_array_brand_error() -> ! {
@@ -312,12 +360,12 @@ pub(crate) fn typed_array_constructor_this_kind() -> Option<u8> {
     crate::typedarray::kind_for_name(&name)
 }
 
-fn typed_array_buffer_value(ta: *const crate::typedarray::TypedArrayHeader) -> f64 {
-    let buf = crate::typedarray::typed_array_to_array_buffer(ta);
-    if buf.is_null() {
+fn typed_array_buffer_value(receiver: TypedArrayAccessorReceiver) -> f64 {
+    let backing = receiver.backing_buffer();
+    if backing == 0 {
         typed_array_brand_error();
     }
-    crate::value::js_nanbox_pointer(buf as i64)
+    crate::value::js_nanbox_pointer(backing as i64)
 }
 
 /// `%TypedArray%.prototype.length` getter — element count of the receiver.
@@ -325,9 +373,8 @@ extern "C" fn typed_array_length_getter_thunk(
     _closure: *const crate::closure::ClosureHeader,
 ) -> f64 {
     match typed_array_receiver() {
-        Some((ta, _)) => {
-            let len = crate::typedarray::js_typed_array_length(ta);
-            f64::from_bits(crate::value::JSValue::number(len as f64).bits())
+        Some(receiver) => {
+            f64::from_bits(crate::value::JSValue::number(receiver.length() as f64).bits())
         }
         None => typed_array_brand_error(),
     }
@@ -338,36 +385,32 @@ extern "C" fn typed_array_byte_length_getter_thunk(
     _closure: *const crate::closure::ClosureHeader,
 ) -> f64 {
     match typed_array_receiver() {
-        Some((ta, kind)) => {
-            let len = crate::typedarray::js_typed_array_length(ta) as usize;
-            let elem_size = crate::typedarray::elem_size_for_kind(kind);
-            f64::from_bits(crate::value::JSValue::number((len * elem_size) as f64).bits())
+        Some(receiver) => {
+            f64::from_bits(crate::value::JSValue::number(receiver.byte_length() as f64).bits())
         }
         None => typed_array_brand_error(),
     }
 }
 
-/// `%TypedArray%.prototype.byteOffset` getter — always 0 (Perry views are not
-/// backed by an offset into a shared `ArrayBuffer`).
+/// `%TypedArray%.prototype.byteOffset` getter.
 extern "C" fn typed_array_byte_offset_getter_thunk(
     _closure: *const crate::closure::ClosureHeader,
 ) -> f64 {
     match typed_array_receiver() {
-        Some(_) => f64::from_bits(crate::value::JSValue::number(0.0).bits()),
+        Some(receiver) => {
+            f64::from_bits(crate::value::JSValue::number(receiver.byte_offset() as f64).bits())
+        }
         None => typed_array_brand_error(),
     }
 }
 
-/// `%TypedArray%.prototype.buffer` getter. Perry does not yet model a
-/// first-class `ArrayBuffer` behind a view, so this returns `undefined` for
-/// now (matching the existing `int8arr.buffer` data-path behavior). The
-/// accessor still exists so reflection sees a real getter — closing the
-/// `getOwnPropertyDescriptor(...).get` cascade in #2060.
+/// `%TypedArray%.prototype.buffer` getter, with the same stable backing
+/// identity as the direct property path.
 extern "C" fn typed_array_buffer_getter_thunk(
     _closure: *const crate::closure::ClosureHeader,
 ) -> f64 {
     match typed_array_receiver() {
-        Some((ta, _)) => typed_array_buffer_value(ta),
+        Some(receiver) => typed_array_buffer_value(receiver),
         None => typed_array_brand_error(),
     }
 }

--- a/crates/perry-runtime/src/object/object_ops_frozen.rs
+++ b/crates/perry-runtime/src/object/object_ops_frozen.rs
@@ -356,11 +356,12 @@ pub extern "C" fn js_object_prevent_extensions(obj_value: f64) -> f64 {
     unsafe {
         let obj = extract_obj_ptr(obj_value);
         if !obj.is_null() && (obj as usize) > 0x10000 {
-            // Typed arrays: side table, NOT the GC header — small typed
-            // arrays are plain-`alloc`ed with no `GcHeader`, so the flag
-            // write below would corrupt allocator metadata.
-            if crate::typedarray::lookup_typed_array_kind(obj as usize).is_some() {
-                crate::typedarray_props::typed_array_mark_no_extend(obj as usize);
+            // Typed arrays use a side table for extensibility. Include Perry's
+            // BufferHeader-backed Uint8Array: lookup_typed_array_kind can
+            // never recognise it, and setting only the Buffer's GC flag is
+            // invisible to the integer-indexed property paths (#9347).
+            if let Some(owner) = crate::typedarray_props::typed_array_addr_from_value(obj_value) {
+                crate::typedarray_props::typed_array_mark_no_extend(owner);
                 return obj_value;
             }
             let gc = gc_header_for(obj);
@@ -613,14 +614,14 @@ pub extern "C" fn js_object_is_extensible(obj_value: f64) -> f64 {
         // report `false` depending on heap layout. Integer-indexed exotic
         // objects are extensible by default; report that instead of reading a
         // header that may not exist.
-        let raw = crate::value::js_nanbox_get_pointer(obj_value) as usize;
-        if raw > 0x10000 && crate::typedarray::lookup_typed_array_kind(raw).is_some() {
-            return if crate::typedarray_props::typed_array_owner_no_extend(raw) {
+        if let Some(owner) = crate::typedarray_props::typed_array_addr_from_value(obj_value) {
+            return if crate::typedarray_props::typed_array_owner_no_extend(owner) {
                 f64::from_bits(TAG_FALSE)
             } else {
                 f64::from_bits(TAG_TRUE)
             };
         }
+        let raw = crate::value::js_nanbox_get_pointer(obj_value) as usize;
         if raw > 0x10000 && crate::buffer::is_registered_buffer(raw) {
             return f64::from_bits(TAG_TRUE);
         }

--- a/crates/perry-runtime/src/object/reflect_support.rs
+++ b/crates/perry-runtime/src/object/reflect_support.rs
@@ -27,9 +27,10 @@ pub(crate) fn obj_value_no_extend(value: f64) -> bool {
             return false;
         }
         // Typed arrays use a side table (small ones carry no `GcHeader`, so
-        // the header read below would be allocator-metadata garbage).
-        if crate::typedarray::lookup_typed_array_kind(obj as usize).is_some() {
-            return crate::typedarray_props::typed_array_owner_no_extend(obj as usize);
+        // the header read below would be allocator-metadata garbage). The
+        // helper also recognises BufferHeader-backed Uint8Arrays (#9347).
+        if let Some(owner) = crate::typedarray_props::typed_array_addr_from_value(value) {
+            return crate::typedarray_props::typed_array_owner_no_extend(owner);
         }
         let gc = gc_header_for(obj);
         (*gc)._reserved & crate::gc::OBJ_FLAG_NO_EXTEND != 0

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -1494,7 +1494,7 @@ fn own_set_descriptor(target: f64, key: f64) -> Option<OwnSetDescriptor> {
     // deliberately gated off for typed arrays). Consult that state directly so
     // a non-writable own data property / setter-less accessor rejects the write
     // (test262 TypedArray internals/Set key-is-not-numeric-index).
-    if crate::typedarray::lookup_typed_array_kind(obj_ptr).is_some() {
+    if crate::typedarray_props::is_typed_array_owner(obj_ptr) {
         return match crate::typedarray_props::typed_array_own_set_descriptor(obj_ptr, &key_name) {
             Some(crate::typedarray_props::TypedArrayOwnSetDescriptor::Data { writable }) => {
                 Some(OwnSetDescriptor::Data { writable })
@@ -1857,7 +1857,7 @@ fn ordinary_set_with_receiver(target: f64, key: f64, value: f64, receiver: f64) 
         let addr = extract_pointer(target.to_bits()) as usize;
         // Typed arrays must be excluded before the header probe: small TAs
         // are plain-alloc'd without a GcHeader.
-        if crate::typedarray::lookup_typed_array_kind(addr).is_none()
+        if !crate::typedarray_props::is_typed_array_owner(addr)
             && crate::object::exotic_expando::exotic_expando_kind_of_value(target).is_none()
             && !crate::closure::is_closure_ptr(addr)
         {
@@ -2094,7 +2094,7 @@ fn ordinary_set_with_receiver(target: f64, key: f64, value: f64, receiver: f64) 
         // ordinary data-descriptor flow (create on receiver); an invalid
         // canonical index is a silent no-op `true`.
         let cur_addr = extract_pointer(current.to_bits()) as usize;
-        if crate::typedarray::lookup_typed_array_kind(cur_addr).is_some() {
+        if crate::typedarray_props::is_typed_array_owner(cur_addr) {
             if let Some(name) = property_key_to_rust_string(key) {
                 match crate::typedarray_props::typed_array_canonical_index_validity(cur_addr, &name)
                 {
@@ -2114,7 +2114,7 @@ fn ordinary_set_with_receiver(target: f64, key: f64, value: f64, receiver: f64) 
                         // CreateDataProperty lands in ITS [[DefineOwnProperty]],
                         // which rejects an index that is invalid FOR THE
                         // RECEIVER (`Reflect.set(ta, "0", v, emptyTa)` → false).
-                        if crate::typedarray::lookup_typed_array_kind(recv_addr).is_some() {
+                        if crate::typedarray_props::is_typed_array_owner(recv_addr) {
                             return match crate::typedarray_props::
                                 typed_array_canonical_index_validity(recv_addr, &name)
                             {

--- a/crates/perry-runtime/src/typedarray_props.rs
+++ b/crates/perry-runtime/src/typedarray_props.rs
@@ -267,6 +267,17 @@ fn barrier_typed_array_own_props(owner: usize, props: &mut [TypedArrayOwnProp]) 
 }
 
 fn upsert_typed_array_own_prop(owner: usize, key: String, value: f64, is_data: bool) {
+    // A constructor-created Uint8Array uses BufferHeader rather than
+    // TypedArrayHeader. Store its ordinary properties in the existing GC-traced
+    // Buffer table, so direct assignment, Reflect.set, descriptors, and
+    // enumeration all observe one value instead of two invisible side tables (#9347).
+    if matches!(
+        typed_array_owner_kind(owner),
+        Some(TypedArrayOwnerKind::Uint8ArrayBuffer)
+    ) {
+        crate::buffer::buffer_define_own_data_prop(owner, &key, value);
+        return;
+    }
     TYPED_ARRAY_OWN_PROPS.with(|m| {
         let mut map = m.borrow_mut();
         let props = map.entry(owner).or_default();
@@ -285,7 +296,7 @@ fn upsert_typed_array_own_prop(owner: usize, key: String, value: f64, is_data: b
 }
 
 fn remove_typed_array_own_prop(owner: usize, key: &str) -> bool {
-    TYPED_ARRAY_OWN_PROPS.with(|m| {
+    let removed_typed_array = TYPED_ARRAY_OWN_PROPS.with(|m| {
         let mut map = m.borrow_mut();
         let Some(props) = map.get_mut(&owner) else {
             return false;
@@ -298,23 +309,38 @@ fn remove_typed_array_own_prop(owner: usize, key: &str) -> bool {
             map.remove(&owner);
         }
         true
-    })
+    });
+    let removed_buffer = matches!(
+        typed_array_owner_kind(owner),
+        Some(TypedArrayOwnerKind::Uint8ArrayBuffer)
+    ) && crate::buffer::buffer_delete_own_prop(owner, key);
+    removed_typed_array || removed_buffer
 }
 
 fn typed_array_own_prop_snapshot(owner: usize, key: &str) -> Option<TypedArrayOwnProp> {
-    TYPED_ARRAY_OWN_PROPS.with(|m| {
+    let typed_array_prop = TYPED_ARRAY_OWN_PROPS.with(|m| {
         m.borrow()
             .get(&owner)
             .and_then(|props| props.iter().find(|prop| prop.key == key).cloned())
+    });
+    if typed_array_prop.is_some() {
+        return typed_array_prop;
+    }
+    if !matches!(
+        typed_array_owner_kind(owner),
+        Some(TypedArrayOwnerKind::Uint8ArrayBuffer)
+    ) {
+        return None;
+    }
+    crate::buffer::buffer_get_own_prop(owner, key).map(|value| TypedArrayOwnProp {
+        key: key.to_string(),
+        value,
+        is_data: crate::object::get_accessor_descriptor(owner, key).is_none(),
     })
 }
 
 fn typed_array_has_ordinary_own_prop(owner: usize, key: &str) -> bool {
-    TYPED_ARRAY_OWN_PROPS.with(|m| {
-        m.borrow()
-            .get(&owner)
-            .is_some_and(|props| props.iter().any(|prop| prop.key == key))
-    })
+    typed_array_own_prop_snapshot(owner, key).is_some()
 }
 
 unsafe fn descriptor_has(desc_ptr: *mut crate::object::ObjectHeader, name: &[u8]) -> bool {
@@ -1170,6 +1196,23 @@ fn typed_array_non_index_keys(owner: usize, enumerable_only: bool) -> Vec<String
             })
             .unwrap_or_default()
     });
+    if matches!(
+        typed_array_owner_kind(owner),
+        Some(TypedArrayOwnerKind::Uint8ArrayBuffer)
+    ) {
+        for key in crate::buffer::buffer_own_prop_names(owner) {
+            if keys.iter().any(|existing| existing == &key) {
+                continue;
+            }
+            if enumerable_only
+                && crate::object::get_property_attrs(owner, &key)
+                    .is_some_and(|attrs| !attrs.enumerable())
+            {
+                continue;
+            }
+            keys.push(key);
+        }
+    }
     for key in crate::object::accessor_descriptor_keys_for_obj(owner) {
         if keys.iter().any(|existing| existing == &key) {
             continue;

--- a/test-files/test_gap_9347_uint8array_extensibility.ts
+++ b/test-files/test_gap_9347_uint8array_extensibility.ts
@@ -1,0 +1,47 @@
+// A BufferHeader-backed Uint8Array misses lookup_typed_array_kind. Its
+// extensibility state must use the same TypedArray side table as every other
+// kind, or Object/Reflect report true and allow new properties after a
+// successful preventExtensions call.
+function inspectReflect(label: string, value: Uint8Array | Int32Array): void {
+  (value as any).existing = 1;
+  console.log(
+    label,
+    "create",
+    Reflect.set(value, "created", 7),
+    (value as any).created,
+    Object.prototype.hasOwnProperty.call(value, "created"),
+  );
+  console.log(label, "before", Object.isExtensible(value), Reflect.isExtensible(value));
+  console.log(label, "prevent", Reflect.preventExtensions(value));
+  console.log(label, "after", Object.isExtensible(value), Reflect.isExtensible(value));
+  console.log(
+    label,
+    "set",
+    Reflect.set(value, "existing", 2),
+    (value as any).existing,
+    Reflect.set(value, "fresh", 3),
+    Object.prototype.hasOwnProperty.call(value, "fresh"),
+  );
+  console.log(
+    label,
+    "define",
+    Reflect.defineProperty(value, "late", { value: 4 }),
+    Object.prototype.hasOwnProperty.call(value, "late"),
+  );
+}
+
+function inspectObject(label: string, value: Uint8Array | Int32Array): void {
+  Object.preventExtensions(value);
+  console.log(
+    label,
+    Object.isExtensible(value),
+    Reflect.isExtensible(value),
+    Reflect.set(value, "fresh", 3),
+    Object.prototype.hasOwnProperty.call(value, "fresh"),
+  );
+}
+
+inspectReflect("reflect-u8", new Uint8Array(2));
+inspectReflect("reflect-i32", new Int32Array(2));
+inspectObject("object-u8", new Uint8Array(2));
+inspectObject("object-i32", new Int32Array(2));

--- a/test-files/test_gap_9347_uint8array_reflected_accessors.ts
+++ b/test-files/test_gap_9347_uint8array_reflected_accessors.ts
@@ -1,0 +1,44 @@
+import { Buffer } from "node:buffer";
+
+// Uint8Array and Buffer use Perry's BufferHeader representation and never
+// enter lookup_typed_array_kind. The intrinsic %TypedArray%.prototype getters
+// must nevertheless accept them, just as they accept TypedArrayHeader kinds.
+const typedArrayPrototype = Object.getPrototypeOf(Uint8Array.prototype);
+const names = ["length", "byteLength", "byteOffset", "buffer"] as const;
+const getters: Record<string, Function> = {};
+for (const name of names) {
+  getters[name] = Object.getOwnPropertyDescriptor(typedArrayPrototype, name)!.get!;
+}
+
+function inspect(label: string, value: Uint8Array | Int32Array): void {
+  const length = getters.length.call(value);
+  const byteLength = getters.byteLength.call(value);
+  const byteOffset = getters.byteOffset.call(value);
+  const firstBuffer = getters.buffer.call(value);
+  const secondBuffer = getters.buffer.call(value);
+  console.log(
+    label,
+    "length", length === value.length,
+    "byteLength", byteLength === value.byteLength,
+    "byteOffset", byteOffset === value.byteOffset,
+    "buffer", firstBuffer === value.buffer,
+    "stable", firstBuffer === secondBuffer,
+  );
+}
+
+const backing = new ArrayBuffer(24);
+inspect("u8-own", new Uint8Array([1, 2, 3]));
+inspect("u8-view", new Uint8Array(backing, 3, 5));
+inspect("i32-view", new Int32Array(backing, 4, 2));
+inspect("buffer", Buffer.from([4, 5, 6]));
+
+const brandErrors: string[] = [];
+for (const name of names) {
+  try {
+    getters[name].call({});
+    brandErrors.push("none");
+  } catch (error) {
+    brandErrors.push((error as Error).name);
+  }
+}
+console.log("plain-object", brandErrors.join(","));


### PR DESCRIPTION
## Summary

- recognize Perry's `BufferHeader`-backed `Uint8Array` representation in reflected `%TypedArray%.prototype` descriptor getters and Node-API typed-array queries
- preserve real view offsets, stable backing `ArrayBuffer` identity, and canonical data spans for those APIs
- route `Reflect.set` and extensibility checks through the buffer-aware typed-array owner path, keep ordinary properties in one side table, and prune that address-keyed state during buffer GC
- add Node parity coverage plus focused Node-API and GC tests

Before this change, calling the intrinsic `length`, `byteLength`, `byteOffset`, or `buffer` getter with a `Uint8Array` receiver threw `TypeError`; Node-API reported the same value as not being a typed array; and `preventExtensions`/`Reflect.set` either reported stale extensibility or lost ordinary-property writes. The `Int32Array` controls already behaved correctly.

Addresses #9347.

## Tests

- `./scripts/pre-tag-check.sh --quick`
- `cargo test -p perry-runtime --lib -- --test-threads=1` (3,070 passed; 4 ignored)
- `cargo test -p perry-runtime --features node-api-host node_api_host::tests -- --test-threads=1` (18 passed)
- `./run_parity_tests.sh --filter test_gap_9347_uint8array_reflected_accessors`
- `./run_parity_tests.sh --filter test_gap_9347_uint8array_extensibility`
- existing #9347 destructuring/`in`, #2060 accessor-descriptor, and dynamic `instanceof` differential controls against Node

No version bump is included.
