### PR TITLE
build: let PERRY_OBJECT_CACHE_BUILD_ID pin the object-cache build id

### DIFF
--- a/changelog.d/object-cache-build-id-override.md
+++ b/changelog.d/object-cache-build-id-override.md
@@ -1,0 +1,7 @@
+### Build
+
+- `PERRY_OBJECT_CACHE_BUILD_ID=<hex>` pins the build-id component of the
+  per-module object-cache key, so a `perry` built from a runtime-only branch
+  can reuse the objects a sibling build cached under the same HIR and options
+  and go straight to the link. Codegen changes still miss through the HIR and
+  option fields of the key; an unparsable value is ignored.

--- a/crates/perry/src/commands/compile/object_cache.rs
+++ b/crates/perry/src/commands/compile/object_cache.rs
@@ -36,6 +36,16 @@ pub fn djb2_hash(bytes: &[u8]) -> u64 {
     hash
 }
 
+/// `PERRY_OBJECT_CACHE_BUILD_ID=<up to 16 hex digits>` pins the build id
+/// component of the object-cache key. A compiler built from a runtime-only
+/// branch can then reuse the objects a sibling build cached under the same
+/// HIR and options (relink workflows: ~3 min link instead of a 40 min
+/// codegen of a 13 MB bundle). Codegen changes still miss through the
+/// `hir`/option fields; an unparsable value is ignored.
+fn pinned_build_id(raw: Option<String>) -> Option<u64> {
+    raw.and_then(|v| u64::from_str_radix(v.trim(), 16).ok())
+}
+
 /// Hash of the running `perry` executable, computed once per process.
 ///
 /// `CARGO_PKG_VERSION` only invalidates the cache on a version bump; during
@@ -53,6 +63,9 @@ pub fn djb2_hash(bytes: &[u8]) -> u64 {
 fn perry_build_id() -> u64 {
     static BUILD_ID: OnceLock<u64> = OnceLock::new();
     *BUILD_ID.get_or_init(|| {
+        if let Some(pinned) = pinned_build_id(std::env::var("PERRY_OBJECT_CACHE_BUILD_ID").ok()) {
+            return pinned;
+        }
         std::env::current_exe()
             .ok()
             .and_then(|p| fs::read(&p).ok())

--- a/crates/perry/src/commands/compile/object_cache/object_cache_tests.rs
+++ b/crates/perry/src/commands/compile/object_cache/object_cache_tests.rs
@@ -1137,3 +1137,15 @@ fn toml_overrides_pkg_via_readers_and_resolver() {
     let resolved = resolve_cache_dir(root.path(), chosen.as_deref());
     assert_eq!(resolved, root.path().join("toml-cache"));
 }
+
+#[test]
+fn pinned_build_id_parses_hex_and_ignores_garbage() {
+    assert_eq!(
+        super::pinned_build_id(Some(" 5458fd55d49a4640\n".to_string())),
+        Some(0x5458_fd55_d49a_4640)
+    );
+    assert_eq!(super::pinned_build_id(Some("0".to_string())), Some(0));
+    assert_eq!(super::pinned_build_id(Some("not-hex".to_string())), None);
+    assert_eq!(super::pinned_build_id(Some(String::new())), None);
+    assert_eq!(super::pinned_build_id(None), None);
+}


### PR DESCRIPTION
A compiler built from a runtime-only branch computes a different `build_id` (djb2 of its own executable) and therefore misses every object a sibling build cached, even though the HIR and every codegen option match. `PERRY_OBJECT_CACHE_BUILD_ID=<hex>` pins that component so relink workflows on large bundles (the 13 MB claude-code bundle: ~3 min link instead of ~40 min codegen) reuse those objects. Codegen changes still miss through the `hir` and option fields of the key; an unparsable value is ignored. Unit test for the parser included.

https://claude.ai/code/session_01YPfnmWZmSpSWpmnoXvH8z2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `PERRY_OBJECT_CACHE_BUILD_ID` environment variable, allowing compatible builds to reuse cached compilation objects and proceed directly to linking.
  * Supports hexadecimal build IDs; invalid values are ignored.
* **Documentation**
  * Added documentation describing the cache build ID override and its compatibility limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->