### PR TITLE
Merge train: #9704, #9710

### DIFF
--- a/changelog.d/9710-typed-array-buffer-miss-consumers.md
+++ b/changelog.d/9710-typed-array-buffer-miss-consumers.md
@@ -1,0 +1,19 @@
+**Buffer-backed `Uint8Array` values now stay typed arrays when a kind-registry
+lookup misses.** Perry deliberately represents JavaScript `Uint8Array` values
+with `BufferHeader`, outside `lookup_typed_array_kind`; three consumers treated
+that expected miss as a failed brand or receiver check.
+
+The reflected `%TypedArray%.prototype` `length`, `byteLength`, `byteOffset`, and
+`buffer` getters now accept both `Uint8Array` and Node `Buffer` receivers. They
+also report real view offsets and the same stable backing `ArrayBuffer` as the
+direct property path. Node-API's `napi_is_typedarray` and
+`napi_get_typedarray_info` likewise report buffer-backed views and Buffers as
+`napi_uint8_array`, including their backing identity, offset, and canonical data
+span.
+
+Finally, `Object.preventExtensions` and its `Reflect` counterparts record and
+read the Uint8Array's side-table state, so it no longer remains extensible or
+admits a fresh expando after successfully preventing extensions. `Reflect.set`
+now also creates and updates its ordinary properties through the same Buffer
+property table as direct assignment. The buffer sweeper removes the
+address-keyed extensibility and TypedArray-property state on death.

--- a/crates/perry-runtime/src/buffer/header.rs
+++ b/crates/perry-runtime/src/buffer/header.rs
@@ -1178,6 +1178,12 @@ pub(crate) fn finalize_collected_dead_buffer(addr: usize) {
     //    `visit_metadata_usize_slot`, which resolves it against whatever now
     //    occupies those bytes and rewrites the key to the new tenant's address.
     super::own_props::clear_buffer_own_props(addr);
+    // A BufferHeader-backed Uint8Array keeps ordinary expandos and its
+    // non-extensible marker in the TypedArray side tables. Prune those here as
+    // well as in unregister_typed_array: this representation never enters the
+    // typed-array registry, so that unregister path can never see it (#9347).
+    crate::typedarray_props::typed_array_clear_own_props(addr);
+    crate::typedarray_props::typed_array_clear_no_extend(addr);
     super::detach::remove_detached_entry_for_dead_buffer(addr);
     super::view::remove_entries_for_dead_buffer(addr);
     // #9342: drop the dead address from the inline-read admission cache before

--- a/crates/perry-runtime/src/buffer/own_props.rs
+++ b/crates/perry-runtime/src/buffer/own_props.rs
@@ -67,8 +67,18 @@ pub fn buffer_set_own_prop(addr: usize, prop: &str, value: f64) {
         }
         return;
     }
-    if crate::object::get_property_attrs(addr, prop).is_some_and(|attrs| !attrs.writable())
-        && buffer_get_own_prop(addr, prop).is_some()
+    let existing = buffer_get_own_prop(addr, prop).is_some();
+    if existing
+        && crate::object::get_property_attrs(addr, prop).is_some_and(|attrs| !attrs.writable())
+    {
+        return;
+    }
+    // BufferHeader-backed typed arrays have no GcHeader flag. Their
+    // preventExtensions state lives in the TypedArray side table, so ordinary
+    // direct writes must consult it before adding a fresh expando (#9347).
+    if !existing
+        && crate::typedarray_props::is_typed_array_owner(addr)
+        && crate::typedarray_props::typed_array_owner_no_extend(addr)
     {
         return;
     }

--- a/crates/perry-runtime/src/gc/tests/buffer_side_tables.rs
+++ b/crates/perry-runtime/src/gc/tests/buffer_side_tables.rs
@@ -270,6 +270,59 @@ fn test_dead_buffer_own_property_entry_pruned_on_full_gc() {
     );
 }
 
+/// Buffer-backed Uint8Arrays use TypedArray metadata tables even though their
+/// owners are swept through the buffer finalizer. The finalizer must clear the
+/// non-extensible marker before the old-arena address can be reused (#9347).
+#[test]
+fn test_dead_uint8array_extensibility_entry_pruned_on_full_gc() {
+    let _guard = GcTestIsolationGuard::new();
+
+    let addr = crate::buffer::js_uint8array_alloc(32) as usize;
+    assert!(unsafe {
+        crate::typedarray_props::typed_array_set_property_by_name(addr, "existing", 1.0)
+    });
+    assert_eq!(
+        crate::buffer::buffer_get_own_prop(addr, "existing"),
+        Some(1.0),
+        "the typed-array Set path must use the canonical Buffer property table"
+    );
+    crate::typedarray_props::typed_array_mark_no_extend(addr);
+    assert!(
+        crate::typedarray_props::typed_array_owner_no_extend(addr),
+        "test premise: the Uint8Array has a side-table marker"
+    );
+    assert!(unsafe {
+        crate::typedarray_props::typed_array_set_property_by_name(addr, "existing", 2.0)
+    });
+    assert_eq!(
+        crate::buffer::buffer_get_own_prop(addr, "existing"),
+        Some(2.0)
+    );
+    assert!(!unsafe {
+        crate::typedarray_props::typed_array_set_property_by_name(addr, "fresh", 3.0)
+    });
+    crate::buffer::buffer_set_own_prop(addr, "direct_fresh", 4.0);
+    assert!(
+        crate::buffer::buffer_get_own_prop(addr, "fresh").is_none()
+            && crate::buffer::buffer_get_own_prop(addr, "direct_fresh").is_none(),
+        "neither reflected nor direct Set may add a key after preventExtensions"
+    );
+
+    // No roots: dead at the full trace. Buffer-backed Uint8Arrays never enter
+    // unregister_typed_array, so only finalize_collected_dead_buffer can
+    // remove this address-keyed entry.
+    full_gc();
+
+    assert!(
+        !crate::typedarray_props::typed_array_owner_no_extend(addr),
+        "a recycled address must not inherit a dead Uint8Array's integrity state"
+    );
+    assert!(
+        crate::buffer::buffer_get_own_prop(addr, "existing").is_none(),
+        "the canonical property table must be pruned with its dead owner"
+    );
+}
+
 /// A LIVE buffer keeps its own properties across a full collection. Without
 /// this the prune above could pass by dropping everything unconditionally.
 ///

--- a/crates/perry-runtime/src/node_api_host/buffers.rs
+++ b/crates/perry-runtime/src/node_api_host/buffers.rs
@@ -30,6 +30,22 @@ fn pointer_owner(env: NapiEnv, value: NapiValue) -> Result<usize, NapiStatus> {
     super::metadata::owner_from_bits(bits).ok_or(NapiStatus::InvalidArg)
 }
 
+#[derive(Clone, Copy)]
+enum NapiTypedArrayOwner {
+    Registered(usize),
+    Uint8Buffer(usize),
+}
+
+fn classify_typed_array_owner(owner: usize) -> Option<NapiTypedArrayOwner> {
+    if crate::typedarray::lookup_typed_array_kind(owner).is_some() {
+        Some(NapiTypedArrayOwner::Registered(owner))
+    } else if crate::object::typed_array_proto_thunks::is_typed_array_buffer(owner) {
+        Some(NapiTypedArrayOwner::Uint8Buffer(owner))
+    } else {
+        None
+    }
+}
+
 fn write_pointer_handle(env: NapiEnv, pointer: *const u8, result: *mut NapiValue) -> NapiStatus {
     if result.is_null() {
         return set_status(env, NapiStatus::InvalidArg, "result must not be null");
@@ -252,7 +268,7 @@ pub unsafe extern "C" fn napi_get_arraybuffer_info(
     };
     let buffer = owner as *const BufferHeader;
     if !data.is_null() {
-        *data = crate::buffer::buffer_data(buffer) as *mut c_void;
+        *data = crate::buffer::resolve_span_data_ptr(buffer) as *mut c_void;
     }
     if !byte_length.is_null() {
         *byte_length = (*buffer).length as usize;
@@ -326,7 +342,9 @@ pub unsafe extern "C" fn napi_is_typedarray(
         return set_status(env, NapiStatus::InvalidArg, "result must not be null");
     }
     *result = pointer_owner(env, value)
-        .is_ok_and(|owner| crate::typedarray::lookup_typed_array_kind(owner).is_some());
+        .ok()
+        .and_then(classify_typed_array_owner)
+        .is_some();
     ok(env)
 }
 
@@ -340,25 +358,51 @@ pub unsafe extern "C" fn napi_get_typedarray_info(
     arraybuffer: *mut NapiValue,
     byte_offset: *mut usize,
 ) -> NapiStatus {
-    let owner = match pointer_owner(env, typedarray) {
-        Ok(owner) if crate::typedarray::lookup_typed_array_kind(owner).is_some() => owner,
+    let owner = match pointer_owner(env, typedarray)
+        .ok()
+        .and_then(classify_typed_array_owner)
+    {
+        Some(owner) => owner,
         _ => return set_status(env, NapiStatus::InvalidArg, "value must be a TypedArray"),
     };
-    let typed_array = owner as *mut TypedArrayHeader;
-    let backing = crate::typedarray_view::js_typed_array_backing_buffer(typed_array);
-    let refreshed_owner = pointer_owner(env, typedarray).unwrap_or(owner);
-    let refreshed = refreshed_owner as *mut TypedArrayHeader;
+    let (reported_kind, reported_length, reported_data, backing, reported_offset) = match owner {
+        NapiTypedArrayOwner::Registered(owner) => {
+            let typed_array = owner as *mut TypedArrayHeader;
+            let backing = crate::typedarray_view::js_typed_array_backing_buffer(typed_array);
+            let refreshed_owner = pointer_owner(env, typedarray).unwrap_or(owner);
+            let refreshed = refreshed_owner as *mut TypedArrayHeader;
+            (
+                std::mem::transmute::<i32, NapiTypedarrayType>((*refreshed).kind as i32),
+                (*refreshed).length as usize,
+                crate::typedarray::data_ptr_mut(refreshed).cast::<c_void>(),
+                backing,
+                crate::typedarray_view::js_typed_array_byte_offset(refreshed) as usize,
+            )
+        }
+        NapiTypedArrayOwner::Uint8Buffer(owner) => {
+            let backing = crate::buffer::buffer_backing_array_buffer(owner);
+            let refreshed_owner = pointer_owner(env, typedarray).unwrap_or(owner);
+            let refreshed = refreshed_owner as *const BufferHeader;
+            (
+                NapiTypedarrayType::Uint8Array,
+                crate::buffer::js_buffer_length(refreshed).max(0) as usize,
+                crate::buffer::resolve_span_data_ptr(refreshed) as *mut c_void,
+                backing as *mut BufferHeader,
+                crate::buffer::buffer_byte_offset(refreshed_owner) as usize,
+            )
+        }
+    };
     if !kind.is_null() {
-        *kind = std::mem::transmute::<i32, NapiTypedarrayType>((*refreshed).kind as i32);
+        *kind = reported_kind;
     }
     if !length.is_null() {
-        *length = (*refreshed).length as usize;
+        *length = reported_length;
     }
     if !data.is_null() {
-        *data = crate::typedarray::data_ptr_mut(refreshed).cast();
+        *data = reported_data;
     }
     if !byte_offset.is_null() {
-        *byte_offset = crate::typedarray_view::js_typed_array_byte_offset(refreshed) as usize;
+        *byte_offset = reported_offset;
     }
     if !arraybuffer.is_null() {
         *arraybuffer =

--- a/crates/perry-runtime/src/node_api_host/tests.rs
+++ b/crates/perry-runtime/src/node_api_host/tests.rs
@@ -756,6 +756,133 @@ fn buffers_views_detach_and_promises_keep_backing_identity() {
     );
 }
 
+#[test]
+fn buffer_backed_uint8arrays_report_typedarray_info() {
+    let env = test_env();
+
+    let inspect = |value: NapiValue,
+                   expected_length: usize,
+                   expected_offset: usize,
+                   expected_data: *mut c_void,
+                   expected_backing: Option<NapiValue>| {
+        let mut is_typed_array = false;
+        assert_eq!(
+            unsafe { napi_is_typedarray(env, value, &mut is_typed_array) },
+            NapiStatus::Ok
+        );
+        assert!(is_typed_array);
+
+        let mut kind = NapiTypedarrayType::Int8Array;
+        let mut length = 0;
+        let mut data = std::ptr::null_mut();
+        let mut backing = std::ptr::null_mut();
+        let mut offset = usize::MAX;
+        assert_eq!(
+            unsafe {
+                napi_get_typedarray_info(
+                    env,
+                    value,
+                    &mut kind,
+                    &mut length,
+                    &mut data,
+                    &mut backing,
+                    &mut offset,
+                )
+            },
+            NapiStatus::Ok
+        );
+        assert_eq!(kind, NapiTypedarrayType::Uint8Array);
+        assert_eq!((length, offset), (expected_length, expected_offset));
+        assert_eq!(data, expected_data);
+
+        let mut is_array_buffer = false;
+        assert_eq!(
+            unsafe { napi_is_arraybuffer(env, backing, &mut is_array_buffer) },
+            NapiStatus::Ok
+        );
+        assert!(is_array_buffer);
+        if let Some(expected) = expected_backing {
+            let mut same = false;
+            assert_eq!(
+                unsafe { napi_strict_equals(env, backing, expected, &mut same) },
+                NapiStatus::Ok
+            );
+            assert!(same);
+        }
+
+        let mut backing_data = std::ptr::null_mut();
+        let mut backing_length = 0;
+        assert_eq!(
+            unsafe {
+                napi_get_arraybuffer_info(env, backing, &mut backing_data, &mut backing_length)
+            },
+            NapiStatus::Ok
+        );
+        assert!(backing_length >= expected_offset + expected_length);
+        assert_eq!(
+            data,
+            unsafe { (backing_data as *mut u8).add(expected_offset) }.cast()
+        );
+
+        let mut backing_again = std::ptr::null_mut();
+        assert_eq!(
+            unsafe {
+                napi_get_typedarray_info(
+                    env,
+                    value,
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                    &mut backing_again,
+                    std::ptr::null_mut(),
+                )
+            },
+            NapiStatus::Ok
+        );
+        let mut same = false;
+        assert_eq!(
+            unsafe { napi_strict_equals(env, backing, backing_again, &mut same) },
+            NapiStatus::Ok
+        );
+        assert!(
+            same,
+            "the reported backing ArrayBuffer identity must be stable"
+        );
+    };
+
+    let mut arraybuffer = std::ptr::null_mut();
+    let mut arraybuffer_data = std::ptr::null_mut();
+    assert_eq!(
+        unsafe { napi_create_arraybuffer(env, 8, &mut arraybuffer_data, &mut arraybuffer) },
+        NapiStatus::Ok
+    );
+    let arraybuffer_bits = value_bits(env, arraybuffer).unwrap();
+    let view_ptr = crate::buffer::js_uint8array_view(f64::from_bits(arraybuffer_bits), 2.0, 3.0);
+    let view = add_handle(env, crate::value::JSValue::pointer(view_ptr.cast()).bits()).unwrap();
+    inspect(
+        view,
+        3,
+        2,
+        unsafe { (arraybuffer_data as *mut u8).add(2) }.cast(),
+        Some(arraybuffer),
+    );
+
+    let mut node_buffer = std::ptr::null_mut();
+    let mut node_buffer_data = std::ptr::null_mut();
+    assert_eq!(
+        unsafe { napi_create_buffer(env, 4, &mut node_buffer_data, &mut node_buffer) },
+        NapiStatus::Ok
+    );
+    inspect(node_buffer, 4, 0, node_buffer_data, None);
+
+    let mut is_typed_array = true;
+    assert_eq!(
+        unsafe { napi_is_typedarray(env, arraybuffer, &mut is_typed_array) },
+        NapiStatus::Ok
+    );
+    assert!(!is_typed_array, "an ArrayBuffer is not a TypedArray");
+}
+
 static ASYNC_EXECUTED: AtomicUsize = AtomicUsize::new(0);
 static ASYNC_COMPLETED: AtomicUsize = AtomicUsize::new(0);
 static ASYNC_OFF_THREAD_REJECTED: AtomicUsize = AtomicUsize::new(0);

--- a/crates/perry-runtime/src/object/global_this/typed_array.rs
+++ b/crates/perry-runtime/src/object/global_this/typed_array.rs
@@ -256,13 +256,55 @@ fn jsvalue_extends_typed_array(value: f64) -> bool {
     }
 }
 
-/// Resolve the `IMPLICIT_THIS` receiver to a `(typed-array ptr, kind)` if it
-/// is a typed array, else `None`. Backs the `%TypedArray%.prototype` accessor
-/// getters installed for reflection (#2060) — these fire when user code does
-/// `desc.get.call(int8arr)` after pulling the descriptor out via
-/// `Object.getOwnPropertyDescriptor`. Mirrors the receiver-extraction the
-/// `Array.prototype.slice` thunk uses (NaN-boxed pointer or raw-i64 form).
-fn typed_array_receiver() -> Option<(*const crate::typedarray::TypedArrayHeader, u8)> {
+#[derive(Clone, Copy)]
+enum TypedArrayAccessorReceiver {
+    Registered(*const crate::typedarray::TypedArrayHeader, u8),
+    Uint8Buffer(usize),
+}
+
+impl TypedArrayAccessorReceiver {
+    fn length(self) -> u32 {
+        match self {
+            Self::Registered(ta, _) => crate::typedarray::js_typed_array_length(ta).max(0) as u32,
+            Self::Uint8Buffer(addr) => {
+                crate::buffer::js_buffer_length(addr as *const crate::buffer::BufferHeader).max(0)
+                    as u32
+            }
+        }
+    }
+
+    fn byte_length(self) -> usize {
+        match self {
+            Self::Registered(_, kind) => {
+                self.length() as usize * crate::typedarray::elem_size_for_kind(kind)
+            }
+            Self::Uint8Buffer(_) => self.length() as usize,
+        }
+    }
+
+    fn byte_offset(self) -> u32 {
+        match self {
+            Self::Registered(ta, _) => crate::typedarray_view::js_typed_array_byte_offset(ta),
+            Self::Uint8Buffer(addr) => crate::buffer::buffer_byte_offset(addr),
+        }
+    }
+
+    fn backing_buffer(self) -> usize {
+        match self {
+            Self::Registered(ta, _) => {
+                crate::typedarray_view::js_typed_array_backing_buffer(ta) as usize
+            }
+            Self::Uint8Buffer(addr) => crate::buffer::buffer_backing_array_buffer(addr),
+        }
+    }
+}
+
+/// Resolve the `IMPLICIT_THIS` receiver for the reflected
+/// `%TypedArray%.prototype` accessors installed by #2060. A Perry
+/// `Uint8Array` (and Node's `Buffer` subclass) uses `BufferHeader`, so a miss
+/// in `lookup_typed_array_kind` must continue through the strict buffer brand
+/// check instead of becoming a `TypeError` (#9347).
+fn typed_array_receiver() -> Option<TypedArrayAccessorReceiver> {
     use crate::value::JSValue;
     let this_bits = IMPLICIT_THIS.with(|c| c.get());
     let this_jsv = JSValue::from_bits(this_bits);
@@ -273,8 +315,14 @@ fn typed_array_receiver() -> Option<(*const crate::typedarray::TypedArrayHeader,
     } else {
         return None;
     };
-    let kind = crate::typedarray::lookup_typed_array_kind(raw)?;
-    Some((raw as *const crate::typedarray::TypedArrayHeader, kind))
+    if let Some(kind) = crate::typedarray::lookup_typed_array_kind(raw) {
+        return Some(TypedArrayAccessorReceiver::Registered(
+            raw as *const _,
+            kind,
+        ));
+    }
+    crate::object::typed_array_proto_thunks::is_typed_array_buffer(raw)
+        .then_some(TypedArrayAccessorReceiver::Uint8Buffer(raw))
 }
 
 fn typed_array_brand_error() -> ! {
@@ -312,12 +360,12 @@ pub(crate) fn typed_array_constructor_this_kind() -> Option<u8> {
     crate::typedarray::kind_for_name(&name)
 }
 
-fn typed_array_buffer_value(ta: *const crate::typedarray::TypedArrayHeader) -> f64 {
-    let buf = crate::typedarray::typed_array_to_array_buffer(ta);
-    if buf.is_null() {
+fn typed_array_buffer_value(receiver: TypedArrayAccessorReceiver) -> f64 {
+    let backing = receiver.backing_buffer();
+    if backing == 0 {
         typed_array_brand_error();
     }
-    crate::value::js_nanbox_pointer(buf as i64)
+    crate::value::js_nanbox_pointer(backing as i64)
 }
 
 /// `%TypedArray%.prototype.length` getter — element count of the receiver.
@@ -325,9 +373,8 @@ extern "C" fn typed_array_length_getter_thunk(
     _closure: *const crate::closure::ClosureHeader,
 ) -> f64 {
     match typed_array_receiver() {
-        Some((ta, _)) => {
-            let len = crate::typedarray::js_typed_array_length(ta);
-            f64::from_bits(crate::value::JSValue::number(len as f64).bits())
+        Some(receiver) => {
+            f64::from_bits(crate::value::JSValue::number(receiver.length() as f64).bits())
         }
         None => typed_array_brand_error(),
     }
@@ -338,36 +385,32 @@ extern "C" fn typed_array_byte_length_getter_thunk(
     _closure: *const crate::closure::ClosureHeader,
 ) -> f64 {
     match typed_array_receiver() {
-        Some((ta, kind)) => {
-            let len = crate::typedarray::js_typed_array_length(ta) as usize;
-            let elem_size = crate::typedarray::elem_size_for_kind(kind);
-            f64::from_bits(crate::value::JSValue::number((len * elem_size) as f64).bits())
+        Some(receiver) => {
+            f64::from_bits(crate::value::JSValue::number(receiver.byte_length() as f64).bits())
         }
         None => typed_array_brand_error(),
     }
 }
 
-/// `%TypedArray%.prototype.byteOffset` getter — always 0 (Perry views are not
-/// backed by an offset into a shared `ArrayBuffer`).
+/// `%TypedArray%.prototype.byteOffset` getter.
 extern "C" fn typed_array_byte_offset_getter_thunk(
     _closure: *const crate::closure::ClosureHeader,
 ) -> f64 {
     match typed_array_receiver() {
-        Some(_) => f64::from_bits(crate::value::JSValue::number(0.0).bits()),
+        Some(receiver) => {
+            f64::from_bits(crate::value::JSValue::number(receiver.byte_offset() as f64).bits())
+        }
         None => typed_array_brand_error(),
     }
 }
 
-/// `%TypedArray%.prototype.buffer` getter. Perry does not yet model a
-/// first-class `ArrayBuffer` behind a view, so this returns `undefined` for
-/// now (matching the existing `int8arr.buffer` data-path behavior). The
-/// accessor still exists so reflection sees a real getter — closing the
-/// `getOwnPropertyDescriptor(...).get` cascade in #2060.
+/// `%TypedArray%.prototype.buffer` getter, with the same stable backing
+/// identity as the direct property path.
 extern "C" fn typed_array_buffer_getter_thunk(
     _closure: *const crate::closure::ClosureHeader,
 ) -> f64 {
     match typed_array_receiver() {
-        Some((ta, _)) => typed_array_buffer_value(ta),
+        Some(receiver) => typed_array_buffer_value(receiver),
         None => typed_array_brand_error(),
     }
 }

--- a/crates/perry-runtime/src/object/object_ops_frozen.rs
+++ b/crates/perry-runtime/src/object/object_ops_frozen.rs
@@ -356,11 +356,12 @@ pub extern "C" fn js_object_prevent_extensions(obj_value: f64) -> f64 {
     unsafe {
         let obj = extract_obj_ptr(obj_value);
         if !obj.is_null() && (obj as usize) > 0x10000 {
-            // Typed arrays: side table, NOT the GC header — small typed
-            // arrays are plain-`alloc`ed with no `GcHeader`, so the flag
-            // write below would corrupt allocator metadata.
-            if crate::typedarray::lookup_typed_array_kind(obj as usize).is_some() {
-                crate::typedarray_props::typed_array_mark_no_extend(obj as usize);
+            // Typed arrays use a side table for extensibility. Include Perry's
+            // BufferHeader-backed Uint8Array: lookup_typed_array_kind can
+            // never recognise it, and setting only the Buffer's GC flag is
+            // invisible to the integer-indexed property paths (#9347).
+            if let Some(owner) = crate::typedarray_props::typed_array_addr_from_value(obj_value) {
+                crate::typedarray_props::typed_array_mark_no_extend(owner);
                 return obj_value;
             }
             let gc = gc_header_for(obj);
@@ -613,14 +614,14 @@ pub extern "C" fn js_object_is_extensible(obj_value: f64) -> f64 {
         // report `false` depending on heap layout. Integer-indexed exotic
         // objects are extensible by default; report that instead of reading a
         // header that may not exist.
-        let raw = crate::value::js_nanbox_get_pointer(obj_value) as usize;
-        if raw > 0x10000 && crate::typedarray::lookup_typed_array_kind(raw).is_some() {
-            return if crate::typedarray_props::typed_array_owner_no_extend(raw) {
+        if let Some(owner) = crate::typedarray_props::typed_array_addr_from_value(obj_value) {
+            return if crate::typedarray_props::typed_array_owner_no_extend(owner) {
                 f64::from_bits(TAG_FALSE)
             } else {
                 f64::from_bits(TAG_TRUE)
             };
         }
+        let raw = crate::value::js_nanbox_get_pointer(obj_value) as usize;
         if raw > 0x10000 && crate::buffer::is_registered_buffer(raw) {
             return f64::from_bits(TAG_TRUE);
         }

--- a/crates/perry-runtime/src/object/reflect_support.rs
+++ b/crates/perry-runtime/src/object/reflect_support.rs
@@ -27,9 +27,10 @@ pub(crate) fn obj_value_no_extend(value: f64) -> bool {
             return false;
         }
         // Typed arrays use a side table (small ones carry no `GcHeader`, so
-        // the header read below would be allocator-metadata garbage).
-        if crate::typedarray::lookup_typed_array_kind(obj as usize).is_some() {
-            return crate::typedarray_props::typed_array_owner_no_extend(obj as usize);
+        // the header read below would be allocator-metadata garbage). The
+        // helper also recognises BufferHeader-backed Uint8Arrays (#9347).
+        if let Some(owner) = crate::typedarray_props::typed_array_addr_from_value(value) {
+            return crate::typedarray_props::typed_array_owner_no_extend(owner);
         }
         let gc = gc_header_for(obj);
         (*gc)._reserved & crate::gc::OBJ_FLAG_NO_EXTEND != 0

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -1494,7 +1494,7 @@ fn own_set_descriptor(target: f64, key: f64) -> Option<OwnSetDescriptor> {
     // deliberately gated off for typed arrays). Consult that state directly so
     // a non-writable own data property / setter-less accessor rejects the write
     // (test262 TypedArray internals/Set key-is-not-numeric-index).
-    if crate::typedarray::lookup_typed_array_kind(obj_ptr).is_some() {
+    if crate::typedarray_props::is_typed_array_owner(obj_ptr) {
         return match crate::typedarray_props::typed_array_own_set_descriptor(obj_ptr, &key_name) {
             Some(crate::typedarray_props::TypedArrayOwnSetDescriptor::Data { writable }) => {
                 Some(OwnSetDescriptor::Data { writable })
@@ -1857,7 +1857,7 @@ fn ordinary_set_with_receiver(target: f64, key: f64, value: f64, receiver: f64) 
         let addr = extract_pointer(target.to_bits()) as usize;
         // Typed arrays must be excluded before the header probe: small TAs
         // are plain-alloc'd without a GcHeader.
-        if crate::typedarray::lookup_typed_array_kind(addr).is_none()
+        if !crate::typedarray_props::is_typed_array_owner(addr)
             && crate::object::exotic_expando::exotic_expando_kind_of_value(target).is_none()
             && !crate::closure::is_closure_ptr(addr)
         {
@@ -2094,7 +2094,7 @@ fn ordinary_set_with_receiver(target: f64, key: f64, value: f64, receiver: f64) 
         // ordinary data-descriptor flow (create on receiver); an invalid
         // canonical index is a silent no-op `true`.
         let cur_addr = extract_pointer(current.to_bits()) as usize;
-        if crate::typedarray::lookup_typed_array_kind(cur_addr).is_some() {
+        if crate::typedarray_props::is_typed_array_owner(cur_addr) {
             if let Some(name) = property_key_to_rust_string(key) {
                 match crate::typedarray_props::typed_array_canonical_index_validity(cur_addr, &name)
                 {
@@ -2114,7 +2114,7 @@ fn ordinary_set_with_receiver(target: f64, key: f64, value: f64, receiver: f64) 
                         // CreateDataProperty lands in ITS [[DefineOwnProperty]],
                         // which rejects an index that is invalid FOR THE
                         // RECEIVER (`Reflect.set(ta, "0", v, emptyTa)` → false).
-                        if crate::typedarray::lookup_typed_array_kind(recv_addr).is_some() {
+                        if crate::typedarray_props::is_typed_array_owner(recv_addr) {
                             return match crate::typedarray_props::
                                 typed_array_canonical_index_validity(recv_addr, &name)
                             {

--- a/crates/perry-runtime/src/typedarray_props.rs
+++ b/crates/perry-runtime/src/typedarray_props.rs
@@ -267,6 +267,17 @@ fn barrier_typed_array_own_props(owner: usize, props: &mut [TypedArrayOwnProp]) 
 }
 
 fn upsert_typed_array_own_prop(owner: usize, key: String, value: f64, is_data: bool) {
+    // A constructor-created Uint8Array uses BufferHeader rather than
+    // TypedArrayHeader. Store its ordinary properties in the existing GC-traced
+    // Buffer table, so direct assignment, Reflect.set, descriptors, and
+    // enumeration all observe one value instead of two invisible side tables (#9347).
+    if matches!(
+        typed_array_owner_kind(owner),
+        Some(TypedArrayOwnerKind::Uint8ArrayBuffer)
+    ) {
+        crate::buffer::buffer_define_own_data_prop(owner, &key, value);
+        return;
+    }
     TYPED_ARRAY_OWN_PROPS.with(|m| {
         let mut map = m.borrow_mut();
         let props = map.entry(owner).or_default();
@@ -285,7 +296,7 @@ fn upsert_typed_array_own_prop(owner: usize, key: String, value: f64, is_data: b
 }
 
 fn remove_typed_array_own_prop(owner: usize, key: &str) -> bool {
-    TYPED_ARRAY_OWN_PROPS.with(|m| {
+    let removed_typed_array = TYPED_ARRAY_OWN_PROPS.with(|m| {
         let mut map = m.borrow_mut();
         let Some(props) = map.get_mut(&owner) else {
             return false;
@@ -298,23 +309,38 @@ fn remove_typed_array_own_prop(owner: usize, key: &str) -> bool {
             map.remove(&owner);
         }
         true
-    })
+    });
+    let removed_buffer = matches!(
+        typed_array_owner_kind(owner),
+        Some(TypedArrayOwnerKind::Uint8ArrayBuffer)
+    ) && crate::buffer::buffer_delete_own_prop(owner, key);
+    removed_typed_array || removed_buffer
 }
 
 fn typed_array_own_prop_snapshot(owner: usize, key: &str) -> Option<TypedArrayOwnProp> {
-    TYPED_ARRAY_OWN_PROPS.with(|m| {
+    let typed_array_prop = TYPED_ARRAY_OWN_PROPS.with(|m| {
         m.borrow()
             .get(&owner)
             .and_then(|props| props.iter().find(|prop| prop.key == key).cloned())
+    });
+    if typed_array_prop.is_some() {
+        return typed_array_prop;
+    }
+    if !matches!(
+        typed_array_owner_kind(owner),
+        Some(TypedArrayOwnerKind::Uint8ArrayBuffer)
+    ) {
+        return None;
+    }
+    crate::buffer::buffer_get_own_prop(owner, key).map(|value| TypedArrayOwnProp {
+        key: key.to_string(),
+        value,
+        is_data: crate::object::get_accessor_descriptor(owner, key).is_none(),
     })
 }
 
 fn typed_array_has_ordinary_own_prop(owner: usize, key: &str) -> bool {
-    TYPED_ARRAY_OWN_PROPS.with(|m| {
-        m.borrow()
-            .get(&owner)
-            .is_some_and(|props| props.iter().any(|prop| prop.key == key))
-    })
+    typed_array_own_prop_snapshot(owner, key).is_some()
 }
 
 unsafe fn descriptor_has(desc_ptr: *mut crate::object::ObjectHeader, name: &[u8]) -> bool {
@@ -1170,6 +1196,23 @@ fn typed_array_non_index_keys(owner: usize, enumerable_only: bool) -> Vec<String
             })
             .unwrap_or_default()
     });
+    if matches!(
+        typed_array_owner_kind(owner),
+        Some(TypedArrayOwnerKind::Uint8ArrayBuffer)
+    ) {
+        for key in crate::buffer::buffer_own_prop_names(owner) {
+            if keys.iter().any(|existing| existing == &key) {
+                continue;
+            }
+            if enumerable_only
+                && crate::object::get_property_attrs(owner, &key)
+                    .is_some_and(|attrs| !attrs.enumerable())
+            {
+                continue;
+            }
+            keys.push(key);
+        }
+    }
     for key in crate::object::accessor_descriptor_keys_for_obj(owner) {
         if keys.iter().any(|existing| existing == &key) {
             continue;

--- a/crates/perry-transform/src/inline/exact_receivers.rs
+++ b/crates/perry-transform/src/inline/exact_receivers.rs
@@ -1,6 +1,6 @@
 use perry_hir::types::LocalId;
 use perry_hir::walker::walk_expr_children;
-use perry_hir::{Expr, Stmt};
+use perry_hir::{Class, Expr, Module, Stmt};
 use std::collections::{HashMap, HashSet};
 
 use super::*;
@@ -33,6 +33,239 @@ pub fn resolve_receiver_class(
         }
         _ => None,
     }
+}
+
+/// Module-wide proof that a declared class's prototype chain keeps the method
+/// table recorded by its class declaration.
+///
+/// Exact-receiver facts only prove that a local came from `new C()`. They do
+/// not make `C.prototype` immutable: after `C.prototype.m = replacement`, a
+/// later fresh `C` is still exact while its `m` lookup no longer resolves to
+/// the declaration-time body. Keep prototype stability separate from receiver
+/// identity so the method inliner needs both proofs (#9239).
+#[derive(Debug, Default)]
+pub(crate) struct ModulePrototypeFacts {
+    touched_classes: HashSet<String>,
+    opaque_prototype_access: bool,
+}
+
+impl ModulePrototypeFacts {
+    /// True when neither this class nor a known parent has a prototype that is
+    /// named or replaced anywhere in the module.
+    pub(crate) fn method_table_is_stable(&self, classes: &[Class], class_name: &str) -> bool {
+        if self.opaque_prototype_access {
+            return false;
+        }
+
+        let mut current = Some(class_name);
+        let mut seen = HashSet::new();
+        while let Some(name) = current {
+            if !seen.insert(name) || self.touched_classes.contains(name) {
+                return false;
+            }
+
+            let Some(class) = classes.iter().find(|class| class.name == name) else {
+                // Cross-module candidates do not carry their source module's
+                // class table. A destination-side named touch was checked
+                // above; otherwise preserve their existing eligibility.
+                return true;
+            };
+            if class.extends_expr.is_some() || class.native_extends.is_some() {
+                return false;
+            }
+            current = class.extends_name.as_deref();
+        }
+        true
+    }
+}
+
+/// Collect every module site that can expose or replace a declared class
+/// prototype. Naming a prototype is conservatively a touch because it can be
+/// retained in an alias and mutated by a later statement or closure.
+pub(crate) fn collect_module_prototype_facts(module: &Module) -> ModulePrototypeFacts {
+    fn note_holder(object: &Expr, facts: &mut ModulePrototypeFacts) {
+        match object {
+            Expr::ClassRef(name) => {
+                facts.touched_classes.insert(name.clone());
+            }
+            // Function-classic prototypes use runtime synthetic class ids and
+            // cannot replace a declared class's method table.
+            Expr::FuncRef(_) => {}
+            _ => facts.opaque_prototype_access = true,
+        }
+    }
+
+    fn visit_expr(expr: &Expr, facts: &mut ModulePrototypeFacts) {
+        match expr {
+            Expr::RegisterPrototypeMethod { class_name, .. }
+            | Expr::RegisterClassParentDynamic { class_name, .. } => {
+                facts.touched_classes.insert(class_name.clone());
+            }
+            Expr::SetFunctionPrototype { func, .. } => {
+                if let Expr::ClassRef(name) = func.as_ref() {
+                    facts.touched_classes.insert(name.clone());
+                }
+            }
+            Expr::PropertyGet {
+                object, property, ..
+            }
+            | Expr::PropertySet {
+                object, property, ..
+            }
+            | Expr::PropertyUpdate {
+                object, property, ..
+            } if property == "prototype" || property == "__proto__" => {
+                note_holder(object, facts);
+            }
+            Expr::IndexGet { object, index } | Expr::IndexSet { object, index, .. } if matches!(index.as_ref(), Expr::String(key) if key == "prototype" || key == "__proto__") =>
+            {
+                note_holder(object, facts);
+            }
+            Expr::PutValueSet { target, key, .. } if matches!(key.as_ref(), Expr::String(name) if name == "prototype" || name == "__proto__") =>
+            {
+                note_holder(target, facts);
+            }
+            _ => {}
+        }
+
+        // The ordinary expression walker deliberately treats a closure body
+        // as non-executing. Prototype stability is module-wide, so a mutation
+        // in that body still has to participate in this proof.
+        if let Expr::Closure { body, .. } = expr {
+            visit_stmts(body, facts);
+        }
+        walk_expr_children(expr, &mut |child| visit_expr(child, facts));
+    }
+
+    fn visit_stmt(stmt: &Stmt, facts: &mut ModulePrototypeFacts) {
+        match stmt {
+            Stmt::Let { init, .. } => {
+                if let Some(init) = init {
+                    visit_expr(init, facts);
+                }
+            }
+            Stmt::Expr(expr) | Stmt::Throw(expr) | Stmt::Return(Some(expr)) => {
+                visit_expr(expr, facts);
+            }
+            Stmt::If {
+                condition,
+                then_branch,
+                else_branch,
+            } => {
+                visit_expr(condition, facts);
+                visit_stmts(then_branch, facts);
+                if let Some(else_branch) = else_branch {
+                    visit_stmts(else_branch, facts);
+                }
+            }
+            Stmt::While { condition, body } | Stmt::DoWhile { body, condition } => {
+                visit_expr(condition, facts);
+                visit_stmts(body, facts);
+            }
+            Stmt::For {
+                init,
+                condition,
+                update,
+                body,
+            } => {
+                if let Some(init) = init {
+                    visit_stmt(init, facts);
+                }
+                if let Some(condition) = condition {
+                    visit_expr(condition, facts);
+                }
+                if let Some(update) = update {
+                    visit_expr(update, facts);
+                }
+                visit_stmts(body, facts);
+            }
+            Stmt::Try {
+                body,
+                catch,
+                finally,
+            } => {
+                visit_stmts(body, facts);
+                if let Some(catch) = catch {
+                    visit_stmts(&catch.body, facts);
+                }
+                if let Some(finally) = finally {
+                    visit_stmts(finally, facts);
+                }
+            }
+            Stmt::Switch {
+                discriminant,
+                cases,
+            } => {
+                visit_expr(discriminant, facts);
+                for case in cases {
+                    if let Some(test) = &case.test {
+                        visit_expr(test, facts);
+                    }
+                    visit_stmts(&case.body, facts);
+                }
+            }
+            Stmt::Labeled { body, .. } => visit_stmt(body, facts),
+            Stmt::Return(None)
+            | Stmt::Break
+            | Stmt::Continue
+            | Stmt::LabeledBreak(_)
+            | Stmt::LabeledContinue(_)
+            | Stmt::PreallocateBoxes(_)
+            | Stmt::PreallocateTdzBoxes(_)
+            | Stmt::ReleaseBoxes(_) => {}
+        }
+    }
+
+    fn visit_stmts(stmts: &[Stmt], facts: &mut ModulePrototypeFacts) {
+        for stmt in stmts {
+            visit_stmt(stmt, facts);
+        }
+    }
+
+    fn visit_function(function: &perry_hir::Function, facts: &mut ModulePrototypeFacts) {
+        for param in &function.params {
+            if let Some(default) = &param.default {
+                visit_expr(default, facts);
+            }
+        }
+        visit_stmts(&function.body, facts);
+    }
+
+    let mut facts = ModulePrototypeFacts::default();
+    visit_stmts(&module.init, &mut facts);
+    for function in &module.functions {
+        visit_function(function, &mut facts);
+    }
+    for class in &module.classes {
+        if let Some(extends) = &class.extends_expr {
+            visit_expr(extends, &mut facts);
+        }
+        if let Some(constructor) = &class.constructor {
+            visit_function(constructor, &mut facts);
+        }
+        for method in class
+            .methods
+            .iter()
+            .chain(class.static_methods.iter())
+            .chain(class.getters.iter().map(|(_, function)| function))
+            .chain(class.setters.iter().map(|(_, function)| function))
+            .chain(class.computed_members.iter().map(|member| &member.function))
+        {
+            visit_function(method, &mut facts);
+        }
+        for field in class.fields.iter().chain(class.static_fields.iter()) {
+            if let Some(init) = &field.init {
+                visit_expr(init, &mut facts);
+            }
+            if let Some(key) = &field.key_expr {
+                visit_expr(key, &mut facts);
+            }
+        }
+        for member in &class.computed_members {
+            visit_expr(&member.key_expr, &mut facts);
+        }
+    }
+    facts
 }
 
 pub fn intersect_exact_receiver_facts(

--- a/crates/perry-transform/src/inline/mod.rs
+++ b/crates/perry-transform/src/inline/mod.rs
@@ -40,8 +40,8 @@ pub(crate) use closure_analysis::{
 };
 pub(crate) use exact_receivers::{
     apply_exact_receiver_stmt_effect, apply_exact_receiver_stmt_effects,
-    intersect_exact_receiver_facts, invalidate_exact_receivers_for_expr,
-    kill_referenced_exact_receivers,
+    collect_module_prototype_facts, intersect_exact_receiver_facts,
+    invalidate_exact_receivers_for_expr, kill_referenced_exact_receivers,
 };
 pub(crate) use factory_specialize::specialize_captured_class_factories;
 pub(crate) use imul::{detect_math_imul_polyfill, rewrite_imul_calls_in_stmts};
@@ -557,6 +557,10 @@ fn inline_functions_inner(
     // class regardless of native_extends), so it lives at the top of
     // the loop body before the native_extends short-circuit for method
     // collection.
+    // A fresh exact receiver still observes later prototype replacement. The
+    // receiver proof used by the call inliner therefore needs an independent,
+    // module-wide stable-method-table proof (#9239).
+    let prototype_facts = collect_module_prototype_facts(module);
     let mut method_candidates: HashMap<(String, String), MethodCandidate> = HashMap::new();
     let mut class_names: HashMap<String, String> = HashMap::new();
     // (class_name, field_name) → field's class type (when the field is
@@ -604,6 +608,9 @@ fn inline_functions_inner(
     // `import_function_prefixes`.
     let mut needed_imports: BTreeMap<String, Vec<String>> = BTreeMap::new();
     method_candidates.extend(extra_methods.iter().filter_map(|(k, v)| {
+        if !prototype_facts.method_table_is_stable(&module.classes, &k.0) {
+            return None;
+        }
         // If any required (name, path) is missing from dest, queue an import.
         // We always admit when the path is reachable from the destination —
         // if dest has no import that resolves to that path, we synthesize
@@ -681,7 +688,9 @@ fn inline_functions_inner(
         // EventEmitter) — the `this` reference needs special handling
         // in those contexts. The class_name lookup above still records
         // the type so other passes can reference it.
-        if class.native_extends.is_some() {
+        if class.native_extends.is_some()
+            || !prototype_facts.method_table_is_stable(&module.classes, &class.name)
+        {
             continue;
         }
         for method in &class.methods {
@@ -912,6 +921,30 @@ mod tests {
             byte_offset: 0,
             cap_args_appended: 0,
         })
+    }
+
+    #[test]
+    fn prototype_mutation_facts_are_module_wide_and_class_specific() {
+        let base = anon_class(1, "Base");
+        let mut derived = anon_class(2, "Derived");
+        derived.extends_name = Some("Base".to_string());
+        let unrelated = anon_class(3, "Unrelated");
+
+        let mut module = Module::new("prototype-facts");
+        module.classes = vec![base, derived, unrelated];
+        module.functions.push(function(
+            10,
+            vec![Stmt::Expr(Expr::RegisterPrototypeMethod {
+                class_name: "Base".to_string(),
+                method_name: "m".to_string(),
+                value: Box::new(Expr::Integer(1)),
+            })],
+        ));
+
+        let facts = collect_module_prototype_facts(&module);
+        assert!(!facts.method_table_is_stable(&module.classes, "Base"));
+        assert!(!facts.method_table_is_stable(&module.classes, "Derived"));
+        assert!(facts.method_table_is_stable(&module.classes, "Unrelated"));
     }
 
     #[test]

--- a/crates/perry/tests/issue_9131_prototype_method_replacement.rs
+++ b/crates/perry/tests/issue_9131_prototype_method_replacement.rs
@@ -102,6 +102,49 @@ console.log("swap-after:", readA(a));
     );
 }
 
+/// #9239: constructing another exact receiver after replacing a prototype
+/// method must not let the HIR inliner substitute the declaration-time body.
+/// Keep both a stored fresh receiver and a dynamic-constructor call here: the
+/// direct `new C().m()` shape already stays on runtime dispatch and would not
+/// catch a stale exact-receiver optimization fact.
+#[test]
+fn fresh_instances_observe_replaced_prototype_methods() {
+    let stdout = compile_and_run(
+        r#"
+class C {
+  m() { return "orig"; }
+}
+
+const old = new C();
+console.log("before:", old.m());
+(C.prototype as any).m = function () { return "replaced"; };
+console.log("old:", old.m());
+
+const fresh = new C();
+console.log("fresh:", fresh.m());
+console.log("direct:", new C().m());
+
+const DynamicC: any = C;
+console.log("dynamic:", new DynamicC().m());
+
+class HelperC {
+  m() { return "helper-orig"; }
+}
+function replaceThroughHelper() {
+  (HelperC.prototype as any).m = function () { return "helper-replaced"; };
+}
+replaceThroughHelper();
+const helperFresh = new HelperC();
+console.log("helper:", helperFresh.m());
+"#,
+    );
+
+    assert_eq!(
+        stdout,
+        "before: orig\nold: replaced\nfresh: replaced\ndirect: replaced\ndynamic: replaced\nhelper: helper-replaced\n"
+    );
+}
+
 /// #9244: the per-instance prototype-override fast path in
 /// `js_native_call_method` resolves the method by ordinary property lookup.
 /// Before #9251, a runtime-wired generator carried the shared override flag but

--- a/test-files/test_gap_9239_fresh_instance_prototype_replacement.ts
+++ b/test-files/test_gap_9239_fresh_instance_prototype_replacement.ts
@@ -1,0 +1,28 @@
+// #9239: a class prototype replacement applies to existing and fresh
+// instances. The stored fresh receiver is important: it exercises Perry's
+// exact-receiver method inliner instead of only the runtime dispatch path.
+class C {
+  m() { return "orig"; }
+}
+
+const old = new C();
+console.log("before:", old.m());
+(C.prototype as any).m = function () { return "replaced"; };
+console.log("old:", old.m());
+
+const fresh = new C();
+console.log("fresh:", fresh.m());
+console.log("direct:", new C().m());
+
+const DynamicC: any = C;
+console.log("dynamic:", new DynamicC().m());
+
+class HelperC {
+  m() { return "helper-orig"; }
+}
+function replaceThroughHelper() {
+  (HelperC.prototype as any).m = function () { return "helper-replaced"; };
+}
+replaceThroughHelper();
+const helperFresh = new HelperC();
+console.log("helper:", helperFresh.m());

--- a/test-files/test_gap_9347_uint8array_extensibility.ts
+++ b/test-files/test_gap_9347_uint8array_extensibility.ts
@@ -1,0 +1,47 @@
+// A BufferHeader-backed Uint8Array misses lookup_typed_array_kind. Its
+// extensibility state must use the same TypedArray side table as every other
+// kind, or Object/Reflect report true and allow new properties after a
+// successful preventExtensions call.
+function inspectReflect(label: string, value: Uint8Array | Int32Array): void {
+  (value as any).existing = 1;
+  console.log(
+    label,
+    "create",
+    Reflect.set(value, "created", 7),
+    (value as any).created,
+    Object.prototype.hasOwnProperty.call(value, "created"),
+  );
+  console.log(label, "before", Object.isExtensible(value), Reflect.isExtensible(value));
+  console.log(label, "prevent", Reflect.preventExtensions(value));
+  console.log(label, "after", Object.isExtensible(value), Reflect.isExtensible(value));
+  console.log(
+    label,
+    "set",
+    Reflect.set(value, "existing", 2),
+    (value as any).existing,
+    Reflect.set(value, "fresh", 3),
+    Object.prototype.hasOwnProperty.call(value, "fresh"),
+  );
+  console.log(
+    label,
+    "define",
+    Reflect.defineProperty(value, "late", { value: 4 }),
+    Object.prototype.hasOwnProperty.call(value, "late"),
+  );
+}
+
+function inspectObject(label: string, value: Uint8Array | Int32Array): void {
+  Object.preventExtensions(value);
+  console.log(
+    label,
+    Object.isExtensible(value),
+    Reflect.isExtensible(value),
+    Reflect.set(value, "fresh", 3),
+    Object.prototype.hasOwnProperty.call(value, "fresh"),
+  );
+}
+
+inspectReflect("reflect-u8", new Uint8Array(2));
+inspectReflect("reflect-i32", new Int32Array(2));
+inspectObject("object-u8", new Uint8Array(2));
+inspectObject("object-i32", new Int32Array(2));

--- a/test-files/test_gap_9347_uint8array_reflected_accessors.ts
+++ b/test-files/test_gap_9347_uint8array_reflected_accessors.ts
@@ -1,0 +1,44 @@
+import { Buffer } from "node:buffer";
+
+// Uint8Array and Buffer use Perry's BufferHeader representation and never
+// enter lookup_typed_array_kind. The intrinsic %TypedArray%.prototype getters
+// must nevertheless accept them, just as they accept TypedArrayHeader kinds.
+const typedArrayPrototype = Object.getPrototypeOf(Uint8Array.prototype);
+const names = ["length", "byteLength", "byteOffset", "buffer"] as const;
+const getters: Record<string, Function> = {};
+for (const name of names) {
+  getters[name] = Object.getOwnPropertyDescriptor(typedArrayPrototype, name)!.get!;
+}
+
+function inspect(label: string, value: Uint8Array | Int32Array): void {
+  const length = getters.length.call(value);
+  const byteLength = getters.byteLength.call(value);
+  const byteOffset = getters.byteOffset.call(value);
+  const firstBuffer = getters.buffer.call(value);
+  const secondBuffer = getters.buffer.call(value);
+  console.log(
+    label,
+    "length", length === value.length,
+    "byteLength", byteLength === value.byteLength,
+    "byteOffset", byteOffset === value.byteOffset,
+    "buffer", firstBuffer === value.buffer,
+    "stable", firstBuffer === secondBuffer,
+  );
+}
+
+const backing = new ArrayBuffer(24);
+inspect("u8-own", new Uint8Array([1, 2, 3]));
+inspect("u8-view", new Uint8Array(backing, 3, 5));
+inspect("i32-view", new Int32Array(backing, 4, 2));
+inspect("buffer", Buffer.from([4, 5, 6]));
+
+const brandErrors: string[] = [];
+for (const name of names) {
+  try {
+    getters[name].call({});
+    brandErrors.push("none");
+  } catch (error) {
+    brandErrors.push((error as Error).name);
+  }
+}
+console.log("plain-object", brandErrors.join(","));


### PR DESCRIPTION
Merge train: **#9704, #9710**. Cherry-picked onto one branch, validated once as a tree, rebase-merged so each commit keeps its author.

**#9704 — the exact-receiver inliner ignored prototype replacement (#9239).** It substituted a declared method body even when the prototype had been monkey-patched at run time, so the replacement was never observed. Admission now requires a module-wide stable prototype-chain proof, and only the touched classes and their descendants lose inlining.

What makes this one sound is the direction it fails in. An unrecognized prototype *holder* sets `opaque_prototype_access = true`; the child walk runs unconditionally after the match, so the bare `_ => {}` means "this node isn't an access" rather than "stop descending"; `walk_expr_children` is an exhaustive match, so a new `Expr` variant breaks the build instead of silently escaping the proof; and `visit_stmt` enumerates its no-op variants rather than using a catch-all. Closure bodies get an explicit visit because the shared walker deliberately doesn't descend them (per the 2026-07-02 audit note in `deforest/walk.rs`) — that one is load-bearing, not incidental.

**#9710 — buffer-backed `Uint8Array` misses (#9347).** The intrinsic `length` / `byteLength` / `byteOffset` / `buffer` getters threw `TypeError` on a `Uint8Array` receiver, Node-API reported it as not a typed array, and `preventExtensions` / `Reflect.set` either reported stale extensibility or lost ordinary-property writes. `Int32Array` was already correct. Both GC-holder gates confirm its address-keyed `TYPED_ARRAY_OWN_PROPS` state is already classified, and the PR adds `gc/tests/buffer_side_tables.rs` covering prune-on-death.

## Validation

64/64 lint gates; release build; `perry-runtime`, `perry-stdlib`, `perry-transform` (all `RUST_TEST_THREADS=1`), and `issue_9131_prototype_method_replacement` — all green.

A first gate run reported `cargo clippy --workspace` red; it did not reproduce. The gate's exact command with all 18 exclude args exits 0, and the warnings it printed were in `perry-ext-ads` / `perry-ext-events`, which neither PR touches. The full 64 were re-run clean rather than waiving it on one gate's say-so.

## Not in this train

**#9705** was pulled after audit — its borrowing `_static` registration spelling is unsound for plugin dylibs, which `perry_plugin_unload` `dlclose`s while the registries still borrow their rodata. Fix written and landing separately.
