### PR TITLE
fix(transform): unwind a labeled escape out of nested loops

### DIFF
--- a/changelog.d/9730-labeled-escape-nested-loops.md
+++ b/changelog.d/9730-labeled-escape-nested-loops.md
@@ -1,0 +1,51 @@
+**A labeled `break`/`continue` that targets an outer loop from inside a nested
+loop now works in generators, async generators and async functions** (#9199).
+It previously threw `TypeError: Cannot read properties of undefined (reading
+'done')` for `break`, and silently produced nothing for `continue`.
+
+```ts
+async function* g() {
+  O: for (const x of [1, 2]) { I: for (const y of [0, 1]) { yield "b" + x + y; break O; } }
+}
+// node: b10        before: TypeError … reading 'done'
+```
+
+Generator linearization gives each loop a single `break` sentinel and a single
+`continue` sentinel, so a completion can only name the loop it sits in.
+`rewrite_labeled_bc_in_stmts` therefore converted `break label` / `continue
+label` to plain completions **only at the labeled loop's own body level** and
+stopped at nested loops — correctly, since a plain completion inside a nested
+loop would bind to that loop. What was missing is what happens to the escape
+that is left: it survived verbatim into a state body, where the dispatch
+lowering has no sentinel for it and dropped it. The limitation was noted in the
+code ("the single-sentinel scheme can't yet distinguish targets").
+
+Rather than teach the state machine to name a distant target, the escape is now
+unwound one loop at a time through a carrier local, so every completion the
+linearizer sees is plain and binds to the loop it is in:
+
+```
+__esc = 0;
+inner: while (…) { … __esc = 1; break; … }   // was `break label`
+if (__esc == 1) break;                        // in the labeled loop
+if (__esc == 2) continue;
+```
+
+Deeper nesting reuses the same carrier and propagates outward with a bare
+`if (__esc != 0) break;` after each intermediate loop. A `switch` that carries
+an escape is desugared to `if`s first, since a plain `break` inside a switch
+would bind to the switch.
+
+The hole was wider than the issue's own repro, which #9189 had already closed:
+it reached sync generators and async functions as well as async generators,
+and the `switch` in the report was incidental — a bare `break outer` in a
+nested loop failed on its own, while the switch-wrapped form worked because
+#9186's routing already handled it.
+
+`test-files/test_gap_9199_labeled_escape_nested_loops.ts` pins 13 shapes:
+`break`/`continue` of an outer label from a nested loop in all three function
+kinds, three-deep nesting, a `while` outer, an `await` before the escape, a
+conditional escape, `try`/`finally` around it (finalizers still run in order),
+a reused label name on a sibling loop, and the switch-wrapped form that already
+worked. Unpatched the fixture throws on its first row and then hangs; patched
+it is byte-identical to node 26.5.1.

--- a/crates/perry-transform/src/generator/break_continue.rs
+++ b/crates/perry-transform/src/generator/break_continue.rs
@@ -817,3 +817,288 @@ pub fn stmts_have_continue_inside_try_finally(stmts: &[Stmt]) -> bool {
         _ => false,
     })
 }
+
+// ── #9199: labeled break/continue that escapes a NESTED loop ──────────────
+//
+// `rewrite_labeled_bc_in_stmts` converts `break label` / `continue label` to
+// plain completions only at the labeled loop's OWN body level, and stops at
+// nested loops (a plain completion there would bind to the nested loop). The
+// linearizer's single break/continue sentinel per loop then has no way to name
+// an outer loop's target, so a labeled completion crossing a loop boundary
+// survived verbatim into a state body and the dispatch lowering dropped it:
+// `break` produced a malformed iterator result ("Cannot read properties of
+// undefined (reading 'done')"), `continue` silently produced nothing at all.
+//
+// The fix is to stop asking the state machine to name a distant target. A
+// carrier local unwinds the escape one loop at a time, so every completion the
+// linearizer sees is plain and binds to the loop it sits in:
+//
+//     __esc = 0;
+//     inner: while (…) { … __esc = 1; break; … }   // `break label`
+//     if (__esc == 1) break;                        // in the labeled loop
+//     if (__esc == 2) continue;
+//
+// Deeper nesting reuses the same carrier and propagates with a bare
+// `if (__esc != 0) break;` after each intermediate loop, so an escape from any
+// depth walks out to the labeled loop without the linearizer ever seeing a
+// labeled completion.
+
+/// Carrier value for a `break <label>` in flight.
+const ESCAPE_BREAK: f64 = 1.0;
+/// Carrier value for a `continue <label>` in flight.
+const ESCAPE_CONTINUE: f64 = 2.0;
+
+fn escape_set(carrier: LocalId, value: f64) -> Stmt {
+    Stmt::Expr(Expr::LocalSet(carrier, Box::new(Expr::Number(value))))
+}
+
+fn escape_is(carrier: LocalId, op: CompareOp, value: f64) -> Expr {
+    Expr::Compare {
+        op,
+        left: Box::new(Expr::LocalGet(carrier)),
+        right: Box::new(Expr::Number(value)),
+    }
+}
+
+fn is_loop_stmt(s: &Stmt) -> bool {
+    match s {
+        Stmt::While { .. } | Stmt::DoWhile { .. } | Stmt::For { .. } => true,
+        Stmt::Labeled { body, .. } => is_loop_stmt(body),
+        _ => false,
+    }
+}
+
+/// The body statements of a loop-shaped statement, seeing through `Labeled`.
+fn loop_body_mut(s: &mut Stmt) -> Option<&mut Vec<Stmt>> {
+    match s {
+        Stmt::While { body, .. } | Stmt::DoWhile { body, .. } | Stmt::For { body, .. } => {
+            Some(body)
+        }
+        Stmt::Labeled { body, .. } => loop_body_mut(body),
+        _ => None,
+    }
+}
+
+/// Whether `stmts` can reach `break label` / `continue label` at any depth,
+/// including through nested loops — the question "does anything in here escape
+/// to `label`", not "does it escape without crossing a loop".
+pub fn stmts_can_escape_to_label(stmts: &[Stmt], label: &str) -> bool {
+    stmts.iter().any(|s| stmt_can_escape_to_label(s, label))
+}
+
+fn stmt_can_escape_to_label(s: &Stmt, label: &str) -> bool {
+    match s {
+        Stmt::LabeledBreak(l) | Stmt::LabeledContinue(l) => l == label,
+        Stmt::If {
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            stmts_can_escape_to_label(then_branch, label)
+                || else_branch
+                    .as_ref()
+                    .is_some_and(|eb| stmts_can_escape_to_label(eb, label))
+        }
+        Stmt::Try {
+            body,
+            catch,
+            finally,
+        } => {
+            stmts_can_escape_to_label(body, label)
+                || catch
+                    .as_ref()
+                    .is_some_and(|c| stmts_can_escape_to_label(&c.body, label))
+                || finally
+                    .as_ref()
+                    .is_some_and(|f| stmts_can_escape_to_label(f, label))
+        }
+        Stmt::Switch { cases, .. } => cases
+            .iter()
+            .any(|c| stmts_can_escape_to_label(&c.body, label)),
+        Stmt::While { body, .. } | Stmt::DoWhile { body, .. } | Stmt::For { body, .. } => {
+            stmts_can_escape_to_label(body, label)
+        }
+        // A nested statement that re-declares the same label shadows it, so
+        // completions inside it target the inner one, not ours.
+        Stmt::Labeled { label: l, body } => l != label && stmt_can_escape_to_label(body, label),
+        _ => false,
+    }
+}
+
+/// At a labeled loop's own body level: replace every nested loop that can
+/// escape to `label` with `carrier = 0; <loop>; if (carrier == 1) break;
+/// if (carrier == 2) continue;`, having rewritten the escape inside the loop
+/// into carrier writes plus plain completions.
+///
+/// Only nested loops are touched. Same-level `break label` / `continue label`
+/// stay for [`super::linearize::rewrite_labeled_bc_in_stmts`], which maps them
+/// to plain completions directly — no carrier needed there.
+pub fn desugar_labeled_escape_across_nested_loops(
+    stmts: &mut Vec<Stmt>,
+    label: &str,
+    next_local_id: &mut u32,
+) {
+    let mut i = 0;
+    while i < stmts.len() {
+        // Non-loop containers do not capture a completion: recurse and move on.
+        match &mut stmts[i] {
+            Stmt::If {
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                desugar_labeled_escape_across_nested_loops(then_branch, label, next_local_id);
+                if let Some(eb) = else_branch.as_mut() {
+                    desugar_labeled_escape_across_nested_loops(eb, label, next_local_id);
+                }
+                i += 1;
+                continue;
+            }
+            Stmt::Try {
+                body,
+                catch,
+                finally,
+            } => {
+                desugar_labeled_escape_across_nested_loops(body, label, next_local_id);
+                if let Some(c) = catch.as_mut() {
+                    desugar_labeled_escape_across_nested_loops(&mut c.body, label, next_local_id);
+                }
+                if let Some(f) = finally.as_mut() {
+                    desugar_labeled_escape_across_nested_loops(f, label, next_local_id);
+                }
+                i += 1;
+                continue;
+            }
+            Stmt::Switch { cases, .. } => {
+                for case in cases.iter_mut() {
+                    desugar_labeled_escape_across_nested_loops(
+                        &mut case.body,
+                        label,
+                        next_local_id,
+                    );
+                }
+                i += 1;
+                continue;
+            }
+            _ => {}
+        }
+
+        if !is_loop_stmt(&stmts[i]) || !stmt_can_escape_to_label(&stmts[i], label) {
+            i += 1;
+            continue;
+        }
+
+        let carrier = alloc_local(next_local_id);
+        if let Some(body) = loop_body_mut(&mut stmts[i]) {
+            rewrite_escape_in_stmts(body, label, carrier, next_local_id);
+        }
+        let nested = stmts[i].clone();
+        let replacement = vec![
+            escape_set(carrier, 0.0),
+            nested,
+            Stmt::If {
+                condition: escape_is(carrier, CompareOp::Eq, ESCAPE_BREAK),
+                then_branch: vec![Stmt::Break],
+                else_branch: None,
+            },
+            Stmt::If {
+                condition: escape_is(carrier, CompareOp::Eq, ESCAPE_CONTINUE),
+                then_branch: vec![Stmt::Continue],
+                else_branch: None,
+            },
+        ];
+        let advance = replacement.len();
+        stmts.splice(i..=i, replacement);
+        i += advance;
+    }
+}
+
+/// Inside a nested loop: turn `break label` / `continue label` into a carrier
+/// write plus a plain `break` out of THIS loop, and make a deeper loop's escape
+/// propagate outward the same way.
+fn rewrite_escape_in_stmts(
+    stmts: &mut Vec<Stmt>,
+    label: &str,
+    carrier: LocalId,
+    next_local_id: &mut u32,
+) {
+    let mut i = 0;
+    while i < stmts.len() {
+        // A plain `break` inside a switch binds to the switch, so a switch that
+        // carries an escape has to become `if`s before the rewrite below can
+        // use one. (`continue` is never captured by a switch, so a switch that
+        // only carries `continue label` needs no desugaring.)
+        let desugared = match &stmts[i] {
+            Stmt::Switch {
+                discriminant,
+                cases,
+            } if cases
+                .iter()
+                .any(|c| stmts_can_escape_to_label(&c.body, label)) =>
+            {
+                Some(desugar_switch_to_ifs(discriminant, cases, next_local_id))
+            }
+            _ => None,
+        };
+        if let Some(desugared) = desugared {
+            stmts.splice(i..=i, desugared);
+            continue;
+        }
+
+        match &mut stmts[i] {
+            Stmt::LabeledBreak(l) if l == label => {
+                stmts.splice(i..=i, [escape_set(carrier, ESCAPE_BREAK), Stmt::Break]);
+                i += 2;
+                continue;
+            }
+            Stmt::LabeledContinue(l) if l == label => {
+                stmts.splice(i..=i, [escape_set(carrier, ESCAPE_CONTINUE), Stmt::Break]);
+                i += 2;
+                continue;
+            }
+            Stmt::If {
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                rewrite_escape_in_stmts(then_branch, label, carrier, next_local_id);
+                if let Some(eb) = else_branch.as_mut() {
+                    rewrite_escape_in_stmts(eb, label, carrier, next_local_id);
+                }
+            }
+            Stmt::Try {
+                body,
+                catch,
+                finally,
+            } => {
+                rewrite_escape_in_stmts(body, label, carrier, next_local_id);
+                if let Some(c) = catch.as_mut() {
+                    rewrite_escape_in_stmts(&mut c.body, label, carrier, next_local_id);
+                }
+                if let Some(f) = finally.as_mut() {
+                    rewrite_escape_in_stmts(f, label, carrier, next_local_id);
+                }
+            }
+            _ => {
+                if is_loop_stmt(&stmts[i]) && stmt_can_escape_to_label(&stmts[i], label) {
+                    if let Some(body) = loop_body_mut(&mut stmts[i]) {
+                        rewrite_escape_in_stmts(body, label, carrier, next_local_id);
+                    }
+                    // Unwind one more level: the carrier is already set, so
+                    // leaving this loop is all that is left to do here.
+                    stmts.insert(
+                        i + 1,
+                        Stmt::If {
+                            condition: escape_is(carrier, CompareOp::Ne, 0.0),
+                            then_branch: vec![Stmt::Break],
+                            else_branch: None,
+                        },
+                    );
+                    i += 2;
+                    continue;
+                }
+            }
+        }
+        i += 1;
+    }
+}

--- a/crates/perry-transform/src/generator/linearize.rs
+++ b/crates/perry-transform/src/generator/linearize.rs
@@ -1585,16 +1585,23 @@ pub fn linearize_body(
             // catch-all and was emitted unsplit). `break label` / `continue
             // label` that target this loop from its own body level are first
             // rewritten to plain break/continue, which the loop's own
-            // linearization then maps to its state targets. (Labeled
-            // break/continue from a *nested* loop is left unconverted — the
-            // single-sentinel scheme can't yet distinguish targets; this was
-            // already unsupported before this arm existed, so no regression.)
+            // linearization then maps to its state targets. A labeled
+            // completion that escapes a *nested* loop cannot be rewritten that
+            // way — a plain completion there would bind to the nested loop —
+            // so it is unwound through a carrier local first (#9199), and the
+            // single break/continue sentinel per loop never has to name a
+            // distant target.
             Stmt::Labeled { label, body } if body_contains_yield(std::slice::from_ref(&**body)) => {
                 let mut inner = (**body).clone();
                 match &mut inner {
                     Stmt::For { body, .. }
                     | Stmt::While { body, .. }
                     | Stmt::DoWhile { body, .. } => {
+                        super::break_continue::desugar_labeled_escape_across_nested_loops(
+                            body,
+                            label,
+                            next_local_id,
+                        );
                         rewrite_labeled_bc_in_stmts(body, label, next_local_id);
                     }
                     // A statically-typed array `for...of` lowers to a runtime
@@ -1618,6 +1625,11 @@ pub fn linearize_body(
                     // into the done-flag (#5868).
                     Stmt::Switch { cases, .. } => {
                         for case in cases.iter_mut() {
+                            super::break_continue::desugar_labeled_escape_across_nested_loops(
+                                &mut case.body,
+                                label,
+                                next_local_id,
+                            );
                             rewrite_labeled_bc_in_stmts(&mut case.body, label, next_local_id);
                         }
                     }
@@ -1694,6 +1706,11 @@ fn rewrite_labeled_bc_in_lowered_for_of_arm(
     for stmt in stmts.iter_mut() {
         match stmt {
             Stmt::For { body, .. } | Stmt::While { body, .. } | Stmt::DoWhile { body, .. } => {
+                super::break_continue::desugar_labeled_escape_across_nested_loops(
+                    body,
+                    label,
+                    next_local_id,
+                );
                 rewrite_labeled_bc_in_stmts(body, label, next_local_id);
             }
             _ => {}

--- a/test-files/test_gap_9199_labeled_escape_nested_loops.ts
+++ b/test-files/test_gap_9199_labeled_escape_nested_loops.ts
@@ -1,0 +1,106 @@
+// #9199: a labeled `break`/`continue` that targets an OUTER loop from inside a
+// NESTED loop, in a function the generator linearizer rewrites (sync generator,
+// async generator, async function). The linearizer converted labeled
+// completions only at the labeled loop's own body level and stopped at nested
+// loops, so an escape that crossed a loop boundary survived into a state body
+// and the dispatch lowering dropped it: `break` produced a malformed iterator
+// result ("Cannot read properties of undefined (reading 'done')") and
+// `continue` silently produced nothing at all.
+//
+// Rows that already worked before the fix are kept: the switch-wrapped forms
+// took a different route (#9186/#9189) and must not regress.
+
+async function drain(label: string, mk: () => AsyncIterable<string>): Promise<void> {
+  const acc: string[] = [];
+  try {
+    for await (const v of mk()) acc.push(v);
+    console.log(label + ": " + acc.join(","));
+  } catch (e) {
+    console.log(label + ": THREW " + String((e as Error) && (e as Error).message));
+  }
+}
+function drainSync(label: string, it: Iterable<string>): void {
+  const acc: string[] = [];
+  try {
+    for (const v of it) acc.push(v);
+    console.log(label + ": " + acc.join(","));
+  } catch (e) {
+    console.log(label + ": THREW " + String((e as Error) && (e as Error).message));
+  }
+}
+
+// ── async generators ──────────────────────────────────────────────────────
+async function* agBreakOuter() {
+  O: for (const x of [1, 2]) { I: for (const y of [0, 1]) { yield "b" + x + y; break O; } }
+}
+async function* agContinueOuter() {
+  O: for (const x of [1, 2]) { I: for (const y of [0, 1]) { yield "c" + x + y; continue O; } }
+}
+async function* agBreakOuterAwait() {
+  O: for (const x of [1, 2]) { I: for (const y of [0, 1]) { await Promise.resolve(); yield "w" + x + y; break O; } }
+}
+async function* agThreeDeep() {
+  A: for (const x of [1, 2]) { B: for (const y of [0, 1]) { C: for (const z of [0, 1]) {
+    yield "t" + x + y + z; if (y === 1) break A; continue B; } } }
+}
+async function* agConditional() {
+  O: for (const x of [1, 2, 3]) { I: for (const y of [0, 1]) {
+    yield "n" + x + y; if (x === 2) break O; if (y === 1) continue O; } }
+}
+async function* agSwitchBreakOuter() {
+  O: for (const x of [1, 2]) { I: for (const y of [0, 1]) {
+    switch (x + y) { case 3: break O; case 1: yield "s" + x + y; break; default: break I; } } }
+}
+async function* agTryFinally() {
+  const seen: string[] = [];
+  O: for (const x of [1, 2]) { I: for (const y of [0, 1]) {
+    try { yield "f" + x + y; if (y === 0) continue O; break O; } finally { seen.push("fin" + x + y); } } }
+  yield "seen=" + seen.join("/");
+}
+// A sibling loop reusing a label name after the first one closed: legal, and
+// the escape must bind to the loop that is actually enclosing.
+async function* agReusedLabel() {
+  L: for (const x of [1, 2]) { I: for (const y of [0, 1]) { yield "h" + x + y; break L; } }
+  L: for (const x of [3, 4]) { I: for (const y of [0, 1]) { yield "h" + x + y; continue L; } }
+}
+async function* agWhileOuter() {
+  let i = 0;
+  O: while (i < 2) { i++; I: for (const y of [0, 1]) { yield "l" + i + y; continue O; } }
+}
+
+// ── sync generators ───────────────────────────────────────────────────────
+function* sgBreakOuter() {
+  O: for (const x of [1, 2]) { I: for (const y of [0, 1]) { yield "B" + x + y; break O; } }
+}
+function* sgContinueOuter() {
+  O: for (const x of [1, 2]) { I: for (const y of [0, 1]) { yield "C" + x + y; continue O; } }
+}
+
+// ── async functions ───────────────────────────────────────────────────────
+async function afBreakOuter(): Promise<string> {
+  const a: string[] = [];
+  O: for (const x of [1, 2]) { I: for (const y of [0, 1]) { await Promise.resolve(); a.push("F" + x + y); break O; } }
+  return a.join(",");
+}
+async function afContinueOuter(): Promise<string> {
+  const a: string[] = [];
+  O: for (const x of [1, 2]) { I: for (const y of [0, 1]) { await Promise.resolve(); a.push("G" + x + y); continue O; } }
+  return a.join(",");
+}
+
+(async () => {
+  await drain("ag-break-outer", agBreakOuter);
+  await drain("ag-continue-outer", agContinueOuter);
+  await drain("ag-break-outer-await", agBreakOuterAwait);
+  await drain("ag-three-deep", agThreeDeep);
+  await drain("ag-conditional", agConditional);
+  await drain("ag-switch-break-outer", agSwitchBreakOuter);
+  await drain("ag-try-finally", agTryFinally);
+  await drain("ag-reused-label", agReusedLabel);
+  await drain("ag-while-outer", agWhileOuter);
+  drainSync("sg-break-outer", sgBreakOuter());
+  drainSync("sg-continue-outer", sgContinueOuter());
+  console.log("af-break-outer: " + (await afBreakOuter()));
+  console.log("af-continue-outer: " + (await afContinueOuter()));
+  console.log("DONE");
+})();


### PR DESCRIPTION
Closes #9199.

A labeled `break`/`continue` that targets an **outer** loop from inside a **nested** loop threw or silently vanished in every function kind the generator linearizer rewrites.

```ts
async function* g() { O: for (const x of [1,2]) { I: for (const y of [0,1]) { yield "b"+x+y; break O; } } }
// node: b10        perry: TypeError: Cannot read properties of undefined (reading 'done')

async function* h() { O: for (const x of [1,2]) { I: for (const y of [0,1]) { yield "c"+x+y; continue O; } } }
// node: c10,c20    perry: no output at all — the `for await` never yields and never settles
```

## Root cause

Generator linearization gives each loop a single break sentinel and a single continue sentinel, so a completion can only name the loop it sits in. `rewrite_labeled_bc_in_stmts` therefore converts `break label` / `continue label` into plain completions **only at the labeled loop's own body level**, and stops at nested loops — correctly, because a plain completion inside a nested loop would bind to that loop.

What was missing is what happens to the escape that is left over. It survived verbatim into a state body, where the dispatch lowering has no sentinel for it and dropped it. `linearize.rs` said as much:

> *(Labeled break/continue from a \*nested\* loop is left unconverted — the single-sentinel scheme can't yet distinguish targets; this was already unsupported before this arm existed, so no regression.)*

## The fix

Stop asking the state machine to name a distant target. A carrier local unwinds the escape one loop at a time, so every completion the linearizer sees is plain and binds to the loop it is in:

```
__esc = 0;
inner: while (…) { … __esc = 1; break; … }   // was `break label`
if (__esc == 1) break;                        // in the labeled loop
if (__esc == 2) continue;
```

Deeper nesting reuses the same carrier and propagates outward with a bare `if (__esc != 0) break;` after each intermediate loop, so an escape from any depth walks out without the linearizer ever seeing a labeled completion. A `switch` carrying an escape is desugared to `if`s first (a plain `break` inside a switch binds to the switch), reusing the existing `desugar_switch_to_ifs`. A nested statement that redeclares the same label shadows it and is skipped.

## Scope was wider than the report

The issue's own one-level repro (`break loop` from a `switch` in a single labeled `for…of`) **already passes on main** — #9189 covered it after all. Re-measuring turned up the surviving hole one level deeper, with the identical error, and it is broader than the issue's framing:

* the `switch` is incidental — a bare `break outer` in a nested loop fails on its own, while the switch-wrapped form works because #9186's routing already handles it;
* it is not async-generator-specific — sync generators and async functions fail the same way;
* `break` and `continue` fail differently (malformed iterator result vs. silent drop).

The sibling "`async function` form hangs" noted at the bottom of #9199 does not reproduce and is not part of this.

## Validation

Same-commit A/B on `28c292517`, two isolated worktrees with their own target dirs, built identically:

| | `test_gap_9199_labeled_escape_nested_loops.ts` |
|---|---|
| unpatched `28c292517` | throws on the first row, then **hangs** (rc 124) |
| patched | **byte-identical to node 26.5.1**, all 13 rows |

The fixture covers `break`/`continue` of an outer label from a nested loop in all three function kinds, three-deep nesting, a `while` outer, an `await` before the escape, a conditional escape, `try`/`finally` around it (finalizers still run, in order), a reused label name on a sibling loop, and the switch-wrapped form that already worked — so the rows this PR did not change are pinned too.

Every probe from the diagnosis also matches node on the patched build, including the issue's original program and the two isolated `p5`/`p6` shapes.

`cargo test --release -p perry-transform -p perry-codegen -p perry-hir` on the patched tree: **2619 passed, 0 failed**. `cargo fmt --all -- --check` clean; `scripts/check_file_size.sh` clean (`break_continue.rs` 1104 lines).

The red `self-test-checkers` is pre-existing on main — its thread-local ratchet names `perry-runtime` files this PR does not touch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed labeled `break` and `continue` statements targeting outer loops within nested loops.
  * Corrected behavior across generators, async generators, and async functions, including cases involving `await`, switches, conditionals, and `try/finally` blocks.
  * Prevented runtime errors and missing output when these control-flow statements are used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->