### PR TITLE
perf(runtime): route four recent thread_local declarations through hot TLS

### DIFF
--- a/changelog.d/9741-hot-tls-for-recent-declarations.md
+++ b/changelog.d/9741-hot-tls-for-recent-declarations.md
@@ -1,0 +1,14 @@
+**Route four recent `thread_local!` declarations through the runtime's hot-TLS
+cache.** `fs/deferred.rs`, `gc/idle_compact.rs`, `gc/idle_reclaim.rs` and
+`gc/oldgen_defrag.rs` were added on 2026-09-03 using raw `thread_local!`, which
+costs a `_tlv_get_addr` call per access instead of landing the address in this
+thread's hot cache (#7469), and left `tls-budget` red on `main`. All four use
+only the init forms `perry_thread_local!` accepts, so the conversion is
+mechanical and behaviour-preserving.
+
+Converting them made `gc_runtime_root_holders` see the declarations for the
+first time — it enumerates `perry_thread_local!`, so a raw block escapes both
+gates. `fs/deferred.rs`'s `PENDING_PATH_WRITES` is classified here;
+`gc/census.rs` is deliberately left unconverted because its `PASS1_MARKED`
+holds real GC header addresses that no existing verdict describes truthfully,
+tracked in #9740.

--- a/crates/perry-runtime/src/fs/deferred.rs
+++ b/crates/perry-runtime/src/fs/deferred.rs
@@ -65,7 +65,7 @@ const MODE_WRITE_CALLBACK: f64 = 3.0;
 const MODE_UNLINK_PROMISE: f64 = 4.0;
 const MODE_UNLINK_CALLBACK: f64 = 5.0;
 
-thread_local! {
+crate::perry_thread_local! {
     /// Number of parked writes by decoded path. File-descriptor writes do not
     /// participate: an unlink has no fd form, so they can never alias it.
     static PENDING_PATH_WRITES: RefCell<HashMap<String, usize>> = RefCell::new(HashMap::new());

--- a/crates/perry-runtime/src/gc/idle_compact.rs
+++ b/crates/perry-runtime/src/gc/idle_compact.rs
@@ -110,7 +110,7 @@ struct IdleCompactState {
     backoff_shift: u32,
 }
 
-thread_local! {
+crate::perry_thread_local! {
     static STATE: RefCell<IdleCompactState> = RefCell::new(IdleCompactState::default());
     #[cfg(test)]
     static TEST_ENABLED: Cell<Option<bool>> = const { Cell::new(None) };

--- a/crates/perry-runtime/src/gc/idle_reclaim.rs
+++ b/crates/perry-runtime/src/gc/idle_reclaim.rs
@@ -189,7 +189,7 @@ struct IdleReclaimState {
     work_in_window_ms: u64,
 }
 
-thread_local! {
+crate::perry_thread_local! {
     static STATE: RefCell<IdleReclaimState> = RefCell::new(IdleReclaimState::default());
     #[cfg(test)]
     static TEST_NOW_MS: Cell<Option<u64>> = const { Cell::new(None) };

--- a/crates/perry-runtime/src/gc/oldgen_defrag.rs
+++ b/crates/perry-runtime/src/gc/oldgen_defrag.rs
@@ -100,7 +100,7 @@ pub(super) fn select_old_page_defrag_pages_from_snapshot(
     selection
 }
 
-thread_local! {
+crate::perry_thread_local! {
     /// Set for the duration of one `gc/idle_compact.rs` collection.
     static IDLE_COMPACT_ARMED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
@@ -128,7 +128,7 @@ impl Drop for IdleCompactDefragArm {
 // Test override for selection-policy tests. Thread-local so parallel tests do
 // not race with the production default or one another.
 #[cfg(test)]
-thread_local! {
+crate::perry_thread_local! {
     pub(crate) static OLD_DEFRAG_TEST_OVERRIDE: std::cell::Cell<Option<bool>> =
         const { std::cell::Cell::new(None) };
 }

--- a/scripts/gc_runtime_root_holders.json
+++ b/scripts/gc_runtime_root_holders.json
@@ -214,6 +214,12 @@
       "why": "#9707: dense side array of `TrustedTargets`, two `Option<TrustedDirectTarget>` per eligible arrow. TrustedDirectTarget{func_ptr:*const u8, capture_count:u32, boxed_capture_mask:u64} is a static code pointer plus plain integers \u2014 the same payload the deleted CLOSURE_ARROW_FUNCTION_REGISTRY / CLOSURE_VERSIONED_LOOP_REGISTRY held under this verdict. Nothing for the collector."
     },
     {
+      "file": "crates/perry-runtime/src/fs/deferred.rs",
+      "name": "PENDING_PATH_WRITES",
+      "verdict": "not_a_gc_pointer",
+      "why": "#9541: parked-write counts keyed by decoded path. `String` keys are Rust-owned heap, not GC heap, and the values are counts. No field can hold a managed pointer."
+    },
+    {
       "file": "crates/perry-runtime/src/fs/dir_glob_watch/watch_backend.rs",
       "name": "QUEUE",
       "verdict": "not_a_gc_pointer",


### PR DESCRIPTION
Clears four of the five raw `thread_local!` blocks keeping `tls-budget` red on `main`.

## What and why

`fs/deferred.rs`, `gc/idle_compact.rs`, `gc/idle_reclaim.rs` and `gc/oldgen_defrag.rs` were all added on **2026-09-03**, across four separate PRs, using raw `thread_local!` — which costs a `_tlv_get_addr` call per access instead of landing the address in this thread's hot cache (#7469). These look like the convention being missed rather than deliberate choices, so this is a mechanical conversion; if any declaration was meant to stay cold, say so and I will record it via `--update` instead.

The conversion is behaviour-preserving: all four blocks use only the init forms `perry_thread_local!` accepts (`= const { … }` and `= expr`), and their attributes — including several `#[cfg(test)]` — pass through its `$(#[$attr:meta])*` arm.

## What converting exposed

`gc_runtime_root_holders` enumerates `perry_thread_local!` declarations, so a **raw** `thread_local!` is audited by neither gate: `check_thread_locals` flags the TLS-perf violation, but nothing asks whether it holds a heap pointer. Converting these surfaced six previously-unclassified holders. `PENDING_PATH_WRITES` is classified here (`String` keys and `usize` counts — Rust-owned, nothing for the collector).

## Why `gc/census.rs` is NOT converted

Its `PASS1_MARKED` is `RefCell<Option<Vec<usize>>>` holding **real GC header addresses**, and no verdict in the inventory's vocabulary describes it truthfully — `not_a_gc_pointer` is defined as ids/counters/code addresses/rodata/Rust-owned state and would be false; `covered_elsewhere` needs a registered scanner, and none should visit it (tracing the marked set would retain exactly the garbage the census exists to observe); `open_gap` and `unverified` both fail the gate and misdescribe something that is safe by construction.

The contract is real and documented — written at end of mark propagation, `take()`n at sweep entry in the same synchronous full cycle, where per the module's own docs "the mark bits are authoritative and nothing moves" — the vocabulary just cannot express it. Forcing a wrong label to turn a gate green is the failure mode these gates exist to prevent, so `census.rs` stays raw and `tls-budget` stays red on that one file, tracked in **#9740** with a proposed verdict.

## Validation

64/64 lint gates (`check_thread_locals` now down to one file, `gc_runtime_root_holders` green); `perry-runtime` **3143 passed, 0 failed**, exit 0 — the full suite, since four of the five files are GC code.
