### PR TITLE
fix(runtime): restore hot TLS for arena right-sizing

### DIFF
--- a/changelog.d/9731-arena-right-sizing.md
+++ b/changelog.d/9731-arena-right-sizing.md
@@ -14,7 +14,7 @@ stays disarmed until utilization reaches 70% or capacity grows materially
 into a periodic full-GC loop.
 
 On the compiled Claude Code 2.1.112 workload from the report, arena capacity
-fell from 96.5 MiB before the episode to 36.7 MiB, then 35.7 MiB and 35.7 MiB
-across a five-minute idle soak with about 23 MiB live. RSS fell from 401 MiB at
-the first census to 132 MiB at the last, and exactly one idle full was attributed
+fell from 96.5 MB before the episode to 36.7 MB, then 35.7 MB and 35.7 MB
+across a five-minute idle soak with about 23 MB live. RSS fell from 401 MB at
+the first census to 132 MB at the last, and exactly one idle full was attributed
 to arena right-sizing.

--- a/crates/perry-runtime/src/gc/arena_right_size.rs
+++ b/crates/perry-runtime/src/gc/arena_right_size.rs
@@ -82,7 +82,7 @@ struct ArenaRightSizeState {
     last_usage: ArenaUsage,
 }
 
-thread_local! {
+crate::perry_thread_local! {
     static STATE: RefCell<ArenaRightSizeState> =
         RefCell::new(ArenaRightSizeState::default());
     #[cfg(test)]


### PR DESCRIPTION
## Summary

Follow-up to #9731, which landed through merge train #9735. The train was assembled before the final two reviewed branch commits, so it retained a raw `thread_local!` declaration and mislabeled decimal byte measurements as MiB.

- route arena right-sizing state through the runtime's hot-TLS cache
- label the reported decimal workload measurements as MB
- keep the landed right-sizing policy and behavior unchanged

Closes #9709.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p perry-runtime`
- `cargo test -p perry-runtime --lib gc::tests::arena_right_size -- --test-threads=1` (5 passed)
- `cargo test -p perry-runtime --lib gc::tests::idle_reclaim -- --test-threads=1` (12 passed)
- `python3 scripts/check_thread_locals.py --self-test`
- policy checker before/after: `gc/arena_right_size.rs` is reported on landed `main` and absent with this patch; remaining reports are pre-existing files on `main`
- the underlying branch passed 3,104 runtime unit tests, focused arena/idle-reclaim tests, clippy, and all 62 applicable static lint gates before merge-train landing

## Release checklist

- no version bump
- no `Cargo.toml`, `Cargo.lock`, `CLAUDE.md`, or `CHANGELOG.md` change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved memory management for idle workloads by allowing arenas to reclaim excess capacity after sustained low utilization.
  - Right-sizing is bounded and remains paused until usage increases significantly, helping avoid repeated resizing.
  - Updated workload measurements to use MB instead of MiB for clearer capacity reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->