### PR TITLE
perf(codegen): reuse receiver validation in ordinary counted loops

### DIFF
--- a/changelog.d/9712-receiver-descriptor-counted-loops.md
+++ b/changelog.d/9712-receiver-descriptor-counted-loops.md
@@ -1,0 +1,15 @@
+**Ordinary counted loops now consume the shared receiver descriptor model**
+(#9254 phase 3). For a strict, call-free `i < array.length` numeric-array loop,
+codegen validates the receiver and element layout once in the preheader, keeps
+the boxed receiver precisely rooted, and carries a cached base handle through
+the loop. Exact bounded `array[i]` reads select an invariant raw-load arm instead
+of repeating the receiver tag, header, integrity, length, capacity, and layout
+checks at every use; a failed one-time validation retains the existing guarded
+fallback semantics.
+
+Admission is intentionally conservative: the shared region analysis rejects
+calls, allocations, coercions, suspensions, unwind edges, and every unmodelled
+operation, while fired back-edge GC polls refresh both the rooted receiver and
+its derived handle. Regression coverage pins the call-free fast block, the
+allocating-region rejection, the guard-miss fallback, and a real rate-1 moving
+collection with evacuated from-space protected.

--- a/crates/perry-codegen/src/collectors/mod.rs
+++ b/crates/perry-codegen/src/collectors/mod.rs
@@ -110,7 +110,10 @@ pub(crate) use ptr_numarray::{NumArrayDensity, NumArrayLocal};
 pub(crate) use ptr_shape::{ptr_shape_locals_enabled, PtrShapeLocal};
 pub(crate) use ptr_shape_callbacks::collect_array_callback_shapes;
 pub(crate) use ptr_shape_returns::collect_exported_return_shapes;
-pub(crate) use receiver_regions::ReceiverDescriptorTable;
+pub(crate) use receiver_regions::{
+    region_enders_in_stmts_with_trusted_operations, ReceiverArrayValidationKind,
+    ReceiverDescriptorTable, RegionEnder,
+};
 pub(crate) use refs::{
     collect_let_ids, collect_ref_ids_in_expr, collect_ref_ids_in_stmts, is_clamp_call,
 };

--- a/crates/perry-codegen/src/collectors/receiver_regions.rs
+++ b/crates/perry-codegen/src/collectors/receiver_regions.rs
@@ -35,8 +35,11 @@
 //! the packed/versioned clone's receiver hoist through
 //! [`ReceiverDescriptorTable`]: the table owns the rooted box, pre-masked base
 //! handle and poll refresh recipe as one entry, and asks [`boundary_admits`]
-//! before carrying that address across a back-edge poll. Other fact tables are
-//! migrated one consumer at a time.
+//! before carrying that address across a back-edge poll. Phase 3 lets ordinary
+//! counted loops attach a conditional plain/numeric-array validation to the
+//! same entry, but only after this module proves the loop region contains no
+//! ender other than the poll covered by that refresh recipe. Other fact tables
+//! are migrated one consumer at a time.
 //!
 //! The precedent is `TypeFacts::purity` / `TypeFacts::shape_stability`
 //! (`collectors/hir_facts.rs`, #854): a subgraph the collector populates and
@@ -55,12 +58,10 @@
 //! what keeps this file honest: the model is checked against a shipping,
 //! audited predicate rather than against its own restatement.
 
-// #9254 phase 2: `ReceiverDescriptorTable` and the poll boundary algebra are
-// production consumers. Region formation remains lint-only until ordinary
-// counted loops migrate in phase 3, so the rest of this module is still dead
-// in a non-test build. Keep that incomplete state explicit rather than
-// scattering per-item allows; this attribute can go when region formation is
-// itself consumed.
+// #9254 phases 2/3: `ReceiverDescriptorTable`, the poll boundary algebra and
+// region formation are production consumers. Some inventory/lint helpers stay
+// test-only while the remaining fact tables await phase 4, so keep that
+// incomplete state explicit rather than scattering per-item allows.
 #![allow(dead_code)]
 
 use crate::loop_purity;
@@ -261,10 +262,39 @@ pub(crate) struct ReceiverPollRefresh {
     pub(crate) source_root: String,
 }
 
+/// Strength of the one-time array validation attached by an ordinary counted
+/// loop. Numeric validation includes every plain-array invariant and also
+/// proves raw-f64 element representation, so it may serve a plain read too.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReceiverArrayValidationKind {
+    Plain,
+    Numeric,
+}
+
+/// Descriptor data consumed at an ordinary bounded array read.
+///
+/// `valid_i1` is loop-invariant. When false the read takes its established
+/// guarded fallback and never consumes `base_handle_slot`; when true the
+/// region contract guarantees the cached handle remains usable until the next
+/// poll refresh.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ReceiverArrayAccess {
+    pub(crate) valid_i1: String,
+    pub(crate) base_handle_slot: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ActiveArrayValidation {
+    contract: ReceiverDescriptor,
+    kind: ReceiverArrayValidationKind,
+    valid_i1: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ActiveReceiverDescriptor {
     contract: ReceiverDescriptor,
     refresh: ReceiverPollRefresh,
+    array_validation: Option<ActiveArrayValidation>,
 }
 
 /// Active materialised receiver descriptors for one function lowering.
@@ -321,8 +351,69 @@ impl ReceiverDescriptorTable {
                 base_handle_slot,
                 source_root,
             },
+            array_validation: None,
         });
         true
+    }
+
+    /// Install phase 3's ordinary-counted-loop descriptor.
+    ///
+    /// The caller supplies the exact region enders after replacing only the
+    /// indexed read that will consume this validation with its trusted form.
+    /// Both the cached-address and representation contracts must admit every
+    /// ender before the entry becomes visible to lowering. A duplicate reuses
+    /// an outer descriptor; callers can query [`Self::array_access`] to learn
+    /// whether that outer entry is strong enough for their read.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn materialize_region_validated_array(
+        &mut self,
+        receiver: u32,
+        rooted_box_slot: String,
+        base_handle_slot: String,
+        source_root: String,
+        kind: ReceiverArrayValidationKind,
+        valid_i1: String,
+        enders: &[RegionEnder],
+    ) -> Result<bool, BoundaryViolation> {
+        if self.contains(receiver) {
+            return Ok(false);
+        }
+        let address_contract = ReceiverDescriptor {
+            table: "receiver_descriptors",
+            receiver,
+            claim: ReceiverClaim::Address,
+            boundary: FactBoundary::PollRefresh,
+            // The supplied ender list is the proof: an unwind edge below is
+            // rejected rather than excused by claiming it was excluded.
+            excludes_try: false,
+        };
+        for &ender in enders {
+            boundary_admits(&address_contract, ender)?;
+        }
+        let representation_contract = ReceiverDescriptor {
+            table: "receiver_descriptors[array_validation]",
+            receiver,
+            claim: ReceiverClaim::Representation,
+            boundary: FactBoundary::DynamicExtent,
+            excludes_try: false,
+        };
+        for &ender in enders {
+            boundary_admits(&representation_contract, ender)?;
+        }
+        self.entries.push(ActiveReceiverDescriptor {
+            contract: address_contract,
+            refresh: ReceiverPollRefresh {
+                rooted_box_slot,
+                base_handle_slot,
+                source_root,
+            },
+            array_validation: Some(ActiveArrayValidation {
+                contract: representation_contract,
+                kind,
+                valid_i1,
+            }),
+        });
+        Ok(true)
     }
 
     /// End the dynamic extent of one materialised receiver.
@@ -354,6 +445,28 @@ impl ReceiverDescriptorTable {
             .map(|entry| entry.refresh.base_handle_slot.as_str())
     }
 
+    /// Conditional validation and refreshed base handle for an ordinary array
+    /// read. A numeric consumer requires the stronger numeric validation; a
+    /// plain consumer may reuse either kind.
+    pub(crate) fn array_access(
+        &self,
+        receiver: u32,
+        require_numeric: bool,
+    ) -> Option<ReceiverArrayAccess> {
+        let entry = self
+            .entries
+            .iter()
+            .find(|entry| entry.contract.receiver == receiver)?;
+        let validation = entry.array_validation.as_ref()?;
+        if require_numeric && validation.kind != ReceiverArrayValidationKind::Numeric {
+            return None;
+        }
+        Some(ReceiverArrayAccess {
+            valid_i1: validation.valid_i1.clone(),
+            base_handle_slot: entry.refresh.base_handle_slot.clone(),
+        })
+    }
+
     /// Refresh recipes admitted at a back-edge poll.
     ///
     /// Every active entry is checked at the boundary before its recipe is
@@ -364,6 +477,9 @@ impl ReceiverDescriptorTable {
         let mut refreshes = Vec::with_capacity(self.entries.len());
         for entry in &self.entries {
             boundary_admits(&entry.contract, RegionEnder::BackEdgePoll)?;
+            if let Some(validation) = &entry.array_validation {
+                boundary_admits(&validation.contract, RegionEnder::BackEdgePoll)?;
+            }
             refreshes.push(entry.refresh.clone());
         }
         Ok(refreshes)
@@ -390,6 +506,21 @@ pub(crate) fn violations_for(
 /// Returns the *first* reason found; an expression can qualify several ways
 /// and the caller only needs to know the region ends.
 pub(crate) fn expr_region_ender(e: &Expr, is_inert: &dyn Fn(&Expr) -> bool) -> Option<RegionEnder> {
+    expr_region_ender_with_trusted_operation(e, is_inert, &|_| false)
+}
+
+fn expr_region_ender_with_trusted_operation(
+    e: &Expr,
+    is_inert: &dyn Fn(&Expr) -> bool,
+    is_trusted_operation: &dyn Fn(&Expr) -> bool,
+) -> Option<RegionEnder> {
+    // A production consumer may replace one exact operation with a form whose
+    // guard establishes that it cannot dispatch or allocate. Children still
+    // run through the ordinary walker before this classification, so trusting
+    // `arr[i]` never accidentally trusts an effectful `i`.
+    if is_trusted_operation(e) {
+        return None;
+    }
     match e {
         // ---- Provably not a relocation point -------------------------------
         // Constants, reads of a local/global, and references. No dispatch.
@@ -522,36 +653,60 @@ pub(crate) fn region_enders_in_stmts(
     controls: &[&Expr],
     is_inert: &dyn Fn(&Expr) -> bool,
 ) -> Vec<RegionEnder> {
+    region_enders_in_stmts_with_trusted_operations(stmts, controls, is_inert, &|_| false)
+}
+
+/// Region walk used by a guarded consumer that replaces a precisely matched
+/// operation with a non-dispatching form. Only the operation node is trusted;
+/// its children retain normal ender classification and execution order.
+pub(crate) fn region_enders_in_stmts_with_trusted_operations(
+    stmts: &[Stmt],
+    controls: &[&Expr],
+    is_inert: &dyn Fn(&Expr) -> bool,
+    is_trusted_operation: &dyn Fn(&Expr) -> bool,
+) -> Vec<RegionEnder> {
     let mut out = Vec::new();
     for s in stmts {
-        enders_in_stmt(s, is_inert, &mut out);
+        enders_in_stmt(s, is_inert, is_trusted_operation, &mut out);
     }
     for c in controls {
-        enders_in_expr(c, is_inert, &mut out);
+        enders_in_expr(c, is_inert, is_trusted_operation, &mut out);
     }
     out
 }
 
-fn enders_in_expr(e: &Expr, is_inert: &dyn Fn(&Expr) -> bool, out: &mut Vec<RegionEnder>) {
+fn enders_in_expr(
+    e: &Expr,
+    is_inert: &dyn Fn(&Expr) -> bool,
+    is_trusted_operation: &dyn Fn(&Expr) -> bool,
+    out: &mut Vec<RegionEnder>,
+) {
     // Child expressions execute before the operation represented by their
     // parent (`f(makeClosure())` allocates the closure before it calls `f`).
     // Region boundaries are ordered data once a lowering path consumes them,
     // so a pre-order walk would put the call before the allocation.
-    perry_hir::walker::walk_expr_children(e, &mut |child| enders_in_expr(child, is_inert, out));
-    if let Some(r) = expr_region_ender(e, is_inert) {
+    perry_hir::walker::walk_expr_children(e, &mut |child| {
+        enders_in_expr(child, is_inert, is_trusted_operation, out)
+    });
+    if let Some(r) = expr_region_ender_with_trusted_operation(e, is_inert, is_trusted_operation) {
         out.push(r);
     }
 }
 
-fn enders_in_stmt(s: &Stmt, is_inert: &dyn Fn(&Expr) -> bool, out: &mut Vec<RegionEnder>) {
+fn enders_in_stmt(
+    s: &Stmt,
+    is_inert: &dyn Fn(&Expr) -> bool,
+    is_trusted_operation: &dyn Fn(&Expr) -> bool,
+    out: &mut Vec<RegionEnder>,
+) {
     match s {
         // A throw is an unwind edge *and* the helper allocates the Error.
         Stmt::Throw(e) => {
-            enders_in_expr(e, is_inert, out);
+            enders_in_expr(e, is_inert, is_trusted_operation, out);
             out.push(RegionEnder::UnwindEdge);
         }
         Stmt::Let { init: Some(e), .. } | Stmt::Expr(e) | Stmt::Return(Some(e)) => {
-            enders_in_expr(e, is_inert, out)
+            enders_in_expr(e, is_inert, is_trusted_operation, out)
         }
         Stmt::Let { init: None, .. } | Stmt::Return(None) => {}
         Stmt::If {
@@ -559,13 +714,13 @@ fn enders_in_stmt(s: &Stmt, is_inert: &dyn Fn(&Expr) -> bool, out: &mut Vec<Regi
             then_branch,
             else_branch,
         } => {
-            enders_in_expr(condition, is_inert, out);
+            enders_in_expr(condition, is_inert, is_trusted_operation, out);
             for st in then_branch {
-                enders_in_stmt(st, is_inert, out);
+                enders_in_stmt(st, is_inert, is_trusted_operation, out);
             }
             if let Some(else_branch) = else_branch {
                 for st in else_branch {
-                    enders_in_stmt(st, is_inert, out);
+                    enders_in_stmt(st, is_inert, is_trusted_operation, out);
                 }
             }
         }
@@ -573,17 +728,17 @@ fn enders_in_stmt(s: &Stmt, is_inert: &dyn Fn(&Expr) -> bool, out: &mut Vec<Regi
         // *enclosing* region too — this is why the armed-poll refresh reloads
         // every active receiver cache, not just the innermost scope's.
         Stmt::While { condition, body } => {
-            enders_in_expr(condition, is_inert, out);
+            enders_in_expr(condition, is_inert, is_trusted_operation, out);
             for st in body {
-                enders_in_stmt(st, is_inert, out);
+                enders_in_stmt(st, is_inert, is_trusted_operation, out);
             }
             out.push(RegionEnder::BackEdgePoll);
         }
         Stmt::DoWhile { body, condition } => {
             for st in body {
-                enders_in_stmt(st, is_inert, out);
+                enders_in_stmt(st, is_inert, is_trusted_operation, out);
             }
-            enders_in_expr(condition, is_inert, out);
+            enders_in_expr(condition, is_inert, is_trusted_operation, out);
             out.push(RegionEnder::BackEdgePoll);
         }
         Stmt::For {
@@ -593,20 +748,20 @@ fn enders_in_stmt(s: &Stmt, is_inert: &dyn Fn(&Expr) -> bool, out: &mut Vec<Regi
             body,
         } => {
             if let Some(init) = init {
-                enders_in_stmt(init, is_inert, out);
+                enders_in_stmt(init, is_inert, is_trusted_operation, out);
             }
             if let Some(condition) = condition {
-                enders_in_expr(condition, is_inert, out);
+                enders_in_expr(condition, is_inert, is_trusted_operation, out);
             }
             for st in body {
-                enders_in_stmt(st, is_inert, out);
+                enders_in_stmt(st, is_inert, is_trusted_operation, out);
             }
             if let Some(update) = update {
-                enders_in_expr(update, is_inert, out);
+                enders_in_expr(update, is_inert, is_trusted_operation, out);
             }
             out.push(RegionEnder::BackEdgePoll);
         }
-        Stmt::Labeled { body, .. } => enders_in_stmt(body, is_inert, out),
+        Stmt::Labeled { body, .. } => enders_in_stmt(body, is_inert, is_trusted_operation, out),
         // Every statement in a `try` body may divert to the handler.
         Stmt::Try {
             body,
@@ -614,17 +769,17 @@ fn enders_in_stmt(s: &Stmt, is_inert: &dyn Fn(&Expr) -> bool, out: &mut Vec<Regi
             finally,
         } => {
             for st in body {
-                enders_in_stmt(st, is_inert, out);
+                enders_in_stmt(st, is_inert, is_trusted_operation, out);
             }
             out.push(RegionEnder::UnwindEdge);
             if let Some(catch) = catch {
                 for st in &catch.body {
-                    enders_in_stmt(st, is_inert, out);
+                    enders_in_stmt(st, is_inert, is_trusted_operation, out);
                 }
             }
             if let Some(finally) = finally {
                 for st in finally {
-                    enders_in_stmt(st, is_inert, out);
+                    enders_in_stmt(st, is_inert, is_trusted_operation, out);
                 }
             }
         }
@@ -632,13 +787,13 @@ fn enders_in_stmt(s: &Stmt, is_inert: &dyn Fn(&Expr) -> bool, out: &mut Vec<Regi
             discriminant,
             cases,
         } => {
-            enders_in_expr(discriminant, is_inert, out);
+            enders_in_expr(discriminant, is_inert, is_trusted_operation, out);
             for c in cases {
                 if let Some(t) = &c.test {
-                    enders_in_expr(t, is_inert, out);
+                    enders_in_expr(t, is_inert, is_trusted_operation, out);
                 }
                 for st in &c.body {
-                    enders_in_stmt(st, is_inert, out);
+                    enders_in_stmt(st, is_inert, is_trusted_operation, out);
                 }
             }
         }

--- a/crates/perry-codegen/src/collectors/receiver_regions_tests.rs
+++ b/crates/perry-codegen/src/collectors/receiver_regions_tests.rs
@@ -263,6 +263,94 @@ fn active_descriptor_table_owns_lookup_refresh_and_dynamic_extent() {
     assert!(!table.dematerialize(OBJ));
 }
 
+#[test]
+fn ordinary_loop_descriptor_carries_conditional_array_validation() {
+    let mut table = ReceiverDescriptorTable::default();
+    assert!(table
+        .materialize_region_validated_array(
+            OBJ,
+            "%region.box".into(),
+            "%region.handle".into(),
+            "%region.source".into(),
+            ReceiverArrayValidationKind::Numeric,
+            "%region.valid".into(),
+            &[RegionEnder::BackEdgePoll],
+        )
+        .expect("the poll is covered by the refresh recipe"));
+
+    let expected = ReceiverArrayAccess {
+        valid_i1: "%region.valid".into(),
+        base_handle_slot: "%region.handle".into(),
+    };
+    assert_eq!(table.array_access(OBJ, false), Some(expected.clone()));
+    assert_eq!(table.array_access(OBJ, true), Some(expected));
+    assert_eq!(
+        table.poll_refreshes().unwrap(),
+        vec![ReceiverPollRefresh {
+            rooted_box_slot: "%region.box".into(),
+            base_handle_slot: "%region.handle".into(),
+            source_root: "%region.source".into(),
+        }]
+    );
+}
+
+#[test]
+fn plain_validation_cannot_serve_a_numeric_read() {
+    let mut table = ReceiverDescriptorTable::default();
+    table
+        .materialize_region_validated_array(
+            OBJ,
+            "%box".into(),
+            "%handle".into(),
+            "%source".into(),
+            ReceiverArrayValidationKind::Plain,
+            "%valid".into(),
+            &[],
+        )
+        .unwrap();
+    assert!(table.array_access(OBJ, false).is_some());
+    assert_eq!(table.array_access(OBJ, true), None);
+}
+
+#[test]
+fn ordinary_loop_descriptor_is_not_installed_across_a_call() {
+    let mut table = ReceiverDescriptorTable::default();
+    let violation = table
+        .materialize_region_validated_array(
+            OBJ,
+            "%box".into(),
+            "%handle".into(),
+            "%source".into(),
+            ReceiverArrayValidationKind::Numeric,
+            "%valid".into(),
+            &[RegionEnder::CollectingCall],
+        )
+        .expect_err("a call can move and mutate the receiver");
+    assert_eq!(violation.ender, RegionEnder::CollectingCall);
+    assert!(!table.contains(OBJ));
+}
+
+#[test]
+fn trusting_an_operation_does_not_trust_its_effectful_children() {
+    let read = Expr::IndexGet {
+        object: Box::new(num(OBJ)),
+        index: Box::new(call(vec![])),
+    };
+    let ordinary = region_enders_in_stmts(&[Stmt::Expr(read.clone())], &[], &stub_inert);
+    assert_eq!(
+        ordinary,
+        vec![RegionEnder::CollectingCall, RegionEnder::CollectingCall]
+    );
+
+    let trusted = region_enders_in_stmts_with_trusted_operations(
+        &[Stmt::Expr(read)],
+        &[],
+        &stub_inert,
+        &|expr| matches!(expr, Expr::IndexGet { .. }),
+    );
+    assert_eq!(trusted, vec![RegionEnder::CollectingCall]);
+}
+
 /// A cached address dies at a call no matter how the table scopes itself —
 /// scoping is not a substitute for the region being call-free.
 #[test]

--- a/crates/perry-codegen/src/expr/index_get.rs
+++ b/crates/perry-codegen/src/expr/index_get.rs
@@ -53,7 +53,8 @@ use foreign_counter::{
 mod inline_dyn_typed_array;
 
 use guarded_array::{
-    lower_guarded_array_index_get, lower_packed_f64_loop_index_get, packed_f64_loop_fact,
+    lower_guarded_array_index_get, lower_packed_f64_loop_index_get,
+    lower_region_validated_array_index_get, packed_f64_loop_fact,
 };
 use inline_dyn_typed_array::lower_inline_dyn_typed_array_get;
 
@@ -837,8 +838,9 @@ pub(crate) fn lower_numeric_index_get_for_number_context(
                 let repair_slot = receiver_repair_slot(ctx, object);
                 let arr_box = lower_expr(ctx, object)?;
                 let idx_i32 = ctx.block().load(I32, &i32_slot);
-                return lower_guarded_array_index_get(
+                return lower_region_validated_array_index_get(
                     ctx,
+                    *arr_id,
                     &arr_box,
                     &idx_i32,
                     "bidx.num",
@@ -969,6 +971,44 @@ pub(crate) fn lower_unknown_local_index_get_for_number_context(
 }
 
 fn lower_bounded_array_index_get(
+    ctx: &mut FnCtx<'_>,
+    arr_id: u32,
+    arr_box: &str,
+    idx_i32: &str,
+) -> Result<String> {
+    let Some(access) = ctx.receiver_descriptors.array_access(arr_id, false) else {
+        return lower_bounded_array_index_get_checked(ctx, arr_box, idx_i32);
+    };
+
+    let fast_idx = ctx.new_block("bidx.receiver_region.fast");
+    let fallback_idx = ctx.new_block("bidx.receiver_region.fallback");
+    let merge_idx = ctx.new_block("bidx.receiver_region.merge");
+    let fast_label = ctx.block_label(fast_idx);
+    let fallback_label = ctx.block_label(fallback_idx);
+    let merge_label = ctx.block_label(merge_idx);
+    ctx.block()
+        .cond_br(&access.valid_i1, &fast_label, &fallback_label);
+
+    ctx.current_block = fast_idx;
+    let array_handle = ctx.block().load(I64, &access.base_handle_slot);
+    let fast_value =
+        guarded_array::lower_trusted_plain_array_index_get(ctx, &array_handle, idx_i32);
+    let fast_end = ctx.block().label.clone();
+    ctx.block().br(&merge_label);
+
+    ctx.current_block = fallback_idx;
+    let fallback_value = lower_bounded_array_index_get_checked(ctx, arr_box, idx_i32)?;
+    let fallback_end = ctx.block().label.clone();
+    ctx.block().br(&merge_label);
+
+    ctx.current_block = merge_idx;
+    Ok(ctx.block().phi(
+        DOUBLE,
+        &[(&fast_value, &fast_end), (&fallback_value, &fallback_end)],
+    ))
+}
+
+fn lower_bounded_array_index_get_checked(
     ctx: &mut FnCtx<'_>,
     arr_box: &str,
     idx_i32: &str,
@@ -1646,8 +1686,9 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                             let arr_box = lower_expr(ctx, object)?;
                             let idx_i32 = ctx.block().load(I32, &i32_slot);
                             if require_numeric_layout {
-                                return lower_guarded_array_index_get(
+                                return lower_region_validated_array_index_get(
                                     ctx,
+                                    *arr_id,
                                     &arr_box,
                                     &idx_i32,
                                     "bidx.num",
@@ -1656,7 +1697,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                                     repair_slot.as_deref(),
                                 );
                             }
-                            return lower_bounded_array_index_get(ctx, &arr_box, &idx_i32);
+                            return lower_bounded_array_index_get(ctx, *arr_id, &arr_box, &idx_i32);
                         }
                     }
                 }

--- a/crates/perry-codegen/src/expr/index_get/guarded_array.rs
+++ b/crates/perry-codegen/src/expr/index_get/guarded_array.rs
@@ -20,7 +20,8 @@ use anyhow::Result;
 
 use crate::nanbox::POINTER_MASK_I64;
 use crate::native_value::{
-    BoundsState, BufferAccessMode, LoweredValue, MaterializationReason, NativeRep, SemanticKind,
+    BoundsProof, BoundsState, BufferAccessMode, LoweredValue, MaterializationReason, NativeRep,
+    SemanticKind,
 };
 use crate::types::{DOUBLE, I1, I16, I32, I64, I8};
 
@@ -50,6 +51,134 @@ pub(super) fn lower_trusted_plain_array_index_get(
     let is_hole = blk.icmp_eq(I64, &raw_bits, crate::nanbox::TAG_HOLE_I64);
     let undefined = blk.bitcast_i64_to_double(crate::nanbox::TAG_UNDEFINED_I64);
     blk.select(I1, &is_hole, DOUBLE, &undefined, &raw)
+}
+
+fn lower_trusted_numeric_array_index_get(
+    ctx: &mut FnCtx<'_>,
+    array_handle: &str,
+    idx_i32: &str,
+    coerce_numeric_fallback: bool,
+) -> String {
+    let blk = ctx.block();
+    let idx_i64 = blk.zext(I32, idx_i32, I64);
+    let byte_offset = blk.shl(I64, &idx_i64, "3");
+    let with_header = blk.add(I64, &byte_offset, "8");
+    let element_addr = blk.add(I64, array_handle, &with_header);
+    let element_ptr = blk.inttoptr(I64, &element_addr);
+    let raw = blk.load(DOUBLE, &element_ptr);
+    if coerce_numeric_fallback {
+        // A number-context consumer accepts the same raw-f64-or-holes
+        // contract as the established guarded tier. Phase 3 currently installs
+        // only the stronger dense numeric descriptor, but retaining the
+        // canonicalization here keeps this consumer correct if that admission
+        // widens later.
+        let is_ordered = blk.fcmp("ord", &raw, &raw);
+        blk.select(I1, &is_ordered, DOUBLE, &raw, "0x7FF8000000000000")
+    } else {
+        raw
+    }
+}
+
+/// Consume #9254 phase 3's one-time receiver validation at an exact bounded
+/// read. `valid_i1` dominates the loop and is invariant; the true arm needs
+/// only the refreshed handle load and raw element access, while the false arm
+/// is the pre-existing guarded implementation in full.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn lower_region_validated_array_index_get(
+    ctx: &mut FnCtx<'_>,
+    arr_id: u32,
+    arr_box: &str,
+    idx_i32: &str,
+    block_prefix: &str,
+    require_numeric_layout: bool,
+    coerce_numeric_fallback: bool,
+    receiver_slot: Option<&str>,
+) -> Result<String> {
+    let Some(access) = ctx
+        .receiver_descriptors
+        .array_access(arr_id, require_numeric_layout)
+    else {
+        return lower_guarded_array_index_get(
+            ctx,
+            arr_box,
+            idx_i32,
+            block_prefix,
+            require_numeric_layout,
+            coerce_numeric_fallback,
+            receiver_slot,
+        );
+    };
+
+    let fast_idx = ctx.new_block(&format!("{}.receiver_region.fast", block_prefix));
+    let fallback_idx = ctx.new_block(&format!("{}.receiver_region.fallback", block_prefix));
+    let merge_idx = ctx.new_block(&format!("{}.receiver_region.merge", block_prefix));
+    let fast_label = ctx.block_label(fast_idx);
+    let fallback_label = ctx.block_label(fallback_idx);
+    let merge_label = ctx.block_label(merge_idx);
+    ctx.block()
+        .cond_br(&access.valid_i1, &fast_label, &fallback_label);
+
+    ctx.current_block = fast_idx;
+    let array_handle = ctx.block().load(I64, &access.base_handle_slot);
+    let fast_value = if require_numeric_layout {
+        lower_trusted_numeric_array_index_get(ctx, &array_handle, idx_i32, coerce_numeric_fallback)
+    } else {
+        lower_trusted_plain_array_index_get(ctx, &array_handle, idx_i32)
+    };
+    let fast_end = ctx.block().label.clone();
+    ctx.block().br(&merge_label);
+
+    if require_numeric_layout {
+        let lowered = LoweredValue {
+            semantic: SemanticKind::JsNumber,
+            rep: NativeRep::F64,
+            llvm_ty: DOUBLE,
+            value: fast_value.clone(),
+        };
+        ctx.record_lowered_value_with_access_mode_and_facts(
+            "NumericArrayIndexGet",
+            Some(arr_id),
+            "receiver_descriptor",
+            &lowered,
+            Some(BoundsState::Proven {
+                proof: BoundsProof::LoopGuard,
+            }),
+            None,
+            Some(BufferAccessMode::CheckedNative),
+            None,
+            None,
+            None,
+            vec![raw_f64_layout_fact(
+                Some(arr_id),
+                "consumed",
+                "receiver_descriptor",
+                None,
+            )],
+            Vec::new(),
+            false,
+            false,
+            vec!["receiver_region=validated_once".to_string()],
+        );
+    }
+
+    ctx.current_block = fallback_idx;
+    let fallback_value = lower_guarded_array_index_get(
+        ctx,
+        arr_box,
+        idx_i32,
+        &format!("{}.receiver_region.checked", block_prefix),
+        require_numeric_layout,
+        coerce_numeric_fallback,
+        receiver_slot,
+    )?;
+    let fallback_end = ctx.block().label.clone();
+    ctx.block().br(&merge_label);
+
+    ctx.current_block = merge_idx;
+    Ok(ctx.block().phi(
+        DOUBLE,
+        &[(&fast_value, &fast_end), (&fallback_value, &fallback_end)],
+    ))
 }
 
 pub(super) fn lower_guarded_array_index_get(

--- a/crates/perry-codegen/src/stmt/loops.rs
+++ b/crates/perry-codegen/src/stmt/loops.rs
@@ -3,9 +3,10 @@
 use super::*;
 
 use crate::expr::{
-    array_kind_fact, effect_fact, emit_typed_feedback_register_site, nanbox_pointer_inline,
-    raw_f64_layout_fact, BoundedIndexPair, PackedF64LoopFact, PackedNumericLoopKind,
-    TypedFeedbackContract, TypedFeedbackKind,
+    array_kind_fact, effect_fact, emit_typed_feedback_register_site,
+    expr_has_numeric_pointer_free_array_layout, nanbox_pointer_inline, raw_f64_layout_fact,
+    BoundedIndexPair, PackedF64LoopFact, PackedNumericLoopKind, TypedFeedbackContract,
+    TypedFeedbackKind,
 };
 use crate::loop_purity::body_needs_asm_barrier;
 use crate::lower_conditional::lower_truthy;
@@ -76,6 +77,61 @@ struct LengthHoist {
     op: perry_hir::CompareOp,
     lhs_addend: i32,
     buffer_bounds_width_units: Option<u32>,
+}
+
+/// #9254 phase 3: prove the dynamic extent in which an ordinary
+/// `i < arr.length` loop may consume a one-time receiver validation.
+///
+/// Only the exact bounded `arr[i]` operation is replaced by the descriptor's
+/// non-dispatching load. Its children and every surrounding operation retain
+/// the conservative region classification. The outer back-edge poll is added
+/// explicitly because the caller passes the loop body rather than a `Stmt::For`
+/// node; nested-loop polls are discovered by the statement walker itself.
+fn ordinary_counted_array_region_enders(
+    ctx: &FnCtx<'_>,
+    hoist: LengthHoist,
+    update: Option<&perry_hir::Expr>,
+    body: &[Stmt],
+) -> Option<Vec<crate::collectors::RegionEnder>> {
+    use std::cell::Cell;
+
+    if !matches!(hoist.op, perry_hir::CompareOp::Lt)
+        || hoist.lhs_addend != 0
+        || !loop_counter_bounds_are_safe(ctx, hoist.counter_id, update, body)
+    {
+        return None;
+    }
+
+    let saw_bounded_read = Cell::new(false);
+    let is_trusted_operation = |expr: &perry_hir::Expr| {
+        let trusted = matches!(
+            expr,
+            perry_hir::Expr::IndexGet { object, index }
+                if matches!(object.as_ref(), perry_hir::Expr::LocalGet(id) if *id == hoist.arr_id)
+                    && matches!(index.as_ref(), perry_hir::Expr::LocalGet(id) if *id == hoist.counter_id)
+        );
+        if trusted {
+            saw_bounded_read.set(true);
+        }
+        trusted
+    };
+    let is_inert = |expr: &perry_hir::Expr| crate::rooting::expr_is_inert_primitive(ctx, expr);
+    let controls: Vec<&perry_hir::Expr> = update.into_iter().collect();
+    let mut enders = crate::collectors::region_enders_in_stmts_with_trusted_operations(
+        body,
+        &controls,
+        &is_inert,
+        &is_trusted_operation,
+    );
+    if !saw_bounded_read.get()
+        || enders
+            .iter()
+            .any(|ender| !matches!(ender, crate::collectors::RegionEnder::BackEdgePoll))
+    {
+        return None;
+    }
+    enders.push(crate::collectors::RegionEnder::BackEdgePoll);
+    Some(enders)
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -826,6 +882,113 @@ struct PackedAccumulatorScope {
     hoisted_receivers: Vec<u32>,
 }
 
+/// Materialize the address half shared by packed clones and phase 3 ordinary
+/// counted loops. The returned box is a precise root, while the handle slot is
+/// refreshed from it after every fired loop poll.
+fn create_poll_refreshed_receiver_cache(
+    ctx: &mut FnCtx<'_>,
+    arr_id: u32,
+) -> Option<(String, String, String)> {
+    let source_ref = if let Some(slot) = ctx.locals.get(&arr_id) {
+        slot.clone()
+    } else {
+        format!("@{}", ctx.module_globals.get(&arr_id)?)
+    };
+    let current = ctx.block().load(DOUBLE, &source_ref);
+    let rooted_box_slot = ctx.func.alloca_entry(DOUBLE);
+    let base_handle_slot = ctx.func.alloca_entry(I64);
+    // `root_entry_alloca` hoists the bind into entry setup, so seed the cache
+    // before that bind can make the collector dereference it. The later store
+    // publishes the live receiver and the bind makes evacuation rewrite this
+    // cache itself.
+    let undefined = crate::nanbox::double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
+    ctx.func
+        .entry_allocas_push_store(DOUBLE, &undefined, &rooted_box_slot);
+    ctx.block().store(DOUBLE, &current, &rooted_box_slot);
+    crate::expr::root_entry_alloca(ctx, &rooted_box_slot);
+    {
+        let blk = ctx.block();
+        let bits = blk.bitcast_double_to_i64(&current);
+        let handle = blk.and(I64, &bits, crate::nanbox::POINTER_MASK_I64);
+        blk.store(I64, &handle, &base_handle_slot);
+    }
+    Some((rooted_box_slot, base_handle_slot, source_ref))
+}
+
+/// Attach a numeric-array validation to an ordinary counted loop. This is
+/// intentionally narrower than the descriptor model: phase 3 targets the
+/// numeric `arr[i]` shape whose guarded header chain dominates matmul-style
+/// kernels. A false one-time guard keeps the established per-read fallback;
+/// a true guard makes every exact bounded read a raw load from the refreshed
+/// handle slot.
+fn materialize_ordinary_counted_array_descriptor(
+    ctx: &mut FnCtx<'_>,
+    hoist: LengthHoist,
+    update: Option<&perry_hir::Expr>,
+    body: &[Stmt],
+) -> bool {
+    if ctx.receiver_descriptors.contains(hoist.arr_id)
+        || !expr_has_numeric_pointer_free_array_layout(
+            ctx,
+            &perry_hir::Expr::LocalGet(hoist.arr_id),
+        )
+    {
+        return false;
+    }
+    let Some(enders) = ordinary_counted_array_region_enders(ctx, hoist, update, body) else {
+        return false;
+    };
+    let Some((rooted_box_slot, base_handle_slot, source_root)) =
+        create_poll_refreshed_receiver_cache(ctx, hoist.arr_id)
+    else {
+        return false;
+    };
+
+    let feedback_site_id = emit_typed_feedback_register_site(
+        ctx,
+        TypedFeedbackKind::ArrayElement,
+        "array[index].receiver_region",
+        TypedFeedbackContract::numeric_array_get_index(),
+    );
+    let receiver = ctx.block().load(DOUBLE, &rooted_box_slot);
+    let guard_i32 = ctx.block().call(
+        I32,
+        "js_typed_feedback_numeric_array_index_get_guard",
+        &[
+            (I64, &feedback_site_id),
+            (DOUBLE, &receiver),
+            // Receiver-only validation: the surrounding strict length bound
+            // supplies the per-use index proof.
+            (I32, "0"),
+            (I32, "0"),
+        ],
+    );
+    let valid_i1 = ctx.block().icmp_ne(I32, &guard_i32, "0");
+
+    // The numeric guard is non-collecting, but it may verify/rewrite boxed
+    // numeric slots into raw-f64 representation. Derive the cached handle
+    // after that operation so the ordering is explicit in the IR contract.
+    {
+        let blk = ctx.block();
+        let fresh = blk.load(DOUBLE, &rooted_box_slot);
+        let bits = blk.bitcast_double_to_i64(&fresh);
+        let handle = blk.and(I64, &bits, crate::nanbox::POINTER_MASK_I64);
+        blk.store(I64, &handle, &base_handle_slot);
+    }
+
+    ctx.receiver_descriptors
+        .materialize_region_validated_array(
+            hoist.arr_id,
+            rooted_box_slot,
+            base_handle_slot,
+            source_root,
+            crate::collectors::ReceiverArrayValidationKind::Numeric,
+            valid_i1,
+            &enders,
+        )
+        .expect("region analysis admitted only poll-refreshable boundaries")
+}
+
 impl PackedAccumulatorScope {
     fn empty() -> Self {
         Self {
@@ -933,40 +1096,15 @@ impl PackedAccumulatorScope {
             if ctx.receiver_descriptors.contains(*arr_id) {
                 continue;
             }
-            let source_ref = if let Some(slot) = ctx.locals.get(arr_id) {
-                slot.clone()
-            } else if let Some(global_name) = ctx.module_globals.get(arr_id) {
-                format!("@{}", global_name)
-            } else {
+            let Some((rooted_box_slot, base_handle_slot, source_ref)) =
+                create_poll_refreshed_receiver_cache(ctx, *arr_id)
+            else {
                 continue;
             };
-            let current = ctx.block().load(DOUBLE, &source_ref);
-            let alloca = ctx.func.alloca_entry(DOUBLE);
-            let handle_alloca = ctx.func.alloca_entry(I64);
-            // `root_entry_alloca` hoists the bind into entry setup, so seed
-            // the cache before that bind can make the collector dereference
-            // it. The later store publishes the live receiver and the bind
-            // makes evacuation rewrite this cache itself. Under native roots
-            // the bind becomes an addrspace(1) value that mem2reg can still
-            // promote, retaining the receiver-cache fast path while making
-            // its liveness across a strided poll explicit to the checker.
-            let undef = crate::nanbox::double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
-            ctx.func.entry_allocas_push_store(DOUBLE, &undef, &alloca);
-            {
-                let blk = ctx.block();
-                blk.store(DOUBLE, &current, &alloca);
-            }
-            crate::expr::root_entry_alloca(ctx, &alloca);
-            {
-                let blk = ctx.block();
-                let bits = blk.bitcast_double_to_i64(&current);
-                let handle = blk.and(I64, &bits, crate::nanbox::POINTER_MASK_I64);
-                blk.store(I64, &handle, &handle_alloca);
-            }
             let installed = ctx.receiver_descriptors.materialize_poll_refreshed_address(
                 *arr_id,
-                alloca,
-                handle_alloca,
+                rooted_box_slot,
+                base_handle_slot,
                 source_ref,
                 // Packed loop admission rejects Stmt::Try. A throw may
                 // leave the clone, but no descriptor is live in the
@@ -6890,6 +7028,19 @@ pub(super) fn lower_for_after_init_with_i32_bound(
         None
     };
 
+    // #9254 phase 3: once both the strict loop bound and its i32 storage are
+    // concrete, validate a numeric receiver once for the dynamic extent of
+    // this ordinary loop. Specialized clones keep precedence and own their
+    // existing descriptors; this path is for the generic counted-loop tier.
+    let ordinary_receiver_descriptor_installed =
+        if !in_call_free_clone && hoisted_length_slot.is_some() && i32_length_slot.is_some() {
+            hoist_classification.is_some_and(|hoist| {
+                materialize_ordinary_counted_array_descriptor(ctx, hoist, update, body)
+            })
+        } else {
+            false
+        };
+
     // Issue #168: when the `i < arr.length` peephole didn't fire, also
     // detect the simpler `i < n` shape where `n` is a statically proven
     // loop-invariant i32 local. Emitting `fptosi(n)` once at the loop head
@@ -7241,6 +7392,12 @@ pub(super) fn lower_for_after_init_with_i32_bound(
     ctx.active_region_id = previous_region_id;
 
     ctx.loop_targets.pop();
+
+    if ordinary_receiver_descriptor_installed {
+        let arr_id = hoisted_length_arr_id.expect("installed descriptor has a length receiver");
+        let removed = ctx.receiver_descriptors.dematerialize(arr_id);
+        debug_assert!(removed, "loop owns the receiver descriptor it installed");
+    }
 
     // Pop the hoisted-length entry so nested loops or sibling loops
     // don't see a stale slot. Repsel Phase 1: only when THIS site inserted

--- a/crates/perry/tests/issue_9254_receiver_descriptor_counted_loop.rs
+++ b/crates/perry/tests/issue_9254_receiver_descriptor_counted_loop.rs
@@ -1,0 +1,185 @@
+//! Regression coverage for #9254 phase 3: ordinary `i < arr.length` loops can
+//! validate a numeric receiver once, then carry its refreshed address through
+//! loop polls instead of repeating the full structural guard at every read.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile(dir: &Path, source: &str) -> (PathBuf, String) {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .env("PERRY_NO_CACHE", "1")
+        .env("PERRY_NO_AUTO_OPTIMIZE", "1")
+        .env("PERRY_LLVM_KEEP_IR", "1")
+        .env_remove("PERRY_GC_MOVING_LOOP_POLLS")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    (
+        output,
+        String::from_utf8_lossy(&compile.stderr).into_owned(),
+    )
+}
+
+fn kept_ir(stderr: &str) -> String {
+    let path = stderr
+        .lines()
+        .find_map(|line| line.split("kept LLVM IR: ").nth(1))
+        .map(str::trim)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| panic!("PERRY_LLVM_KEEP_IR did not report an IR path\n{stderr}"));
+    std::fs::read_to_string(path).expect("read kept LLVM IR")
+}
+
+fn run(bin: &Path, dir: &Path, scheduled_gc: bool) -> Output {
+    let mut command = Command::new(bin);
+    command.current_dir(dir);
+    for key in [
+        "PERRY_GC_SCHEDULE_SEED",
+        "PERRY_GC_SCHEDULE_RATE",
+        "PERRY_GC_SCHEDULE_ALLOC_KB",
+        "PERRY_GC_FORCE_EVACUATE",
+        "PERRY_GC_VERIFY_EVACUATION",
+        "PERRY_GC_PROTECT_FROMSPACE",
+        "PERRY_GC_PROTECT_FROMSPACE_DEPTH",
+    ] {
+        command.env_remove(key);
+    }
+    if scheduled_gc {
+        command
+            .env("PERRY_GC_SCHEDULE_SEED", "9254")
+            .env("PERRY_GC_SCHEDULE_RATE", "1")
+            .env("PERRY_GC_SCHEDULE_ALLOC_KB", "0")
+            .env("PERRY_GC_FORCE_EVACUATE", "1")
+            .env("PERRY_GC_VERIFY_EVACUATION", "1")
+            .env("PERRY_GC_PROTECT_FROMSPACE", "1")
+            .env("PERRY_GC_PROTECT_FROMSPACE_DEPTH", "64");
+    }
+    command.output().expect("run compiled binary")
+}
+
+fn verdict_field(stderr: &str, field: &str) -> u64 {
+    let verdict = stderr
+        .lines()
+        .rev()
+        .find(|line| line.contains("[gc-schedule] forced_collections="))
+        .unwrap_or_else(|| panic!("scheduled run emitted no exercise verdict\n{stderr}"));
+    verdict
+        .split_ascii_whitespace()
+        .find_map(|part| part.strip_prefix(&format!("{field}=")))
+        .and_then(|value| value.parse().ok())
+        .unwrap_or_else(|| panic!("scheduled verdict has no numeric {field}\n{verdict}"))
+}
+
+const VALUES: &str = "[0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5, 10.5, 11.5, 12.5, \
+     13.5, 14.5, 15.5, 16.5, 17.5, 18.5, 19.5, 20.5, 21.5, 22.5, 23.5, 24.5, \
+     25.5, 26.5, 27.5, 28.5, 29.5, 30.5, 31.5]";
+
+fn admitted_source() -> &'static str {
+    include_str!("../../../test-files/test_issue_9254_receiver_descriptor_counted_loop.ts")
+}
+
+#[test]
+fn ordinary_counted_loop_consumes_the_descriptor_and_refreshes_it_at_real_polls() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (bin, compile_stderr) = compile(dir.path(), admitted_source());
+    let ir = kept_ir(&compile_stderr);
+
+    let fast_start = ir
+        .find("\nbidx.num.receiver_region.fast")
+        .unwrap_or_else(|| panic!("the ordinary bounded read did not consume a descriptor\n{ir}"));
+    let fast_tail = &ir[fast_start + 1..];
+    let fast_end = fast_tail
+        .find("\nbidx.num.receiver_region.fallback")
+        .expect("receiver-region fallback block follows its fast block");
+    let fast_block = &fast_tail[..fast_end];
+    assert!(
+        fast_block.contains("load i64") && fast_block.contains("load double"),
+        "descriptor fast block must load the refreshed handle and raw element\n{fast_block}"
+    );
+    assert!(
+        !fast_block.contains("call "),
+        "the descriptor fast block repeated a runtime guard/call\n{fast_block}"
+    );
+    assert!(
+        ir.contains("call i32 @js_typed_feedback_numeric_array_index_get_guard")
+            && ir.contains("i32 0, i32 0"),
+        "receiver-only numeric validation was not emitted in the preheader\n{ir}"
+    );
+    assert!(
+        ir.contains("call void @js_gc_loop_safepoint"),
+        "the subject has no real poll and cannot prove refresh safety\n{ir}"
+    );
+
+    let plain = run(&bin, dir.path(), false);
+    assert!(
+        plain.status.success(),
+        "plain run failed\nstderr:\n{}",
+        String::from_utf8_lossy(&plain.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&plain.stdout), "32\n0\n");
+
+    let scheduled = run(&bin, dir.path(), true);
+    assert!(
+        scheduled.status.success(),
+        "scheduled moving-GC run failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&scheduled.stdout),
+        String::from_utf8_lossy(&scheduled.stderr)
+    );
+    assert_eq!(scheduled.stdout, plain.stdout);
+    let scheduled_stderr = String::from_utf8_lossy(&scheduled.stderr);
+    for field in ["copying_minors", "moved_objects", "loop_polls"] {
+        assert!(
+            verdict_field(&scheduled_stderr, field) > 0,
+            "scheduled run did not exercise {field}\n{scheduled_stderr}"
+        );
+    }
+}
+
+#[test]
+fn allocating_region_keeps_the_per_read_guard() {
+    let source = format!(
+        r#"
+function sum(a: number[]): number {{
+  let total = 0;
+  for (let i = 0; i < a.length; i++) {{
+    const scratch = {{ value: i }};
+    if (scratch.value < -1) total = total + 1000000;
+    total = total + a[i];
+  }}
+  return total;
+}}
+const values: number[] = {VALUES};
+console.log(sum(values));
+"#
+    );
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (_, compile_stderr) = compile(dir.path(), &source);
+    let ir = kept_ir(&compile_stderr);
+    assert!(
+        !ir.contains("receiver_region.fast"),
+        "an allocation/user-code-capable region incorrectly carried the descriptor\n{ir}"
+    );
+    assert!(
+        ir.contains("bidx.num.guard.deref")
+            || ir.contains("call i32 @js_typed_feedback_numeric_array_index_get_guard"),
+        "negative control did not retain the established per-read guard\n{ir}"
+    );
+}

--- a/test-files/test_issue_9254_receiver_descriptor_counted_loop.ts
+++ b/test-files/test_issue_9254_receiver_descriptor_counted_loop.ts
@@ -1,0 +1,24 @@
+function sum(a: number[]): number {
+  let matched = 0;
+  for (let i = 0; i < a.length; i++) {
+    // Keep this on the ordinary counted-loop lowering: the switch makes the
+    // specialized packed-loop tiers decline without adding a collection point.
+    switch (i & 0) {
+      case 1:
+        matched = -1000000;
+        break;
+    }
+    if (a[i] === i + 0.5) matched++;
+  }
+  return matched;
+}
+
+const values: number[] = [
+  0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5,
+  8.5, 9.5, 10.5, 11.5, 12.5, 13.5, 14.5, 15.5,
+  16.5, 17.5, 18.5, 19.5, 20.5, 21.5, 22.5, 23.5,
+  24.5, 25.5, 26.5, 27.5, 28.5, 29.5, 30.5, 31.5,
+];
+console.log(sum(values));
+// A failed one-time receiver validation must retain the guarded fallback.
+console.log(sum(["x", "y"] as any));


### PR DESCRIPTION
## Summary

- Implement #9254 Phase 3 for ordinary strict `i < array.length` numeric-array loops without adding another specialized loop tier.
- Materialize one loop-invariant receiver validation in the preheader, keep its box precisely rooted, and refresh the cached base handle after every fired back-edge GC poll.
- Route exact bounded reads through an invariant fast/fallback diamond: validated receivers use a raw load, while validation misses preserve the existing guarded semantics.
- Keep admission conservative: the descriptor is installed only when the shared receiver-region model finds no boundary other than covered loop polls; calls, allocation, coercion, suspension, and unwind all decline it.

This deliberately leaves Phase 4 (retiring the remaining fact tables one at a time) for follow-up work.

Refs #9254.

## Validation

- `cargo build --release`
- `cargo test -p perry-codegen --lib` — 1,404 passed, 1 ignored
- `cargo test -p perry --test issue_9254_receiver_descriptor_counted_loop -- --test-threads=1` — 2 passed, including a rate-1 scheduled moving-GC run with from-space protection
- `./run_parity_tests.sh --filter issue_9254_receiver_descriptor_counted_loop` under the pinned Node 26.5.1 — 1 passed
- `./scripts/pre-tag-check.sh --quick`
- `python3 scripts/check_test_registration.py`
- `cargo clippy -p perry-codegen --lib`
- `cargo clippy -p perry --test issue_9254_receiver_descriptor_counted_loop`

`./scripts/test_affected_crates.sh --base origin/main` ran 1,073 Perry bin tests successfully and found one unrelated failure: the existing build-cache inventory does not classify `PERRY_CONCAT_SITE_CACHE`. The same exact test fails unchanged on a clean detached worktree at base commit `75b886a381918e345f22b7f84dde7f4bb42e8a9a`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved counted loops over numeric arrays by validating array structure once and reusing the result during iteration.
  * Optimized eligible indexed array reads while preserving guarded fallback behavior when validation fails.
  * Maintained correct behavior during garbage collection and for loops containing allocation or other unsupported operations.

* **Tests**
  * Added coverage for optimized loops, validation fallback, allocation-sensitive loops, and moving garbage collection scenarios.

* **Documentation**
  * Documented the counted-loop optimization and its conservative eligibility rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->