### PR TITLE
fix(hir): preserve nested object callback methods (#9701)

### DIFF
--- a/changelog.d/9701-nested-object-array-method.md
+++ b/changelog.d/9701-nested-object-array-method.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Nested object methods such as React's `Children.map` now preserve their own
+  dispatch instead of being mistaken for `Array.prototype` calls (#9701).

--- a/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
@@ -630,6 +630,50 @@ pub(super) fn try_array_only_methods(
                     || chain_roots_at_stream(ctx, member_obj)
                     || chain_roots_at_builtin_iterator(ctx, member_obj)
                     || is_util_mime_params_receiver(ctx, member_obj);
+                // #9701: a nested property receiver is not evidence of an
+                // Array. React exposes `Children.map(children, callback)` on a
+                // plain-object facade; treating that call as
+                // `Array.prototype.map(callback, thisArg)` made `children` the
+                // callback and failed with "object is not a function" before
+                // React's own method was entered. The same ambiguity applies
+                // to the other callback/comparator-taking Array names below.
+                //
+                // Defer unknown property receivers to shape-aware dynamic
+                // dispatch, which still selects the dense helper for a real
+                // Array and preserves an object's own method. Statically typed
+                // Array fields keep the specialized HIR path.
+                let nested_callback_receiver_is_ambiguous =
+                    matches!(member_obj, ast::Expr::Member(_))
+                        && matches!(
+                            method_name,
+                            "map"
+                                | "filter"
+                                | "forEach"
+                                | "find"
+                                | "findIndex"
+                                | "findLast"
+                                | "findLastIndex"
+                                | "some"
+                                | "every"
+                                | "reduce"
+                                | "reduceRight"
+                                | "sort"
+                                | "toSorted"
+                        )
+                        && {
+                            let recv_ty =
+                                crate::lower_types::infer_type_from_expr(&member.obj, ctx);
+                            !matches!(recv_ty, Type::Array(_) | Type::Tuple(_))
+                                && !matches!(
+                                    &recv_ty,
+                                    Type::Generic { base, .. }
+                                        if base == "Array" || base == "ReadonlyArray"
+                                )
+                                && !chain_roots_at_array(ctx, &member.obj)
+                        };
+                if nested_callback_receiver_is_ambiguous {
+                    return Ok(Err(args));
+                }
                 // `entries` / `keys` / `values` are not Array-only names.
                 // Maps, Sets, iterator-like facades, and ordinary user objects
                 // can all provide them. In particular, OpenCode's

--- a/crates/perry-hir/src/lower/expr_call/array_only_methods_tests.rs
+++ b/crates/perry-hir/src/lower/expr_call/array_only_methods_tests.rs
@@ -1,0 +1,81 @@
+//! Verdict tests for array-method lowering on nested property receivers.
+
+#![cfg(test)]
+
+use crate::Module;
+use perry_diagnostics::SourceCache;
+
+fn lower(src: &str) -> Module {
+    let src = src.to_string();
+    std::thread::Builder::new()
+        .stack_size(32 * 1024 * 1024)
+        .spawn(move || {
+            let mut cache = SourceCache::new();
+            let parsed = perry_parser::parse_typescript_with_cache(
+                &src,
+                "nested_array_method.ts",
+                &mut cache,
+            )
+            .expect("parse should succeed");
+            crate::lower_module(&parsed.module, "test", "nested_array_method.ts")
+                .expect("lower should succeed")
+        })
+        .expect("spawn lower thread")
+        .join()
+        .expect("lower thread panicked")
+}
+
+#[test]
+fn nested_object_map_with_two_args_uses_own_method() {
+    let hir = format!(
+        "{:?}",
+        lower(
+            r#"
+            function render(children: any[], callback: (value: any) => any) {
+                const react = {
+                    default: {
+                        Children: {
+                            map(items: any[], fn: (value: any) => any) {
+                                return items.map(fn);
+                            },
+                        },
+                    },
+                };
+                return react.default.Children.map(children, callback);
+            }
+            "#,
+        )
+    );
+
+    assert!(
+        !hir.contains("ArrayLikeMethod"),
+        "an object's own map method was lowered as Array.prototype.map: {hir}"
+    );
+    assert_eq!(
+        hir.matches("ArrayMap").count(),
+        1,
+        "only map() inside the facade implementation is an Array map: {hir}"
+    );
+}
+
+#[test]
+fn typed_nested_array_field_keeps_array_map_specialization() {
+    let hir = format!(
+        "{:?}",
+        lower(
+            r#"
+            class Box {
+                items: number[] = [1, 2];
+                run() {
+                    return this.items.map((value) => value * 2);
+                }
+            }
+            "#,
+        )
+    );
+
+    assert!(
+        hir.contains("ArrayMap"),
+        "a statically typed Array field should retain the dense fast path: {hir}"
+    );
+}

--- a/crates/perry-hir/src/lower/expr_call/mod.rs
+++ b/crates/perry-hir/src/lower/expr_call/mod.rs
@@ -53,6 +53,8 @@ fn typed_array_lacks_array_method(name: &str) -> bool {
 }
 
 mod array_only_methods;
+#[cfg(test)]
+mod array_only_methods_tests;
 mod crypto;
 mod globals;
 mod imported_array_methods;

--- a/crates/perry/tests/issue_9701_nested_object_map.rs
+++ b/crates/perry/tests/issue_9701_nested_object_map.rs
@@ -1,0 +1,55 @@
+//! Regression for #9701: React's nested `Children.map` facade must dispatch
+//! its own method instead of being lowered as `Array.prototype.map`.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonicalize workspace root")
+}
+
+#[test]
+fn nested_object_map_receives_its_declared_arguments() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = workspace_root().join("test-files/test_issue_9701_nested_object_map.ts");
+    let output = dir.path().join("main_bin");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-cache")
+        .arg("--no-auto-optimize")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .output()
+        .expect("run compiled fixture");
+    assert!(
+        run.status.success(),
+        "compiled fixture failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "custom-map-entered\n3,6\n8,10\n"
+    );
+}

--- a/test-files/test_issue_9701_nested_object_map.ts
+++ b/test-files/test_issue_9701_nested_object_map.ts
@@ -1,0 +1,26 @@
+function mapChildren(
+  children: number[],
+  callback: (value: number) => number,
+): number[] {
+  console.log("custom-map-entered");
+  return children.map(callback);
+}
+
+const react: any = {
+  default: {
+    Children: {
+      map: mapChildren,
+    },
+  },
+};
+
+const result = react.default.Children.map(
+  [1, 2],
+  (value: number) => value * 3,
+);
+console.log(result.join(","));
+
+// Dynamic dispatch must still recognize a real Array behind an untyped
+// property receiver.
+const holder: any = { values: [4, 5] };
+console.log(holder.values.map((value: number) => value * 2).join(","));


### PR DESCRIPTION
## Summary

- defer callback/comparator Array fast paths when a nested property receiver is
  not proven to be an Array
- retain dense Array HIR for statically typed nested Array fields
- add lowering-verdict and executable parity regressions for the reported
  React `Children.map(children, callback)` shape

## Root cause

The failing `Lw5` frame calls `qC.default.Children.map(children, callback)`.
The arbitrary-expression Array lowering selected `ArrayLikeMethod` from the
method name and two-argument shape alone. It therefore interpreted `children`
as the Array callback and threw `object is not a function` before React's own
method was entered.

Unknown nested property receivers now fall through to shape-aware dynamic
dispatch. Real Arrays still select the runtime Array implementation, while
plain objects retain their own methods. This is a deterministic dispatch bug,
not a Yoga or GC failure.

PR #9700's prerequisite promise fix has landed on `main` through merge train
#9711; this branch is rebased on that result.

## Validation

All compilation and runtime checks below ran on `perrymaster.skelpo.net`:

- `cargo build --release -j4 -p perry -p perry-runtime-static -p perry-stdlib-static`
- `cargo test --release -p perry-hir --lib` (382 passed, 1 ignored)
- `cargo test --release -p perry --test issue_9701_nested_object_map -- --nocapture`
- pre-fix executable regression: `TypeError: object is not a function`
- patched Perry output matches Node: `custom-map-entered`, `3,6`, `8,10`
- compiled the full cc 2.1.112 bundle and completed onboarding from a fresh HOME
  through theme selection and REPL entry (`VERDICT: PASS`)
- repeated the full fresh-HOME onboarding run with
  `PERRY_GC_PROTECT_FROMSPACE=1` (`VERDICT: PASS`)
- `cargo fmt --all -- --check`
- `./scripts/check_file_size.sh`
- `python3 scripts/check_test_registration.py`
- `git diff --check`

No version metadata was changed.

Closes #9701.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed method dispatch for nested object properties with names shared by array methods, such as `map`, `filter`, and `reduce`.
  - Calls like React’s `Children.map` now correctly use the object’s own implementation instead of being treated as array operations.
  - Preserved optimized array behavior when the receiver is known to be an array.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
