### PR TITLE
fix(runtime): preserve this for dynamic Object heritage

### DIFF
--- a/changelog.d/9749-dynamic-heritage-this.md
+++ b/changelog.d/9749-dynamic-heritage-this.md
@@ -1,0 +1,9 @@
+**Dynamic-heritage classes now retain the receiver created by `super()` when
+their runtime superclass resolves to `Object`.**
+
+Perry replayed these constructors against a provisional instance but discarded
+the constructor's effective return value. Writes after `super()` therefore
+landed on the new receiver while `new` returned the abandoned one. Dynamic
+construction now propagates the replacement receiver and preserves its derived
+prototype and per-evaluation private brand, matching Node for both shared class
+references and fresh captured class expressions.

--- a/crates/perry-runtime/src/object/class_constructors.rs
+++ b/crates/perry-runtime/src/object/class_constructors.rs
@@ -1183,7 +1183,7 @@ pub(crate) unsafe fn replay_class_object_constructor(
     inst: *mut ObjectHeader,
     args_ptr: *const f64,
     args_len: usize,
-) {
+) -> f64 {
     // Callers scope their argument read with `with_mut_ptr`; establish this
     // function's own roots before any constructor-replay path can allocate.
     let scope = crate::gc::RuntimeHandleScope::new();
@@ -1219,7 +1219,7 @@ pub(crate) unsafe fn replay_class_object_constructor(
         inst_handle.with_mut_ptr::<ObjectHeader, _>(|inst| {
             default_error_init_for_implicit_chain(class_cid, inst, args_ptr, args_len);
         });
-        return;
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
     };
 
     // Read the snapshotted captures (an own array, in capture-param order).
@@ -1348,7 +1348,7 @@ pub(crate) unsafe fn replay_class_object_constructor(
     let _active_evaluation =
         super::class_registry::push_active_class_evaluation(capture_owner_handle.get_nanbox_f64());
     inst_handle.with_mut_ptr::<ObjectHeader, _>(|inst| {
-        let _ = call_vtable_method(
+        call_vtable_method(
             ctor_ptr,
             inst as i64,
             final_args.as_ptr(),
@@ -1358,8 +1358,8 @@ pub(crate) unsafe fn replay_class_object_constructor(
             // Capture-forwarding constructor args are materialized positionally
             // above (including any caps), so no trailing rest re-packing here.
             false,
-        );
-    });
+        )
+    })
 }
 
 /// Replay a registered class declaration constructor for an INT32-tagged
@@ -1371,7 +1371,7 @@ pub(crate) unsafe fn replay_registered_class_constructor(
     inst: *mut ObjectHeader,
     args_ptr: *const f64,
     args_len: usize,
-) {
+) -> f64 {
     // Spec: a derived class with no own `constructor` gets the implicit
     // `constructor(...args) { super(...args) }` — the nearest ancestor's ctor
     // runs with the same argument list. `lookup_class_constructor` holds OWN
@@ -1400,7 +1400,7 @@ pub(crate) unsafe fn replay_registered_class_constructor(
         // #6469: all-implicit ctor chain to a native base — run the spec
         // default Error-init instead of silently constructing message-less.
         default_error_init_for_implicit_chain(class_cid, inst, args_ptr, args_len);
-        return;
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
     };
 
     // A function-nested class declaration may carry a decl-site capture
@@ -1456,7 +1456,7 @@ pub(crate) unsafe fn replay_registered_class_constructor(
     for slot in 0..sig_caps as usize {
         final_args.push(caps.get(slot).map(|b| f64::from_bits(*b)).unwrap_or(undef));
     }
-    let _ = call_vtable_method(
+    call_vtable_method(
         ctor_ptr,
         inst as i64,
         final_args.as_ptr(),
@@ -1464,5 +1464,5 @@ pub(crate) unsafe fn replay_registered_class_constructor(
         total_params,
         false,
         false,
-    );
+    )
 }

--- a/crates/perry-runtime/src/object/class_registry/construct.rs
+++ b/crates/perry-runtime/src/object/class_registry/construct.rs
@@ -964,15 +964,44 @@ pub unsafe extern "C-unwind" fn js_new_function_construct(
             // capture params from the snapshotted `__perry_ctor_caps`. The
             // mechanism lives in `class_constructors` to keep this file under
             // the 2,000-line CI gate.
-            inst_handle.with_mut_ptr::<ObjectHeader, _>(|inst| {
+            // Publish this exact class evaluation as newTarget while replaying
+            // the standalone constructor. Dynamic builtin `super()` uses it
+            // to give a replacement receiver the evaluation-specific
+            // prototype and private brand (#9503).
+            let prev_new_target = crate::object::js_new_target_get();
+            let prev_new_target_handle = scope.root_nanbox_f64(prev_new_target);
+            let active_new_target = class_handle.get_nanbox_f64();
+            crate::object::js_new_target_set(active_new_target);
+            let prev_current_new_target =
+                CURRENT_NEW_TARGET.with(|value| value.replace(active_new_target.to_bits()));
+            let prev_current_new_target_handle = scope.root_nanbox_u64(prev_current_new_target);
+            let ctor_result = inst_handle.with_mut_ptr::<ObjectHeader, _>(|inst| {
                 super::super::class_constructors::replay_class_object_constructor(
                     class_handle.get_nanbox_f64(),
                     class_cid,
                     inst,
                     args_ptr,
                     args_len,
-                );
+                )
             });
+            CURRENT_NEW_TARGET
+                .with(|value| value.set(prev_current_new_target_handle.get_nanbox_u64()));
+            crate::object::js_new_target_set(prev_new_target_handle.get_nanbox_f64());
+            // The standalone constructor publishes its final `this` when a
+            // dynamic super-constructor can replace the provisional receiver.
+            // A class-object replay used to discard that result and return the
+            // allocation above, so writes after `super()` landed on an object
+            // that `new` never exposed (#9503). Return an actual replacement
+            // immediately; when the constructor retained the allocation, keep
+            // the native-backing completion paths below unchanged.
+            let current_inst = crate::value::js_nanbox_pointer(
+                inst_handle.get_raw_mut_ptr::<ObjectHeader>() as i64,
+            );
+            if constructor_return_overrides_this(ctor_result)
+                && ctor_result.to_bits() != current_inst.to_bits()
+            {
+                return ctor_result;
+            }
             // `class X extends Request/Response {}` constructed via the dynamic
             // (class-expression value) path: the replayed ctor's `super()`
             // can't statically route an aliased parent, so attach the native
@@ -1499,12 +1528,22 @@ unsafe fn construct_registered_class_ref(
     let prev_current_new_target =
         CURRENT_NEW_TARGET.with(|value| value.replace(new_target.to_bits()));
     let prev_current_new_target_handle = scope.root_nanbox_u64(prev_current_new_target);
-    super::super::class_constructors::replay_registered_class_constructor(
+    let ctor_result = super::super::class_constructors::replay_registered_class_constructor(
         target_cid, inst, args_ptr, args_len,
     );
     let inst: *mut ObjectHeader = inst_handle.get_raw_mut_ptr();
     CURRENT_NEW_TARGET.with(|value| value.set(prev_current_new_target_handle.get_nanbox_u64()));
     crate::object::js_new_target_set(prev_new_target_handle.get_nanbox_f64());
+    // A replayed standalone constructor can bind a replacement `this` from
+    // its dynamic super-constructor. Preserve that result across the runtime
+    // ClassRef construction boundary instead of publishing the provisional
+    // allocation whose fields the constructor stopped updating (#9503).
+    let current_inst = crate::value::js_nanbox_pointer(inst as i64);
+    if constructor_return_overrides_this(ctor_result)
+        && ctor_result.to_bits() != current_inst.to_bits()
+    {
+        return ctor_result;
+    }
     // ClassRef `new` of a Request/Response subclass — attach the native fetch
     // handle on the dynamic path (mirrors the class-expression arm above).
     if let Some(kind) = fetch_parent_kind_in_chain(target_cid) {
@@ -1635,6 +1674,9 @@ pub unsafe extern "C" fn js_new_function_construct_with_new_target(
             } else {
                 crate::error::js_throw_bigint_constructor_type_error()
             };
+        }
+        if ta_name == "Object" {
+            return construct_object_with_new_target(nt);
         }
         // `Reflect.construct(Date, args, newTarget)` (#5989) — Next.js 16's
         // cacheComponents Date extension constructs through exactly this

--- a/crates/perry-runtime/src/object/class_registry/construct/class_object.rs
+++ b/crates/perry-runtime/src/object/class_registry/construct/class_object.rs
@@ -17,3 +17,46 @@ fn link_class_object_instance_prototype(class_value: f64, instance: *mut ObjectH
         )
     });
 }
+
+/// Object's constructor has special newTarget semantics: when invoked as the
+/// super-constructor of a derived class it ignores `value` and performs
+/// OrdinaryCreateFromConstructor(newTarget). Calling the ordinary Object thunk
+/// would instead coerce and return the first argument, binding an unrelated
+/// object as the derived `this` and losing its class prototype and brand.
+unsafe fn construct_object_with_new_target(new_target: f64) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let new_target = scope.root_nanbox_f64(new_target);
+    let instance_cid = new_target_class_id(new_target.get_nanbox_f64())
+        .unwrap_or_else(|| synthetic_class_id_for_function(new_target.get_nanbox_f64()));
+    let instance =
+        if let Some((keys_array, field_count)) = registered_class_keys_array(instance_cid) {
+            js_object_alloc_class_inline_keys(instance_cid, 0, field_count, keys_array)
+        } else {
+            js_object_alloc(
+                instance_cid,
+                crate::object::learned_inline_field_count(instance_cid),
+            )
+        };
+    let instance = scope.root_raw_mut_ptr(instance);
+    let prototype = new_target_custom_object_prototype(new_target.get_nanbox_f64())
+        .or_else(global_object_prototype_bits)
+        .map(|bits| scope.root_heap_word_u64(bits));
+    let new_target_value = new_target.get_nanbox_f64();
+    if is_class_object_value(new_target_value) {
+        instance.with_mut_ptr::<ObjectHeader, _>(|instance| {
+            super::super::field_get_set::stamp_private_evaluation_brand(
+                instance,
+                new_target_value,
+            )
+        });
+    }
+    if let Some(prototype) = prototype {
+        instance.with_mut_ptr::<ObjectHeader, _>(|instance| {
+            super::super::prototype_chain::object_set_static_prototype(
+                instance as usize,
+                prototype.get_heap_word_u64(),
+            )
+        });
+    }
+    crate::value::js_nanbox_pointer(instance.get_raw_mut_ptr::<ObjectHeader>() as i64)
+}

--- a/crates/perry-runtime/src/object/global_this/fetch_globals.rs
+++ b/crates/perry-runtime/src/object/global_this/fetch_globals.rs
@@ -826,7 +826,28 @@ pub unsafe extern "C" fn js_fetch_or_value_super(
             if cid == 0 {
                 return undef;
             }
-            let new_target = crate::object::class_constructor_ref_value(cid);
+            // A per-evaluation class object is its own newTarget. Collapsing it
+            // to the shared template ClassRef loses that evaluation's
+            // prototype and private brand when the builtin allocates a
+            // replacement receiver (#9503). Static/inlined construction does
+            // not always publish the runtime cell, so retain the ClassRef
+            // fallback when no matching dynamic newTarget is active.
+            let active_new_target = crate::object::js_new_target_get();
+            let active_matches = crate::object::class_ref_id(active_new_target) == Some(cid)
+                || if super::super::class_registry::is_class_object_value(active_new_target) {
+                    let class_object =
+                        crate::value::JSValue::from_bits(active_new_target.to_bits())
+                            .as_pointer::<crate::object::ObjectHeader>();
+                    !class_object.is_null()
+                        && crate::object::js_object_get_class_id(class_object) == cid
+                } else {
+                    false
+                };
+            let new_target = if active_matches {
+                active_new_target
+            } else {
+                crate::object::class_constructor_ref_value(cid)
+            };
             return crate::object::js_new_function_construct_with_new_target(
                 parent_val, args_ptr, args_len, new_target,
             );
@@ -923,7 +944,7 @@ pub unsafe extern "C" fn js_fetch_or_value_super(
                             // `tag`. Use the class-object replay path so this
                             // exact parent's `__perry_ctor_caps` supplies its
                             // synthesized capture params.
-                            super::super::class_constructors::replay_class_object_constructor(
+                            return super::super::class_constructors::replay_class_object_constructor(
                                 parent_val, parent_cid, obj, args_ptr, args_len,
                             );
                         }

--- a/test-files/test_gap_9503_dynamic_heritage_builtin_this.ts
+++ b/test-files/test_gap_9503_dynamic_heritage_builtin_this.ts
@@ -1,0 +1,57 @@
+// #9503: a runtime-valued heritage that resolves to Object must bind the
+// object returned by the builtin super-constructor as the derived `this`, and
+// `new` must publish that same object after the explicit constructor returns.
+function mkc(P?: any): any {
+  class D extends (P ?? Object) {
+    marker = "field";
+
+    constructor(def: any) {
+      super(def);
+      (this as any).def = def;
+    }
+
+    ping(): string {
+      return "pong";
+    }
+  }
+  return D;
+}
+
+const A = mkc();
+const a = new A({ t: 1 });
+console.log("default:", a.def.t, a.marker, a.ping(), a instanceof A);
+
+// Keep the value path dynamic even when Object is supplied explicitly.
+const B = mkc(Object);
+const b = new B({ t: 2 });
+console.log("explicit:", b.def.t, b.marker, b.ping(), b instanceof B);
+
+const a2 = new A({ t: 3 });
+console.log("distinct:", a !== a2, a2.def.t);
+
+// A capture forces a fresh class object rather than a shared ClassRef. Its
+// evaluation-specific prototype must survive the same builtin-super path.
+function mkFresh(P: any, label: string): any {
+  const captured = label;
+  return class extends P {
+    #label = captured;
+
+    constructor(def: any) {
+      super(def);
+      (this as any).def = def;
+    }
+
+    read(): string {
+      return `${this.#label}:${(this as any).def.t}`;
+    }
+  };
+}
+
+const Fresh = mkFresh(Object, "fresh");
+const fresh = new Fresh({ t: 4 });
+console.log(
+  "fresh:",
+  fresh.read(),
+  fresh instanceof Fresh,
+  Object.getPrototypeOf(fresh) === Fresh.prototype,
+);


### PR DESCRIPTION
## Summary

- honor `Object` constructor semantics when a runtime-valued superclass is constructed with a distinct `newTarget`
- propagate the effective receiver returned by replayed class constructors instead of publishing the abandoned provisional allocation
- preserve per-evaluation class prototypes and private brands, with Node-parity coverage for both ClassRef and fresh class-object paths

Fixes #9503

## Testing

- `PERRY_SKIP_BUILD=1 ./run_parity_tests.sh --filter test_gap_9503_dynamic_heritage_builtin_this`
- targeted parity: #9364 dynamic parent chains, class-expression capture refresh, standalone constructor return overrides, and GC-rooted dynamic construction
- `cargo test --lib -p perry-runtime` (3,123 passed, 4 ignored)
- `python3 scripts/check_test_registration.py`
- `scripts/pre-tag-check.sh --quick`

`scripts/test_affected_crates.sh --base upstream/main` passed the runtime suite, then stopped in the unrelated `perry` suite after 1,073 passes because the current upstream source references `PERRY_CONCAT_SITE_CACHE` without listing it in `BUILD_CACHE_ENV_VARS` or `BUILD_CACHE_ENV_EXCLUSIONS`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dynamic class inheritance when the runtime superclass resolves to `Object`, ensuring the object returned by `super()` is preserved.
  * Corrected derived-class construction to retain replacement objects and apply the expected prototype and private-field behavior.
  * Improved `Reflect.construct` and dynamic class construction to honor `new.target` semantics.

* **Tests**
  * Added coverage for dynamic heritage, returned objects, prototype identity, and private fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->