### PR TITLE
Merge train: #9697, #9698, #9699, #9700, #9702 + MERGE_GUIDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,11 @@ A `--module` selector scopes `--check`/`--update-baseline` to just that slice (a
 
 ## Workflow Requirements
 
+**Auditing and landing the open-PR queue: `MERGE_GUIDE.md`.** The merge-train protocol, the per-PR audit
+checklist, how to resolve Rust merge conflicts by shape, and the validation/landing traps that have bitten
+this repo (stale PR heads, stale `.a` archives, the rebase-merge coherence stamp). Read it before picking up
+a queue of PRs.
+
 **Default flow is PR-based.** `main` is protected: pushes require a pull request, CI must pass, and only squash or rebase merges are allowed (no merge commits, linear history enforced). **The single required status context is `pr-gate`** — the fan-in of `test.yml`'s PR tier (`lint`, `check`, `warnings`, scoped `cargo-test`, the 6-shard fast-mode gap suite, `gc-stress`, `e2e-scoped`, and `security-audit` when a lockfile/manifest changed). What runs in which tier is decided by `scripts/ci_plan.py` (`--table`), documented in `docs/src/testing/ci-tiers.md`: **pr** (every PR push, ~11 jobs, must be green on `main`), **sweep** (every push to `main`, coalesced), **full** (nightly / tags / dispatch / `run-extended-tests` label — parity, compile-smoke, doc-tests, package smokes, the auto-optimize gap shards). Releases wait for a `full-suite-gate` on the release SHA. The satellite GC/perf gates run on PRs only with the `run-extended-tests` label; their six-hourly `main` sweeps are unchanged. Admins can bypass for hotfixes/version bumps, but the standard path is:
 
 1. Branch from `main`, push, open a PR.

--- a/MERGE_GUIDE.md
+++ b/MERGE_GUIDE.md
@@ -1,0 +1,252 @@
+# MERGE_GUIDE.md — auditing and landing the open-PR queue
+
+How a session picks up the PR queue, audits it honestly, and lands it. Written
+from the trains that produced v0.5.1512→v0.5.1520; every trap below cost real
+time at least once.
+
+Companion docs: `CLAUDE.md` (architecture, gates, GC knobs),
+`docs/src/testing/ci-tiers.md` (what CI runs where).
+
+## 0. The one-paragraph version
+
+Cherry-pick the open PRs onto one train branch, fix whatever gates the train
+breaks, validate **once** as a tree, and land the whole train as a single
+own-branch PR merged with `gh pr merge --rebase --admin`. Rebase-merge keeps
+each cherry-pick's authorship. Then prove main is byte-identical to what you
+validated: `git diff origin/main train<N> --stat` must be empty.
+
+## 1. Working tree
+
+Use a dedicated worktree with its own target dir — never the user's checkout,
+never another session's:
+
+```bash
+cd /Users/amlug/agent-a3                       # this session's worktree
+export CARGO_TARGET_DIR=/Users/amlug/agent-targets/val
+```
+
+Rules that are not negotiable:
+
+- **Never `git stash`** in a worktree — the stash is shared across all of them.
+- **Never `git reset --hard`** or a broad clean; other sessions have live work.
+- **Keep the `-p` package set identical** across every build in an A/B or a
+  bisect. Dropping `-p perry` changes cargo feature unification and silently
+  changes what you measured.
+- Before deleting any worktree or target pool, require an OWNER file and
+  announce it. A process check cannot prove a target dir idle.
+
+## 2. Triage
+
+```bash
+gh pr list --state open --limit 40 --json number,title,isDraft,additions,deletions \
+  --jq '.[] | select(.isDraft|not) | "#\(.number) +\(.additions)/-\(.deletions) \(.title)"'
+```
+
+Drafts are excluded, with one caveat: **a pushed draft is a landing candidate
+within minutes** here. Re-check `gh pr view <n>` state before every push.
+
+Fetch each head to a local ref:
+
+```bash
+git fetch -q origin refs/pull/<n>/head:t<n> --force
+```
+
+**`--force` matters.** Authors push updates mid-audit. A stale `t<n>` lands the
+wrong code silently — the only tell is the diffstat drifting from what
+`gh pr list` reports. Re-fetch immediately before building the train, and
+compare `git rev-list --count origin/main..t<n>` against the PR's commit count.
+
+## 3. Auditing a PR
+
+Read the diff, not the PR body. The body says what the author meant; the diff
+says what ships. What to check, in rough order of how often it finds something:
+
+**Does the change's own test actually exercise the subject?**
+A gate that runs but whose subject never did is the most dangerous kind,
+because the job is genuinely green. Assert the subject was live
+(`copied_objects > 0`, a counter moved, the fixture starts in the proven
+state), not merely that nothing threw.
+
+**Which direction does the analysis fail in?**
+For any scanner, ratchet, or static proof, ask what an *unrecognized* input
+does. Unknown must mean unsafe. A catch-all `_ => {}` that also stops
+descending into children is the classic hole — check that the child walk runs
+unconditionally after the match, and that the walker it delegates to is
+exhaustive (no `_ =>`, so a new variant breaks the build).
+
+**Is a regex/string-scan test vacuous on a reword?**
+`!source.contains("fn js_foo(")` is a tripwire, not a proof. Fine as a
+tripwire; never accept it as evidence the mechanism works.
+
+**Rooting (the expensive class).**
+A GC value's root store must dominate every later site that can collect. In
+runtime code that means: no bare Rust local holding a heap pointer across a
+call that allocates. The idioms are `with_{mut,const}_ptr` (scoped argument to
+a non-allocating callee) and `across_{mut,const,nanbox}` (callee can collect —
+re-read after). An empty-closure `across_nanbox(|| ())` is gaming the ratchet,
+not a fix. Note the shape of the bug: an unrooted *register* is intermittent;
+an unrooted *cache or side table* fails at collection #0 and stays failed, so a
+perfectly reproducible GC bug points at a table.
+
+**Published ABI.**
+Tightening the contract of a `#[no_mangle] pub extern "C"` symbol in place is a
+break for FFI and separately-loaded provider images even when the tree
+compiles. The fix is a second symbol, not a stricter comment.
+
+**Cross-platform.**
+libc signatures differ (`openpty`'s trailing params are `*mut` on macOS and
+`*const` on Linux). An address floor that looks fine on macOS can admit real
+Linux addresses — use `is_above_handle_band` / `HANDLE_BAND_MAX`, never a bare
+`>= 0x10000`.
+
+**Version metadata.** External contributors must not touch
+`[workspace.package] version` in `Cargo.toml` or `**Current Version:**` in
+`CLAUDE.md`. Check and strip:
+
+```bash
+git diff origin/main train<N> -- Cargo.toml CLAUDE.md | grep -cE '^\+.*(^version|Current Version)'   # want 0
+```
+
+**Changelog.** Every PR needs `changelog.d/<PR>-<slug>.md`. Never append to
+`CHANGELOG.md` (frozen at v0.5.1264). Write the fragment yourself if it is
+missing.
+
+### When to hold rather than land
+
+Hold when the failure mode is **silent** and the shipped tests only prove
+mechanics. The examples that earned this rule: a refactor that makes an
+extension registry the sole seam for event pumps (failure = a server that
+accepts connections and never dispatches, i.e. a hang, not an error), and
+anything that removes a redundant path so a hole has no backup. Those need an
+end-to-end run, not a unit test. Holding is not blocking — say what evidence
+would clear it, and get that evidence yourself if you can.
+
+Do **not** hold for style, for a non-blocking follow-up, or for CI. Note those
+in the train PR body and move on.
+
+## 4. Building the train
+
+```bash
+git checkout -q -B train<N> origin/main
+for pr in 9697 9698 9699; do
+  git cherry-pick origin/main..t$pr || { echo "CONFLICT #$pr"; git cherry-pick --abort; }
+done
+```
+
+Pick the **range** (`origin/main..t<n>`), not the tip commit — PRs often carry
+several commits, and picking the tip drops the rest.
+
+`git merge-tree` reporting no conflict does **not** mean the cherry-pick is
+clean: merge-tree models a merge, a cherry-pick is a rebase. Trust the real pick.
+
+### Resolving conflicts in Rust
+
+Automated resolvers mangle Rust in four distinct ways. Resolve by hand, by shape:
+
+| shape | resolution |
+|---|---|
+| entry lists (allowlists, JSON gate registries) | sorted union |
+| ordinary code hunks | concatenate both sides — never dedupe |
+| match-arm alternations (`A \| B =>`) | hand-merge; a sorted union corrupts them |
+| a conflict cutting through a struct literal | take one side whole; concatenation gives "field specified more than once" |
+
+Never dedupe a closing `}` that legitimately appears on both sides. When two
+sides both define a signature, read the authoring PR's own file to see which is
+right. Regenerate generated docs (`scripts/regen_api_docs.sh`) rather than
+merging them — `docs/api/perry.d.ts` and `docs/src/api/reference.md` say "do
+not edit by hand" and mean it.
+
+### If you fix something the author should have fixed
+
+Write the fix as its own commit on the train so authorship stays clean. But
+**check whether the author already pushed one** — convergence is common, and
+their version is usually the better idiom and is theirs to own. Drop yours.
+
+## 5. Validating
+
+Cheap checks first, so a bad train dies in seconds:
+
+```bash
+cargo fmt --all -- --check
+./scripts/check_file_size.sh          # 2000-line cap
+python3 scripts/raw_handle_debt.py    # bare + --no-raise-vs origin/main + --self-test
+```
+
+Then the full suite. **Run `scripts/run_lint_gates.sh` — all of it.**
+Hand-picking gates is how three breaks reached main in one day. It is generated
+from `test.yml` and currently carries 64 steps.
+
+```bash
+./scripts/run_lint_gates.sh
+cargo build --release -p perry -p perry-runtime-static -p perry-stdlib-static
+RUST_TEST_THREADS=1 cargo test --release -p perry-runtime
+RUST_TEST_THREADS=1 cargo test --release -p perry-stdlib
+# plus each integration suite the train touches:
+RUST_TEST_THREADS=1 cargo test --release -p perry --test <suite> --no-fail-fast
+```
+
+- `perry-runtime` and `perry-stdlib` are **not parallel-safe** — they share
+  process-global side tables. `RUST_TEST_THREADS=1` always. A failure whose
+  message is about a *fixture precondition* ("must start proven") is another
+  thread wiping a global, not a defect in the code under test.
+- The runtime/stdlib `.a` come from the **`-static` wrapper crates**. Building
+  `-p perry-runtime -p perry-stdlib` does not emit them, so you link a stale
+  archive and **both arms of an A/B behave identically** — a vacuous
+  "no regressions". Integration tests under `crates/*/tests/` need the wrappers
+  built first for the same reason.
+- **Set `PERRY_WORKSPACE_ROOT` for `crates/perry/tests/*` integration suites**
+  when `CARGO_TARGET_DIR` lives outside the worktree. Otherwise the compiled
+  `perry` cannot find the workspace, silently falls back to the *prebuilt*
+  stdlib, and every test in the suite dies on the coherence stamp
+  ("runtime library does not match this Perry compiler"). All-tests-fail at the
+  same helper line is the signature — read the stderr before believing it is a
+  regression. It also flips `ws` to `perry-ext-ws`.
+- Check the **harness's** exit code, not a wrapper shell's. A pipeline through
+  `grep` reports 0 while the harness failed. zsh does not word-split `$c`.
+- `--profile perry-dev` inherits release, so `debug_assert!` is compiled out —
+  a SIGABRTing runtime suite reads green. Don't validate with it.
+
+Run one chain at a time. Two concurrent chains contend on the target-dir lock
+and each blocks the other.
+
+## 6. Landing
+
+```bash
+git push -u origin train<N>
+gh pr create --title "..." --body-file <file>     # never inline --body
+gh pr merge <train-pr> --rebase --admin
+```
+
+Then, always:
+
+```bash
+git fetch origin main
+git diff origin/main train<N> --stat              # MUST be empty
+```
+
+Close each fork original with a comment pointing at the train. Use one
+`Closes #N` keyword per issue — GitHub evaluates them at merge and one keyword
+closes exactly one issue. Verify with `gh issue view <n> --json state`.
+
+Post-merge traps:
+
+- **Rebase-merge mints new SHAs.** A binary built from the pre-merge train
+  branch fails the runtime coherence stamp against merged main even though the
+  trees are identical — the stamp compares commits, not content. Any post-merge
+  sweep needs a binary built at the merged commit.
+- **Never `cp` over an existing signed macOS binary.** Same inode + new content
+  = stale CDHash cache = instant SIGKILL, empty logs, every test reporting a
+  compile error with an empty `.compile_error.log`. `rm` first, then `cp`.
+- **Rebuild the compiler after every commit**, including docs-only ones, or
+  ext-routed gap tests fail on commit skew rather than on your change.
+
+## 7. Reporting
+
+Say what was verified and how. "Gates green" means you ran them; "tests pass"
+names the suites. If something is pre-existing on main, prove it by A/B against
+the merge base before calling it pre-existing — a regression list is a
+hypothesis until then. "Main is green" is worthless evidence unless main's run
+descends from the suspect commit.
+
+Report what you held and why, in one line each. Do not chase CI to green:
+one pass classifying failures as mine-or-pre-existing, say so, stop.

--- a/changelog.d/9697-shared-stdin-reader.md
+++ b/changelog.d/9697-shared-stdin-reader.md
@@ -1,0 +1,5 @@
+Fixed `process.stdin` listener and keypress delivery across runtime and
+`node:readline` APIs. Both surfaces now share one ordered fd-0 reader, so
+`readline.emitKeypressEvents()` works with cooked and piped input and
+`removeAllListeners([event])` reliably clears stdin listeners without racing or
+dropping buffered bytes.

--- a/changelog.d/9698-bare-receiver-entry-decision.md
+++ b/changelog.d/9698-bare-receiver-entry-decision.md
@@ -1,0 +1,119 @@
+**A dynamic method call on a *bare* managed receiver — a real GC pointer whose
+value was never NaN-boxed — was rooted under a tag the collector ignores, and
+reboxed as an object even when it was a string.** `js_native_call_method` did
+recover the shape, but only in the last few lines of the ~1200-line dispatch
+tower and only ever as `POINTER_TAG`. Three defects followed, and a `.slice`
+on a value that must be a string is what they surface as (#9675).
+
+**1. The receiver was not a root.** The tower parks its receiver in a
+`RuntimeHandleSlot::Nanbox` via `RuntimeHandleScope::root_nanbox_f64`. That slot
+kind is marked by `gc::try_mark_value` and rewritten by
+`gc::try_rewrite_nanboxed_value`, and *both* begin by rejecting any word whose
+tag is not `POINTER_TAG`/`STRING_TAG`/`BIGINT_TAG`. A bare pointer's tag is
+zero, so rooting one there neither **marks** the receiver — a full mark-sweep
+inside dispatch can reap it — nor **rewrites** the slot — an evacuating minor
+leaves it holding a from-space address. This is #6910's hole re-opened in a
+different registry: that issue fixed exactly this mismatch for shadow-stack and
+global-root slots (`gc/tests/root_words.rs` pins it, "bare address" included),
+and the transient-handle registry's nanbox slot kind was never converted.
+#7528's fix — re-read the root slot at every use instead of caching a local —
+is necessary but not sufficient here, because re-reading a slot the collector
+never rewrote returns the same stale address.
+
+**2. Strings and BigInts came back as objects.** `JSValue::pointer` stamps
+`POINTER_TAG` unconditionally. `string_methods::dispatch_string` gates on
+`is_any_string()`, which accepts only `STRING_TAG`/`SHORT_STRING_TAG` — so a
+bare `GC_TYPE_STRING` receiver was reboxed into something that is not a string
+and `.slice` never reached the string arm.
+
+**3. No forwarding walk.** A bare receiver a collection had already moved was
+reboxed at its from-space address.
+
+**4. And the mirror image: an unvouched bare word was still read as a pointer,
+and faulted.** A genuine positive subnormal double has bits that look like an
+address — `1e-310` is `0x1268_8b70_e62b`, above the handle band and inside
+`is_valid_obj_ptr`'s platform window. The tower's probes are magnitude-gated:
+`try_read_gc_header` classifies by address range and then dereferences
+`addr - GC_HEADER_SIZE`, a contract written for a *stale* heap address, where
+the page is still mapped. An arbitrary number is not a stale address; nothing
+was ever mapped there. So `(1e-310 as any).toString()` **SIGSEGV'd** inside
+`url::search_params::shape_is_url_search_params` — a probe that is itself
+careful (it gates on `try_read_gc_header` precisely so a `Date` cell cannot
+fault it) and simply cannot tell a number from an address. Node prints
+`1e-310`. A smaller subnormal aliases the *handle* band instead: `5e-324` is
+`0x1`, so the handle dispatcher answered it and `(5e-324 as any).toString()`
+returned `undefined` where node returns `"5e-324"`. Both were found while
+validating this change, both reproduce on unfixed `main`, and both are fixed
+here — the backtrace was taken rather than assumed, and it named a probe
+nobody would have guessed.
+
+`canonicalize_bare_gc_receiver` now runs as the first statement of
+`js_native_call_method`, before the root and before the first probe. The gate is
+**allocator ownership, not address magnitude**:
+`value::addr_class::try_read_tracked_gc_header` requires arena page membership
+or an exact malloc-registry hit, plus a valid `obj_type`/`size`/arena-flag
+triple, before the first header byte is touched. Forwarding is then followed
+through `value::resolve_forwarding`, and the tag is chosen from the resolved
+header: `STRING_TAG` for `GC_TYPE_STRING`, `BIGINT_TAG` for `GC_TYPE_BIGINT`,
+`POINTER_TAG` otherwise. `GC_TYPE_STRING` is also what `alloc_symbol`
+gc_mallocs, so the string arm carries the same `SYMBOL_MAGIC` content screen
+`gc_pointer_and_type_from_value` uses — a fresh `Symbol()` keeps `POINTER_TAG`,
+which is how symbols are boxed.
+
+The allocator is not the only owner that can answer without touching memory, so
+the gate also asks the address-keyed registries that own **headerless**
+allocations — a `Symbol.for` symbol, an `ArrayBuffer`/`Uint8Array` backing
+store, a typed array. Those have no `GcHeader` for the allocator gate to find,
+are boxed as POINTERs, and are exactly the case the old tail recovery
+legitimately served. Each is a table lookup behind an idle latch, and each is
+already consulted by `gc_pointer_and_type_from_value` for the same reason.
+
+Once every owner has been asked and declined, the word is *definitively not a
+managed pointer*, so it is the number its bits spell and
+`dispatch_unvouched_bare_as_number` answers it there and then — it never reaches
+a pointer-shaped probe. Fixing only the probe that happened to fault would have
+been whack-a-mole; every magnitude-gated probe in the tower has the same
+exposure, and CLAUDE.md's "Known-weak areas" records this codebase paying for
+that pattern three times over. Deciding once, at the chokepoint, makes the class
+unreachable instead of fixing its current instance.
+
+That also makes the tower's magnitude-only **tail recovery unreachable**, and it
+is deleted here: it was the last place that treated address magnitude as proof,
+it did neither of the two things the entry now does (correct tag, and a root the
+collector traces), and its one legitimate constituency — headerless registry
+allocations — is served by the vouch set above.
+
+Every NaN-boxed receiver returns from one `bits >> 48` compare, so the ordinary
+dispatch path is unchanged. `+0.0` is deliberately left on the ordinary path: it
+is not address-shaped, so no probe can mistake it for a pointer.
+
+**What the pre-fix path actually did**, measured by flipping the new guard off
+and re-running the tests: `.slice(1)` on a bare managed string receiver did not
+throw — it returned a `POINTER_TAG` value whose payload
+`try_read_tracked_gc_header` does not recognise at all, at a *different address
+on every run*. A wild pointer handed back to codegen, which NaN-unboxes and
+dereferences it. Seven of the eleven new tests fail on that arm; all eleven pass
+with the fix.
+
+`native_call_method/bare_receiver/tests.rs` covers both directions, because the
+second is what keeps a gate like this honest. Reclassification: string →
+`STRING_TAG` (and satisfying the exact `is_any_string()` predicate
+`dispatch_string` gates on), BigInt → `BIGINT_TAG`, plain object/array →
+`POINTER_TAG`, a hand-forwarded receiver → its *current* address, and an
+end-to-end `js_native_call_method(bare, "slice", [1])` returning `"bcdef"`.
+Non-reclassification: genuine positive subnormal doubles whose bits sit squarely
+inside the platform heap window the old tail recovery accepted, a `Box`
+allocation carrying a hand-built `GcHeader`, headerless registry handle ids
+across every band, a fresh `Symbol()`, and twelve NaN-boxed forms returned
+bit-for-bit. Routing: the two subnormals that actually bit (`1e-310`, `5e-324`)
+must reach number dispatch; a `Symbol.for` symbol — asserted in the test to be
+registered *and* not allocator-tracked, so the registry arm is load-bearing
+rather than incidental — must not; neither must any allocator-vouched receiver;
+and `+0.0` must stay on the ordinary path.
+
+Rejected alternative: root the receiver with `root_heap_word_u64` instead, whose
+`HeapWord` slot kind *does* accept bare addresses (that is #6910's fix). One
+line, but it closes only defect 1 — strings would still dispatch as objects and
+a forwarded receiver would still be used at its old address — and it would move
+every ordinary receiver onto the more conservative `try_mark_value_or_raw`
+interior-pointer path on the hot dispatch route.

--- a/changelog.d/9702-labeled-for-of-await.md
+++ b/changelog.d/9702-labeled-for-of-await.md
@@ -1,0 +1,2 @@
+Fixed async functions hanging when an awaited `switch` inside a labeled
+`for...of` loop executes a labeled `break` or `continue`.

--- a/changelog.d/9706-merge-guide.md
+++ b/changelog.d/9706-merge-guide.md
@@ -1,0 +1,13 @@
+**`MERGE_GUIDE.md`: the process for auditing and landing the open-PR queue.**
+Captures the merge-train protocol (cherry-pick onto one branch, fix gates on
+the train, validate once as a tree, land via `gh pr merge --rebase --admin` so
+per-commit authorship survives, then prove `git diff origin/main train<N>` is
+empty), the per-PR audit checklist, and the failure modes that have cost real
+time here: a stale `refs/pull/<n>/head` landing code the author has already
+replaced, a stale `libperry_{runtime,stdlib}.a` making both arms of an A/B
+identical, `RUST_TEST_THREADS=1` for the two non-parallel-safe suites,
+`--profile perry-dev` compiling out `debug_assert!`, and the rebase-merge
+coherence stamp. Also records which merge-conflict shapes an automated resolver
+mangles, and the rule for when a PR is held for end-to-end evidence rather than
+landed: when its failure mode is silent (a hang, not an error) and the shipped
+tests only prove mechanics. Referenced from `CLAUDE.md`.

--- a/changelog.d/affine-window-hoist-and-accumulator-set.md
+++ b/changelog.d/affine-window-hoist-and-accumulator-set.md
@@ -1,6 +1,6 @@
-**`16_matrix_multiply` is now twice as fast as node** (100 ms → 16 ms against
-node's 32 on an idle machine; checksums identical) — the last benchmark in
-the suite crosses parity, via two changes and one guard fix.
+**Fixes #9248: `16_matrix_multiply` is now twice as fast as node** (100 ms →
+16 ms against node's 32 on an idle machine; checksums identical) — the last
+benchmark in the suite crosses parity, via two changes and one guard fix.
 
 **The affine window is proven at the loop's endpoints.** An index tree linear
 in the counter takes its extremes at the interval's ends, so the entry guard

--- a/changelog.d/promise-executor-evacuation-9587.md
+++ b/changelog.d/promise-executor-evacuation-9587.md
@@ -1,0 +1,48 @@
+**`new Promise(executor)` no longer returns a dead promise when the executor
+allocates.** Claude Code's first-run setup screen wedged on a fresh `HOME`
+100% of the time (#9587); onboarding therefore never wrote `theme` /
+`hasCompletedOnboarding` (#9674).
+
+The executor is arbitrary user JS and it runs while
+`js_promise_new_with_executor` still owns the promise it is about to return.
+cc's dialog helper is the shape that exposed it —
+`new Promise((res) => { let z = (y) => void res(y); root.render(ui(z)) })` runs
+a whole ink/React render, megabytes of allocation, inside the executor. The
+evacuating young collection that lands there MOVES the Promise. The resolving
+closures survive correctly (their capture slots are GC slots, so the collector
+rewrites them), but `promise`, `resolve_closure` and `reject_closure` lived in
+bare Rust locals across `js_closure_call2`, so the function handed the caller
+the PRE-COLLECTION address. From-space is reset and handed back to the mutator
+at the end of the same cycle, so that pointer names recycled memory, and
+`await`ing it goes one of two ways:
+
+* the recycled header decodes as `Fulfilled`, so the `await` never suspends and
+  resumes immediately with a garbage value — cc advanced past the onboarding
+  dialog nobody had answered; or
+* it still decodes as `Pending`, so the async step parks its continuation on the
+  dead copy. `resolve()` then settles the LIVE promise, which has no reaction,
+  and nothing ever resumes — a silent permanent hang with **no throw and no
+  rejection**.
+
+Neither failure raises anything a probe can see: `PERRY_REJECTION_DIAG` is
+silent and the whole-heap `PERRY_GC_FROMSPACE_SCAN` reports CLEAN, because at
+the moment of the collection the stale address exists only in a Rust register,
+and by the time it reaches JS from-space has already been flipped. The
+instrument that does catch it is `PERRY_GC_PROTECT_FROMSPACE=1`, which faults on
+the stale read with `obj_type=5` (`GC_TYPE_PROMISE`).
+
+All three values are now rooted in a `RuntimeHandleScope` for the duration of
+the executor and re-read from their handles afterwards — the discipline
+`js_promise_subclass_init` and `new_promise_capability` already follow. Two
+smaller holes on the same path close with it: `executor` itself was live across
+those allocations (rooted now, and only when it really is a closure, so
+`new Promise(42)` still cannot hand the collector a non-pointer), and
+`make_resolving_functions` rooted `promise` *after*
+`ensure_native_resolving_arity_registered`, which allocates on its first call
+per thread.
+
+Regression: `crates/perry/tests/issue_9587_promise_executor_evacuation.rs`
+(node-oracle output under a nursery-cap sweep, a
+`PERRY_GC_SCHEDULE_RATE=1` forced-collection arm, and a `PERRY_GEN_GC=0`
+never-relocates control) plus the parity fixture
+`test-files/test_issue_9587_promise_executor_evacuation.ts`.

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -8,6 +8,7 @@
 
 use super::*;
 
+mod bare_receiver;
 mod collection_methods;
 mod common_methods;
 mod disposal;
@@ -26,6 +27,9 @@ mod probe_dispatch_tests;
 mod to_locale_string_tests;
 mod typed_array;
 
+use bare_receiver::{
+    canonicalize_bare_gc_receiver, dispatch_unvouched_bare_as_number, is_unvouched_bare_word,
+};
 use disposal::{
     js_using_check_disposable, try_disposable_stack_method_dispatch, try_symbol_dispose_dispatch,
 };
@@ -1188,6 +1192,27 @@ pub unsafe extern "C-unwind" fn js_native_call_method(
     args_ptr: *const f64,
     args_len: usize,
 ) -> f64 {
+    // #9675: a LEGACY BARE managed receiver — a real GC pointer that was never
+    // NaN-boxed — must be reboxed under its true tag HERE, before the root
+    // below and before the first probe. See `bare_receiver` for why the tail
+    // recovery was too late (an unrooted receiver goes stale mid-dispatch) and
+    // too coarse (its unconditional POINTER_TAG hid strings from
+    // `dispatch_string`). Every NaN-boxed receiver returns from one compare.
+    let object = canonicalize_bare_gc_receiver(object);
+    // #9675: no owner claimed it, so it is not a managed pointer — it is the
+    // number its bits spell. Answer it here rather than letting ~1200 lines of
+    // magnitude-gated probes dereference it: `1e-310` is `0x1268_8b70_e62b`,
+    // address-shaped enough for `try_read_gc_header` to deref `addr - 8` and
+    // SIGSEGV, and `5e-324` is `0x1`, which the handle dispatcher answered.
+    if is_unvouched_bare_word(object) {
+        return dispatch_unvouched_bare_as_number(
+            object,
+            method_name_ptr,
+            method_name_len,
+            args_ptr,
+            args_len,
+        );
+    }
     if !method_name_ptr.is_null() && method_name_len > 0 {
         let method_name_bytes =
             std::slice::from_raw_parts(method_name_ptr as *const u8, method_name_len);
@@ -2388,30 +2413,14 @@ pub unsafe extern "C-unwind" fn js_native_call_method(
             }
         }
     }
-    // A BARE heap pointer — a real object whose value was never NaN-boxed, so its
-    // top 16 bits are zero and it decodes as a denormal double. Classifying it as a
-    // "number" here throws `<method> is not a function` on a perfectly good object.
-    // Validate deref-free (above the handle band + a genuinely tracked allocation),
-    // rebox as a POINTER_TAG value and dispatch on the object it actually is.
-    // Perry already recovers bare pointers on other dispatch paths; this one threw
-    // before it ever got the chance.
-    if jsval().is_number() && (jsval().bits() >> 48) == 0 {
-        let raw = jsval().bits() as usize;
-        if crate::value::addr_class::is_above_handle_band(raw)
-            && crate::value::addr_class::is_valid_obj_ptr(raw as *const u8)
-        {
-            let reboxed = crate::value::JSValue::pointer(raw as *const u8);
-            if reboxed.bits() != jsval().bits() {
-                return js_native_call_method(
-                    f64::from_bits(reboxed.bits()),
-                    method_name_ptr,
-                    method_name_len,
-                    args_ptr,
-                    args_len,
-                );
-            }
-        }
-    }
+    // #9675: the BARE-heap-pointer recovery that used to sit here is gone. It
+    // reboxed any word whose magnitude looked like a heap address, which is what
+    // let a genuine subnormal double be dispatched as an object. Both halves of
+    // that decision now live at this function's ENTRY, where an owner is asked
+    // before the first probe runs: a vouched bare pointer is reboxed under its
+    // true tag AND rooted (this recovery did neither), and an unvouched one is
+    // dispatched as the number it is. Nothing address-shaped reaches this point
+    // any more. See `bare_receiver`.
     let primitive_kind: Option<&'static str> = if jsval().is_any_string() {
         Some("string")
     } else if jsval().is_int32() || jsval().is_number() {

--- a/crates/perry-runtime/src/object/native_call_method/bare_receiver.rs
+++ b/crates/perry-runtime/src/object/native_call_method/bare_receiver.rs
@@ -1,0 +1,233 @@
+//! #9675: canonicalizing a LEGACY BARE managed receiver at the dispatch
+//! tower's entry, before it is rooted and before the first probe.
+//!
+//! A "bare" receiver is a real GC pointer whose value was never NaN-boxed, so
+//! its top 16 bits are zero and it decodes as a positive subnormal double.
+//! Perry still produces this shape — `gc_pointer_and_type_from_value` accepts
+//! it explicitly — and `js_native_call_method` recovered it, but only in the
+//! last few lines of the tower and only ever as `POINTER_TAG`. Three separate
+//! defects followed from that, and this module closes all three by rewriting
+//! the receiver into the tag it actually deserves *at the entry*.
+//!
+//! ## 1. The receiver was rooted under a tag the collector ignores
+//!
+//! The tower roots its receiver with
+//! [`RuntimeHandleScope::root_nanbox_f64`](crate::gc::RuntimeHandleScope::root_nanbox_f64),
+//! which parks it in a `RuntimeHandleSlot::Nanbox`. That slot kind is marked by
+//! `gc::try_mark_value` and rewritten by `gc::try_rewrite_nanboxed_value`, and
+//! **both begin by rejecting any word whose tag is not
+//! `POINTER_TAG`/`STRING_TAG`/`BIGINT_TAG`**. A bare pointer's tag is zero, so
+//! rooting one as a nanbox
+//!
+//! * does not MARK the receiver — a full mark-sweep inside dispatch can reap
+//!   it, and
+//! * does not REWRITE the slot — an evacuating minor inside dispatch leaves it
+//!   holding a from-space address.
+//!
+//! #7528 already established that the tower runs "~1160 more lines across a
+//! dozen probes that allocate" after that root, and made every use re-read the
+//! root slot rather than a local copy. That fix is necessary but not
+//! sufficient: re-reading a slot the collector never rewrote returns the same
+//! stale address. The tail recovery then validates it with magnitude-only
+//! predicates (`is_above_handle_band` + `is_valid_obj_ptr`), which cannot tell
+//! a live address from a stale one, and dispatches on whatever now occupies
+//! those bytes.
+//!
+//! Canonicalizing here means the value the tower roots carries a tag the
+//! collector traces AND rewrites, so the receiver is kept alive and every
+//! `object()` re-read below yields its current address. This is the runtime-side
+//! form of the root-dominance invariant in
+//! `docs/src/internals/gc-rooting-invariant.md`: the static checker reads
+//! emitted LLVM IR and cannot see a mis-tagged runtime root at all.
+//!
+//! ## 2. Strings and BigInts came back as objects
+//!
+//! `JSValue::pointer` stamps `POINTER_TAG` unconditionally. `is_any_string()`
+//! accepts only `STRING_TAG`/`SHORT_STRING_TAG`, and `string_methods::
+//! dispatch_string` gates on exactly that predicate — so a bare `GC_TYPE_STRING`
+//! receiver was reboxed into something that is not a string, `.slice` never
+//! reached the string arm, and the call fell through to the `<m> is not a
+//! function` catch-all on a perfectly good string. `.slice` on a value that
+//! must be a string is the reported symptom of #9675. BigInt had the same
+//! shape via `BIGINT_TAG`.
+//!
+//! ## 3. An already-forwarded receiver was dispatched at its old address
+//!
+//! The tail recovery did no forwarding walk, so a bare receiver that a
+//! collection had already moved was reboxed at its from-space address.
+//!
+//! ## What the gate is, and what it deliberately leaves alone
+//!
+//! Ownership, not address magnitude.
+//! [`try_read_tracked_gc_header`](crate::value::addr_class::try_read_tracked_gc_header)
+//! requires arena page membership or an exact malloc-registry hit, plus a valid
+//! `obj_type`/`size`/arena-flag triple, before the first header byte is
+//! touched. So this path does not reclassify
+//!
+//! * genuine subnormal numbers (including pointer-magnitude bit patterns),
+//! * unrelated non-Perry allocations, even ones carrying synthetic GC headers,
+//! * headerless registry handles and every other handle-band id, or
+//! * any NaN-boxed value at all — one `bits >> 48` compare returns those
+//!   untouched, so the ordinary receiver pays nothing.
+//!
+//! ## 4. An unvouched bare word was still read as a pointer, and faulted
+//!
+//! The mirror image of the above, and the reason this module owns the decision
+//! rather than reboxing opportunistically. A genuine positive subnormal double
+//! has bits that *look* like an address: `1e-310` is `0x1268_8b70_e62b`, which
+//! is above the handle band and inside `is_valid_obj_ptr`'s platform window. The
+//! tower's probes are magnitude-gated — `try_read_gc_header` classifies by
+//! address range and then dereferences `addr - GC_HEADER_SIZE` — and that
+//! contract is written for a STALE heap address, where the page is still
+//! mapped. An arbitrary number is not a stale address; nothing was ever mapped
+//! there. `(1e-310 as any).toString()` therefore SIGSEGV'd inside
+//! `url::search_params::shape_is_url_search_params`, a probe that is itself
+//! careful (it gates on `try_read_gc_header` precisely so a Date cell cannot
+//! fault it) and simply cannot tell a number from an address. Node prints
+//! `1e-310`. A smaller subnormal aliases the *handle* band instead — `5e-324`
+//! is `0x1`, so the handle dispatcher answered it and
+//! `(5e-324 as any).toString()` returned `undefined` where node returns
+//! `"5e-324"`.
+//!
+//! Fixing the one probe that happened to fault would be whack-a-mole: every
+//! magnitude-gated probe in the tower has the same exposure, and this codebase
+//! has paid for that pattern three times over (CLAUDE.md, "Known-weak areas").
+//! The chokepoint is here. Once an owner has been asked and declined, the word
+//! is *definitively not a managed pointer*, so it is the number its bits spell
+//! and [`dispatch_unvouched_bare_as_number`] dispatches it as one — it never
+//! reaches a pointer-shaped probe at all. That makes the whole class
+//! unreachable rather than fixing its current instance.
+//!
+//! Because of that, the tower's magnitude-only tail recovery is now
+//! unreachable for bare words and is deleted with this change: it was the last
+//! place that treated address magnitude as proof.
+
+/// Rebox an allocator-proven bare managed receiver into a properly tagged
+/// NaN-box, following forwarding. Returns `object` unchanged for everything
+/// else. See the module docs for why this must happen before the root.
+#[inline]
+pub(super) unsafe fn canonicalize_bare_gc_receiver(object: f64) -> f64 {
+    let bits = object.to_bits();
+    // Every NaN-boxed value — `INT32_TAG` and `SHORT_STRING_TAG` included — has
+    // non-zero top 16 bits, and 0 is not an address. One compare returns every
+    // ordinary receiver before any probe runs.
+    if bits == 0 || (bits >> 48) != 0 {
+        return object;
+    }
+    let addr = bits as usize;
+    if !bare_word_has_an_owner(addr) {
+        return object;
+    }
+    if crate::value::addr_class::try_read_tracked_gc_header(addr).is_none() {
+        // Vouched for by a header-free registry rather than by the allocator:
+        // there is no `GcHeader` to read a kind out of, and every such
+        // allocation (a `Symbol.for` symbol, a registered buffer, a typed
+        // array) is boxed as a POINTER.
+        return f64::from_bits(
+            crate::value::POINTER_TAG | (addr as u64 & crate::value::POINTER_MASK),
+        );
+    }
+    // A collection may already have moved it; the root taken by the caller is
+    // only useful once it holds the CURRENT address.
+    let resolved = crate::value::resolve_forwarding(addr);
+    let Some(header) = crate::value::addr_class::try_read_tracked_gc_header(resolved) else {
+        // A forwarding target that is no longer a tracked allocation is not
+        // something to dispatch on. Leave the value alone rather than
+        // manufacture a pointer to it.
+        return object;
+    };
+    let tag = match (*header.as_ptr()).obj_type {
+        // `alloc_symbol` gc_mallocs a `SymbolHeader` as `GC_TYPE_STRING`, so the
+        // header alone cannot separate a string from a fresh `Symbol()`. Screen
+        // on the object's own first word the way
+        // `gc_pointer_and_type_from_value` does — `may_be_symbol_header` is
+        // exact in the `false` direction, so a string pays one content load and
+        // a symbol keeps `POINTER_TAG`, which is how symbols are boxed.
+        crate::gc::GC_TYPE_STRING
+            if !(crate::symbol::may_be_symbol_header(resolved as *const u8)
+                && crate::symbol::is_registered_symbol(resolved)) =>
+        {
+            crate::value::STRING_TAG
+        }
+        crate::gc::GC_TYPE_BIGINT => crate::value::BIGINT_TAG,
+        _ => crate::value::POINTER_TAG,
+    };
+    f64::from_bits(tag | (resolved as u64 & crate::value::POINTER_MASK))
+}
+
+/// Can any owner answer for `addr` **without dereferencing it**?
+///
+/// The allocator is the strongest answer (`try_read_tracked_gc_header` proves
+/// arena page membership or an exact malloc-registry hit). The rest are the
+/// address-keyed registries that own allocations carrying no `GcHeader` at all —
+/// a `Symbol.for` symbol, an `ArrayBuffer`/`Uint8Array` backing store, a typed
+/// array. Every one of these is a table lookup behind an idle latch, so a
+/// program that never made one pays a single atomic load; and every one of them
+/// is consulted by `gc_pointer_and_type_from_value` for the same reason.
+///
+/// Nothing here reads memory at `addr`, which is the whole point: this runs on
+/// words that may not be addresses.
+#[inline]
+fn bare_word_has_an_owner(addr: usize) -> bool {
+    let allocator_owns = unsafe { crate::value::addr_class::try_read_tracked_gc_header(addr) };
+    allocator_owns.is_some()
+        || crate::symbol::is_registered_symbol(addr)
+        || crate::buffer::is_registered_buffer(addr)
+        || crate::buffer::is_any_array_buffer(addr)
+        || crate::buffer::is_uint8array_buffer(addr)
+        || crate::typedarray::lookup_typed_array_kind(addr).is_some()
+}
+
+/// True when `object` is still a bare word after
+/// [`canonicalize_bare_gc_receiver`] has run — i.e. no owner claimed it, so it
+/// cannot be a managed pointer.
+///
+/// `+0.0` (all-zero bits) is deliberately excluded: it is not address-shaped,
+/// no probe can mistake it for one, and leaving it on the ordinary path keeps
+/// this change to the words that actually alias addresses.
+#[inline]
+pub(super) fn is_unvouched_bare_word(object: f64) -> bool {
+    let bits = object.to_bits();
+    bits != 0 && (bits >> 48) == 0
+}
+
+/// Dispatch an unvouched bare word as the number its bits spell.
+///
+/// This is what the tower's `primitive_kind` arm would have done for it, minus
+/// the ~1200 lines of pointer-shaped probes in between — any one of which may
+/// dereference the word on nothing more than its magnitude. Reaching the same
+/// answer without them is the fix for defect 4 above.
+#[inline]
+pub(super) unsafe fn dispatch_unvouched_bare_as_number(
+    object: f64,
+    method_name_ptr: *const i8,
+    method_name_len: usize,
+    args_ptr: *const f64,
+    args_len: usize,
+) -> f64 {
+    let method_name_cow = if method_name_ptr.is_null() || method_name_len == 0 {
+        std::borrow::Cow::Borrowed("")
+    } else {
+        let bytes = std::slice::from_raw_parts(method_name_ptr as *const u8, method_name_len);
+        String::from_utf8_lossy(bytes)
+    };
+    let method_name: &str = &method_name_cow;
+    if let Some(result) = super::call_primitive_builtin_prototype_method(
+        object,
+        b"Number",
+        method_name,
+        args_ptr,
+        args_len,
+    ) {
+        return result;
+    }
+    crate::error::js_throw_type_error_not_a_function(
+        b"number".as_ptr(),
+        b"number".len(),
+        method_name.as_ptr(),
+        method_name.len(),
+    )
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/perry-runtime/src/object/native_call_method/bare_receiver/tests.rs
+++ b/crates/perry-runtime/src/object/native_call_method/bare_receiver/tests.rs
@@ -1,0 +1,517 @@
+//! #9675 regression coverage for [`canonicalize_bare_gc_receiver`].
+//!
+//! Two claims, and the second is the one that keeps a fix like this honest:
+//!
+//! * **the reclassification happens** — a bare `GC_TYPE_STRING` receiver comes
+//!   back a STRING, a bare `GC_TYPE_BIGINT` receiver a BIGINT, an ordinary
+//!   managed object a POINTER, an already-forwarded receiver at its CURRENT
+//!   address, and a bare string receiver's dynamic `.slice` returns the sliced
+//!   string instead of throwing;
+//! * **nothing else is reclassified** — genuine subnormal doubles whose bits sit
+//!   squarely in the heap-address range, unrelated allocations carrying
+//!   synthetic GC headers, headerless registry handles, a fresh `Symbol()`
+//!   (which is itself a `GC_TYPE_STRING` allocation), and every NaN-boxed value
+//!   are returned bit-for-bit unchanged — and a word nothing vouched for is
+//!   routed to NUMBER dispatch, so no magnitude-gated probe can dereference it.
+//!
+//! Without the second half this file would pass with the gate widened to "any
+//! address-shaped word", which is exactly the mistake the magnitude-only tail
+//! recovery makes.
+
+use super::*;
+use crate::gc::{GcHeader, GC_FLAG_FORWARDED, GC_HEADER_SIZE};
+use crate::value::{JSValue, BIGINT_TAG, POINTER_MASK, POINTER_TAG, STRING_TAG, TAG_MASK};
+
+/// Encode `addr` the way a managed pointer looks when it was never NaN-boxed:
+/// the raw address, top 16 bits zero. This is the shape
+/// `gc_pointer_and_type_from_value` already accepts and the shape
+/// `js_native_call_method` classified as a "number".
+fn bare(addr: usize) -> f64 {
+    f64::from_bits(addr as u64)
+}
+
+/// Every test below is vacuous unless the receiver really is bare-encodable on
+/// this host, and unless a bare word really does carry the zero tag that both
+/// `try_mark_value` and `try_rewrite_nanboxed_value` reject (see
+/// `gc/tests/root_words.rs`, #6910 — the same hole, in the shadow/global
+/// registries).
+fn assert_bare_premise(addr: usize, what: &str) {
+    assert!(addr != 0, "test premise: {what} allocated");
+    assert_eq!(
+        (addr as u64) >> 48,
+        0,
+        "test premise: {what} must be representable as a bare receiver on this \
+         host (top 16 bits zero)"
+    );
+    assert_eq!(
+        bare(addr).to_bits() & TAG_MASK,
+        0,
+        "test premise: a bare receiver's tag is zero, which is why a `Nanbox` \
+         root slot holding one is neither marked nor rewritten"
+    );
+}
+
+fn tag_of(value: f64) -> u64 {
+    value.to_bits() & TAG_MASK
+}
+
+fn payload_of(value: f64) -> usize {
+    (value.to_bits() & POINTER_MASK) as usize
+}
+
+unsafe fn rust_string(header: *const crate::StringHeader) -> String {
+    let bytes = std::slice::from_raw_parts(
+        crate::string::string_data(header),
+        (*header).byte_len as usize,
+    );
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+unsafe fn header_of(addr: usize) -> *mut GcHeader {
+    (addr - GC_HEADER_SIZE) as *mut GcHeader
+}
+
+// ---------------------------------------------------------------------------
+// The reclassification happens.
+// ---------------------------------------------------------------------------
+
+/// The #9675 shape. `string_methods::dispatch_string` gates on
+/// `is_any_string()`, which accepts only `STRING_TAG`/`SHORT_STRING_TAG` — so
+/// the tail recovery's unconditional `JSValue::pointer` rebox produced a
+/// receiver that is not a string, `.slice` never reached the string arm, and
+/// the call fell through to the `<m> is not a function` catch-all.
+#[test]
+fn bare_gc_string_receiver_is_canonicalized_to_string_tag() {
+    let header = crate::string::js_string_from_str("abcdef");
+    let addr = header as usize;
+    assert_bare_premise(addr, "a GC string");
+
+    let canonical = unsafe { canonicalize_bare_gc_receiver(bare(addr)) };
+    assert_eq!(
+        tag_of(canonical),
+        STRING_TAG,
+        "a bare GC_TYPE_STRING receiver must be reboxed with STRING_TAG"
+    );
+    assert_eq!(
+        payload_of(canonical),
+        addr,
+        "payload must be the same object"
+    );
+    assert!(
+        JSValue::from_bits(canonical.to_bits()).is_any_string(),
+        "the canonical receiver must satisfy the exact predicate \
+         `string_methods::dispatch_string` gates on"
+    );
+
+    // What the tail recovery produced instead, stated so the reason this test
+    // exists cannot be lost: same object, wrong kind.
+    let as_the_tail_reboxed_it = f64::from_bits(JSValue::pointer(addr as *const u8).bits());
+    assert!(
+        !JSValue::from_bits(as_the_tail_reboxed_it.to_bits()).is_any_string(),
+        "premise of the bug: an unconditional POINTER_TAG rebox of a GC string \
+         is not a string, so `.slice` cannot dispatch"
+    );
+}
+
+/// The user-visible statement: a dynamic `.slice` on a bare managed string
+/// receiver returns the sliced string.
+#[test]
+fn bare_gc_string_receiver_dispatches_slice_as_a_string() {
+    let header = crate::string::js_string_from_str("abcdef");
+    let addr = header as usize;
+    assert_bare_premise(addr, "a GC string");
+
+    let args = [1.0f64];
+    let result = unsafe {
+        crate::object::js_native_call_method(
+            bare(addr),
+            b"slice".as_ptr() as *const i8,
+            5,
+            args.as_ptr(),
+            args.len(),
+        )
+    };
+    assert!(
+        JSValue::from_bits(result.to_bits()).is_any_string(),
+        "`.slice(1)` on a bare managed string receiver must return a string"
+    );
+    let out = crate::value::js_get_string_pointer_unified(result) as *const crate::StringHeader;
+    assert!(!out.is_null(), "the returned string must be readable");
+    assert_eq!(unsafe { rust_string(out) }, "bcdef");
+}
+
+#[test]
+fn bare_gc_bigint_receiver_is_canonicalized_to_bigint_tag() {
+    let mut limbs = [0u64; crate::bigint::BIGINT_LIMBS];
+    limbs[0] = 42;
+    let addr = crate::bigint::bigint_alloc_with_limbs(limbs) as usize;
+    assert_bare_premise(addr, "a GC BigInt");
+
+    let canonical = unsafe { canonicalize_bare_gc_receiver(bare(addr)) };
+    assert_eq!(
+        tag_of(canonical),
+        BIGINT_TAG,
+        "a bare GC_TYPE_BIGINT receiver must be reboxed with BIGINT_TAG"
+    );
+    assert_eq!(payload_of(canonical), addr);
+    assert!(JSValue::from_bits(canonical.to_bits()).is_bigint());
+}
+
+#[test]
+fn bare_gc_object_receiver_is_canonicalized_to_pointer_tag() {
+    let addr = crate::object::js_object_alloc(0, 4) as usize;
+    assert_bare_premise(addr, "a plain managed object");
+
+    let canonical = unsafe { canonicalize_bare_gc_receiver(bare(addr)) };
+    assert_eq!(
+        tag_of(canonical),
+        POINTER_TAG,
+        "an ordinary managed receiver keeps POINTER_TAG — the tag it always had"
+    );
+    assert_eq!(payload_of(canonical), addr);
+}
+
+/// The tail recovery did no forwarding walk, so a receiver a collection had
+/// already moved was reboxed at its from-space address and dispatched there.
+#[test]
+fn bare_receiver_canonicalization_follows_forwarding() {
+    let from = crate::string::js_string_from_str("abcdef") as usize;
+    let to = crate::string::js_string_from_str("uvwxyz") as usize;
+    assert_bare_premise(from, "the from-space GC string");
+    assert_bare_premise(to, "the to-space GC string");
+    assert_ne!(from, to, "test premise: two distinct allocations");
+
+    unsafe {
+        let header = header_of(from);
+        crate::gc::set_forwarding_address(header, to as *mut u8);
+        (*header).gc_flags |= GC_FLAG_FORWARDED;
+    }
+
+    let canonical = unsafe { canonicalize_bare_gc_receiver(bare(from)) };
+    assert_eq!(
+        payload_of(canonical),
+        to,
+        "a forwarded bare receiver must canonicalize to its CURRENT address, \
+         not the from-space one the tail recovery used"
+    );
+    assert_eq!(tag_of(canonical), STRING_TAG);
+
+    unsafe {
+        (*header_of(from)).gc_flags &= !GC_FLAG_FORWARDED;
+    }
+}
+
+/// The canonical receiver's whole purpose is to be rootable: the tower parks it
+/// in a `RuntimeHandleSlot::Nanbox`, and that slot kind is marked by
+/// `try_mark_value` and rewritten by `try_rewrite_nanboxed_value`, both of
+/// which accept exactly `POINTER_TAG`/`STRING_TAG`/`BIGINT_TAG` and reject
+/// everything else.
+#[test]
+fn every_canonical_receiver_carries_a_tag_the_collector_traces() {
+    let mut limbs = [0u64; crate::bigint::BIGINT_LIMBS];
+    limbs[0] = 7;
+    let candidates = [
+        (
+            "string",
+            crate::string::js_string_from_str("abcdef") as usize,
+        ),
+        (
+            "bigint",
+            crate::bigint::bigint_alloc_with_limbs(limbs) as usize,
+        ),
+        ("object", crate::object::js_object_alloc(0, 4) as usize),
+        ("array", crate::array::js_array_alloc(4) as usize),
+    ];
+    for (what, addr) in candidates {
+        assert_bare_premise(addr, what);
+        let canonical = unsafe { canonicalize_bare_gc_receiver(bare(addr)) };
+        assert!(
+            matches!(tag_of(canonical), POINTER_TAG | STRING_TAG | BIGINT_TAG),
+            "{what}: a bare receiver must be reboxed under a tag a `Nanbox` root \
+             slot is marked and rewritten through; a zero tag is dropped by both \
+             passes (#6910's hole, re-opened in the transient-handle registry)"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Nothing else is reclassified.
+// ---------------------------------------------------------------------------
+
+/// Address magnitude is not evidence of anything. These are genuine positive
+/// subnormal doubles whose bit patterns sit squarely inside the platform heap
+/// window the tail recovery's `is_valid_obj_ptr` accepts.
+#[test]
+fn pointer_magnitude_subnormal_numbers_are_not_reclassified() {
+    for bits in [
+        0x1000u64,
+        0x0010_0000,
+        0x0000_5555_5555_5555,
+        0x0000_7fff_ffff_f000,
+        0x0000_0001_0000_0008,
+        1,
+        0,
+    ] {
+        let value = f64::from_bits(bits);
+        assert!(
+            JSValue::from_bits(bits).is_number(),
+            "test premise: {bits:#x} decodes as a number, so the tower would \
+             report it as `(number)`"
+        );
+        let out = unsafe { canonicalize_bare_gc_receiver(value) };
+        assert_eq!(
+            out.to_bits(),
+            bits,
+            "{bits:#x} is owned by nothing and must be returned bit-for-bit \
+             unchanged"
+        );
+    }
+}
+
+/// An unrelated allocation with a hand-built `GcHeader` in front of it passes
+/// every magnitude test and every header-content test. Only allocator
+/// ownership rejects it.
+#[test]
+fn unrelated_allocations_with_synthetic_headers_are_not_reclassified() {
+    #[repr(C)]
+    struct Synthetic {
+        header: GcHeader,
+        payload: [u64; 4],
+    }
+
+    let synthetic = Box::new(Synthetic {
+        header: GcHeader {
+            obj_type: crate::gc::GC_TYPE_STRING,
+            gc_flags: 0,
+            _reserved: 0,
+            size: std::mem::size_of::<Synthetic>() as u32,
+        },
+        payload: [0; 4],
+    });
+    let user = &synthetic.payload as *const [u64; 4] as usize;
+    assert_bare_premise(user, "a non-Perry allocation");
+
+    let out = unsafe { canonicalize_bare_gc_receiver(bare(user)) };
+    assert_eq!(
+        out.to_bits(),
+        user as u64,
+        "a `Box` allocation is owned by neither the arena nor the GC malloc \
+         registry, so it must not be reboxed as a managed receiver"
+    );
+}
+
+/// Registry handles (timers, sockets, zlib streams, proxies, …) are small ids
+/// with no header at all. Dereferencing one is the #4665/#4800 SIGSEGV.
+#[test]
+fn headerless_registry_handles_are_not_reclassified() {
+    for id in [1u64, 0x1008, 0x1_0000, 0x4_0000, 0xF_0000, 0xF_FFF8] {
+        let out = unsafe { canonicalize_bare_gc_receiver(f64::from_bits(id)) };
+        assert_eq!(
+            out.to_bits(),
+            id,
+            "handle id {id:#x} must be returned unchanged, without a header read"
+        );
+    }
+}
+
+/// `alloc_symbol` gc_mallocs a `SymbolHeader` as `GC_TYPE_STRING`, so the
+/// header alone would call a fresh `Symbol()` a string. Tagging one STRING_TAG
+/// would hand `js_get_string_pointer_unified` a `SymbolHeader` to read as text.
+#[test]
+fn a_fresh_symbol_receiver_keeps_pointer_tag() {
+    let addr = unsafe { crate::value::js_nanbox_get_pointer(crate::symbol::js_symbol_new_empty()) }
+        as usize;
+    assert_bare_premise(addr, "a fresh Symbol()");
+    assert!(
+        unsafe { crate::symbol::may_be_symbol_header(addr as *const u8) },
+        "test premise: a symbol carries SYMBOL_MAGIC in its first word; without \
+         it this test cannot distinguish the symbol screen from its absence"
+    );
+
+    let canonical = unsafe { canonicalize_bare_gc_receiver(bare(addr)) };
+    assert_eq!(
+        tag_of(canonical),
+        POINTER_TAG,
+        "a fresh Symbol() is a GC_TYPE_STRING allocation but is boxed as a \
+         POINTER; the SYMBOL_MAGIC screen is what keeps it out of the string arm"
+    );
+    assert_eq!(payload_of(canonical), addr);
+}
+
+/// Defect 4. A word no owner claims is not a pointer, so the tower must answer
+/// it as a number instead of handing it to probes that classify by address
+/// magnitude and then dereference `addr - GC_HEADER_SIZE`.
+///
+/// These are the two shapes that actually bit. `1e-310` is `0x1268_8b70_e62b`:
+/// above the handle band, inside `is_valid_obj_ptr`'s window, and unmapped —
+/// `(1e-310 as any).toString()` SIGSEGV'd in
+/// `url::search_params::shape_is_url_search_params`. `5e-324` is `0x1`, which
+/// aliases the handle band instead, and the handle dispatcher answered it with
+/// `undefined`. Node prints `1e-310` and `5e-324`.
+#[test]
+fn address_shaped_subnormals_route_to_number_dispatch() {
+    for (label, bits) in [
+        ("1e-310 (heap-magnitude alias)", 1e-310f64.to_bits()),
+        ("5e-324 (handle-band alias)", 5e-324f64.to_bits()),
+        ("the largest bare-shaped word", 0x0000_FFFF_FFFF_FFFFu64),
+        ("mid-range bare-shaped word", 0x0000_5555_5555_5555u64),
+    ] {
+        let value = f64::from_bits(bits);
+        assert_eq!(
+            (bits >> 48),
+            0,
+            "test premise: {label} is a bare-shaped word, or it cannot alias an \
+             address at all"
+        );
+        assert!(
+            is_unvouched_bare_word(unsafe { canonicalize_bare_gc_receiver(value) }),
+            "{label}: no owner may claim a genuine subnormal double — if one \
+             does, it is about to be dereferenced as an object"
+        );
+    }
+}
+
+/// The boundary, and why the routing arm can be this narrow. Only a word whose
+/// bits are BELOW 2^48 is address-shaped, so only those reach a bare-pointer
+/// arm. A subnormal near the top of its range — `2.2e-308` is
+/// `bits >> 48 == 15` — is not bare-shaped, and
+/// `as_pointer()` masking cannot expose it either: every probe that masks is
+/// gated on `is_pointer()`, and its tag is not `POINTER_TAG`. It therefore stays
+/// on the ordinary path, which is where it already behaved correctly.
+///
+/// This test exists because the first version of the routing test above asserted
+/// `2.2e-308` WAS bare-shaped and went red on its own premise.
+#[test]
+fn subnormals_above_the_bare_shaped_range_stay_on_the_ordinary_path() {
+    for (label, value) in [
+        ("2.2e-308", 2.2e-308f64),
+        ("f64::MIN_POSITIVE", f64::MIN_POSITIVE),
+        ("1e-300", 1e-300f64),
+    ] {
+        let bits = value.to_bits();
+        assert_ne!(
+            bits >> 48,
+            0,
+            "test premise: {label} must NOT be bare-shaped, or this test is \
+             asserting the wrong side of the boundary"
+        );
+        assert!(
+            !JSValue::from_bits(bits).is_pointer(),
+            "{label}: not POINTER_TAG, so no `as_pointer()`-masking probe can \
+             reach it as an address"
+        );
+        let out = unsafe { canonicalize_bare_gc_receiver(value) };
+        assert_eq!(out.to_bits(), bits, "{label} must be returned unchanged");
+        assert!(
+            !is_unvouched_bare_word(out),
+            "{label} must not be routed to number dispatch — it was never \
+             address-shaped"
+        );
+    }
+}
+
+/// The other direction of the same predicate: a real managed allocation must
+/// NOT be routed to number dispatch, or every bare receiver starts throwing.
+#[test]
+fn vouched_bare_receivers_are_not_routed_to_number_dispatch() {
+    let mut limbs = [0u64; crate::bigint::BIGINT_LIMBS];
+    limbs[0] = 3;
+    let candidates = [
+        (
+            "string",
+            crate::string::js_string_from_str("abcdef") as usize,
+        ),
+        (
+            "bigint",
+            crate::bigint::bigint_alloc_with_limbs(limbs) as usize,
+        ),
+        ("object", crate::object::js_object_alloc(0, 4) as usize),
+        ("array", crate::array::js_array_alloc(4) as usize),
+    ];
+    for (what, addr) in candidates {
+        assert_bare_premise(addr, what);
+        let canonical = unsafe { canonicalize_bare_gc_receiver(bare(addr)) };
+        assert!(
+            !is_unvouched_bare_word(canonical),
+            "{what}: the allocator vouched for this address, so it must reach \
+             the dispatch tower, not the number arm"
+        );
+    }
+}
+
+/// `+0.0` is not address-shaped and no probe can mistake it for a pointer, so it
+/// deliberately stays on the ordinary path — this change is scoped to the words
+/// that actually alias addresses.
+#[test]
+fn positive_zero_is_not_routed_to_number_dispatch() {
+    assert!(!is_unvouched_bare_word(0.0f64));
+}
+
+/// A headerless registry allocation has no `GcHeader` for the allocator gate to
+/// find, but its owning registry can answer for the address without touching
+/// memory. Such a receiver must be reboxed as a POINTER, not sent to the number
+/// arm — that is the case the deleted tail recovery legitimately served.
+#[test]
+fn headerless_registry_allocations_are_vouched_as_pointers() {
+    // `Symbol.for` leaks a `Box` with no GcHeader; a unique key guarantees this
+    // thread allocates and registers it (see `probe_dispatch_tests`).
+    let key = crate::string::js_string_from_str("perry-9675-vouch");
+    let key_f64 = f64::from_bits(crate::value::js_nanbox_string(key as i64).to_bits());
+    let addr = unsafe { crate::value::js_nanbox_get_pointer(crate::symbol::js_symbol_for(key_f64)) }
+        as usize;
+    assert_bare_premise(addr, "a Symbol.for symbol");
+    assert!(
+        crate::symbol::is_registered_symbol(addr),
+        "test premise: Symbol.for registered on this thread; otherwise no owner \
+         can vouch and this test proves nothing"
+    );
+    assert!(
+        unsafe { crate::value::addr_class::try_read_tracked_gc_header(addr) }.is_none(),
+        "test premise: a Box-leaked symbol is NOT an allocator-tracked \
+         allocation — that is what makes the registry arm load-bearing"
+    );
+
+    let canonical = unsafe { canonicalize_bare_gc_receiver(bare(addr)) };
+    assert!(
+        !is_unvouched_bare_word(canonical),
+        "a registered symbol must be vouched for, not dispatched as a number"
+    );
+    assert_eq!(
+        tag_of(canonical),
+        POINTER_TAG,
+        "a headerless registry allocation has no GcHeader to read a kind from \
+         and is boxed as a POINTER"
+    );
+    assert_eq!(payload_of(canonical), addr);
+}
+
+/// The ordinary path pays one compare. Every NaN-boxed receiver — including
+/// `INT32_TAG`, which shares its high half with nothing else, and a real
+/// pointer, which is already canonical — comes back untouched.
+#[test]
+fn nanboxed_receivers_are_returned_unchanged() {
+    let object = crate::object::js_object_alloc(0, 4) as usize;
+    let string = crate::string::js_string_from_str("hello") as usize;
+    let probes = [
+        ("undefined", crate::value::TAG_UNDEFINED),
+        ("null", crate::value::TAG_NULL),
+        ("true", crate::value::TAG_TRUE),
+        ("false", crate::value::TAG_FALSE),
+        ("int32 0", crate::value::INT32_TAG),
+        ("int32 42", crate::value::INT32_TAG | 42),
+        ("double 3.5", 3.5f64.to_bits()),
+        ("double -1.0", (-1.0f64).to_bits()),
+        ("double 1e300", 1e300f64.to_bits()),
+        ("nan", f64::NAN.to_bits()),
+        ("pointer", POINTER_TAG | object as u64),
+        ("string", STRING_TAG | string as u64),
+    ];
+    for (what, bits) in probes {
+        let out = unsafe { canonicalize_bare_gc_receiver(f64::from_bits(bits)) };
+        assert_eq!(
+            out.to_bits(),
+            bits,
+            "{what} is already NaN-boxed and must be returned unchanged"
+        );
+    }
+}

--- a/crates/perry-runtime/src/os.rs
+++ b/crates/perry-runtime/src/os.rs
@@ -842,10 +842,12 @@ mod process_streams;
 #[cfg(test)]
 pub(crate) use process_streams::test_set_stdin_data_listener;
 pub use process_streams::{
-    js_process_stderr, js_process_stdin, js_process_stdout, mark_process_stdin_destroyed,
-    pump_process_stdin, scan_process_stream_singleton_roots_mut, set_process_stdin_raw_state,
-    stdin_chunk_jsvalue, stdin_chunk_jsvalue_opt, stdin_encoding_flush_jsvalue, stdin_has_encoding,
-    stdin_is_detached, stdin_listeners_keep_loop_alive, stdin_push_bytes,
+    disable_process_stdin_keypress_events, enable_process_stdin_keypress_events,
+    ensure_process_stdin_reader, is_process_stdin_handle, js_process_stderr, js_process_stdin,
+    js_process_stdout, mark_process_stdin_destroyed, pump_process_stdin,
+    scan_process_stream_singleton_roots_mut, set_process_stdin_raw_state, stdin_chunk_jsvalue,
+    stdin_chunk_jsvalue_opt, stdin_encoding_flush_jsvalue, stdin_has_encoding, stdin_is_detached,
+    stdin_keypress_events_enabled, stdin_listeners_keep_loop_alive, stdin_push_bytes,
 };
 
 /// Get the operating system name

--- a/crates/perry-runtime/src/os_process_streams.rs
+++ b/crates/perry-runtime/src/os_process_streams.rs
@@ -205,14 +205,9 @@ extern "C" fn process_stdin_unref_stub(
 /// `process.stdin.ref()` — restore the event-loop hold (#9676). Was a no-op
 /// stub, which is what made `unref()` a one-way latch.
 ///
-/// Deliberately does NOT start a reader. `ref` is the inverse of `unref` and
-/// nothing more, exactly as in Node: it does not resume a `pause()`d stream,
-/// and starting one here would be actively harmful — perry-stdlib's readline
-/// runs its own fd-0 reader, both readers take `std::io::stdin()`'s process
-/// lock, and a program whose listeners live in readline's registry would end
-/// up with the runtime's reader parked on that lock (or, worse, consuming
-/// bytes into a buffer those listeners never see). `resume()` remains the one
-/// call that restarts a stopped reader.
+/// Deliberately does NOT start the shared reader. `ref` is the inverse of
+/// `unref` and nothing more, exactly as in Node: it does not resume a paused
+/// stream. `resume()` remains the one call that restarts a stopped reader.
 extern "C" fn process_stdin_ref_stub(
     _closure: *const crate::closure::ClosureHeader,
     _arg: f64,
@@ -250,6 +245,8 @@ pub fn set_process_stdin_raw_state(enabled: bool) {
 }
 
 pub fn mark_process_stdin_destroyed() {
+    STDIN_DETACHED.store(true, std::sync::atomic::Ordering::Release);
+    disable_process_stdin_keypress_events();
     set_stdin_bool_field(b"readable", false);
     set_stdin_bool_field(b"readableEnded", true);
     set_stdin_bool_field(b"destroyed", true);
@@ -263,8 +260,8 @@ pub fn mark_process_stdin_destroyed() {
 // `setRawMode(!0); on("readable", () => { let c = stdin.read(); while (c !==
 // null) { …; c = stdin.read() } })`. Previously `on`/`read`/`resume` were
 // no-op stubs ("encoding-aware reads remain future work"), so input was dead
-// even though `perry/tui` had its own working reader. A dedicated reader
-// thread reads fd 0, buffers the bytes and wakes the event loop; the loop
+// even though `perry/tui` had its own working reader. The runtime-owned reader
+// thread reads fd 0, routes the bytes and wakes the event loop; the loop
 // pump (`pump_process_stdin`, called each tick from `js_callback_timer_tick`)
 // drains the buffer and fires the registered `data`/`readable` listeners.
 static STDIN_BUFFER: std::sync::Mutex<Vec<u8>> = std::sync::Mutex::new(Vec::new());
@@ -286,10 +283,76 @@ static STDIN_END_FIRED: std::sync::atomic::AtomicBool = std::sync::atomic::Atomi
 static STDIN_READER_STARTED: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
+/// Optional consumer installed by perry-stdlib's readline implementation.
+///
+/// fd 0 must have exactly one physical reader. Historically this module and
+/// `perry-stdlib::readline` each spawned a thread that held
+/// `std::io::StdinLock` for its whole lifetime; whichever thread won the lock
+/// consumed every byte and the other parked forever. The runtime now owns the
+/// sole reader and forwards each read (and EOF) through these callbacks when
+/// readline is linked. The callbacks only enqueue Rust-owned bytes/flags; JS
+/// dispatch remains on the main-thread pumps.
+static STDIN_READER_DATA_FN: std::sync::atomic::AtomicPtr<()> =
+    std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());
+static STDIN_READER_EOF_FN: std::sync::atomic::AtomicPtr<()> =
+    std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());
+
+/// Serializes the initial buffered-byte handoff with live reader deliveries.
+/// Without it, a read that arrives just after callback registration could be
+/// forwarded before bytes that the runtime reader had already buffered.
+static STDIN_READER_ROUTE: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn stdin_reader_data_consumer() -> Option<extern "C" fn(*const u8, usize)> {
+    let ptr = STDIN_READER_DATA_FN.load(std::sync::atomic::Ordering::Acquire);
+    if ptr.is_null() {
+        None
+    } else {
+        // SAFETY: `js_register_stdin_reader_consumer` stores this exact ABI.
+        Some(unsafe { std::mem::transmute::<*mut (), extern "C" fn(*const u8, usize)>(ptr) })
+    }
+}
+
+fn stdin_reader_eof_consumer() -> Option<extern "C" fn()> {
+    let ptr = STDIN_READER_EOF_FN.load(std::sync::atomic::Ordering::Acquire);
+    if ptr.is_null() {
+        None
+    } else {
+        // SAFETY: `js_register_stdin_reader_consumer` stores this exact ABI.
+        Some(unsafe { std::mem::transmute::<*mut (), extern "C" fn()>(ptr) })
+    }
+}
+
+/// Register readline as a subscriber to the runtime-owned fd-0 reader.
+///
+/// Bytes read before stdlib initialized are handed over synchronously while
+/// the route lock is held, preserving their order relative to future reads.
+#[no_mangle]
+pub extern "C" fn js_register_stdin_reader_consumer(
+    on_data: extern "C" fn(*const u8, usize),
+    on_eof: extern "C" fn(),
+) {
+    let _route = STDIN_READER_ROUTE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    STDIN_READER_DATA_FN.store(on_data as *mut (), std::sync::atomic::Ordering::Release);
+    STDIN_READER_EOF_FN.store(on_eof as *mut (), std::sync::atomic::Ordering::Release);
+
+    let pending = STDIN_BUFFER
+        .lock()
+        .map(|mut bytes| std::mem::take(&mut *bytes))
+        .unwrap_or_default();
+    if !pending.is_empty() {
+        on_data(pending.as_ptr(), pending.len());
+    }
+    if STDIN_EOF_SEEN.load(std::sync::atomic::Ordering::Acquire) {
+        on_eof();
+    }
+}
+
 fn ensure_stdin_reader() {
     use std::sync::atomic::Ordering;
-    // A previous reader may have exited (EOF, error, or detach via
-    // `pause`/`unref`); its drop guard resets `STDIN_READER_STARTED` to false,
+    // A previous reader may have exited (EOF, error, or explicit detach); its
+    // drop guard resets `STDIN_READER_STARTED` to false,
     // so a later `resume()`/`on(...)` can spin up a fresh reader.
     if STDIN_READER_STARTED
         .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
@@ -315,7 +378,11 @@ fn ensure_stdin_reader() {
             // bytes are available (it does not wait to fill the buffer), so a
             // lone keystroke is unaffected — it returns 1 byte immediately —
             // while a burst collapses into one lock + one notify.
-            let mut buf = [0u8; 4096];
+            // 64 KiB matches Node's pipe read size and the former readline
+            // reader's #9489 chunking contract. With this module now owning
+            // the sole fd-0 read, a smaller buffer would regress a 1 MiB pipe
+            // from ~16 `data` events to hundreds.
+            let mut buf = [0u8; 65536];
             loop {
                 // #9676: `stdin_reader_should_stop`, NOT `stdin_is_detached` —
                 // an `unref()`d stdin still delivers data in Node, and reading
@@ -329,12 +396,23 @@ fn ensure_stdin_reader() {
                         // `'end'`/`'close'` listeners after the buffer drains,
                         // and wake the loop so a final pump runs even when no
                         // more bytes arrive (e.g. `< /dev/null`).
+                        let _route = STDIN_READER_ROUTE
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner());
                         STDIN_EOF_SEEN.store(true, std::sync::atomic::Ordering::Release);
+                        if let Some(on_eof) = stdin_reader_eof_consumer() {
+                            on_eof();
+                        }
                         crate::event_pump::js_notify_main_thread();
                         break;
                     }
                     Ok(n) => {
-                        if let Ok(mut q) = STDIN_BUFFER.lock() {
+                        let _route = STDIN_READER_ROUTE
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner());
+                        if let Some(on_data) = stdin_reader_data_consumer() {
+                            on_data(buf.as_ptr(), n);
+                        } else if let Ok(mut q) = STDIN_BUFFER.lock() {
                             q.extend_from_slice(&buf[..n]);
                         }
                         crate::event_pump::js_notify_main_thread();
@@ -346,15 +424,22 @@ fn ensure_stdin_reader() {
     }
 }
 
+/// Start (or restart) the single runtime-owned fd-0 reader.
+///
+/// Readline calls this after installing its consumer callbacks. Keeping the
+/// compare/exchange in this module makes it impossible for the two surfaces to
+/// race separate `StdinLock`s again.
+pub fn ensure_process_stdin_reader() {
+    ensure_stdin_reader();
+}
+
 /// Append bytes to the buffer that `process.stdin.read()` drains.
 ///
 /// `process.stdin.on(...)` / `.setRawMode(...)` / `.pause()` / `.resume()` do NOT
 /// dispatch on this object — codegen lowers them to direct extern calls into
-/// `perry-stdlib`'s readline, which runs its own fd-0 reader. `read()` has no such
-/// route, so it stays a method here and drains `STDIN_BUFFER`. Paused-mode input
-/// (`on("readable")` + `read()`) therefore needs readline's reader to deposit its
-/// bytes here, or the two halves of that pattern would talk to different buffers
-/// and `read()` would always return null.
+/// `perry-stdlib`'s readline. `read()` has no such route, so it stays a method
+/// here and drains `STDIN_BUFFER`. The shared reader's stdlib consumer deposits
+/// non-flowing bytes here so `on("readable")` and `read()` use the same buffer.
 /// `perry-stdlib`'s readline owns the `process.stdin` listener lists (codegen
 /// lowers `stdin.on(...)` to a direct extern into it), but the stdin *object*
 /// lives here — so `stdin.listeners(event)` cannot see them without a bridge.
@@ -383,6 +468,8 @@ pub extern "C" fn js_register_stdin_listeners_provider(f: extern "C" fn(*const u
 static STDIN_ON_FN: std::sync::atomic::AtomicPtr<()> =
     std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());
 static STDIN_OFF_FN: std::sync::atomic::AtomicPtr<()> =
+    std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());
+static STDIN_REMOVE_ALL_FN: std::sync::atomic::AtomicPtr<()> =
     std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());
 
 /// Encoding set via `process.stdin.setEncoding(enc)`. `None` — Node's default —
@@ -517,9 +604,11 @@ extern "C" fn process_stdin_set_encoding(
 pub extern "C" fn js_register_stdin_listener_ops(
     on: extern "C" fn(*const u8, usize, i64, i32),
     off: extern "C" fn(*const u8, usize, i64),
+    remove_all: extern "C" fn(*const u8, usize, i32),
 ) {
     STDIN_ON_FN.store(on as *mut (), std::sync::atomic::Ordering::Release);
     STDIN_OFF_FN.store(off as *mut (), std::sync::atomic::Ordering::Release);
+    STDIN_REMOVE_ALL_FN.store(remove_all as *mut (), std::sync::atomic::Ordering::Release);
 }
 
 /// #9676: perry-stdlib's readline `pause`/`resume`, so the stdin OBJECT's
@@ -528,8 +617,8 @@ pub extern "C" fn js_register_stdin_listener_ops(
 ///
 /// Without this bridge the two spellings latched DIFFERENT flags. `rl.close()`
 /// and a literal `process.stdin.pause()` both set readline's `STDIN_PAUSED`,
-/// whose pump branch returns without draining `PENDING_DATA` — while readline's
-/// fd-0 reader keeps reading and keeps notifying the main thread. Recovering
+/// whose pump branch returns without draining `PENDING_DATA` — while the shared
+/// fd-0 reader keeps reading and notifying the main thread. Recovering
 /// with an ALIASED `stdin.resume()` (`const s = process.stdin; s.resume()`, and
 /// every TUI that holds stdin in a variable) landed on the runtime object stub,
 /// which cleared only the runtime's own flags and left `STDIN_PAUSED` set for
@@ -561,18 +650,97 @@ fn stdin_flow_op(slot: &std::sync::atomic::AtomicPtr<()>) -> Option<extern "C" f
 fn stdin_ops_provider() -> Option<(
     extern "C" fn(*const u8, usize, i64, i32),
     extern "C" fn(*const u8, usize, i64),
+    extern "C" fn(*const u8, usize, i32),
 )> {
     let on = STDIN_ON_FN.load(std::sync::atomic::Ordering::Acquire);
     let off = STDIN_OFF_FN.load(std::sync::atomic::Ordering::Acquire);
-    if on.is_null() || off.is_null() {
+    let remove_all = STDIN_REMOVE_ALL_FN.load(std::sync::atomic::Ordering::Acquire);
+    if on.is_null() || off.is_null() || remove_all.is_null() {
         return None;
     }
     unsafe {
         Some((
             std::mem::transmute::<*mut (), extern "C" fn(*const u8, usize, i64, i32)>(on),
             std::mem::transmute::<*mut (), extern "C" fn(*const u8, usize, i64)>(off),
+            std::mem::transmute::<*mut (), extern "C" fn(*const u8, usize, i32)>(remove_all),
         ))
     }
+}
+
+/// Move listeners registered on the stdin object before readline initialized
+/// into readline's canonical registry. This is called only after stdlib has
+/// finished installing the provider, and before the reader-buffer handoff, so
+/// no already-read byte can overtake an earlier listener registration.
+#[no_mangle]
+pub extern "C" fn js_migrate_stdin_listeners_to_provider() {
+    let Some((on, _, _)) = stdin_ops_provider() else {
+        return;
+    };
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let take = |list: &std::sync::Mutex<Vec<i64>>| {
+        list.lock()
+            .map(|mut listeners| std::mem::take(&mut *listeners))
+            .unwrap_or_default()
+    };
+    for (name, listeners, once) in [
+        (b"data".as_slice(), take(&STDIN_DATA_LISTENERS), 0),
+        (b"data".as_slice(), take(&STDIN_DATA_ONCE), 1),
+        (b"readable".as_slice(), take(&STDIN_READABLE_LISTENERS), 0),
+        (b"readable".as_slice(), take(&STDIN_READABLE_ONCE), 1),
+        (b"end".as_slice(), take(&STDIN_END_LISTENERS), 0),
+        (b"end".as_slice(), take(&STDIN_END_ONCE), 1),
+    ] {
+        let callbacks: Vec<_> = listeners
+            .into_iter()
+            .map(|callback| {
+                scope.root_raw_const_ptr(callback as *const crate::closure::ClosureHeader)
+            })
+            .collect();
+        for callback in callbacks {
+            on(
+                name.as_ptr(),
+                name.len(),
+                callback.get_raw_const_ptr::<crate::closure::ClosureHeader>() as i64,
+                once,
+            );
+        }
+    }
+}
+
+/// Whether `readline.emitKeypressEvents(process.stdin)` has installed its
+/// data-to-keypress parser. Keypress listeners alone do not make Node emit;
+/// the readline helper is the plumbing that activates them.
+static STDIN_KEYPRESS_EVENTS_ENABLED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+pub fn stdin_keypress_events_enabled() -> bool {
+    STDIN_KEYPRESS_EVENTS_ENABLED.load(std::sync::atomic::Ordering::Acquire)
+}
+
+pub fn disable_process_stdin_keypress_events() {
+    STDIN_KEYPRESS_EVENTS_ENABLED.store(false, std::sync::atomic::Ordering::Release);
+}
+
+/// True when a raw object handle is the process-global stdin singleton.
+pub fn is_process_stdin_handle(handle: i64) -> bool {
+    STDIN_STREAM_SINGLETON.with(|slot| *slot.borrow() == handle as usize)
+}
+
+/// Install the hidden `data` listener used by
+/// `readline.emitKeypressEvents(process.stdin)` into the same registry as
+/// ordinary stdin data listeners. That makes cooked/piped input flow through
+/// the keypress parser too, and lets `removeAllListeners("data")` remove the
+/// plumbing exactly as Node does.
+pub fn enable_process_stdin_keypress_events(callback: i64) {
+    if STDIN_KEYPRESS_EVENTS_ENABLED.swap(true, std::sync::atomic::Ordering::AcqRel) {
+        return;
+    }
+    if let Some((on, _, _)) = stdin_ops_provider() {
+        on(b"data".as_ptr(), 4, callback, 0);
+    } else if let Ok(mut listeners) = STDIN_DATA_LISTENERS.lock() {
+        listeners.push(callback);
+    }
+    ensure_stdin_reader();
 }
 
 /// `process.stdin.addListener(event, cb)` / `.on(...)` reached as an object method.
@@ -581,7 +749,7 @@ extern "C" fn process_stdin_add_listener(
     event: f64,
     callback: f64,
 ) -> f64 {
-    if let Some((on, _)) = stdin_ops_provider() {
+    if let Some((on, _, _)) = stdin_ops_provider() {
         let name = stdin_event_name(event).unwrap_or_default();
         let cb = stdin_callback_ptr(callback);
         if cb != 0 {
@@ -598,7 +766,7 @@ extern "C" fn process_stdin_add_listener_once(
     event: f64,
     callback: f64,
 ) -> f64 {
-    if let Some((on, _)) = stdin_ops_provider() {
+    if let Some((on, _, _)) = stdin_ops_provider() {
         let name = stdin_event_name(event).unwrap_or_default();
         let cb = stdin_callback_ptr(callback);
         if cb != 0 {
@@ -620,7 +788,7 @@ extern "C" fn process_stdin_remove_listener(
         return stdin_this_value();
     }
     let name = stdin_event_name(event).unwrap_or_default();
-    if let Some((_, off)) = stdin_ops_provider() {
+    if let Some((_, off, _)) = stdin_ops_provider() {
         off(name.as_ptr(), name.len(), cb);
     }
     // #9399: ALSO drop it from the runtime-local lists. `on`/`once` on the
@@ -643,7 +811,95 @@ extern "C" fn process_stdin_remove_listener(
             l.retain(|entry| *entry != cb);
         }
     }
+    // A `keypress` listener registered before readline's provider existed is
+    // kept in node:stream's generic emitter registry (the hidden parser emits
+    // there). Removing through the stdin object must reach it too.
+    if name == "keypress" {
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let stream = scope.root_nanbox_f64(stdin_this_value());
+        let event = scope.root_nanbox_f64(event);
+        let callback = scope.root_nanbox_f64(callback);
+        let stream_raw = crate::value::js_nanbox_get_pointer(stream.get_nanbox_f64()) as i64;
+        if stream_raw != 0 {
+            let _ = crate::node_stream::js_node_stream_method_remove_listener(
+                stream_raw,
+                event.get_nanbox_f64(),
+                callback.get_nanbox_f64(),
+            );
+        }
+    }
     stdin_this_value()
+}
+
+fn clear_stdin_listener_list(list: &std::sync::Mutex<Vec<i64>>) {
+    if let Ok(mut listeners) = list.lock() {
+        listeners.clear();
+    }
+}
+
+/// `process.stdin.removeAllListeners([event])` across both stdin registries.
+///
+/// The stdin object has its own native listener surface, while
+/// `emitKeypressEvents` uses node:stream's hidden EventEmitter storage for its
+/// generated `keypress` emission. Both must be cleared or callbacks survive a
+/// call that Node treats as authoritative.
+extern "C" fn process_stdin_remove_all_listeners(
+    _closure: *const crate::closure::ClosureHeader,
+    event: f64,
+) -> f64 {
+    let name = stdin_event_name(event);
+    if let Some((_, _, remove_all)) = stdin_ops_provider() {
+        match name.as_deref() {
+            Some(name) => remove_all(name.as_ptr(), name.len(), 1),
+            None => remove_all(std::ptr::null(), 0, 0),
+        }
+    }
+
+    match name.as_deref() {
+        Some("data") => {
+            clear_stdin_listener_list(&STDIN_DATA_LISTENERS);
+            clear_stdin_listener_list(&STDIN_DATA_ONCE);
+            disable_process_stdin_keypress_events();
+        }
+        Some("readable") => {
+            clear_stdin_listener_list(&STDIN_READABLE_LISTENERS);
+            clear_stdin_listener_list(&STDIN_READABLE_ONCE);
+        }
+        Some("end") | Some("close") => {
+            clear_stdin_listener_list(&STDIN_END_LISTENERS);
+            clear_stdin_listener_list(&STDIN_END_ONCE);
+        }
+        Some(_) => {}
+        None => {
+            for list in [
+                &STDIN_DATA_LISTENERS,
+                &STDIN_DATA_ONCE,
+                &STDIN_READABLE_LISTENERS,
+                &STDIN_READABLE_ONCE,
+                &STDIN_END_LISTENERS,
+                &STDIN_END_ONCE,
+            ] {
+                clear_stdin_listener_list(list);
+            }
+            disable_process_stdin_keypress_events();
+        }
+    }
+
+    // A pre-provider keypress listener lives in node:stream's generic emitter
+    // registry, so clear that registry too. Root both values across the array
+    // allocations performed by remove-all.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let stream = scope.root_nanbox_f64(stdin_this_value());
+    let event = scope.root_nanbox_f64(event);
+    let stream_value = stream.get_nanbox_f64();
+    let stream_raw = crate::value::js_nanbox_get_pointer(stream_value) as i64;
+    if stream_raw != 0 {
+        let _ = crate::node_stream::js_node_stream_method_remove_all_listeners(
+            stream_raw,
+            event.get_nanbox_f64(),
+        );
+    }
+    stream.get_nanbox_f64()
 }
 
 /// `process.stdin.listeners(event)` — the registered listeners for `event`,
@@ -657,6 +913,17 @@ extern "C" fn process_stdin_listeners(
     if !f.is_null() {
         let func: extern "C" fn(*const u8, usize) -> f64 = unsafe { std::mem::transmute(f) };
         return func(name.as_ptr(), name.len());
+    }
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let stream = scope.root_nanbox_f64(stdin_this_value());
+    let event = scope.root_nanbox_f64(event);
+    let stream_raw = crate::value::js_nanbox_get_pointer(stream.get_nanbox_f64()) as i64;
+    if stream_raw != 0 {
+        let listeners =
+            crate::node_stream::js_node_stream_method_listeners(stream_raw, event.get_nanbox_f64());
+        return f64::from_bits(
+            crate::value::JSValue::array_ptr(listeners as *mut crate::array::ArrayHeader).bits(),
+        );
     }
     let arr = crate::array::js_array_alloc(0);
     f64::from_bits(crate::value::JSValue::array_ptr(arr).bits())
@@ -836,6 +1103,13 @@ extern "C" fn process_stdin_on(
                 &STDIN_END_ONCE,
                 false,
             ),
+            Some("keypress") => {
+                let stream_raw = crate::value::js_nanbox_get_pointer(stdin_this_value()) as i64;
+                if stream_raw != 0 {
+                    let _ =
+                        crate::node_stream::js_node_stream_method_on(stream_raw, event, callback);
+                }
+            }
             _ => {}
         }
     }
@@ -872,6 +1146,13 @@ extern "C" fn process_stdin_once(
                 &STDIN_END_ONCE,
                 true,
             ),
+            Some("keypress") => {
+                let stream_raw = crate::value::js_nanbox_get_pointer(stdin_this_value()) as i64;
+                if stream_raw != 0 {
+                    let _ =
+                        crate::node_stream::js_node_stream_method_once(stream_raw, event, callback);
+                }
+            }
             _ => {}
         }
     }
@@ -1316,11 +1597,9 @@ fn build_stream_object_with_write(
             JSValue::from_bits(crate::tty::tty_listener_remove_all_value().to_bits()),
         );
     }
-    // #3962: install the appended listener-removal + lifecycle methods.
-    // `on`/`once` above are no-ops here, so `addListener`/`removeListener`/
-    // `off`/`removeAllListeners`/`resume` are no-ops too. On *stdin* (fd 0),
-    // `pause`/`unref`/`destroy` additionally detach the reader so the loop can
-    // quiesce after TUI teardown; on stdout/stderr they stay no-ops.
+    // #3962: install the appended listener-removal + lifecycle methods. stdin
+    // replaces the stream stubs below with its real listener/flow operations;
+    // stdout and stderr retain the stubs.
     if let Some(start) = teardown_start {
         let set_field_with_stub =
             |idx: u32, stub: extern "C" fn(*const crate::closure::ClosureHeader, f64) -> f64| {
@@ -1354,7 +1633,16 @@ fn build_stream_object_with_write(
             set_field_with_stub(start + 1, process_stream_on_once_stub); // removeListener
             set_field_with_stub(start + 2, process_stream_on_once_stub); // off
         }
-        set_field_with_stub(start + 3, process_stream_on_once_stub); // removeAllListeners
+        if is_stdin {
+            let remove_all = stdin_native_method(
+                process_stdin_remove_all_listeners as *const u8,
+                "removeAllListeners",
+                1,
+            );
+            js_object_set_field(obj, start + 3, JSValue::from_bits(remove_all.to_bits()));
+        } else {
+            set_field_with_stub(start + 3, process_stream_on_once_stub);
+        }
         set_field_with_stub(start + 4, lifecycle); // pause
                                                    // resume: real flowing-mode start on stdin, no-op on stdout/stderr.
         set_field_with_stub(

--- a/crates/perry-runtime/src/os_process_streams.rs
+++ b/crates/perry-runtime/src/os_process_streams.rs
@@ -697,12 +697,9 @@ pub extern "C" fn js_migrate_stdin_listeners_to_provider() {
             })
             .collect();
         for callback in callbacks {
-            on(
-                name.as_ptr(),
-                name.len(),
-                callback.get_raw_const_ptr::<crate::closure::ClosureHeader>() as i64,
-                once,
-            );
+            callback.with_const_ptr::<crate::closure::ClosureHeader, _>(|callback| {
+                on(name.as_ptr(), name.len(), callback as i64, once)
+            });
         }
     }
 }
@@ -1070,6 +1067,30 @@ fn register_stdin_listener(
     }
 }
 
+fn register_generic_stdin_keypress_listener(event: f64, callback: f64, once: bool) {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let stream = scope.root_nanbox_f64(stdin_this_value());
+    let event = scope.root_nanbox_f64(event);
+    let callback = scope.root_nanbox_f64(callback);
+    let stream_raw = crate::value::js_nanbox_get_pointer(stream.get_nanbox_f64()) as i64;
+    if stream_raw == 0 {
+        return;
+    }
+    if once {
+        let _ = crate::node_stream::js_node_stream_method_once(
+            stream_raw,
+            event.get_nanbox_f64(),
+            callback.get_nanbox_f64(),
+        );
+    } else {
+        let _ = crate::node_stream::js_node_stream_method_on(
+            stream_raw,
+            event.get_nanbox_f64(),
+            callback.get_nanbox_f64(),
+        );
+    }
+}
+
 /// `process.stdin.on(event, cb)` — registers a persistent `data`/`readable`
 /// listener and starts the reader. Returns `this` so callers can chain.
 extern "C" fn process_stdin_on(
@@ -1103,13 +1124,7 @@ extern "C" fn process_stdin_on(
                 &STDIN_END_ONCE,
                 false,
             ),
-            Some("keypress") => {
-                let stream_raw = crate::value::js_nanbox_get_pointer(stdin_this_value()) as i64;
-                if stream_raw != 0 {
-                    let _ =
-                        crate::node_stream::js_node_stream_method_on(stream_raw, event, callback);
-                }
-            }
+            Some("keypress") => register_generic_stdin_keypress_listener(event, callback, false),
             _ => {}
         }
     }
@@ -1146,13 +1161,7 @@ extern "C" fn process_stdin_once(
                 &STDIN_END_ONCE,
                 true,
             ),
-            Some("keypress") => {
-                let stream_raw = crate::value::js_nanbox_get_pointer(stdin_this_value()) as i64;
-                if stream_raw != 0 {
-                    let _ =
-                        crate::node_stream::js_node_stream_method_once(stream_raw, event, callback);
-                }
-            }
+            Some("keypress") => register_generic_stdin_keypress_listener(event, callback, true),
             _ => {}
         }
     }

--- a/crates/perry-runtime/src/promise/combinators.rs
+++ b/crates/perry-runtime/src/promise/combinators.rs
@@ -613,12 +613,66 @@ pub extern "C" fn js_promise_new_with_executor(
 ) -> *mut Promise {
     use crate::closure::js_closure_call2;
 
-    let promise = js_promise_new();
+    // #9587: the executor is ARBITRARY USER JS and it runs while this function
+    // still owns the promise it is about to return. Claude Code's dialog helper
+    // is the shape that exposed it:
+    //
+    //     new Promise((res) => { let z = (y) => void res(y); root.render(ui(z)) })
+    //
+    // — a whole ink/React render (megabytes of allocation) inside the executor.
+    // The evacuating young collection that lands there MOVES the Promise. The
+    // resolving closures survive it correctly (their capture slots are GC
+    // slots, so the collector rewrites them), but pre-fix `promise`,
+    // `resolve_closure` and `reject_closure` lived in bare Rust locals across
+    // `js_closure_call2`, so this function handed the caller the
+    // PRE-COLLECTION address. From-space is reset and reused at the end of the
+    // same cycle, so the returned pointer names recycled memory, and `await`ing
+    // it goes one of two ways — both observed on cc 2.1.112:
+    //
+    //   * the recycled header decodes as `Fulfilled`, so the `await` never
+    //     suspends and resumes immediately with a garbage value (cc's setup
+    //     screen advanced past the onboarding dialog nobody had answered); or
+    //   * it still decodes as `Pending`, so the async step parks its
+    //     continuation on the dead copy. `resolve()` then settles the LIVE
+    //     promise — which has no reaction — and nothing ever resumes: a silent,
+    //     permanent hang with no throw and no rejection (cc's trust dialog
+    //     wedged 100% of the time on a fresh HOME).
+    //
+    // Root all three for the duration of the call and take every address back
+    // out of a handle afterwards.
+    // `executor` arrives as a bare pointer and is first USED after two
+    // allocating steps (`js_promise_new`, `make_resolving_functions`), so it
+    // needs the same treatment — `js_promise_subclass_init` already roots its
+    // own executor for exactly this reason. Classify it BEFORE the first
+    // allocation and root it only when it really is a closure: a non-callable
+    // executor (`new Promise(42)`) is not a heap pointer at all, and handing
+    // that to the root set would have the collector trace an address that was
+    // never an object.
+    let executor_is_closure = crate::closure::is_closure_ptr(executor as usize);
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let ptr_of = |h: &crate::gc::RuntimeHandle<'_>| -> i64 {
+        crate::value::js_nanbox_get_pointer(h.get_nanbox_f64())
+    };
+    let executor_h = if executor_is_closure {
+        Some(scope.root_nanbox_f64(crate::value::js_nanbox_pointer(executor as i64)))
+    } else {
+        None
+    };
+    let rooted_executor = || -> *const crate::closure::ClosureHeader {
+        match &executor_h {
+            Some(h) => ptr_of(h) as *const crate::closure::ClosureHeader,
+            None => executor,
+        }
+    };
+    let promise_h = scope.root_nanbox_f64(crate::value::js_nanbox_pointer(js_promise_new() as i64));
 
     // Create the resolve/reject pair sharing a [[AlreadyResolved]] guard, so
     // calling one disables the other (27.2.1.3 CreateResolvingFunctions). The
     // resolve fn also assimilates thenables/promises and rejects self-resolution.
-    let (resolve_closure, reject_closure) = make_resolving_functions(promise);
+    let (resolve_closure, reject_closure) =
+        make_resolving_functions(ptr_of(&promise_h) as *mut Promise);
+    let resolve_h = scope.root_nanbox_f64(crate::value::js_nanbox_pointer(resolve_closure as i64));
+    let reject_h = scope.root_nanbox_f64(crate::value::js_nanbox_pointer(reject_closure as i64));
 
     // Call the executor with (resolve_closure, reject_closure) as proper
     // NaN-boxed POINTER_TAG closure values — so user code that *reflects* on
@@ -627,28 +681,37 @@ pub extern "C" fn js_promise_new_with_executor(
     // object, not a bare number. The call path already accepts POINTER_TAG
     // closures (this mirrors `NewPromiseCapability`'s fast path, which has
     // always boxed them). test262 `resolve-function-*` / `reject-function-*`.
-    let resolve_f64: f64 = crate::value::js_nanbox_pointer(resolve_closure as i64);
-    let reject_f64: f64 = crate::value::js_nanbox_pointer(reject_closure as i64);
     // 27.2.3.1: a non-callable executor throws a TypeError SYNCHRONOUSLY at
     // step 2 (before/instead of being run) — that throw must propagate out of
     // `new Promise(...)`, not be converted into a rejection. Only a genuinely
     // callable executor's abrupt completion (step 10) is caught and rejected.
-    if crate::closure::is_closure_ptr(executor as usize) {
+    if executor_is_closure {
         // Callable executor: catch a throw from its body and reject the promise
         // with the thrown value via the resolving `reject` function (so the
         // shared [[AlreadyResolved]] guard makes a throw AFTER a resolve/reject a
         // no-op). test262 reject-via-abrupt / exception-after-resolve-in-executor.
-        if let Err(reason) =
-            combinator_catch_js(|| js_closure_call2(executor, resolve_f64, reject_f64))
-        {
-            crate::closure::js_closure_call1(reject_closure, reason);
+        if let Err(reason) = combinator_catch_js(|| {
+            js_closure_call2(
+                rooted_executor(),
+                resolve_h.get_nanbox_f64(),
+                reject_h.get_nanbox_f64(),
+            )
+        }) {
+            crate::closure::js_closure_call1(
+                ptr_of(&reject_h) as *mut crate::closure::ClosureHeader,
+                reason,
+            );
         }
     } else {
         // Non-callable: preserve the prior synchronous TypeError (uncaught).
-        js_closure_call2(executor, resolve_f64, reject_f64);
+        js_closure_call2(
+            rooted_executor(),
+            resolve_h.get_nanbox_f64(),
+            reject_h.get_nanbox_f64(),
+        );
     }
 
-    promise
+    ptr_of(&promise_h) as *mut Promise
 }
 
 /// A resolving function's shared `[[AlreadyResolved]]` record. Per ECMA-262
@@ -727,13 +790,18 @@ pub(super) fn make_resolving_functions(
     *mut crate::closure::ClosureHeader,
 ) {
     use crate::closure::{js_closure_alloc, js_closure_set_capture_ptr};
-    ensure_native_resolving_arity_registered();
     // #7497: four allocations follow, and `promise` / `guard` are STORED into
     // capture slots after them. Pre-fix all three lived in bare Rust locals, so
     // a copying minor here wrote pre-collection addresses into the two closures
     // — the from-space-publishing shape, not merely a stale read.
+    //
+    // #9587: `ensure_native_resolving_arity_registered` registers four closure
+    // arities and so can allocate on its first call per thread — root `promise`
+    // BEFORE it, not after, or the very first `new Promise(executor)` on a
+    // thread can publish a pre-collection address into the capture slots.
     let scope = crate::gc::RuntimeHandleScope::new();
     let promise_h = scope.root_nanbox_f64(crate::value::js_nanbox_pointer(promise as i64));
+    ensure_native_resolving_arity_registered();
     let guard_h = scope.root_nanbox_f64(crate::value::js_nanbox_pointer(
         alloc_already_resolved_guard() as i64,
     ));

--- a/crates/perry-runtime/src/readline_helpers.rs
+++ b/crates/perry-runtime/src/readline_helpers.rs
@@ -153,16 +153,18 @@ fn build_keypress_object(name: &str, ctrl: bool, shift: bool, meta: bool, seq: &
     let packed = b"name\0ctrl\0shift\0meta\0sequence\0";
     let obj = js_object_alloc_with_shape(0x7FFF_FF48, 5, packed.as_ptr(), packed.len() as u32);
     let obj_handle = scope.root_raw_mut_ptr(obj);
-    let name_str = js_string_from_bytes(name.as_ptr(), name.len() as u32);
-    let obj = obj_handle.get_raw_mut_ptr();
+    let (name_str, obj) = obj_handle.across_mut::<crate::object::ObjectHeader, _>(|| {
+        js_string_from_bytes(name.as_ptr(), name.len() as u32)
+    });
     js_object_set_field(obj, 0, JSValue::string_ptr(name_str));
     js_object_set_field(obj, 1, JSValue::bool(ctrl));
     js_object_set_field(obj, 2, JSValue::bool(shift));
     js_object_set_field(obj, 3, JSValue::bool(meta));
-    let seq_str = js_string_from_bytes(seq.as_ptr(), seq.len() as u32);
-    let obj = obj_handle.get_raw_mut_ptr();
+    let (seq_str, obj) = obj_handle.across_mut::<crate::object::ObjectHeader, _>(|| {
+        js_string_from_bytes(seq.as_ptr(), seq.len() as u32)
+    });
     js_object_set_field(obj, 4, JSValue::string_ptr(seq_str));
-    f64::from_bits(JSValue::pointer(obj as *const u8).bits())
+    obj_handle.with_const_ptr::<u8, _>(|obj| f64::from_bits(JSValue::pointer(obj).bits()))
 }
 
 fn parse_keypress(chunk: &[u8]) -> Option<(Option<String>, String, bool, bool, bool, String)> {
@@ -264,18 +266,24 @@ extern "C" fn emit_keypress_data(closure: *const ClosureHeader, chunk: f64) -> f
         let key = build_keypress_object(&name, ctrl, shift, meta, &seq);
         let key = scope.root_nanbox_f64(key);
         let args = scope.root_raw_mut_ptr(js_array_alloc(0));
-        let pushed = js_array_push_f64(args.get_raw_mut_ptr(), first.get_nanbox_f64());
+        let pushed = args.with_mut_ptr::<crate::array::ArrayHeader, _>(|args| {
+            js_array_push_f64(args, first.get_nanbox_f64())
+        });
         args.set_raw_mut_ptr(pushed);
-        let pushed = js_array_push_f64(args.get_raw_mut_ptr(), key.get_nanbox_f64());
+        let pushed = args.with_mut_ptr::<crate::array::ArrayHeader, _>(|args| {
+            js_array_push_f64(args, key.get_nanbox_f64())
+        });
         args.set_raw_mut_ptr(pushed);
         let Some(raw) = raw_ptr_from_value(stream.get_nanbox_f64()) else {
             return undefined();
         };
-        crate::node_stream::js_node_stream_method_emit_args(
-            raw,
-            event.get_nanbox_f64(),
-            args.get_raw_mut_ptr::<crate::array::ArrayHeader>() as i64,
-        );
+        args.with_mut_ptr::<crate::array::ArrayHeader, _>(|args| {
+            crate::node_stream::js_node_stream_method_emit_args(
+                raw,
+                event.get_nanbox_f64(),
+                args as i64,
+            )
+        });
     }
     undefined()
 }
@@ -296,15 +304,19 @@ pub extern "C" fn js_readline_emit_keypress_events_args(
         return undefined();
     };
     if crate::os::is_process_stdin_handle(raw) {
-        crate::os::enable_process_stdin_keypress_events(
-            listener.get_raw_const_ptr::<ClosureHeader>() as i64,
-        );
+        listener.with_const_ptr::<ClosureHeader, _>(|listener| {
+            crate::os::enable_process_stdin_keypress_events(listener as i64)
+        });
     } else {
         let event = scope.root_nanbox_f64(boxed_str(b"data"));
-        let listener_value = f64::from_bits(
-            JSValue::pointer(listener.get_raw_const_ptr::<ClosureHeader>() as *const u8).bits(),
-        );
-        crate::node_stream::js_node_stream_method_on(raw, event.get_nanbox_f64(), listener_value);
+        listener.with_const_ptr::<ClosureHeader, _>(|listener| {
+            let listener_value = f64::from_bits(JSValue::pointer(listener as *const u8).bits());
+            crate::node_stream::js_node_stream_method_on(
+                raw,
+                event.get_nanbox_f64(),
+                listener_value,
+            )
+        });
     }
     undefined()
 }

--- a/crates/perry-runtime/src/readline_helpers.rs
+++ b/crates/perry-runtime/src/readline_helpers.rs
@@ -8,19 +8,6 @@ use crate::closure::{
 use crate::object::{js_object_alloc_with_shape, js_object_set_field};
 use crate::string::{js_string_from_bytes, StringHeader};
 use crate::value::{js_jsvalue_to_string, JSValue, TAG_FALSE, TAG_UNDEFINED};
-use std::cell::RefCell;
-use std::collections::HashMap;
-
-#[derive(Default)]
-struct KeypressReplayState {
-    emitted: Vec<Vec<u8>>,
-    replay_index: Option<usize>,
-}
-
-thread_local! {
-    static KEYPRESS_REPLAY: RefCell<HashMap<i64, KeypressReplayState>> =
-        RefCell::new(HashMap::new());
-}
 
 fn undefined() -> f64 {
     f64::from_bits(TAG_UNDEFINED)
@@ -162,14 +149,18 @@ fn string_bytes(value: f64) -> Vec<u8> {
 }
 
 fn build_keypress_object(name: &str, ctrl: bool, shift: bool, meta: bool, seq: &str) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
     let packed = b"name\0ctrl\0shift\0meta\0sequence\0";
     let obj = js_object_alloc_with_shape(0x7FFF_FF48, 5, packed.as_ptr(), packed.len() as u32);
+    let obj_handle = scope.root_raw_mut_ptr(obj);
     let name_str = js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    let obj = obj_handle.get_raw_mut_ptr();
     js_object_set_field(obj, 0, JSValue::string_ptr(name_str));
     js_object_set_field(obj, 1, JSValue::bool(ctrl));
     js_object_set_field(obj, 2, JSValue::bool(shift));
     js_object_set_field(obj, 3, JSValue::bool(meta));
     let seq_str = js_string_from_bytes(seq.as_ptr(), seq.len() as u32);
+    let obj = obj_handle.get_raw_mut_ptr();
     js_object_set_field(obj, 4, JSValue::string_ptr(seq_str));
     f64::from_bits(JSValue::pointer(obj as *const u8).bits())
 }
@@ -209,52 +200,82 @@ fn parse_keypress(chunk: &[u8]) -> Option<(Option<String>, String, bool, bool, b
     Some((Some(seq.clone()), seq.clone(), false, false, false, seq))
 }
 
-fn is_replayed_keypress_chunk(stream_raw: i64, bytes: &[u8]) -> bool {
-    KEYPRESS_REPLAY.with(|states| {
-        let mut states = states.borrow_mut();
-        let state = states.entry(stream_raw).or_default();
-        if let Some(index) = state.replay_index {
-            if index < state.emitted.len() && state.emitted[index] == bytes {
-                state.replay_index = if index + 1 >= state.emitted.len() {
-                    None
-                } else {
-                    Some(index + 1)
-                };
-                return true;
+/// Split a cooked-mode stream chunk into the logical key units that Node's
+/// `emitKeypressEvents` parser emits. Raw-mode input already arrives one byte
+/// at a time, while a pipe commonly arrives as `"abc\n"` in one read; treating
+/// that whole read as one key was the cooked-input half of #9692.
+pub fn split_keypress_chunks(bytes: &[u8]) -> Vec<Vec<u8>> {
+    let mut chunks = Vec::new();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == 0x1b
+            && index + 2 < bytes.len()
+            && matches!(bytes[index + 1], b'[' | b'O')
+        {
+            let mut end = index + 2;
+            while end < bytes.len() && end - index < 16 {
+                if (0x40..=0x7e).contains(&bytes[end]) {
+                    end += 1;
+                    break;
+                }
+                end += 1;
             }
-            state.replay_index = None;
+            chunks.push(bytes[index..end].to_vec());
+            index = end;
+            continue;
         }
-        if state.emitted.len() > 1 && state.emitted.first().is_some_and(|first| first == bytes) {
-            state.replay_index = Some(1);
-            return true;
+
+        let width = match bytes[index] {
+            0x00..=0x7f => 1,
+            0xc2..=0xdf => 2,
+            0xe0..=0xef => 3,
+            0xf0..=0xf4 => 4,
+            _ => 1,
+        };
+        let end = (index + width).min(bytes.len());
+        if std::str::from_utf8(&bytes[index..end]).is_ok() {
+            chunks.push(bytes[index..end].to_vec());
+            index = end;
+        } else {
+            chunks.push(vec![bytes[index]]);
+            index += 1;
         }
-        state.emitted.push(bytes.to_vec());
-        if state.emitted.len() > 32 {
-            state.emitted.remove(0);
-        }
-        false
-    })
+    }
+    chunks
 }
 
 extern "C" fn emit_keypress_data(closure: *const ClosureHeader, chunk: f64) -> f64 {
-    let stream = js_closure_get_capture_f64(closure, 0);
-    let Some(raw) = raw_ptr_from_value(stream) else {
-        return undefined();
-    };
-    let bytes = string_bytes(chunk);
-    if is_replayed_keypress_chunk(raw, &bytes) {
-        return undefined();
-    }
-    if let Some((str_arg, name, ctrl, shift, meta, seq)) = parse_keypress(&bytes) {
+    let stream_scope = crate::gc::RuntimeHandleScope::new();
+    let stream = stream_scope.root_nanbox_f64(js_closure_get_capture_f64(closure, 0));
+    let chunk = stream_scope.root_nanbox_f64(chunk);
+    let bytes = string_bytes(chunk.get_nanbox_f64());
+    for key_chunk in split_keypress_chunks(&bytes) {
+        let Some((str_arg, name, ctrl, shift, meta, seq)) = parse_keypress(&key_chunk) else {
+            continue;
+        };
+        let scope = crate::gc::RuntimeHandleScope::new();
         let event = boxed_str(b"keypress");
-        let mut args = js_array_alloc(0);
+        let event = scope.root_nanbox_f64(event);
         let first = str_arg
             .as_ref()
             .map(|s| boxed_str(s.as_bytes()))
             .unwrap_or_else(undefined);
-        args = js_array_push_f64(args, first);
-        args = js_array_push_f64(args, build_keypress_object(&name, ctrl, shift, meta, &seq));
-        crate::node_stream::js_node_stream_method_emit_args(raw, event, args as i64);
+        let first = scope.root_nanbox_f64(first);
+        let key = build_keypress_object(&name, ctrl, shift, meta, &seq);
+        let key = scope.root_nanbox_f64(key);
+        let args = scope.root_raw_mut_ptr(js_array_alloc(0));
+        let pushed = js_array_push_f64(args.get_raw_mut_ptr(), first.get_nanbox_f64());
+        args.set_raw_mut_ptr(pushed);
+        let pushed = js_array_push_f64(args.get_raw_mut_ptr(), key.get_nanbox_f64());
+        args.set_raw_mut_ptr(pushed);
+        let Some(raw) = raw_ptr_from_value(stream.get_nanbox_f64()) else {
+            return undefined();
+        };
+        crate::node_stream::js_node_stream_method_emit_args(
+            raw,
+            event.get_nanbox_f64(),
+            args.get_raw_mut_ptr::<crate::array::ArrayHeader>() as i64,
+        );
     }
     undefined()
 }
@@ -263,13 +284,27 @@ extern "C" fn emit_keypress_data(closure: *const ClosureHeader, chunk: f64) -> f
 pub extern "C" fn js_readline_emit_keypress_events_args(
     args: *const crate::array::ArrayHeader,
 ) -> f64 {
-    let stream = arg(args, 0);
-    let Some(raw) = raw_ptr_from_value(stream) else {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let stream = scope.root_nanbox_f64(arg(args, 0));
+    if raw_ptr_from_value(stream.get_nanbox_f64()).is_none() {
+        return undefined();
+    }
+    let listener = js_closure_alloc(emit_keypress_data as *const u8, 1);
+    js_closure_set_capture_f64(listener, 0, stream.get_nanbox_f64());
+    let listener = scope.root_raw_const_ptr(listener as *const ClosureHeader);
+    let Some(raw) = raw_ptr_from_value(stream.get_nanbox_f64()) else {
         return undefined();
     };
-    let listener = js_closure_alloc(emit_keypress_data as *const u8, 1);
-    js_closure_set_capture_f64(listener, 0, stream);
-    let listener_value = f64::from_bits(JSValue::pointer(listener as *const u8).bits());
-    crate::node_stream::js_node_stream_method_on(raw, boxed_str(b"data"), listener_value);
+    if crate::os::is_process_stdin_handle(raw) {
+        crate::os::enable_process_stdin_keypress_events(
+            listener.get_raw_const_ptr::<ClosureHeader>() as i64,
+        );
+    } else {
+        let event = scope.root_nanbox_f64(boxed_str(b"data"));
+        let listener_value = f64::from_bits(
+            JSValue::pointer(listener.get_raw_const_ptr::<ClosureHeader>() as *const u8).bits(),
+        );
+        crate::node_stream::js_node_stream_method_on(raw, event.get_nanbox_f64(), listener_value);
+    }
     undefined()
 }

--- a/crates/perry-stdlib/src/readline/mod.rs
+++ b/crates/perry-stdlib/src/readline/mod.rs
@@ -14,21 +14,17 @@
 //!       // key = { name, ctrl, shift, meta, sequence }
 //!   });
 //!
-//! Architecture: a single background thread reads stdin one byte at a
-//! time. When raw mode is OFF (default), bytes accumulate into a line
-//! buffer and the line is queued on `\n`. When raw mode is ON, byte
-//! chunks are queued immediately for `'data'`/`'keypress'` dispatch.
-//! Mode flips are observed at the start of each byte read, so toggling
-//! mid-stream is supported (the next byte routes to the new mode's
-//! queue). The main event-loop pump drains both queues every tick via
-//! `js_readline_process_pending`.
+//! Architecture: perry-runtime owns the single background fd-0 reader and
+//! forwards each block here. When raw mode is OFF (default), bytes accumulate
+//! into lines or cooked `'data'` chunks. When raw mode is ON, byte chunks are
+//! queued immediately for `'data'`/`'keypress'` dispatch. The main event-loop
+//! pump classifies each ordered block after synchronous listener changes have
+//! settled, then drains both queues via `js_readline_process_pending`.
 //!
 //! Phase 3 (`tty.isatty`, `process.stdout.columns/rows`, SIGWINCH) is
 //! independent of this file.
 
 use std::cell::RefCell;
-#[cfg(not(test))]
-use std::io::Read;
 use std::io::{self, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
@@ -116,6 +112,14 @@ impl ReadlineInterfaceState {
 
 /// Lines waiting for the main thread to dispatch.
 static PENDING_LINES: Mutex<Vec<String>> = Mutex::new(Vec::new());
+/// Ordered blocks received from perry-runtime's sole fd-0 reader. The reader
+/// thread deliberately does not classify them: synchronous JS can remove and
+/// replace listeners before the next event-loop turn, and Node applies the
+/// settled stream mode when it delivers that turn's bytes.
+static PENDING_INPUT: Mutex<Vec<Vec<u8>>> = Mutex::new(Vec::new());
+/// Partial cooked-mode line carried between reads from the runtime-owned fd-0
+/// reader. Classification and line splitting happen on the main thread.
+static PENDING_LINE_BYTES: Mutex<Vec<u8>> = Mutex::new(Vec::new());
 /// Raw byte chunks waiting for the main thread to dispatch as 'data' /
 /// 'keypress' events.
 static PENDING_DATA: Mutex<Vec<Vec<u8>>> = Mutex::new(Vec::new());
@@ -470,8 +474,12 @@ extern "C" fn stdin_on_op(name_ptr: *const u8, name_len: usize, cb: i64, _once: 
         }
         _ => return,
     }
-    try_register_pump();
-    ensure_reader_started();
+    // The provider is already installed before this callback can run. Avoid
+    // re-entering bridge registration while pre-provider listeners are being
+    // migrated; only the pump and shared reader need arming here.
+    #[cfg(all(feature = "async-runtime", not(test)))]
+    crate::common::async_bridge::ensure_pump_registered();
+    start_shared_stdin_reader();
 }
 
 extern "C" fn stdin_off_op(name_ptr: *const u8, name_len: usize, cb: i64) {
@@ -521,6 +529,61 @@ extern "C" fn stdin_off_op(name_ptr: *const u8, name_len: usize, cb: i64) {
     }
 }
 
+/// `stdin.removeAllListeners([event])` reached through the runtime-owned stdin
+/// object. `has_event == 0` distinguishes the no-argument form from an empty
+/// event name.
+extern "C" fn stdin_remove_all_op(name_ptr: *const u8, name_len: usize, has_event: i32) {
+    let name = if has_event == 0 || name_ptr.is_null() {
+        None
+    } else {
+        Some(
+            std::str::from_utf8(unsafe { std::slice::from_raw_parts(name_ptr, name_len) })
+                .unwrap_or(""),
+        )
+    };
+    match name {
+        Some("data") => {
+            if let Ok(mut callbacks) = DATA_CALLBACKS.lock() {
+                callbacks.clear();
+            }
+            STDIN_DATA_FLOWING.store(false, Ordering::Release);
+            perry_runtime::os::disable_process_stdin_keypress_events();
+        }
+        Some("readable") => {
+            if let Ok(mut callbacks) = READABLE_CALLBACKS.lock() {
+                callbacks.clear();
+            }
+            STDIN_PULL_MODE.store(false, Ordering::Release);
+        }
+        Some("keypress") => {
+            if let Ok(mut callbacks) = KEYPRESS_CALLBACKS.lock() {
+                callbacks.clear();
+            }
+        }
+        Some("end") | Some("close") => {
+            if let Ok(mut callbacks) = STDIN_END_CALLBACKS.lock() {
+                callbacks.clear();
+            }
+        }
+        Some(_) => {}
+        None => {
+            for callbacks in [
+                &DATA_CALLBACKS,
+                &READABLE_CALLBACKS,
+                &KEYPRESS_CALLBACKS,
+                &STDIN_END_CALLBACKS,
+            ] {
+                if let Ok(mut callbacks) = callbacks.lock() {
+                    callbacks.clear();
+                }
+            }
+            STDIN_DATA_FLOWING.store(false, Ordering::Release);
+            STDIN_PULL_MODE.store(false, Ordering::Release);
+            perry_runtime::os::disable_process_stdin_keypress_events();
+        }
+    }
+}
+
 /// A `data` chunk as Node would deliver it: a Buffer by default, a decoded
 /// string once an encoding has been set with `setEncoding`. `None` means the
 /// chunk was absorbed into the UTF-8 decoder's held partial and Node would
@@ -548,14 +611,39 @@ fn ensure_stdin_listeners_provider_registered() {
             fn js_register_stdin_listener_ops(
                 on: extern "C" fn(*const u8, usize, i64, i32),
                 off: extern "C" fn(*const u8, usize, i64),
+                remove_all: extern "C" fn(*const u8, usize, i32),
             );
             // #9676: the flow half of the same bridge — see `stdin_pause_op`.
             fn js_register_stdin_flow_ops(pause: extern "C" fn(), resume: extern "C" fn());
         }
         unsafe {
             js_register_stdin_listeners_provider(stdin_listeners_provider);
-            js_register_stdin_listener_ops(stdin_on_op, stdin_off_op);
+            js_register_stdin_listener_ops(stdin_on_op, stdin_off_op, stdin_remove_all_op);
             js_register_stdin_flow_ops(stdin_pause_op, stdin_resume_op);
+        }
+    });
+
+    // Registrations made through an alias before readline initialized live in
+    // the runtime fallback lists. Adopt them before fd-0's already-buffered
+    // bytes are handed to `stdin_reader_data`, preserving both ownership and
+    // event order.
+    extern "C" {
+        fn js_migrate_stdin_listeners_to_provider();
+    }
+    unsafe {
+        js_migrate_stdin_listeners_to_provider();
+    }
+
+    static READER_CONSUMER_ONCE: Once = Once::new();
+    READER_CONSUMER_ONCE.call_once(|| {
+        extern "C" {
+            fn js_register_stdin_reader_consumer(
+                on_data: extern "C" fn(*const u8, usize),
+                on_eof: extern "C" fn(),
+            );
+        }
+        unsafe {
+            js_register_stdin_reader_consumer(stdin_reader_data, stdin_reader_eof);
         }
     });
 }
@@ -1137,164 +1225,40 @@ fn create_interface_from_options(opts: f64) -> i64 {
 }
 
 // ---------------------------------------------------------------------------
-// Background reader
+// Runtime-owned stdin reader consumer
 // ---------------------------------------------------------------------------
 
-/// Spawn the background byte-mode reader if it isn't already running.
-/// Idempotent across threads via `READER_STARTED.compare_exchange`.
-fn ensure_reader_started() {
-    if READER_STARTED
-        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-        .is_err()
-    {
+/// Enqueue one block from perry-runtime's sole fd-0 reader. This callback runs
+/// on the reader thread and must never call JS or touch the GC. In particular,
+/// it leaves mode classification to the main-thread pump so a synchronous
+/// remove/re-add sequence cannot race the producer thread.
+extern "C" fn stdin_reader_data(bytes_ptr: *const u8, bytes_len: usize) {
+    if bytes_ptr.is_null() || bytes_len == 0 || STDIN_DESTROYED.load(Ordering::Acquire) {
         return;
     }
-    // Under `cargo test` never spawn the real reader: it would block on the
-    // test runner's stdin and flip EOF_REACHED / push to the shared queues
-    // at arbitrary points mid-test. The flag still flips so the has-active
-    // logic sees the same state it would in production, and `reset()` can
-    // clear it between tests.
+    let bytes = unsafe { std::slice::from_raw_parts(bytes_ptr, bytes_len) };
+    if let Ok(mut pending) = PENDING_INPUT.lock() {
+        pending.push(bytes.to_vec());
+    }
+}
+
+/// EOF notification from the runtime-owned reader. Queued input is flushed by
+/// `route_pending_stdin_input` on the main thread before EOF events dispatch.
+extern "C" fn stdin_reader_eof() {
+    EOF_REACHED.store(true, Ordering::Release);
+}
+
+/// Connect readline to perry-runtime's reader and ask that single owner to
+/// start. Under unit tests we keep the historical no-I/O behavior.
+fn start_shared_stdin_reader() {
+    READER_STARTED.store(true, Ordering::Release);
     #[cfg(not(test))]
-    std::thread::spawn(move || {
-        let stdin = io::stdin();
-        let mut reader = stdin.lock();
-        // #9489: read a BLOCK per syscall, and cut `'data'` chunks at the
-        // block boundary. This loop used to `read(2)` ONE BYTE at a time and
-        // flush a chunk at every `\n`, so 1 MB of `"line\n"` cost 1,048,576
-        // read syscalls and produced 200,000 `'data'` events in 2.10 s where
-        // Node delivers 16 in 0.04 s.
-        //
-        // 64 KiB is Node's own pipe read size, and `read` still returns as
-        // soon as ANY bytes are available — it does not wait to fill the
-        // buffer — so a lone keystroke is still delivered immediately and
-        // three spaced writes are still three chunks.
-        let mut buf = [0u8; 65536];
-        // Bytes accumulated for the CURRENT read: in cooked flowing / pull
-        // mode this becomes one `'data'` chunk per read; in line mode it is
-        // the partial line carried to the next `\n`.
-        let mut line_buf: Vec<u8> = Vec::with_capacity(65536);
-        // Raw-mode chunks staged for one lock acquisition per read instead of
-        // one per byte. The per-BYTE chunking itself is preserved on purpose:
-        // the keypress path reassembles escape sequences from single-byte
-        // chunks (`pump::coalesce_escape_sequences`), and a paste must still
-        // fire one `'keypress'` per character.
-        let mut raw_chunks: Vec<Vec<u8>> = Vec::new();
-        // #9588: set whenever this read(2) put something the MAIN THREAD has to
-        // dispatch into a shared queue. See the notify below.
-        let mut queued_for_main: bool;
-        loop {
-            let n = match reader.read(&mut buf) {
-                Ok(0) => break, // EOF
-                Ok(n) => n,
-                Err(_) => break,
-            };
-            if STDIN_DESTROYED.load(Ordering::Acquire) {
-                break;
-            }
-            queued_for_main = false;
-            // The mode atomics are still consulted PER BYTE, exactly as
-            // before: a mode flip from the main thread mid-block must land on
-            // the same byte it used to. Only the syscall and the chunk
-            // boundary changed.
-            for &b in &buf[..n] {
-                if RAW_MODE.load(Ordering::Acquire) {
-                    raw_chunks.push(vec![b]);
-                } else if STDIN_DATA_FLOWING.load(Ordering::Acquire)
-                    || STDIN_PULL_MODE.load(Ordering::Acquire)
-                {
-                    // Cooked flowing mode (#5227): a `process.stdin.on('data')`
-                    // listener is attached but raw mode is off. Deliver input
-                    // as 'data' chunks (newline INCLUDED, matching Node's
-                    // piped-stream chunks) rather than routing it to the
-                    // readline 'line' queue. #9489: the chunk is cut at the
-                    // end of this read, NOT at each newline.
-                    line_buf.push(b);
-                } else if b == b'\n' {
-                    // Strip trailing CR for Windows CRLF input.
-                    if line_buf.last() == Some(&b'\r') {
-                        line_buf.pop();
-                    }
-                    let line = String::from_utf8_lossy(&line_buf).into_owned();
-                    line_buf.clear();
-                    if let Ok(mut q) = PENDING_LINES.lock() {
-                        q.push(line);
-                    }
-                    queued_for_main = true;
-                } else {
-                    line_buf.push(b);
-                }
-            }
-            if !raw_chunks.is_empty() {
-                if let Ok(mut q) = PENDING_DATA.lock() {
-                    q.append(&mut raw_chunks);
-                }
-                raw_chunks.clear();
-                queued_for_main = true;
-            }
-            // One `'data'` chunk per read(2) — Node's contract. Line splitting
-            // is the CONSUMER's job (readline does its own, above); imposing
-            // it on the shared `'data'` path is what #9489 fixed.
-            if !line_buf.is_empty()
-                && !RAW_MODE.load(Ordering::Acquire)
-                && (STDIN_DATA_FLOWING.load(Ordering::Acquire)
-                    || STDIN_PULL_MODE.load(Ordering::Acquire))
-            {
-                if let Ok(mut q) = PENDING_DATA.lock() {
-                    q.push(std::mem::take(&mut line_buf));
-                }
-                line_buf = Vec::with_capacity(65536);
-                queued_for_main = true;
-            }
-            // #9588 — WAKE THE PUMP. This reader is a cross-thread producer for
-            // queues only the main thread drains (`js_readline_process_pending`,
-            // reached from `js_run_stdlib_pump`), and it used to push and loop
-            // straight back into `read(2)` without telling anyone. The main loop
-            // therefore learned about a keystroke only when it happened to wake
-            // for some *other* reason, so input latency was the whole
-            // `js_wait_for_event` budget: the next timer deadline, or — for a TUI
-            // sitting idle with no timer armed — the full `IDLE_CAP_MS` (1 s)
-            // safety cap. Measured on the claude-code bundle before this line:
-            // 695-963 ms from keypress to the `'data'` handler, against Node's
-            // sub-millisecond. That is the protocol the event pump documents
-            // ("producer: push_to_queue(); js_notify_main_thread()") and the one
-            // perry-runtime's own stdin reader in `os_process_streams` already
-            // follows; readline's reader was the one producer that skipped it.
-            //
-            // Once per read(2), not per byte: a paste arrives as one syscall and
-            // needs exactly one wake, and the flag keeps a read that queued
-            // nothing (a raw-mode byte absorbed with no listener, a partial line
-            // still accumulating) from waking the loop for no work.
-            if queued_for_main {
-                perry_runtime::event_pump::js_notify_main_thread();
-            }
-        }
-        // Flush any trailing bytes not terminated by a newline. In cooked
-        // flowing mode this is the last 'data' chunk for input like
-        // `printf "abc"` (no final newline); otherwise it's a final 'line'.
-        if !line_buf.is_empty() && !STDIN_DESTROYED.load(Ordering::Acquire) {
-            if (STDIN_DATA_FLOWING.load(Ordering::Acquire)
-                || STDIN_PULL_MODE.load(Ordering::Acquire))
-                && !RAW_MODE.load(Ordering::Acquire)
-            {
-                if let Ok(mut q) = PENDING_DATA.lock() {
-                    q.push(std::mem::take(&mut line_buf));
-                }
-            } else if !RAW_MODE.load(Ordering::Acquire) {
-                if line_buf.last() == Some(&b'\r') {
-                    line_buf.pop();
-                }
-                let line = String::from_utf8_lossy(&line_buf).into_owned();
-                if let Ok(mut q) = PENDING_LINES.lock() {
-                    q.push(line);
-                }
-            }
-        }
-        EOF_REACHED.store(true, Ordering::Release);
-        // #9588: EOF is main-thread-visible work too — the `'end'`/`'close'`
-        // dispatch and the liveness flip that lets the loop exit. Without a wake
-        // here a piped program's exit was delayed by up to `IDLE_CAP_MS`.
-        perry_runtime::event_pump::js_notify_main_thread();
-    });
+    perry_runtime::os::ensure_process_stdin_reader();
+}
+
+fn ensure_reader_started() {
+    ensure_stdin_listeners_provider_registered();
+    start_shared_stdin_reader();
 }
 
 // ---------------------------------------------------------------------------
@@ -1939,6 +1903,12 @@ pub extern "C" fn js_readline_stdin_destroy() -> f64 {
         *deadline = None;
     }
     if let Ok(mut q) = PENDING_LINES.lock() {
+        q.clear();
+    }
+    if let Ok(mut q) = PENDING_INPUT.lock() {
+        q.clear();
+    }
+    if let Ok(mut q) = PENDING_LINE_BYTES.lock() {
         q.clear();
     }
     if let Ok(mut v) = DATA_CALLBACKS.lock() {

--- a/crates/perry-stdlib/src/readline/pump.rs
+++ b/crates/perry-stdlib/src/readline/pump.rs
@@ -241,14 +241,119 @@ fn coalesce_escape_sequences(raw: Vec<Vec<u8>>) -> Vec<Vec<u8>> {
     out
 }
 
+/// Classify reader blocks after synchronous JS for this event-loop turn has
+/// settled the stream mode. This keeps physical I/O single-owned without
+/// exposing producer-thread scheduling as observable listener behavior.
+fn route_pending_stdin_input() {
+    if STDIN_DESTROYED.load(Ordering::Acquire) {
+        if let Ok(mut pending) = PENDING_INPUT.lock() {
+            pending.clear();
+        }
+        if let Ok(mut line) = PENDING_LINE_BYTES.lock() {
+            line.clear();
+        }
+        return;
+    }
+
+    let blocks = PENDING_INPUT
+        .lock()
+        .map(|mut pending| std::mem::take(&mut *pending))
+        .unwrap_or_default();
+    let mut line_buf = PENDING_LINE_BYTES
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let mut raw_chunks: Vec<Vec<u8>> = Vec::new();
+
+    for block in blocks {
+        for byte in block {
+            if RAW_MODE.load(Ordering::Acquire) {
+                // Preserve byte-sized raw chunks so escape sequences can be
+                // reassembled across reads by `coalesce_escape_sequences`.
+                raw_chunks.push(vec![byte]);
+            } else if STDIN_DATA_FLOWING.load(Ordering::Acquire)
+                || STDIN_PULL_MODE.load(Ordering::Acquire)
+            {
+                line_buf.push(byte);
+            } else if byte == b'\n' {
+                if line_buf.last() == Some(&b'\r') {
+                    line_buf.pop();
+                }
+                let line = String::from_utf8_lossy(&line_buf).into_owned();
+                line_buf.clear();
+                if let Ok(mut queue) = PENDING_LINES.lock() {
+                    queue.push(line);
+                }
+            } else {
+                line_buf.push(byte);
+            }
+        }
+
+        if !raw_chunks.is_empty() {
+            if let Ok(mut queue) = PENDING_DATA.lock() {
+                queue.append(&mut raw_chunks);
+            }
+        }
+        // One cooked `'data'` chunk per physical read, preserving #9489's Node
+        // chunking while leaving line splitting to the readline consumer.
+        if !line_buf.is_empty()
+            && !RAW_MODE.load(Ordering::Acquire)
+            && (STDIN_DATA_FLOWING.load(Ordering::Acquire)
+                || STDIN_PULL_MODE.load(Ordering::Acquire))
+        {
+            if let Ok(mut queue) = PENDING_DATA.lock() {
+                queue.push(std::mem::take(&mut *line_buf));
+            }
+            *line_buf = Vec::with_capacity(65536);
+        }
+    }
+
+    // EOF is published after the reader has enqueued its final block. The
+    // producer may publish it while this pump is still classifying an earlier
+    // snapshot, so flush only when no later block remains in PENDING_INPUT.
+    if stdin_eof_input_drained() {
+        if !line_buf.is_empty() {
+            if (STDIN_DATA_FLOWING.load(Ordering::Acquire)
+                || STDIN_PULL_MODE.load(Ordering::Acquire))
+                && !RAW_MODE.load(Ordering::Acquire)
+            {
+                if let Ok(mut queue) = PENDING_DATA.lock() {
+                    queue.push(std::mem::take(&mut *line_buf));
+                }
+            } else if !RAW_MODE.load(Ordering::Acquire) {
+                if line_buf.last() == Some(&b'\r') {
+                    line_buf.pop();
+                }
+                let line = String::from_utf8_lossy(&line_buf).into_owned();
+                line_buf.clear();
+                if let Ok(mut queue) = PENDING_LINES.lock() {
+                    queue.push(line);
+                }
+            }
+        }
+    }
+}
+
+/// Whether physical EOF has been observed and every preceding reader block
+/// has left the handoff queue. The reader enqueues a block before publishing
+/// EOF, so the acquire load followed by the queue lock closes the race where a
+/// pump took an earlier snapshot just before the final blocks arrived.
+fn stdin_eof_input_drained() -> bool {
+    EOF_REACHED.load(Ordering::Acquire)
+        && PENDING_INPUT
+            .lock()
+            .map(|pending| pending.is_empty())
+            .unwrap_or(false)
+}
+
 /// Drain pending lines and byte chunks, dispatching to registered
 /// callbacks. Called from the async-bridge tick on every event-loop
 /// iteration. Returns the number of callbacks fired.
 #[no_mangle]
 pub extern "C" fn js_readline_process_pending() -> i32 {
     let mut fired: i32 = 0;
+    route_pending_stdin_input();
 
-    // Drain raw-mode byte chunks → 'data' / 'keypress' callbacks.
+    // Drain raw- or cooked-mode byte chunks → 'data' / 'keypress' callbacks.
     let chunks: Vec<Vec<u8>> = if STDIN_DESTROYED.load(Ordering::Acquire) {
         if let Ok(mut q) = PENDING_DATA.lock() {
             q.clear();
@@ -302,7 +407,7 @@ pub extern "C" fn js_readline_process_pending() -> i32 {
     // JS busy loop: one registered listener meant a callback invocation on
     // every event-loop iteration forever, and the non-zero `fired` return
     // kept the loop hot.
-    let readable_eof_due = EOF_REACHED.load(Ordering::Acquire)
+    let readable_eof_due = stdin_eof_input_drained()
         && !READABLE_EOF_NOTIFIED.load(Ordering::Acquire)
         && !STDIN_DESTROYED.load(Ordering::Acquire);
     if !chunks.is_empty() || readable_eof_due {
@@ -336,10 +441,14 @@ pub extern "C" fn js_readline_process_pending() -> i32 {
     // drain (not once per chunk) and each chunk is parsed once, not once
     // per callback.
     let data_callbacks = DATA_CALLBACKS.lock().map(|v| v.clone()).unwrap_or_default();
-    let keypress_callbacks = KEYPRESS_CALLBACKS
-        .lock()
-        .map(|v| v.clone())
-        .unwrap_or_default();
+    let keypress_callbacks = if cfg!(test) || perry_runtime::os::stdin_keypress_events_enabled() {
+        KEYPRESS_CALLBACKS
+            .lock()
+            .map(|v| v.clone())
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
     // `stdin_chunk_value`, the sequence string and key-object construction
     // all allocate. Root these cloned callback snapshots because the mutable
     // registry scanner can only rewrite the original listener lists.
@@ -374,10 +483,10 @@ pub extern "C" fn js_readline_process_pending() -> i32 {
                 fired += 1;
             }
         }
-        if keypress_callback_handles.is_empty() {
-            continue;
-        }
-        if let Some((name, ctrl, shift, meta, seq)) = parse_keypress(&chunk) {
+        for key_chunk in perry_runtime::readline_helpers::split_keypress_chunks(&chunk) {
+            let Some((name, ctrl, shift, meta, seq)) = parse_keypress(&key_chunk) else {
+                continue;
+            };
             for callback in &keypress_callback_handles {
                 // Root the sequence string across build_keypress_object's
                 // allocations (a moving minor GC there would leave arg1
@@ -428,7 +537,7 @@ pub extern "C" fn js_readline_process_pending() -> i32 {
     // emits process.stdin's end/close events. `rl.close()` may already have
     // fired the first event without stdin actually ending, so the two
     // one-shot states must not be conflated.
-    if EOF_REACHED.load(Ordering::Acquire) {
+    if stdin_eof_input_drained() {
         let readline_close_already = CLOSE_FIRED.with(|f| {
             let was = *f.borrow();
             *f.borrow_mut() = true;
@@ -503,6 +612,7 @@ pub extern "C" fn js_readline_has_active() -> i32 {
     let paused = STDIN_PAUSED.load(Ordering::Acquire);
     let refed = STDIN_REFED.load(Ordering::Acquire);
     let has_lines = PENDING_LINES.lock().map(|q| !q.is_empty()).unwrap_or(false);
+    let has_input = PENDING_INPUT.lock().map(|q| !q.is_empty()).unwrap_or(false);
     // A held escape prefix counts as pending data: the loop must stay alive
     // until its explicit escapeCodeTimeout deadline can flush it.
     let has_data = PENDING_DATA.lock().map(|q| !q.is_empty()).unwrap_or(false)
@@ -545,7 +655,11 @@ pub extern "C" fn js_readline_has_active() -> i32 {
             || has_close_cb);
     if !destroyed
         && refed
-        && (has_dispatchable_lines || has_dispatchable_data || has_close_cb || reader_keeps_alive)
+        && ((has_input && !paused)
+            || has_dispatchable_lines
+            || has_dispatchable_data
+            || has_close_cb
+            || reader_keeps_alive)
     {
         1
     } else {
@@ -556,6 +670,22 @@ pub extern "C" fn js_readline_has_active() -> i32 {
 #[cfg(test)]
 mod tests {
     use super::parse_keypress;
+
+    #[test]
+    fn eof_waits_for_every_reader_handoff_block() {
+        let _guard = super::super::test_support::reset();
+        super::PENDING_INPUT
+            .lock()
+            .unwrap()
+            .push(b"still pending".to_vec());
+        super::EOF_REACHED.store(true, std::sync::atomic::Ordering::Release);
+
+        assert!(!super::stdin_eof_input_drained());
+        super::PENDING_INPUT.lock().unwrap().clear();
+        assert!(super::stdin_eof_input_drained());
+
+        super::EOF_REACHED.store(false, std::sync::atomic::Ordering::Release);
+    }
 
     #[test]
     fn parse_keypress_arrow_keys() {

--- a/crates/perry-stdlib/src/readline/test_support.rs
+++ b/crates/perry-stdlib/src/readline/test_support.rs
@@ -74,6 +74,8 @@ pub(super) fn reset() -> MutexGuard<'static, ()> {
     }
     STDIN_PULL_MODE.store(false, Ordering::Release);
     PENDING_LINES.lock().unwrap().clear();
+    PENDING_INPUT.lock().unwrap().clear();
+    PENDING_LINE_BYTES.lock().unwrap().clear();
     PENDING_DATA.lock().unwrap().clear();
     PENDING_ESCAPE.lock().unwrap().clear();
     *PENDING_ESCAPE_DEADLINE.lock().unwrap() = None;

--- a/crates/perry-transform/src/generator/linearize.rs
+++ b/crates/perry-transform/src/generator/linearize.rs
@@ -1597,6 +1597,21 @@ pub fn linearize_body(
                     | Stmt::DoWhile { body, .. } => {
                         rewrite_labeled_bc_in_stmts(body, label, next_local_id);
                     }
+                    // A statically-typed array `for...of` lowers to a runtime
+                    // `ArrayIterationPatched` guard whose two branches contain
+                    // the iterator-protocol and indexed loops, respectively.
+                    // The source label still targets either generated loop,
+                    // but wrapping the guard means neither loop sees the label
+                    // directly. Rewrite the completions in both loop bodies
+                    // before the guard is split into generator states (#9198).
+                    Stmt::If {
+                        condition: Expr::ArrayIterationPatched,
+                        then_branch,
+                        else_branch: Some(else_branch),
+                    } => {
+                        rewrite_labeled_bc_in_lowered_for_of_arm(then_branch, label, next_local_id);
+                        rewrite_labeled_bc_in_lowered_for_of_arm(else_branch, label, next_local_id);
+                    }
                     // A labeled yielding SWITCH: `break label` at case-body
                     // level is the switch's own break — rewrite it to plain
                     // `break` so the yielding-switch desugar below folds it
@@ -1663,6 +1678,25 @@ pub fn linearize_body(
             other => {
                 current.push(other.clone());
             }
+        }
+    }
+}
+
+/// Rewrite completions targeting a source label in one branch of the
+/// `ArrayIterationPatched` for-of guard. Each branch consists of setup
+/// statements followed by the generated loop; nested loops in the user's body
+/// remain boundaries inside [`rewrite_labeled_bc_in_stmts`].
+fn rewrite_labeled_bc_in_lowered_for_of_arm(
+    stmts: &mut [Stmt],
+    label: &str,
+    next_local_id: &mut u32,
+) {
+    for stmt in stmts.iter_mut() {
+        match stmt {
+            Stmt::For { body, .. } | Stmt::While { body, .. } | Stmt::DoWhile { body, .. } => {
+                rewrite_labeled_bc_in_stmts(body, label, next_local_id);
+            }
+            _ => {}
         }
     }
 }

--- a/crates/perry/tests/issue_5868_switch_state_machine.rs
+++ b/crates/perry/tests/issue_5868_switch_state_machine.rs
@@ -311,3 +311,33 @@ run();
     );
     assert_eq!(stdout, "in-case\nafter\n");
 }
+
+/// Issue #9198: labeled loop completions from an awaited switch must target
+/// the enclosing for-of loop instead of becoming dispatch-loop completions.
+#[test]
+fn awaited_switch_inside_labeled_for_of() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+async function run(xs: number[]) {
+  const out: string[] = [];
+  outer: for (const x of xs) {
+    switch (x % 4) {
+      case 0: out.push("z" + x); break;
+      case 1: await Promise.resolve(); out.push("a" + x); break;
+      case 2: if (x > 5) break outer; out.push("b" + x); break;
+      default: await Promise.resolve(); if (x > 10) continue outer; out.push("d" + x);
+    }
+    out.push("|");
+  }
+  return out.join("");
+}
+(async () => {
+  console.log(await run([0, 1, 2, 3, 4, 5, 6, 7, 11, 12]));
+  console.log(await run([7, 11, 3]));
+})();
+"#,
+    );
+    assert_eq!(stdout, "z0|a1|b2|d3|z4|a5|\nd7|d3|\n");
+}

--- a/crates/perry/tests/issue_9253_affine_range_index.rs
+++ b/crates/perry/tests/issue_9253_affine_range_index.rs
@@ -1,6 +1,7 @@
-//! Regression coverage for #9253: a counted loop whose reads use an AFFINE
-//! index — `a[i * size + k]` — now hoists its receiver guard into the
-//! preheader instead of re-deriving it on every access.
+//! Regression coverage for #9248 and its affine-index implementation #9253:
+//! a counted loop whose reads use AFFINE indices — `a[i * size + k]` and
+//! `b[k * size + j]` — guards both receivers in the preheader and keeps the
+//! loop-carried accumulator native.
 //!
 //! `16_matrix_multiply`'s inner loop spends 97% of its time inside generated
 //! code with no runtime calls, so the cost was never a missed inlining. Per
@@ -13,13 +14,15 @@
 //! motion barrier.
 //!
 //! The packed-f64 RANGE tier already had everything needed except the index
-//! shape — a loop-invariant local/parameter bound, N-array guard emission, and
-//! GC-safe receiver caching refreshed at the back-edge poll. This adds the
+//! shape and multi-array accumulator admission — a loop-invariant
+//! local/parameter bound, N-array guard emission, and GC-safe receiver caching
+//! refreshed at the back-edge poll. This adds the
 //! affine index: the entry guard proves the RECEIVER once, and each read pays
 //! one inline `icmp ult idx, len` with a side exit.
 //!
-//! Measured on an idle Mac mini, self-timed min of 7: 100 ms -> 69 ms against
-//! node's 33 ms (3.03x -> 2.09x).
+//! Endpoint window hoisting and admitting the guarded array set for the
+//! accumulator then reduced the benchmark from 69 ms to 16 ms against node's
+//! 32 ms (the original baseline was 100 ms).
 
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
@@ -64,6 +67,32 @@ fn ir(stderr: &str) -> String {
     std::fs::read_to_string(path).expect("read kept LLVM IR")
 }
 
+fn specialized_function_ir<'a>(text: &'a str, function: &str) -> &'a str {
+    let marker = format!("__{function}$spec");
+    let marker_at = text
+        .find(&marker)
+        .unwrap_or_else(|| panic!("missing specialized function `{function}`"));
+    let start = text[..marker_at]
+        .rfind("define ")
+        .unwrap_or_else(|| panic!("missing definition for specialized function `{function}`"));
+    let rest = &text[start..];
+    let end = rest
+        .find("\n}\n")
+        .unwrap_or_else(|| panic!("unterminated specialized function `{function}`"));
+    &rest[..end + 2]
+}
+
+fn named_block<'a>(function_ir: &'a str, prefix: &str) -> &'a str {
+    let marker = format!("\n{prefix}");
+    let start = function_ir
+        .find(&marker)
+        .unwrap_or_else(|| panic!("missing block `{prefix}`"))
+        + 1;
+    let rest = &function_ir[start..];
+    let end = rest.find("\n\n").unwrap_or(rest.len());
+    &rest[..end]
+}
+
 fn run(bin: &Path, dir: &Path, moving_gc: bool) -> Output {
     let mut command = Command::new(bin);
     command.current_dir(dir);
@@ -101,10 +130,11 @@ for (let i = 0; i < 64; i++) { a.push(i % 7); b.push(i % 5); }
 console.log("matmul:" + matmul(a, b, 8));
 "#;
 
-/// The affine index shape reaches the clone at all. Without this the guard is
-/// re-derived per access for both receivers, which is the whole issue.
+/// Both affine receiver guards reach the clone and the accumulator remains a
+/// native double. Losing either property restores #9248's per-read guard or
+/// per-iteration dynamic-add cost.
 #[test]
-fn an_affine_index_admits_the_range_clone_and_agrees_with_the_generic_path() {
+fn matmul_guards_both_affine_arrays_and_unboxes_the_accumulator() {
     let dir = tempfile::tempdir().expect("tempdir");
     let (bin, stderr) = compile(dir.path(), MATMUL);
     let text = ir(&stderr);
@@ -114,12 +144,41 @@ fn an_affine_index_admits_the_range_clone_and_agrees_with_the_generic_path() {
     // detector looked for the per-read `packed_f64_affine.index_fits` block,
     // which the window-hoist legitimately removed: a window proven at the
     // loop's endpoints leaves the read as a bare trunc + raw load with no
-    // named block at all.
-    assert!(
-        text.contains("js_typed_feedback_packed_f64_array_loop_guard"),
-        "#9253: `a[i * size + k]` must reach the affine tier; without it \
-         the receiver guard re-executes per access"
+    // named block at all. Count CALLS (not the declaration): one must guard
+    // `a` and one must guard `b`.
+    let matmul_ir = specialized_function_ir(&text, "matmul");
+    assert_eq!(
+        matmul_ir
+            .matches("call i32 @js_typed_feedback_packed_f64_array_loop_guard")
+            .count(),
+        2,
+        "#9248: both affine array receivers must be guarded once in the preheader"
     );
+
+    // The fast body's two raw loads feed one native multiply and add. In
+    // particular, the loop must not regain either generic index helpers or
+    // the boxed accumulator's dynamic add / write-barrier branch.
+    let fast_body = named_block(matmul_ir, "for.packed_f64_range_fast.body.");
+    assert!(
+        fast_body.matches("load double, ptr").count() >= 3,
+        "#9248: expected accumulator plus two raw f64 loads:\n{fast_body}"
+    );
+    for instruction in ["fmul double", "fadd double", "store double"] {
+        assert!(
+            fast_body.contains(instruction),
+            "#9248: missing `{instruction}` in the packed fast body:\n{fast_body}"
+        );
+    }
+    for fallback in [
+        "@js_typed_feedback_array_index_get_fallback_boxed",
+        "@js_dynamic_string_or_number_add",
+        "shadow.root.barrier",
+    ] {
+        assert!(
+            !fast_body.contains(fallback),
+            "#9248: packed fast body regained `{fallback}`:\n{fast_body}"
+        );
+    }
     for moving_gc in [false, true] {
         assert_stdout(
             &run(&bin, dir.path(), moving_gc),

--- a/crates/perry/tests/issue_9587_promise_executor_evacuation.rs
+++ b/crates/perry/tests/issue_9587_promise_executor_evacuation.rs
@@ -1,0 +1,196 @@
+//! #9587 — `new Promise(executor)` must return the LIVE promise when the
+//! executor allocates.
+//!
+//! The executor is arbitrary user JS and it runs while `js_promise_new_with_executor`
+//! still owns the promise it is about to return. Claude Code's dialog helper is
+//! the shape that exposed it:
+//!
+//! ```js
+//! function qA8(root, ui) {
+//!   return new Promise((res) => { let z = (y) => void res(y); root.render(ui(z)) })
+//! }
+//! ```
+//!
+//! — a whole ink/React render (megabytes of allocation) inside the executor. The
+//! evacuating young collection that lands there MOVES the Promise. The resolving
+//! closures survive correctly (their capture slots are GC slots, so the collector
+//! rewrites them), but pre-fix `promise` lived in a bare Rust local across
+//! `js_closure_call2`, so the function returned the PRE-COLLECTION address.
+//! From-space is reset and handed back to the mutator at the end of the same
+//! cycle, so that pointer names recycled memory. `await`ing it goes one of two
+//! ways, both observed on the compiled cc 2.1.112 binary:
+//!
+//! * the recycled header decodes as `Fulfilled`, so the `await` never suspends
+//!   and resumes immediately with a garbage value — cc advanced past an
+//!   onboarding dialog nobody had answered; or
+//! * it still decodes as `Pending`, so the async step parks its continuation on
+//!   the dead copy. `resolve()` then settles the LIVE promise, which has no
+//!   reaction, and nothing ever resumes — a silent permanent hang with no throw
+//!   and no rejection. That is cc's trust dialog wedging 100% of the time on a
+//!   fresh HOME (#9587), which is also why onboarding never wrote `theme` /
+//!   `hasCompletedOnboarding` (#9674).
+//!
+//! Neither failure raises anything: `PERRY_REJECTION_DIAG` is silent and the
+//! whole-heap `PERRY_GC_FROMSPACE_SCAN` reports CLEAN, because at the moment of
+//! the collection the stale address exists only in a Rust register, and by the
+//! time it reaches JS from-space has already been flipped. The instrument that
+//! does see it is `PERRY_GC_PROTECT_FROMSPACE=1`, which faults on the stale read
+//! with `obj_type=5` (`GC_TYPE_PROMISE`).
+//!
+//! # Why the arms are a nursery-cap sweep
+//!
+//! Whether a *relocating* minor lands inside the executor at all depends on where
+//! the nursery happens to fill, so a single configuration is a coin flip on a
+//! given host. `PERRY_GC_SCAVENGE_NURSERY_MB` is a pacing knob only — it moves
+//! the trigger threshold, it does not change what the collector does — so one
+//! binary under a spread of caps puts a relocating minor at many different points
+//! of the executor. `PERRY_GEN_GC=0` (full mark-sweep, never moves) is the
+//! control: correct before and after the fix, so a green run cannot be inertness.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+/// `test-files/test_issue_9587_promise_executor_evacuation.ts`, inlined so the
+/// test is self-contained.
+const SOURCE: &str = r#"
+let saved: (() => void) | null = null;
+const order: string[] = [];
+
+function dialog(): Promise<string> {
+  return new Promise<string>((resolve) => {
+    saved = () => resolve("resolved");
+    let sink: any = null;
+    for (let i = 0; i < 200000; i++) {
+      sink = { a: i, b: [i, i + 1], c: "row" + i, d: { e: i } };
+    }
+    if (sink === null) console.log("unreachable");
+  });
+}
+
+let settled = false;
+
+async function main(): Promise<void> {
+  const p = dialog();
+  order.push("created");
+  p.then(() => { settled = true; });
+  setTimeout(() => {
+    order.push("resolving");
+    console.log("settled-before-resolve:" + settled);
+    (saved as () => void)();
+  }, 10);
+  const v = await p;
+  let vs = "unreadable";
+  try {
+    vs = (v as unknown) === "resolved" ? "resolved" : "other";
+  } catch {
+    vs = "threw";
+  }
+  order.push("value:" + vs);
+  console.log("order:" + order.join(","));
+}
+
+main();
+"#;
+
+/// node 26.5.0 (`.node-version`) on the program above.
+const NODE_ORACLE: &str = "settled-before-resolve:false\norder:created,resolving,value:resolved\n";
+
+/// The collector kill switches an ambient environment could be carrying. Cleared
+/// per arm so an exported `PERRY_GEN_GC=0` cannot silently turn every arm into
+/// the never-relocates control and pass against the unfixed runtime.
+const GC_ENV_OVERRIDES: &[&str] = &[
+    "PERRY_GEN_GC",
+    "PERRY_GC_SCAVENGE",
+    "PERRY_GC_SCAVENGE_NURSERY_MB",
+    "PERRY_GC_MOVING_SAFEPOINT",
+    "PERRY_GC_MOVING_LOOP_POLLS",
+    "PERRY_GC_FORCE_EVACUATE",
+    "PERRY_GC_SCHEDULE_SEED",
+    "PERRY_GC_SCHEDULE_RATE",
+    "PERRY_CONSERVATIVE_STACK_SCAN",
+    "PERRY_WRITE_BARRIERS",
+    "PERRY_GC_INCREMENTAL",
+    "PERRY_GC_HEAP_LIMIT",
+];
+
+#[test]
+fn promise_returned_from_an_allocating_executor_survives_an_evacuating_minor() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    let output = dir.path().join("main_bin");
+    std::fs::write(&entry, SOURCE).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-cache")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    // One binary, many collector configurations: every knob below is
+    // runtime-only, so all arms run exactly the same generated code.
+    let mut arms: Vec<Vec<(&str, &str)>> = vec![vec![]];
+    for mb in ["1", "2", "3", "4", "8", "16"] {
+        arms.push(vec![("PERRY_GC_SCAVENGE_NURSERY_MB", mb)]);
+    }
+    // Force a collection at (nearly) every handled safepoint, with survivors
+    // moving — the densest placement of a relocating minor inside the executor.
+    arms.push(vec![
+        ("PERRY_GC_SCHEDULE_SEED", "1"),
+        ("PERRY_GC_SCHEDULE_RATE", "1"),
+    ]);
+    // Control: full mark-sweep never relocates, so this arm is green before and
+    // after the fix.
+    arms.push(vec![("PERRY_GEN_GC", "0")]);
+
+    for arm in &arms {
+        let mut cmd = Command::new(&output);
+        cmd.current_dir(dir.path());
+        for key in GC_ENV_OVERRIDES {
+            cmd.env_remove(key);
+        }
+        for (k, v) in arm {
+            cmd.env(k, v);
+        }
+        let run = cmd.output().expect("run compiled binary");
+        let label = if arm.is_empty() {
+            "default".to_string()
+        } else {
+            arm.iter()
+                .map(|(k, v)| format!("{k}={v}"))
+                .collect::<Vec<_>>()
+                .join(" ")
+        };
+        assert!(
+            run.status.success(),
+            "[{label}] compiled binary failed (exit {:?})\nstdout:\n{}\nstderr:\n{}",
+            run.status.code(),
+            String::from_utf8_lossy(&run.stdout),
+            String::from_utf8_lossy(&run.stderr)
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&run.stdout),
+            NODE_ORACLE,
+            "[{label}] `new Promise(executor)` must return the promise the \
+             collector kept, not the address it had before the executor \
+             allocated. Output missing the `order:` line entirely means the \
+             await parked on the dead copy and never resumed; an `order:` line \
+             printed BEFORE `settled-before-resolve` (or carrying \
+             `value:other`) means the await fell through on a recycled header \
+             that decoded as Fulfilled (#9587)."
+        );
+    }
+}

--- a/crates/perry/tests/issue_9692_stdin_surface.rs
+++ b/crates/perry/tests/issue_9692_stdin_surface.rs
@@ -1,0 +1,248 @@
+//! Regression coverage for #9692's shared stdin surface.
+//!
+//! Node and Perry run the same fixture with both possible initialization
+//! orders: the runtime object reader requested first through an aliased stream,
+//! or readline requested first through the syntactic `process.stdin` path.
+//! Every scenario is exercised with a pipe, a cooked PTY, and a raw PTY. The
+//! PTY arms are load-bearing: two competing `StdinLock` owners can appear green
+//! under a pipe depending on which reader happens to start first.
+
+#![cfg(unix)]
+
+use std::fs::File;
+use std::io::{BufRead, BufReader, Write};
+use std::os::fd::{FromRawFd, RawFd};
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
+use std::time::{Duration, Instant};
+
+const SOURCE: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../test-files/test_issue_9692_stdin_surface.ts"
+));
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile(dir: &Path) -> (PathBuf, PathBuf) {
+    let source = dir.join("stdin_surface.ts");
+    let binary = dir.join("stdin_surface_bin");
+    std::fs::write(&source, SOURCE).expect("write stdin fixture");
+    let output = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&source)
+        .arg("-o")
+        .arg(&binary)
+        .output()
+        .expect("compile stdin fixture");
+    assert!(
+        output.status.success(),
+        "fixture compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    (source, binary)
+}
+
+fn command_for(program: &Path, is_node: bool) -> Command {
+    if is_node {
+        let mut command = Command::new("node");
+        command.arg("--no-warnings").arg(program);
+        command
+    } else {
+        Command::new(program)
+    }
+}
+
+fn configure(command: &mut Command, scenario: &str, order: &str, raw: bool) {
+    command
+        .env("PERRY_9692_SCENARIO", scenario)
+        .env("PERRY_9692_ORDER", order)
+        .env("PERRY_9692_RAW", if raw { "1" } else { "0" });
+}
+
+fn result_line(output: &str) -> Option<String> {
+    output.lines().find_map(|line| {
+        line.trim_end_matches('\r')
+            .strip_prefix("RESULT:")
+            .map(str::to_owned)
+    })
+}
+
+fn run_pipe(program: &Path, is_node: bool, scenario: &str, order: &str) -> (ExitStatus, String) {
+    let mut command = command_for(program, is_node);
+    configure(&mut command, scenario, order, false);
+    let mut child = command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn pipe fixture");
+    let mut stdin = child.stdin.take().expect("pipe fixture stdin");
+    stdin.write_all(b"ab\n").expect("write pipe input");
+    drop(stdin);
+    let output = child.wait_with_output().expect("wait for pipe fixture");
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let result = result_line(&stdout).unwrap_or_else(|| panic!("missing RESULT line: {stdout:?}"));
+    (output.status, result)
+}
+
+fn open_pty() -> (File, File) {
+    let mut master: RawFd = -1;
+    let mut slave: RawFd = -1;
+    let rc = unsafe {
+        libc::openpty(
+            &mut master,
+            &mut slave,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    };
+    assert_eq!(rc, 0, "openpty failed: {}", std::io::Error::last_os_error());
+    assert!(master >= 0 && slave >= 0);
+    // SAFETY: openpty returned two fresh owned descriptors.
+    unsafe { (File::from_raw_fd(master), File::from_raw_fd(slave)) }
+}
+
+struct PtyChild {
+    child: Child,
+    input: File,
+    lines: Receiver<String>,
+}
+
+impl PtyChild {
+    fn spawn(program: &Path, is_node: bool, scenario: &str, order: &str, raw: bool) -> Self {
+        let (master, slave) = open_pty();
+        let mut command = command_for(program, is_node);
+        configure(&mut command, scenario, order, raw);
+        command
+            .stdin(Stdio::from(slave.try_clone().expect("clone PTY stdin")))
+            .stdout(Stdio::from(slave.try_clone().expect("clone PTY stdout")))
+            .stderr(Stdio::null());
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                if libc::ioctl(0, libc::TIOCSCTTY as _, 0) == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        let child = command.spawn().expect("spawn PTY fixture");
+        drop(slave);
+        let input = master.try_clone().expect("clone PTY master");
+        let (tx, lines) = mpsc::channel();
+        std::thread::spawn(move || {
+            for line in BufReader::new(master).lines() {
+                let Ok(line) = line else { break };
+                if tx.send(line.trim_end_matches('\r').to_string()).is_err() {
+                    break;
+                }
+            }
+        });
+        Self {
+            child,
+            input,
+            lines,
+        }
+    }
+
+    fn recv_until(&self, prefix: &str, timeout: Duration) -> Result<String, RecvTimeoutError> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let line = self.lines.recv_timeout(remaining)?;
+            if line.starts_with(prefix) {
+                return Ok(line);
+            }
+        }
+    }
+}
+
+impl Drop for PtyChild {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn run_pty(
+    program: &Path,
+    is_node: bool,
+    scenario: &str,
+    order: &str,
+    raw: bool,
+) -> (ExitStatus, String) {
+    let mut session = PtyChild::spawn(program, is_node, scenario, order, raw);
+    session
+        .recv_until("READY", Duration::from_secs(20))
+        .unwrap_or_else(|_| panic!("{scenario}/{order}/raw={raw} never became ready"));
+    session
+        .input
+        .write_all(if raw { b"ab\r" } else { b"ab\n" })
+        .expect("write PTY input");
+    session.input.flush().expect("flush PTY input");
+    let line = session
+        .recv_until("RESULT:", Duration::from_secs(5))
+        .unwrap_or_else(|_| panic!("{scenario}/{order}/raw={raw} produced no result"));
+    let result = line.trim_start_matches("RESULT:").to_string();
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let status = loop {
+        if let Some(status) = session.child.try_wait().expect("poll PTY fixture") {
+            break status;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "PTY fixture did not exit: {result}"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    };
+    (status, result)
+}
+
+#[test]
+fn stdin_surface_matches_node_for_pipe_and_cooked_and_raw_ptys() {
+    let dir = tempfile::tempdir().expect("create fixture directory");
+    let (source, binary) = compile(dir.path());
+    let cases = [("pipe", false), ("pty-cooked", false), ("pty-raw", true)];
+
+    for scenario in ["keypress", "remove-data", "remove-all"] {
+        for order in ["runtime-first", "readline-first"] {
+            for (transport, raw) in cases {
+                let run = |program: &Path, is_node: bool| {
+                    if transport == "pipe" {
+                        run_pipe(program, is_node, scenario, order)
+                    } else {
+                        run_pty(program, is_node, scenario, order, raw)
+                    }
+                };
+                let (node_status, node) = run(&source, true);
+                let (perry_status, perry) = run(&binary, false);
+                assert!(
+                    node_status.success(),
+                    "Node oracle failed for {scenario}/{order}/{transport}: {node}"
+                );
+                assert!(
+                    perry_status.success(),
+                    "Perry failed for {scenario}/{order}/{transport}: {perry}"
+                );
+                assert_ne!(
+                    node, "timeout",
+                    "Node oracle timed out for {scenario}/{order}/{transport}"
+                );
+                assert_eq!(
+                    perry, node,
+                    "stdin divergence for {scenario}/{order}/{transport}"
+                );
+            }
+        }
+    }
+}

--- a/test-files/test_issue_9587_promise_executor_evacuation.ts
+++ b/test-files/test_issue_9587_promise_executor_evacuation.ts
@@ -1,0 +1,58 @@
+// #9587 — a `new Promise(executor)` whose executor ALLOCATES must still return
+// the live Promise.
+//
+// The executor is arbitrary user code and it runs before `new Promise` returns.
+// Claude Code's dialog helper is the real-world shape:
+//
+//     new Promise((res) => { const z = (y) => void res(y); root.render(ui(z)) })
+//
+// — an entire ink/React render inside the executor. An evacuating young
+// collection there MOVES the promise. The runtime kept the pre-collection
+// address in a bare local and handed that back, so the `await` either fell
+// through immediately on a recycled header that decoded as `Fulfilled`, or
+// parked its continuation on the dead copy while `resolve()` settled the live
+// one — a silent, permanent hang.
+//
+// Node prints:
+//   order:created,resolving value:resolved
+//   settled-before-resolve:false
+
+let saved: (() => void) | null = null;
+const order: string[] = [];
+
+function dialog(): Promise<string> {
+  return new Promise<string>((resolve) => {
+    saved = () => resolve("resolved");
+    // Stand in for the render: allocate hard enough to trip an evacuating minor
+    // while this promise is young.
+    let sink: any = null;
+    for (let i = 0; i < 200000; i++) {
+      sink = { a: i, b: [i, i + 1], c: "row" + i, d: { e: i } };
+    }
+    if (sink === null) console.log("unreachable");
+  });
+}
+
+let settled = false;
+
+async function main(): Promise<void> {
+  const p = dialog();
+  order.push("created");
+  p.then(() => { settled = true; });
+  setTimeout(() => {
+    order.push("resolving");
+    console.log("settled-before-resolve:" + settled);
+    (saved as () => void)();
+  }, 10);
+  const v = await p;
+  let vs = "unreadable";
+  try {
+    vs = (v as unknown) === "resolved" ? "resolved" : "other";
+  } catch {
+    vs = "threw";
+  }
+  order.push("value:" + vs);
+  console.log("order:" + order.join(","));
+}
+
+main();

--- a/test-files/test_issue_9692_stdin_surface.ts
+++ b/test-files/test_issue_9692_stdin_surface.ts
@@ -1,0 +1,62 @@
+import { emitKeypressEvents } from "node:readline";
+
+const input: any = process.stdin;
+const scenario = process.env.PERRY_9692_SCENARIO || "keypress";
+const order = process.env.PERRY_9692_ORDER || "runtime-first";
+const raw = process.env.PERRY_9692_RAW === "1";
+let done = false;
+
+input.setEncoding("utf8");
+
+function primeRuntimeReader(stream: any, callback: (chunk: unknown) => void) {
+  stream.on("data", callback);
+  stream.removeListener("data", callback);
+}
+
+function primeReadlineReader(callback: (chunk: unknown) => void) {
+  process.stdin.on("data", callback);
+  process.stdin.removeListener("data", callback);
+}
+
+function finish(payload: string, status = 0) {
+  if (done) return;
+  done = true;
+  if (raw && typeof input.setRawMode === "function") input.setRawMode(false);
+  input.pause();
+  console.log("RESULT:" + payload);
+  setTimeout(() => process.exit(status), 20);
+}
+
+const timeout = setTimeout(() => finish("timeout", 2), 2500);
+const prime = (_chunk: unknown) => {};
+if (order === "runtime-first") primeRuntimeReader(input, prime);
+else primeReadlineReader(prime);
+
+if (raw && typeof input.setRawMode === "function") input.setRawMode(true);
+
+if (scenario === "keypress") {
+  emitKeypressEvents(input);
+  const codes: number[] = [];
+  process.stdin.on("keypress", (sequence: string | undefined) => {
+    codes.push(sequence === undefined ? -1 : sequence.charCodeAt(0));
+    if (codes.length === 3) {
+      clearTimeout(timeout);
+      finish("keypress:" + codes.join(","));
+    }
+  });
+} else {
+  const removed: string[] = [];
+  emitKeypressEvents(input);
+  process.stdin.on("keypress", () => removed.push("keypress"));
+  process.stdin.on("data", () => removed.push("data"));
+
+  if (scenario === "remove-data") input.removeAllListeners("data");
+  else input.removeAllListeners();
+
+  process.stdin.on("data", () => {
+    clearTimeout(timeout);
+    finish(scenario + ":" + (removed.join(",") || "none"));
+  });
+}
+
+console.log("READY");


### PR DESCRIPTION
Merge train: **#9697, #9698, #9699, #9700, #9702**, plus `MERGE_GUIDE.md`.

Cherry-picked onto one branch and validated once as a tree. Rebase-merged so
each commit keeps its author.

## What's in it

**#9700 — `new Promise(executor)` returned a dead promise.** The root cause of
Claude Code's onboarding hang (#9587/#9674). The executor is arbitrary user JS
running while `js_promise_new_with_executor` still owns the promise; an ink/React
render inside it triggers an evacuating minor that MOVES the promise, but
`promise` / `resolve_closure` / `reject_closure` lived in bare Rust locals across
`js_closure_call2`, so the caller got the pre-collection address. Fails two ways,
both silent: the recycled header decodes `Fulfilled` and the `await` resumes with
garbage, or it decodes `Pending` and the continuation parks on the dead copy while
`resolve()` settles the live one — a permanent hang with no throw. All three are
rooted now and every address is re-read from its handle. A second hole closes with
it: `make_resolving_functions` rooted `promise` *after*
`ensure_native_resolving_arity_registered`, which allocates on first call.

**#9698 — bare managed receivers decided at the dispatch tower's entry.** A real
GC pointer that was never NaN-boxed was rooted in a `RuntimeHandleSlot::Nanbox`,
whose mark and rewrite paths both reject any word without a
POINTER/STRING/BIGINT tag — so the receiver was neither marked nor rewritten
(#6910's hole, reopened in the transient-handle registry). It was also reboxed as
an object even when it was a string, and never walked forwarding. Canonicalization
now runs as the first statement, gated on **allocator ownership, not address
magnitude**. Two bugs found while validating, both reproducing on unfixed main:
`(1e-310 as any).toString()` SIGSEGV'd (a subnormal double whose bits look like an
address, dereferenced by a magnitude-gated probe), and `5e-324` aliased the handle
band and returned `undefined`.

**#9697 — one physical fd-0 reader.** perry-runtime becomes the sole stdin reader.

**#9702 — labeled `for-of` across `await`.** The `ArrayIterationPatched` guard
wraps both generated loops, so neither saw the source label; `break label` /
`continue label` became dispatch-loop completions and hung.

**#9699 — IR pin for #9248's matmul fast path.** Asserts both affine receivers are
guarded once in the preheader and the accumulator stays a native double.

**`MERGE_GUIDE.md`** — the audit/merge-train process, referenced from `CLAUDE.md`.

## Validation

64/64 lint gates; release build; `perry-runtime`, `perry-stdlib`,
`perry-transform` (all `RUST_TEST_THREADS=1`); and `issue_9692_stdin_surface`,
`issue_9253_affine_range_index`, `issue_9587_promise_executor_evacuation`,
`issue_5868_switch_state_machine` — all green.

#9699's assertions were additionally checked against real emitted IR rather than
trusted from a green test: one `__matmul$spec` define, one packed fast-body block
(unquoted, so no #9494-class blindspot), 2 guard calls, 3 raw loads feeding
`fmul`/`fadd`/`store`.

## Note

#9697's author pushed their own version of the raw-handle fix mid-validation; it
uses `across_mut` around the allocating call, which is the better idiom than the
`with_mut_ptr` I had written. Theirs is what landed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved shared `stdin` handling across runtime and `node:readline`, including reliable keypress delivery, listener removal, and EOF processing.
  - Added merge-train auditing and validation guidance.

- **Bug Fixes**
  - Fixed dynamic method calls on bare managed values and very small positive numbers.
  - Fixed hangs in labeled async `for...of` loops.
  - Fixed `new Promise(executor)` returning invalid promises after garbage collection.

- **Documentation**
  - Added changelog entries and linked the merge guide from workflow documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->