### PR TITLE
Merge train: #9736 + three commits missed by stale-head picks

### DIFF
--- a/changelog.d/9704-fresh-instance-prototype-replacement.md
+++ b/changelog.d/9704-fresh-instance-prototype-replacement.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Fresh instances now observe class prototype methods replaced after class
+  registration. The method inliner keeps runtime dispatch for prototype chains
+  exposed or mutated anywhere in the module, including helper functions and
+  closures. (#9239)

--- a/changelog.d/9731-arena-right-sizing.md
+++ b/changelog.d/9731-arena-right-sizing.md
@@ -14,7 +14,7 @@ stays disarmed until utilization reaches 70% or capacity grows materially
 into a periodic full-GC loop.
 
 On the compiled Claude Code 2.1.112 workload from the report, arena capacity
-fell from 96.5 MiB before the episode to 36.7 MiB, then 35.7 MiB and 35.7 MiB
-across a five-minute idle soak with about 23 MiB live. RSS fell from 401 MiB at
-the first census to 132 MiB at the last, and exactly one idle full was attributed
+fell from 96.5 MB before the episode to 36.7 MB, then 35.7 MB and 35.7 MB
+across a five-minute idle soak with about 23 MB live. RSS fell from 401 MB at
+the first census to 132 MB at the last, and exactly one idle full was attributed
 to arena right-sizing.

--- a/changelog.d/9733-uncarried-shape-descriptors.md
+++ b/changelog.d/9733-uncarried-shape-descriptors.md
@@ -1,0 +1,7 @@
+**Full collections now retire shape descriptors that no live object or
+restamping cache owns.** A full trace records every shaped receiver, and a
+synchronous sweep prunes only records absent from that complete census.
+Minor and budgeted cycles remain conservative. Generated-module ids and
+shape/transition caches retain exact ownership, while unstable transition
+entries validate their target before stamping. In the claude-code census,
+uncarried descriptors without an owner fell from 34,501 to zero.

--- a/crates/perry-runtime/src/gc/arena_right_size.rs
+++ b/crates/perry-runtime/src/gc/arena_right_size.rs
@@ -82,7 +82,7 @@ struct ArenaRightSizeState {
     last_usage: ArenaUsage,
 }
 
-thread_local! {
+crate::perry_thread_local! {
     static STATE: RefCell<ArenaRightSizeState> =
         RefCell::new(ArenaRightSizeState::default());
     #[cfg(test)]

--- a/test-files/test_gap_9718_initializer_self_binding.ts
+++ b/test-files/test_gap_9718_initializer_self_binding.ts
@@ -69,6 +69,16 @@ async function main(): Promise<void> {
   report("nested-await", () => pending[6]!());
   report("earlier-refs-later", h);
 
+  // The shapes the pre-pass's original ordering existed for. They passed
+  // before this fix and must keep passing: moving the initializer scan earlier
+  // is a superset, not a replacement.
+  const fact = (n: number): number => (n <= 1 ? 1 : n * fact(n - 1));
+  const fib = function rec(n: number): number { return n < 2 ? n : rec(n - 1) + rec(n - 2); };
+  const off = renderSync(() => off.u() + "/init-call-result");
+  console.log("self-recursive-arrow=" + fact(5));
+  console.log("named-fn-expr-recursion=" + fib(10));
+  report("init-call-result", () => pending[7]!());
+
   // The declaration is complete by the time these run, so the direct calls
   // must agree with what the closures saw.
   report("direct-plain", () => a.u());


### PR DESCRIPTION
Merge train: **#9736**, plus three commits recovered from PRs I landed with a stale head.

## The mistake this corrects

Merge trains cherry-pick from `refs/pull/<n>/head` fetched at assembly time. If an author pushes reviewed follow-ups between the fetch and the train, the train lands the pre-review version. I caught that on #9697 (re-fetched, took the author's better `across_mut` form) and then failed to re-check before assembling trains 119 and 120.

An audit of every PR landed today, by **patch-id** (`git cherry`, which survives the SHA rewrite that rebase-merge performs — a SHA comparison reports every rebase-merged PR as unlanded and is useless here), found four gaps. Three are recovered below; the fourth was already fixed by #9736.

- **#9736** — #9731 landed without its final two reviewed commits, so `gc/arena_right_size.rs` kept a raw `thread_local!` and the changelog mislabelled decimal bytes as MiB. That raw declaration was a **new** `tls-budget` failure on `main`: the file count went from five to six. With this it is back to the five pre-existing ones (`fs/deferred.rs`, `gc/census.rs`, `gc/idle_compact.rs`, `gc/idle_reclaim.rs`, `gc/oldgen_defrag.rs`), which belong to other authors and are theirs to convert or justify.
- **#9704's changelog fragment** — `changelog.d/9704-fresh-instance-prototype-replacement.md` was never on `main`.
- **#9733's changelog fragment** — `changelog.d/9733-uncarried-shape-descriptors.md`, same.
- **#9720's follow-up gap test** — ten lines added to `test_gap_9718_initializer_self_binding.ts` pinning the self-recursive shapes the old scan ordering served, pushed after the train was assembled.

**#9732 was checked and is fine**: `git cherry` flagged both its commits, but `git diff origin/main <head> -- gc/trace.rs` is empty, so the landed content matches the PR head. Patch-id noise from differing commit boundaries, not missing content.

## Validation

64/64 lint gates (re-run after the three recovered commits, not just before); `cargo test -p perry-runtime gc::` green; `check_thread_locals` back to the five pre-existing files.
