### PR TITLE
fix(stdlib): define the Bun HTTP bridge symbols without web-fetch (#9719)

### DIFF
--- a/changelog.d/9719-bun-bridge-symbols-without-web-fetch.md
+++ b/changelog.d/9719-bun-bridge-symbols-without-web-fetch.md
@@ -1,0 +1,36 @@
+**`node:http` links again from a cold auto-optimize cache.** Any program
+importing `node:http` failed to link with
+`Undefined symbols: _js_bun_http_response_snapshot_json` unless a warm
+`target/perry-auto-*` cache happened to hide it.
+
+`perry-ext-http`'s `server/bun_server.rs` declares that symbol and
+`js_bun_http_request_from_json` in an unconditional `extern "C"` block — only
+its `#[cfg(test)]` arm stubs them — but their definitions live in
+`fetch::bun_server_bridge`, which `perry-stdlib` compiles only under
+`web-fetch`. The auto-optimize feature set for a `node:http` program
+(`async-runtime`, `external-http-{client,server}-pump`, `external-net-tls`,
+`external-tls-server`, `external-ws-pump`) does not include `web-fetch`, so
+definition and reference disagreed about the feature gating them.
+
+The definitions genuinely need Fetch machinery (`FETCH_RESPONSES`,
+`consume_response_body`), so they cannot move out of the gated module; and
+making the http features depend on `web-fetch` would link `reqwest` — an HTTP
+*client* — into every `node:http` *server* build. Instead `perry-stdlib` now
+defines both symbols unconditionally: the real bridge under `web-fetch`, and
+under `cfg(not(web-fetch))` a pair that answers "nothing to bridge" (`null` /
+`undefined`). That is the correct answer rather than a placeholder — with no
+`fetch` module there are no `Response` objects to snapshot, and it matches what
+the real bridge already returns for an unknown handle.
+
+CI could not see this: plain `cargo build` / `cargo test` never link the
+auto-optimize ext-http path. It surfaced only in a full gap sweep run from a
+cold cache, where it accounted for eight `compile_fail` results
+(`test_gap_3527_http_ctor_prototype`,
+`test_gap_gc_http2_pending_event_callback_rooting`,
+`test_gap_http_client_no_redirect_follow`, `test_gap_http_overloads_3226plus`,
+`test_gap_http_req_async_iterator`,
+`test_gap_http_res_socket_writable_onfinished`, `test_gap_http2_settings`,
+`test_gap_regex_replace_dyn_regex_with_http`). All eight compile, link and pass
+against the pinned node oracle with this change; those eight are the
+regression coverage, since they exercise the real cold link that no unit test
+reaches.

--- a/crates/perry-stdlib/src/lib.rs
+++ b/crates/perry-stdlib/src/lib.rs
@@ -134,6 +134,44 @@ pub use framework::*;
 // independent from the external node:http implementation.
 #[cfg(feature = "web-fetch")]
 pub mod fetch;
+
+// #9719: `perry-ext-http`'s `server/bun_server.rs` declares these two bridge
+// symbols in an UNCONDITIONAL `extern "C"` block (only its `#[cfg(test)]` arm
+// stubs them), but their definitions live in `fetch::bun_server_bridge`, which
+// this crate compiles only under `web-fetch`. The auto-optimize feature set for
+// a `node:http` program does not include `web-fetch`, so a cold link of any
+// program importing `node:http` failed with
+// `Undefined symbols: _js_bun_http_response_snapshot_json`. CI never saw it:
+// plain `cargo build` / `cargo test` do not link the auto-optimize ext-http
+// path, and any warm `target/perry-auto-*` cache hides it from a manual check.
+//
+// The definitions genuinely need Fetch machinery (`FETCH_RESPONSES`,
+// `consume_response_body`), so they cannot simply move out; and making the http
+// features depend on `web-fetch` would link `reqwest` — an HTTP *client* — into
+// every `node:http` *server* build. Instead the symbols always exist, and
+// without Web Fetch they answer "nothing to bridge", which is exactly right:
+// with no `fetch` module there are no `Response` objects to snapshot.
+#[cfg(not(feature = "web-fetch"))]
+mod bun_server_bridge_absent {
+    use perry_runtime::string::StringHeader;
+
+    /// No Web Fetch in this build, so no `Response` registry to snapshot from.
+    /// Matches the real symbol's own not-found return (`null_mut`).
+    #[no_mangle]
+    pub extern "C" fn js_bun_http_response_snapshot_json(
+        _response_handle: f64,
+    ) -> *mut StringHeader {
+        std::ptr::null_mut()
+    }
+
+    /// Mirrors the real bridge's failure return for an unusable snapshot.
+    #[no_mangle]
+    pub unsafe extern "C" fn js_bun_http_request_from_json(
+        _snapshot_ptr: *const StringHeader,
+    ) -> f64 {
+        f64::from_bits(perry_runtime::value::JSValue::undefined().bits())
+    }
+}
 #[cfg(feature = "web-fetch")]
 pub use fetch::*;
 // Issue #1211: Blob/File constructors + object-URL helpers split out


### PR DESCRIPTION
Fixes #9719 — a bug I found while validating an unrelated PR, filed, and have now fixed.

## The break

Any program importing `node:http` failed to link from a **cold** auto-optimize cache:

```
Undefined symbols: _js_bun_http_response_snapshot_json,
  referenced from perry_ext_http::server::bun_server::settle_value
```

`perry-ext-http`'s `server/bun_server.rs` declares that symbol and `js_bun_http_request_from_json` in an **unconditional** `extern "C"` block — only its `#[cfg(test)]` arm stubs them. Their definitions live in `fetch::bun_server_bridge`, which `perry-stdlib` compiles only under `web-fetch`. The auto-optimize feature set for a `node:http` program is `async-runtime, external-http-{client,server}-pump, external-net-tls, external-tls-server, external-ws-pump` — no `web-fetch`. Definition and reference disagreed about the feature gating them.

## Why nothing caught it

Plain `cargo build` / `cargo test` never link the auto-optimize ext-http path, and any warm `target/perry-auto-*` cache hides it from a manual check. It surfaced only in a full gap sweep from a cold cache, where it accounted for **eight** `compile_fail` results.

## The fix, and the two alternatives rejected

The definitions genuinely need Fetch machinery (`FETCH_RESPONSES`, `consume_response_body`), so they cannot move out of the gated module. Making the http features depend on `web-fetch` would link `reqwest` — an HTTP *client* — into every `node:http` *server* build, which is a large widening for two small bridge functions.

Instead `perry-stdlib` defines both symbols in every configuration: the real bridge under `web-fetch`, and under `cfg(not(web-fetch))` a pair answering "nothing to bridge" (`null` / `undefined`). That is the correct answer rather than a placeholder — with no `fetch` module there are no `Response` objects to snapshot, and it is what the real bridge already returns for an unknown handle.

## Validation

Both feature configurations compile — no missing symbol without `web-fetch`, no duplicate definition with it.

All **eight** previously-failing gap tests now compile, link and pass against the pinned node 26.5.1: `test_gap_3527_http_ctor_prototype`, `test_gap_gc_http2_pending_event_callback_rooting`, `test_gap_http_client_no_redirect_follow`, `test_gap_http_overloads_3226plus`, `test_gap_http_req_async_iterator`, `test_gap_http_res_socket_writable_onfinished`, `test_gap_http2_settings`, `test_gap_regex_replace_dyn_regex_with_http`. `test_gap_3527`'s output is byte-identical to node's.

64/64 lint gates; `perry-stdlib` 130 passed, 0 failed.

**On regression coverage:** I wrote a `crates/perry-stdlib/tests/` symbol-existence test and then deleted it. An integration test links against the rlib under `-dead_strip`, which removes `#[no_mangle]` symbols nothing references — so it failed to link while the real fix worked, testing the harness rather than the property. The eight gap tests are the real coverage: they exercise the cold auto-optimize link that no unit test reaches, which is exactly the path that broke.
