### PR TITLE
perf(object): pack the per-shape key index into 4-byte cells

### DIFF
--- a/changelog.d/9755-gc-side-table-young-logs.md
+++ b/changelog.d/9755-gc-side-table-young-logs.md
@@ -3,9 +3,9 @@
 - **Minor collections no longer walk every runtime side table.** A copying
   minor's three root-scan passes — and a budgeted minor's initial root scan
   and final remark — visited every entry of the closure dynamic-prop tables,
-  the string-keyed descriptor tables, the shape family/slot-index maps, the
-  transition cache and the shape cache on every collection, to discover that
-  nothing in them pointed at the nursery. On the compiled claude-code TUI
+  the string-keyed descriptor tables, the shape family/slot-index maps and
+  the transition cache on every collection, to discover that nothing in them
+  pointed at the nursery. On the compiled claude-code TUI
   that was ~35k shape families, ~120k descriptors and ~13k closure owners
   per walk, 41 minors per streamed reply, all reporting `slots=0`: 34–56 ms
   of scanner time per minor.
@@ -25,6 +25,13 @@
   a red test rather than a silently collected object. `PERRY_GC_DIAG=1`
   prints `[gc-young-log]` rows (logged / visited / kept / table size) per
   table and cycle.
+
+  The **shape cache** was measured and deliberately left on its plain walk.
+  Its canonical keys arrays are allocated in the longlived arena, which
+  `addr_is_minor_relevant` must answer `true` for, so no entry ever leaves a
+  log there: on the claude-code TUI the log named 100 % of the table in every
+  one of 107 collections (0 % skipped) and cost **35 % more** than the walk it
+  replaced. The four tables above skip 75–93 %.
 
 - **The post-minor remembered-set coverage restore is proportional to what
   the dirty scan could not cover.** `restore_surviving_dirty_coverage`

--- a/crates/perry-runtime/src/gc/tests/young_log_tests.rs
+++ b/crates/perry-runtime/src/gc/tests/young_log_tests.rs
@@ -53,6 +53,11 @@ fn walk(table: &'static str) -> young_log::YoungLogWalk {
     young_log::last_walk(table).unwrap_or_else(|| panic!("no walk recorded for {table}"))
 }
 
+/// For a table that is deliberately NOT young-logged: no walk row at all.
+fn walk_opt(table: &'static str) -> Option<young_log::YoungLogWalk> {
+    young_log::last_walk(table)
+}
+
 // ---------------------------------------------------------------- closures
 
 #[test]
@@ -430,15 +435,18 @@ fn young_transition_key_under_an_old_target_arms_the_log_through_the_writer() {
     );
 }
 
+/// The shape cache is deliberately NOT young-logged (see
+/// `scan_shape_cache_roots_mut`): its keys arrays are longlived, so a log
+/// there names every entry forever and skips nothing. This pins the walk that
+/// replaced it — a young entry reachable only through the cache still moves
+/// and is re-keyed in both the inline slot and the overflow map.
 #[test]
-fn young_shape_cache_entry_is_moved_through_the_log() {
+fn shape_cache_entry_is_moved_by_the_plain_walk() {
     let _guard = CopyingNurseryTestGuard::new(0);
     gc_register_mutable_root_scanner(crate::object::scan_shape_cache_roots_mut);
 
-    // Reachable ONLY through the cache (which roots it). Seeded through the
-    // PRODUCTION writer (`shape_cache_insert`), not a test seam: a seam that
-    // arms the log itself makes this test pass with the writer's own arm site
-    // deleted, which is how #9755 shipped an unenforced rule 1.
+    // Reachable ONLY through the cache (which roots it), seeded through the
+    // PRODUCTION writer (`shape_cache_insert`), not a test seam.
     let keys = unsafe { young_keys_array() };
     let shape_id = 0x9754_0001;
     crate::object::test_shape_cache_insert(shape_id, keys);
@@ -455,9 +463,11 @@ fn young_shape_cache_entry_is_moved_through_the_log() {
         inline, overflow,
         "inline and overflow must agree on the new address"
     );
-    let row = walk("object.shape_cache");
-    assert!(row.partial);
-    assert!(row.visited >= 1, "{row:?}");
+    assert!(
+        walk_opt("object.shape_cache").is_none(),
+        "the shape cache must not report a young-log walk: #9755's log for it \
+         skipped 0 % and cost 35 % more than this walk, and was removed"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -662,21 +662,6 @@ fn shape_cache_get_with_id(shape_id: u32) -> (*mut ArrayHeader, u32) {
         .unwrap_or((std::ptr::null_mut(), 0))
 }
 
-/// Rule 1 of `gc/young_log.rs` for the shape cache: log `shape_id` BEFORE the
-/// entry naming `keys_array` becomes findable.
-///
-/// Every writer of the cache — the production `shape_cache_insert` and the
-/// `#[cfg(test)]` seed seam — arms through this one function. A seam that
-/// re-implements the predicate is the failure mode this exists to prevent:
-/// the tests then validate an arming rule that is not the one that ships, and
-/// deleting the production arm site stays green.
-#[inline]
-pub(super) fn arm_shape_cache_young(shape_id: u32, keys_array: *mut ArrayHeader) {
-    if crate::gc::young_log::addr_is_minor_relevant(keys_array as usize) {
-        SHAPE_CACHE_YOUNG.with(|log| log.borrow_mut().note(shape_id));
-    }
-}
-
 /// Insert a keys_array into the cache. Updates the inline slot
 /// (evicting any prior entry there) and also writes to the overflow
 /// map so misses on the inline cache still find the value.
@@ -706,9 +691,6 @@ fn shape_cache_insert(shape_id: u32, keys_array: *mut ArrayHeader) {
     };
     let st = crate::state::state();
     let slot = (shape_id as usize) & (SHAPE_INLINE_CACHE_SIZE - 1);
-    // #9754 rule 1: log the id BEFORE the entry is published when the keys
-    // array can matter to a minor.
-    arm_shape_cache_young(shape_id, keys_array);
     unsafe {
         // GC_STORE_AUDIT(ROOT): shape_inline_cache entries are scanned by scan_shape_cache_roots_mut.
         let entry = &mut (*st.object_hot.shape_inline_cache.get())[slot];
@@ -822,14 +804,9 @@ crate::perry_thread_local! {
     /// `scan_transition_cache_roots_mut` visits only these.
     static TRANSITION_CACHE_YOUNG: RefCell<crate::gc::young_log::YoungLog<u32>> =
         const { RefCell::new(crate::gc::young_log::YoungLog::new()) };
-    /// #9754: shape-cache ids (inline slot and overflow key alike) whose keys
-    /// array may still be acted on by a minor.
-    static SHAPE_CACHE_YOUNG: RefCell<crate::gc::young_log::YoungLog<u32>> =
-        const { RefCell::new(crate::gc::young_log::YoungLog::new()) };
 }
 
 const TRANSITION_CACHE_YOUNG_LOG_NAME: &str = "object.transition_cache";
-const SHAPE_CACHE_YOUNG_LOG_NAME: &str = "object.shape_cache";
 
 /// Is a transition-cache entry still something a minor can act on?
 #[inline]
@@ -1334,7 +1311,6 @@ pub(crate) fn test_shape_cache_insert(shape_id: u32, keys_array: *mut ArrayHeade
 pub(crate) fn test_seed_shape_cache_root(shape_id: u32, keys_array: *mut ArrayHeader) {
     let st = crate::state::state();
     let slot = (shape_id as usize) & (SHAPE_INLINE_CACHE_SIZE - 1);
-    arm_shape_cache_young(shape_id, keys_array);
     unsafe {
         // GC_STORE_AUDIT(ROOT): test seed mirrors shape_inline_cache roots scanned by scan_shape_cache_roots_mut.
         let entry = &mut (*st.object_hot.shape_inline_cache.get())[slot];

--- a/crates/perry-runtime/src/object/shapes.rs
+++ b/crates/perry-runtime/src/object/shapes.rs
@@ -45,7 +45,7 @@ pub(crate) use shapes_slot_list::{
     object_shape_hole_count, publish_object_shape_holes,
     rekey_stable_tombstone_shape_after_squeeze, retire_owned_shape_history,
     shape_index_migrate_after_delete, shape_index_shift_in_place,
-    try_update_stable_tombstone_shape, try_update_stable_tombstone_shape_cached, SlotList,
+    try_update_stable_tombstone_shape, try_update_stable_tombstone_shape_cached, SlotIndex,
 };
 use shapes_store::{
     IdList, ShapeRecord, ShapeSlab, RECORD_FLAG_CACHE_CARRIER, RECORD_FLAG_CARRIED_SEEN,
@@ -68,7 +68,7 @@ pub(crate) struct ShapeIndex {
     /// `bench_populated_delete.ts` — perry's worst object-model gap against
     /// node — `hash_one::<&usize>` plus `sip::Hasher::write` were **14.7% of
     /// self time**, second only to the lookup that performs them.
-    slots: crate::fast_hash::PtrHashMap<u64, SlotList>,
+    slots: SlotIndex,
 }
 
 /// Immutable facts named by one ShapeId, copied out of the table.
@@ -1627,12 +1627,7 @@ unsafe fn index_range(shape: &mut ShapeIndex, keys: *const ArrayHeader, key_coun
         let v = crate::JSValue::from_bits((*slots.add(i as usize)).to_bits());
         if let Some(b) = crate::string::js_string_key_bytes(v, &mut sso) {
             let h = super::key_bytes_hash(b.as_ptr(), b.len());
-            match shape.slots.entry(h) {
-                std::collections::hash_map::Entry::Occupied(mut e) => e.get_mut().push(i),
-                std::collections::hash_map::Entry::Vacant(e) => {
-                    e.insert(SlotList::One(i));
-                }
-            }
+            shape.slots.push(h, i);
         }
     }
     shape.indexed_len = key_count;
@@ -1699,7 +1694,7 @@ pub(crate) unsafe fn shape_slot_lookup_verdict(
             inner.note_young_keys(keys_id as u64);
             inner.indices.entry(keys_id).or_insert(ShapeIndex {
                 indexed_len: 0,
-                slots: crate::fast_hash::new_ptr_hash_map(),
+                slots: SlotIndex::new(),
             })
         }
     };
@@ -1712,12 +1707,9 @@ pub(crate) unsafe fn shape_slot_lookup_verdict(
     } else {
         KeysIndexVerdict::Unindexed
     };
-    let Some(candidates) = shape.slots.get(&key_hash) else {
-        return absent;
-    };
     let mut sso = [0u8; crate::value::SHORT_STRING_MAX_LEN];
     let (slots, slot_len) = super::keys_array_dense_slots(keys);
-    for &i in candidates.iter() {
+    for i in shape.slots.candidates(key_hash) {
         if (i as usize) >= slot_len || i >= key_count {
             continue;
         }
@@ -1746,12 +1738,7 @@ pub(crate) fn shape_note_append(
     if let Some(shape) = inner.indices.get_mut(&(keys as usize)) {
         if shape.indexed_len + 1 == new_count {
             shape.indexed_len = new_count;
-            match shape.slots.entry(key_hash) {
-                std::collections::hash_map::Entry::Occupied(mut e) => e.get_mut().push(slot),
-                std::collections::hash_map::Entry::Vacant(e) => {
-                    e.insert(SlotList::One(slot));
-                }
-            }
+            shape.slots.push(key_hash, slot);
         }
     }
 }
@@ -1761,12 +1748,7 @@ pub(crate) fn shape_note_append(
 pub(crate) fn shape_note_hit(keys: *const ArrayHeader, key_hash: u64, slot: u32) {
     let mut inner = crate::state::state().shapes.inner.borrow_mut();
     if let Some(shape) = inner.indices.get_mut(&(keys as usize)) {
-        match shape.slots.entry(key_hash) {
-            std::collections::hash_map::Entry::Occupied(mut e) => e.get_mut().push(slot),
-            std::collections::hash_map::Entry::Vacant(e) => {
-                e.insert(SlotList::One(slot));
-            }
-        }
+        shape.slots.push(key_hash, slot);
     }
 }
 
@@ -2314,17 +2296,13 @@ pub(crate) fn shrink_shape_tables() {
 /// `PERRY_GC_CENSUS`: the by-id slab, the per-shape key indices, the
 /// exact-facts accelerator and the keys-address family index.
 pub(crate) fn shape_table_census() -> Vec<crate::gc::census::SideTableRow> {
-    use crate::gc::census::{hash_table_bytes, map_bytes};
+    use crate::gc::census::map_bytes;
     let table = &crate::state::state().shapes;
     let inner = table.inner.borrow();
     let slab = table.slab();
     let mut rows = Vec::new();
     rows.push(("shapes.descriptors", slab.len(), slab.estimated_bytes()));
-    let index_inner: usize = inner
-        .indices
-        .values()
-        .map(|ix| hash_table_bytes(ix.slots.capacity(), std::mem::size_of::<(u64, SlotList)>()))
-        .sum();
+    let index_inner: usize = inner.indices.values().map(|ix| ix.slots.heap_bytes()).sum();
     rows.push((
         "shapes.indices",
         inner.indices.len(),

--- a/crates/perry-runtime/src/object/shapes_slot_list.rs
+++ b/crates/perry-runtime/src/object/shapes_slot_list.rs
@@ -1,81 +1,283 @@
-//! `SlotList` — the shape key index's per-hash slot list, in a sibling file.
+//! `SlotIndex` — the shape key index's content-hash → slot table, in a
+//! sibling file.
 //!
 //! Extracted from `shapes.rs` to keep it under the repo's 2000-line cap.
-//! Also carries the two helpers that are mostly `SlotList` manipulation:
+//! Also carries the two helpers that are mostly index manipulation:
 //! `record_shape_scan_outcome` (the shape scanner's per-descriptor
 //! bookkeeping) and `shape_index_migrate_after_delete`.
 
-/// Slots sharing one content hash.
+/// Content hash → candidate slots for one shape, as an open-addressing table
+/// of packed `(hash tag, slot)` cells.
 ///
-/// Almost always exactly one: the key is an FNV-1a hash of distinct property
-/// names, so a bucket with two entries is a genuine hash collision. Storing
-/// that common case inline removes a heap allocation PER KEY from every index
-/// build — and the index is rebuilt on every populated delete, so a 500-key
-/// object was making ~500 `Vec` allocations per `delete`. Allocator and page
-/// churn is the dominant cost on that benchmark (`clear_page_erms` 5.6%,
-/// `mi_free` 4.2%, `RawVecInner::finish_grow` 2.9%), well above the lookup
-/// work itself.
+/// #9754 memory. This used to be a `PtrHashMap<u64, SlotList>` per shape —
+/// a 33-byte hashbrown bucket (`(u64, enum { One(u32), Many(Vec<u32>) })`
+/// plus its control byte) for every key, in a power-of-two table. The
+/// compiled claude-code TUI holds ~34.5k of these indices, one per keys array
+/// past `KEYS_INDEX_THRESHOLD`, at **2.6 KB each: 89 MB** of the process's
+/// 170 MB of side tables (`PERRY_GC_CENSUS`, 2026-09-04), while the objects
+/// they describe are ~40 keys wide.
+///
+/// The table's only job is to answer "which slots might hold a key with this
+/// hash" — every hit is then re-validated against the key BYTES
+/// (`shape_slot_lookup_verdict`), so a wrong or colliding answer is a miss,
+/// never a wrong property. That validation is what lets the stored hash be
+/// narrow: a cell is a 16-bit tag (the top of a golden-ratio fold of the FNV-1a
+/// hash) and a
+/// 16-bit slot (`Narrow`, 4 bytes), widened to a 16-bit tag and a 32-bit slot
+/// (`Wide`, 8 bytes) only for a shape with 65 535 or more keys. The probe
+/// position is a function of the tag alone, so a cell can be re-placed from
+/// its own bits when the table grows or is rebuilt after a delete. Same
+/// hash, several slots (a genuine collision, or a note-hit under a stale
+/// index) is just several cells with one tag on the probe chain. Load is
+/// kept at or below 7/8.
+///
+/// 40 keys: 64 cells × 4 B = 256 B against the 2.1 KB hashbrown table.
 #[derive(Clone, Debug)]
-pub(crate) enum SlotList {
-    One(u32),
-    Many(Vec<u32>),
+pub(crate) struct SlotIndex {
+    cells: SlotCells,
+    len: u32,
 }
 
-impl SlotList {
-    #[inline]
-    pub(crate) fn push(&mut self, slot: u32) {
-        match self {
-            SlotList::One(existing) => {
-                *self = SlotList::Many(vec![*existing, slot]);
-            }
-            SlotList::Many(v) => v.push(slot),
+#[derive(Clone, Debug)]
+enum SlotCells {
+    /// `(tag16 << 16) | slot16`; slots up to `NARROW_MAX_SLOT`.
+    Narrow(Box<[u32]>),
+    /// `(tag16 << 32) | slot32`.
+    Wide(Box<[u64]>),
+}
+
+const NARROW_EMPTY: u32 = u32::MAX;
+const WIDE_EMPTY: u64 = u64::MAX;
+/// Slot `0xFFFF` is never stored narrow, so `NARROW_EMPTY` is unambiguous.
+const NARROW_MAX_SLOT: u32 = 0xFFFE;
+const MIN_CELLS: usize = 8;
+
+impl Default for SlotIndex {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SlotIndex {
+    pub(crate) fn new() -> Self {
+        Self {
+            cells: SlotCells::Narrow(Box::new([])),
+            len: 0,
         }
     }
 
-    /// Drop `removed` and shift every slot above it down by one.
     #[inline]
-    pub(crate) fn retain_shift(&mut self, removed: u32) {
-        let shift = |s: u32| -> Option<u32> {
-            match s.cmp(&removed) {
-                std::cmp::Ordering::Equal => None,
-                std::cmp::Ordering::Less => Some(s),
-                std::cmp::Ordering::Greater => Some(s - 1),
-            }
-        };
-        match self {
-            SlotList::One(slot) => match shift(*slot) {
-                Some(s) => *slot = s,
-                None => *self = SlotList::Many(Vec::new()),
-            },
-            SlotList::Many(v) => {
-                v.retain_mut(|s| match shift(*s) {
-                    Some(n) => {
-                        *s = n;
-                        true
+    fn capacity(&self) -> usize {
+        match &self.cells {
+            SlotCells::Narrow(cells) => cells.len(),
+            SlotCells::Wide(cells) => cells.len(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.len as usize
+    }
+
+    /// Bytes of the cell array (`PERRY_GC_CENSUS`).
+    pub(crate) fn heap_bytes(&self) -> usize {
+        match &self.cells {
+            SlotCells::Narrow(cells) => cells.len() * std::mem::size_of::<u32>(),
+            SlotCells::Wide(cells) => cells.len() * std::mem::size_of::<u64>(),
+        }
+    }
+
+    /// The 16-bit tag of a key hash. FNV-1a's HIGH bits barely move for
+    /// short keys (`"a"` and `"b"` share their top 16), so fold the whole
+    /// word through a golden-ratio multiply first and take the top of that.
+    #[inline]
+    fn tag_of(hash: u64) -> u32 {
+        (hash.wrapping_mul(0x9E37_79B9_7F4A_7C15) >> 48) as u32
+    }
+
+    /// Where a tag's probe chain starts. Below 65 536 cells the tag itself
+    /// indexes the table; above, its two copies cover the extra bits (two
+    /// tags then share a chain, which is a longer probe, never a wrong answer).
+    #[inline]
+    fn home(tag: u32, mask: usize) -> usize {
+        ((tag as usize) | ((tag as usize) << 16)) & mask
+    }
+
+    /// Record that `slot` holds a key hashing to `hash`. A cell already
+    /// naming exactly this pair is left alone (a note-hit on an indexed key).
+    pub(crate) fn push(&mut self, hash: u64, slot: u32) {
+        self.insert(Self::tag_of(hash), slot);
+    }
+
+    fn insert(&mut self, tag: u32, slot: u32) {
+        if slot > NARROW_MAX_SLOT {
+            self.widen();
+        }
+        if (self.len as usize + 1) * 8 > self.capacity() * 7 {
+            self.grow();
+        }
+        let mask = self.capacity() - 1;
+        let mut pos = Self::home(tag, mask);
+        match &mut self.cells {
+            SlotCells::Narrow(cells) => {
+                let cell = (tag << 16) | slot;
+                loop {
+                    let existing = cells[pos];
+                    if existing == NARROW_EMPTY {
+                        cells[pos] = cell;
+                        self.len += 1;
+                        return;
                     }
-                    None => false,
-                });
-                if v.len() == 1 {
-                    *self = SlotList::One(v[0]);
+                    if existing == cell {
+                        return;
+                    }
+                    pos = (pos + 1) & mask;
+                }
+            }
+            SlotCells::Wide(cells) => {
+                let cell = (u64::from(tag) << 32) | u64::from(slot);
+                loop {
+                    let existing = cells[pos];
+                    if existing == WIDE_EMPTY {
+                        cells[pos] = cell;
+                        self.len += 1;
+                        return;
+                    }
+                    if existing == cell {
+                        return;
+                    }
+                    pos = (pos + 1) & mask;
                 }
             }
         }
     }
 
-    #[inline]
-    pub(crate) fn is_empty(&self) -> bool {
-        match self {
-            SlotList::One(_) => false,
-            SlotList::Many(v) => v.is_empty(),
+    /// Every slot recorded under `hash`, in probe order. Each must still be
+    /// validated against the key bytes by the caller.
+    pub(crate) fn candidates(&self, hash: u64) -> SlotCandidates<'_> {
+        let capacity = self.capacity();
+        let tag = Self::tag_of(hash);
+        SlotCandidates {
+            index: self,
+            pos: if capacity == 0 {
+                0
+            } else {
+                Self::home(tag, capacity - 1)
+            },
+            remaining: capacity,
+            tag,
         }
     }
 
-    #[inline]
-    pub(crate) fn iter(&self) -> impl Iterator<Item = &u32> {
-        match self {
-            SlotList::One(slot) => std::slice::from_ref(slot).iter(),
-            SlotList::Many(v) => v.iter(),
+    /// Drop the cell(s) for `removed` and shift every slot above it down by
+    /// one — the index of a keys array after an in-place or cloned delete.
+    pub(crate) fn retain_shift(&mut self, removed: u32) {
+        let pairs = self.drain_pairs();
+        for (tag, slot) in pairs {
+            match slot.cmp(&removed) {
+                std::cmp::Ordering::Equal => {}
+                std::cmp::Ordering::Less => self.insert(tag, slot),
+                std::cmp::Ordering::Greater => self.insert(tag, slot - 1),
+            }
         }
+    }
+
+    /// Take every `(tag, slot)` pair out, leaving the cells empty at the same
+    /// capacity.
+    fn drain_pairs(&mut self) -> Vec<(u32, u32)> {
+        let mut pairs = Vec::with_capacity(self.len as usize);
+        match &mut self.cells {
+            SlotCells::Narrow(cells) => {
+                for cell in cells.iter_mut() {
+                    if *cell != NARROW_EMPTY {
+                        pairs.push((*cell >> 16, *cell & 0xFFFF));
+                        *cell = NARROW_EMPTY;
+                    }
+                }
+            }
+            SlotCells::Wide(cells) => {
+                for cell in cells.iter_mut() {
+                    if *cell != WIDE_EMPTY {
+                        pairs.push(((*cell >> 32) as u32, (*cell & 0xFFFF_FFFF) as u32));
+                        *cell = WIDE_EMPTY;
+                    }
+                }
+            }
+        }
+        self.len = 0;
+        pairs
+    }
+
+    fn grow(&mut self) {
+        let new_capacity = (self.capacity() * 2).max(MIN_CELLS);
+        let pairs = self.drain_pairs();
+        self.cells = match self.cells {
+            SlotCells::Narrow(_) => SlotCells::Narrow(vec![NARROW_EMPTY; new_capacity].into()),
+            SlotCells::Wide(_) => SlotCells::Wide(vec![WIDE_EMPTY; new_capacity].into()),
+        };
+        for (tag, slot) in pairs {
+            self.insert(tag, slot);
+        }
+    }
+
+    fn widen(&mut self) {
+        if matches!(self.cells, SlotCells::Wide(_)) {
+            return;
+        }
+        let capacity = self.capacity().max(MIN_CELLS);
+        let pairs = self.drain_pairs();
+        self.cells = SlotCells::Wide(vec![WIDE_EMPTY; capacity].into());
+        for (tag, slot) in pairs {
+            self.insert(tag, slot);
+        }
+    }
+}
+
+/// The probe chain of [`SlotIndex::candidates`].
+pub(crate) struct SlotCandidates<'a> {
+    index: &'a SlotIndex,
+    pos: usize,
+    remaining: usize,
+    tag: u32,
+}
+
+impl Iterator for SlotCandidates<'_> {
+    type Item = u32;
+
+    fn next(&mut self) -> Option<u32> {
+        let capacity = self.index.capacity();
+        if capacity == 0 {
+            return None;
+        }
+        let mask = capacity - 1;
+        while self.remaining != 0 {
+            self.remaining -= 1;
+            let pos = self.pos;
+            self.pos = (pos + 1) & mask;
+            match &self.index.cells {
+                SlotCells::Narrow(cells) => {
+                    let cell = cells[pos];
+                    if cell == NARROW_EMPTY {
+                        self.remaining = 0;
+                        return None;
+                    }
+                    if cell >> 16 == self.tag {
+                        return Some(cell & 0xFFFF);
+                    }
+                }
+                SlotCells::Wide(cells) => {
+                    let cell = cells[pos];
+                    if cell == WIDE_EMPTY {
+                        self.remaining = 0;
+                        return None;
+                    }
+                    if (cell >> 32) as u32 == self.tag {
+                        return Some((cell & 0xFFFF_FFFF) as u32);
+                    }
+                }
+            }
+        }
+        None
     }
 }
 
@@ -108,10 +310,7 @@ pub(crate) fn shape_index_shift_in_place(
         inner.indices.remove(&keys_id);
         return false;
     }
-    index.slots.retain(|_, list| {
-        list.retain_shift(removed_slot);
-        !list.is_empty()
-    });
+    index.slots.retain_shift(removed_slot);
     index.indexed_len = old_key_count - 1;
     true
 }
@@ -165,10 +364,7 @@ pub(crate) fn shape_index_migrate_after_delete(
         // misaligned. Dropping it preserves the previous behaviour exactly.
         return false;
     }
-    index.slots.retain(|_, list| {
-        list.retain_shift(removed_slot);
-        !list.is_empty()
-    });
+    index.slots.retain_shift(removed_slot);
     index.indexed_len = old_key_count - 1;
     inner.note_young_keys(new_keys_id as u64);
     inner.indices.insert(new_keys_id, index);
@@ -690,5 +886,81 @@ mod tests {
                 "the deleting object did not receive the shifted index"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod slot_index_tests {
+    use super::SlotIndex;
+
+    fn fnv(bytes: &[u8]) -> u64 {
+        crate::object::key_bytes_hash(bytes.as_ptr(), bytes.len())
+    }
+
+    #[test]
+    fn every_pushed_pair_is_a_candidate_and_nothing_else_is() {
+        let mut index = SlotIndex::new();
+        let names: Vec<String> = (0..3000).map(|i| format!("key_{i}")).collect();
+        for (slot, name) in names.iter().enumerate() {
+            index.push(fnv(name.as_bytes()), slot as u32);
+        }
+        assert_eq!(index.len(), 3000);
+        for (slot, name) in names.iter().enumerate() {
+            let found: Vec<u32> = index.candidates(fnv(name.as_bytes())).collect();
+            assert!(found.contains(&(slot as u32)), "{name} missing: {found:?}");
+        }
+        let absent: Vec<u32> = index.candidates(fnv(b"never_inserted")).collect();
+        assert!(
+            absent.len() <= 2,
+            "a narrow tag should almost never alias: {absent:?}"
+        );
+        assert!(
+            index.heap_bytes() <= 4096 * 4,
+            "3000 keys must fit 4096 narrow cells"
+        );
+    }
+
+    #[test]
+    fn a_repeated_note_hit_does_not_grow_the_table() {
+        let mut index = SlotIndex::new();
+        let hash = fnv(b"hit");
+        for _ in 0..100 {
+            index.push(hash, 7);
+        }
+        assert_eq!(index.len(), 1);
+        assert_eq!(index.candidates(hash).collect::<Vec<_>>(), vec![7]);
+    }
+
+    #[test]
+    fn retain_shift_drops_the_removed_slot_and_shifts_the_rest() {
+        let mut index = SlotIndex::new();
+        let names: Vec<String> = (0..50).map(|i| format!("k{i}")).collect();
+        for (slot, name) in names.iter().enumerate() {
+            index.push(fnv(name.as_bytes()), slot as u32);
+        }
+        index.retain_shift(10);
+        assert_eq!(index.len(), 49);
+        assert!(index.candidates(fnv(b"k10")).next().is_none());
+        for (slot, name) in names.iter().enumerate() {
+            if slot == 10 {
+                continue;
+            }
+            let expected = if slot > 10 { slot - 1 } else { slot } as u32;
+            let found: Vec<u32> = index.candidates(fnv(name.as_bytes())).collect();
+            assert_eq!(found, vec![expected], "{name}");
+        }
+    }
+
+    #[test]
+    fn a_slot_past_the_narrow_range_widens_the_table() {
+        let mut index = SlotIndex::new();
+        index.push(fnv(b"a"), 3);
+        index.push(fnv(b"b"), 70_000);
+        assert_eq!(index.candidates(fnv(b"a")).collect::<Vec<_>>(), vec![3]);
+        assert_eq!(
+            index.candidates(fnv(b"b")).collect::<Vec<_>>(),
+            vec![70_000]
+        );
+        assert!(index.heap_bytes() >= 8 * 8, "wide cells are 8 bytes");
     }
 }

--- a/crates/perry-runtime/src/object/shapes_test_support.rs
+++ b/crates/perry-runtime/src/object/shapes_test_support.rs
@@ -138,18 +138,16 @@ pub(crate) fn test_shape_ids_for_keys(keys_id: usize) -> Vec<u32> {
 
 #[cfg(test)]
 pub(crate) fn test_seed_shape_entry(keys_id: usize) {
-    crate::state::state()
-        .shapes
-        .inner
-        .borrow_mut()
-        .indices
-        .insert(
-            keys_id,
-            ShapeIndex {
-                indexed_len: 0,
-                slots: crate::fast_hash::new_ptr_hash_map(),
-            },
-        );
+    let mut inner = crate::state::state().shapes.inner.borrow_mut();
+    inner.note_young_keys(keys_id as u64);
+    inner.indices.insert(
+        keys_id,
+        ShapeIndex {
+            indexed_len: 0,
+            slots: SlotIndex::new(),
+        },
+    );
+    drop(inner);
     let _ = shape_descriptor_ensure(keys_id as *const ArrayHeader, 0, 0)
         .expect("test shape id range unexpectedly exhausted");
 }

--- a/crates/perry-runtime/src/object/side_table_roots.rs
+++ b/crates/perry-runtime/src/object/side_table_roots.rs
@@ -295,74 +295,24 @@ pub fn scan_shape_cache_roots(mark: &mut dyn FnMut(f64)) {
     scan_shape_cache_roots_mut(&mut visitor);
 }
 
+/// #9754 measured this table and left it alone: a young-entry log here skipped
+/// NOTHING on the compiled claude-code TUI (0.0 % of 3.85 M entry visits over
+/// 107 collections) and cost 35 % MORE than this plain walk, because the
+/// canonical keys arrays live in the LONGLIVED arena, which
+/// `addr_is_minor_relevant` must answer `true` for, so no entry ever leaves
+/// the log. See the four tables that do skip 75-93 % in `gc/young_log.rs`.
 pub fn scan_shape_cache_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
-    use crate::gc::young_log::addr_is_minor_relevant;
     let st = crate::state::state();
-    // The inline array is 256 fixed slots: always walked. The overflow map
-    // holds every shape id ever cached; #9754: a minor-scoped pass visits
-    // only the young-logged ids there, a full pass rebuilds the log.
-    let entries = unsafe { &mut *st.object_hot.shape_inline_cache.get() };
-    for entry in entries.iter_mut() {
-        visitor.visit_raw_mut_ptr_slot(&mut entry.keys_array);
-    }
-    let mut cache = st.object_hot.shape_cache_overflow.borrow_mut();
-    let table_len = cache.len() as u64;
-    if visitor.young_scope() {
-        #[cfg(debug_assertions)]
-        {
-            let relevant: Vec<u32> = cache
-                .iter()
-                .filter(|(_, (arr_ptr, _))| addr_is_minor_relevant(*arr_ptr as usize))
-                .map(|(&id, _)| id)
-                .collect();
-            SHAPE_CACHE_YOUNG.with(|log| {
-                log.borrow()
-                    .debug_assert_logged(SHAPE_CACHE_YOUNG_LOG_NAME, &relevant)
-            });
-        }
-        let batch = SHAPE_CACHE_YOUNG.with(|log| log.borrow_mut().take_sorted());
-        let logged = batch.len() as u64;
-        let mut kept = SHAPE_CACHE_YOUNG.with(|log| log.borrow_mut().take_spare());
-        for id in batch {
-            if let Some((arr_ptr, _)) = cache.get_mut(&id) {
-                visitor.visit_raw_mut_ptr_slot(arr_ptr);
-                if addr_is_minor_relevant(*arr_ptr as usize) {
-                    kept.push(id);
-                }
-            }
-        }
-        let kept_len = kept.len() as u64;
-        SHAPE_CACHE_YOUNG.with(|log| log.borrow_mut().extend(kept));
-        crate::gc::young_log::note_walk(
-            SHAPE_CACHE_YOUNG_LOG_NAME,
-            crate::gc::young_log::YoungLogWalk {
-                partial: true,
-                logged,
-                visited: logged,
-                kept: kept_len,
-                table_len,
-            },
-        );
-        return;
-    }
-    let _ = SHAPE_CACHE_YOUNG.with(|log| log.borrow_mut().take_sorted());
-    let mut kept = Vec::new();
-    for (&id, (arr_ptr, _runtime_shape_id)) in cache.iter_mut() {
-        visitor.visit_raw_mut_ptr_slot(arr_ptr);
-        if addr_is_minor_relevant(*arr_ptr as usize) {
-            kept.push(id);
+    {
+        let entries = unsafe { &mut *st.object_hot.shape_inline_cache.get() };
+        for entry in entries.iter_mut() {
+            visitor.visit_raw_mut_ptr_slot(&mut entry.keys_array);
         }
     }
-    let kept_len = kept.len() as u64;
-    SHAPE_CACHE_YOUNG.with(|log| log.borrow_mut().extend(kept));
-    crate::gc::young_log::note_walk(
-        SHAPE_CACHE_YOUNG_LOG_NAME,
-        crate::gc::young_log::YoungLogWalk {
-            partial: false,
-            logged: table_len,
-            visited: table_len,
-            kept: kept_len,
-            table_len,
-        },
-    );
+    {
+        let mut cache = st.object_hot.shape_cache_overflow.borrow_mut();
+        for (arr_ptr, _runtime_shape_id) in cache.values_mut() {
+            visitor.visit_raw_mut_ptr_slot(arr_ptr);
+        }
+    }
 }

--- a/crates/perry-runtime/src/object/test_root_accessors.rs
+++ b/crates/perry-runtime/src/object/test_root_accessors.rs
@@ -58,7 +58,6 @@ pub(crate) fn test_transition_cache_root() -> usize {
 #[cfg(test)]
 pub(crate) fn test_clear_transition_cache_root() {
     super::TRANSITION_CACHE_YOUNG.with(|log| log.borrow_mut().clear());
-    super::SHAPE_CACHE_YOUNG.with(|log| log.borrow_mut().clear());
     with_transition_cache(|t| unsafe {
         for i in 0..TRANSITION_CACHE_SIZE {
             // GC_STORE_AUDIT(ROOT): test clear writes non-pointer sentinels into scanned TRANSITION_CACHE_GLOBAL roots.


### PR DESCRIPTION
Stacked on #9755 (its commit is included; review only the last commit).

## Summary

`ShapeIndex.slots` — the content-hash → slot accelerator built for every keys array past `KEYS_INDEX_THRESHOLD` — was a `PtrHashMap<u64, SlotList>` per shape: a 33-byte hashbrown bucket per key in a power-of-two table (2.1 KB for a 40-key object). The compiled claude-code TUI holds thousands of these (`shapes.indices`: 18.9 MB / 6.8k entries at 2 s into a streamed reply on today's main; 89 MB / 34.5k on the 2026-09-04 census).

Every hit the index produces is re-validated against the key bytes (`shape_slot_lookup_verdict`), so a colliding answer is a miss and never a wrong property — which is what lets the stored hash be narrow. `SlotIndex` is an open-addressing table of `(16-bit tag, 16-bit slot)` cells (4 B; a 16-bit tag + 32-bit slot only past 65 535 keys); the tag is the top of a golden-ratio fold of the FNV-1a hash (FNV's own high bits barely move for short keys), the probe position is a function of the tag alone so cells re-place themselves on growth and after a delete's `retain_shift`, load ≤ 7/8. 40 keys: 64 × 4 B = 256 B. Same O(1) probe; a repeated note-hit no longer appends a duplicate.

## Measurements

Heap census (`PERRY_GC_CENSUS=<file>`, `stream_scale.py --signal-at 2` into a
3300-char streamed reply) on the compiled claude-code 2.1.112 TUI. Both arms
built by the same relink pipeline from the same object cache, run back to back.
`cc_base` = main `12efed1222`; `cand` = this branch (it also carries #9755,
which is CPU-only and does not change a table's size).

| side table | cc_base | cand |
|---|---|---|
| **`shapes.indices`** | **17.04 MB / 6 227 entries** | **2.44 MB / 6 324 entries** |
| `shapes.families` | 1.73 MB / 48 191 | 3.41 MB / 48 552 |
| `shapes.descriptors` | 6.73 MB / 64 984 | 6.74 MB / 69 635 |
| `shapes.by_facts` | 3.28 MB / 53 615 | 3.28 MB / 58 266 |
| **`side_table_bytes` (all 40 tables)** | **83.59 MB** | **70.55 MB** |
| live JS bytes / objects | 57.13 MB / 444 537 | 57.24 MB / 445 276 |
| `phys_footprint` | 323.4 MB | 289.8 MB |
| RSS | 508.6 MB | 440.5 MB |
| mimalloc commit | 407.4 MB | 344.3 MB |

2.73 KB → 386 B per indexed shape, at an identical live set. The
`shapes.families` row grows because the census attributes the per-family
`SlotIndex` cells there now that they are no longer a separate hashbrown
allocation; the total is the number that matters, and it is 13.0 MB lower.

The 2026-09-04 census that motivated this quoted `shapes.indices` at 89 MB /
34 541 entries — a longer-running process. The per-entry ratio is what
transfers, and it is the same 7×.

### CPU and the footprint gate — `stream_scale.py --mem --idle 12`, 400-char reply

(Stacked arm: #9755 + this. The memory win above is this PR's; the CPU win is #9755's.)

400-char reply, **three interleaved base/candidate pairs** (base, cand, base,
cand, base, cand) plus the node arm, run back to back through the campaign's
`measure_lock.sh`. Reported per run, not averaged, because settled footprint is
bimodal (it depends on whether a full collection fell inside the window).

| | cc_base r1 / r2 / r3 | cand r1 / r2 / r3 | node |
|---|---|---|---|
| **turn CPU s** | 10.33 / 10.61 / 10.59 | **8.49 / 8.25 / 7.99** | 0.23 |
| CPU in the 12 s after the turn | 3.72 / 7.91 / 7.28 | 6.08 / 4.38 / 4.71 | 0.02 |
| **peak RSS MB** | 1893 / 1993 / 1997 | **1897 / 1897 / 1894** | 375 |
| **footprint after turn MB** | 1872 / 1935 / 1934 | **1811 / 1803 / 1799** | 329 |
| settled footprint after 12 s idle MB | 2646 / 724 / 723 | 627 / 534 / 868 | 330 |

Turn CPU −21.6 % (10.51 → 8.24 s mean). Footprint after the turn is lower in
every pair and the candidate's spread collapses (1799–1811 MB against
1872–1935; peak RSS 1894–1897 against 1893–1997). **Neither metric regresses.**
The gap to node is still ~35× on CPU and ~5.5× on footprint — this is one step,
not the fix.

> The lock waits for 1-minute load below 8; five campaign lanes share this
> 10-core box, so it hit its 1200 s ceiling and proceeded at load 76. Absolute
> values are therefore still inflated for **every** arm including node; the
> interleaved pairing is what makes the comparison sound. The scanner-profile,
> `[gc-young-log]` and census rows below are counters, not timings.

## Tests

`slot_index_tests` (3000-key round trip + false-candidate bound, note-hit dedupe, `retain_shift`, narrow→wide promotion), the `object::` suite (319) and the `gc::` suite (1048).

https://claude.ai/code/session_01YPfnmWZmSpSWpmnoXvH8z2



> **Measurement conditions.** Five campaign lanes share this 10-core box and
> 1-minute load reached 147 while these were taken, so the **absolute** CPU
> seconds and footprint figures above are inflated for every arm. They are
> reported as interleaved A/B pairs (base, candidate, base, candidate — one
> after another in the same window), so the *comparison* is sound even though
> the absolute values are not comparable to the quiet-box baselines in
> `BRIEF_COMMON.md`. The scanner-profile, `[gc-young-log]` and census rows are
> counters, not timings, and are unaffected. A re-take under the campaign's new
> `measure_lock.sh` (which waits for load < 8) is queued and will replace the
> absolute columns.

## Correctness — rule 1 is now enforceable, and the audit that says so

The earlier claim in this description ("under `debug_assertions` a minor-scoped
walk re-derives the relevant set and panics on any key the log does not name —
this caught two writer sites while landing") was **true of the mechanism and
false of the verification**. Two things were wrong, and both are fixed here.

**`debug_assert_logged` is compiled out of `--release`.** There is no
`debug-assertions = true` under `[profile.release]`, so no release
`cargo test` run — including the 3152-test run first reported here — ever
executed rule 2. A `gcaudit` profile (release codegen, debug assertions on) is
added for it:

```
cargo test --profile gcaudit -p perry-runtime -- --test-threads=1
```

**Three `#[cfg(test)]` seeds re-implemented the arming**, so the tests
validated a rule that was not the shipped one and never touched the production
writers. Deleting the arm site in `shape_cache_insert` left the suite at
**11 passed / 0 failed**. The transition cache's seeds did not even carry the
same predicate:

| writer | armed on |
|---|---|
| production `transition_cache_insert` | `rel(next_keys) \|\| (len_marker == 0 && rel(kid))` |
| `test_seed_transition_cache_entry` | `rel(next_keys) \|\| rel(key_ptr)` — classifies a packed length as an address |
| `test_seed_transition_cache_root` | `rel(next_keys)` only |

Both caches now arm through one helper (`arm_shape_cache_young`,
`arm_transition_cache_young`) that every writer calls, and the young-log tests
drive the production writers through `test_shape_cache_insert` /
`test_transition_cache_insert`, which are nothing but calls. A new test covers
the clause no seed exercised: a young interned KEY under an OLD target.

### The audit

Each of the 21 arm sites suppressed in turn from one build. **14 fail a test
when removed**, and the failure is rule 2's own diagnostic — e.g.
`young log for object.descriptors does not name 5717278851120, which holds a
minor-relevant pointer: a writer of that table publishes without note-ing the
key first`.

| site | failing test(s) |
|---|---|
| `arm_shape_cache_young` note; `shape_cache_insert`'s call | `young_shape_cache_entry_is_moved_through_the_log` |
| `arm_transition_cache_young` note; `transition_cache_insert`'s call | `young_transition_cache_target_is_rewritten…`, `young_transition_key_under_an_old_target…` |
| transition `next_keys` clause / `kid` clause | the respective one of those two |
| closure helper note; closure owner-moved note | `dead_young_closure_owner_is_pruned…` + `young_value_under_an_old_closure_owner…`; `young_closure_prop_value_is_moved…` |
| `note_young_keys` note; `family_push_back`'s call | `young_keys_array_family_is_rekeyed_through_the_log` |
| descriptor helper note; 3 of its 5 call sites | `dead_young_descriptor_owner_is_pruned…`, `old_descriptor_owners_are_skipped…`, `young_accessor_getter_is_moved…` |

**Seven sites did not fail any test.** Four of them were the entire arming of
`shapes.indices` — the table #9756 restructures — and are now covered, one
dedicated test each, all four re-audited and all four caught by rule 2's own
diagnostic:

| site | test that catches its removal |
|---|---|
| `ShapeTableInner::family_push_front` | `installing_an_external_shape_id_arms_the_family_log` |
| `shape_slot_lookup_verdict` build arm | `building_a_slot_index_on_a_young_keys_array_arms_the_log` |
| `shape_keys_grown` | `growing_an_indexed_keys_array_arms_the_log_for_the_new_address` |
| `shape_index_migrate_after_delete` | `migrating_an_index_after_a_delete_arms_the_log_for_the_new_address` |

Each drives the production writer (a 40-key young array, above
`KEYS_INDEX_THRESHOLD`, or no index is built at all; a *complete* index, or the
delete migration declines and never arms). They are behavioural rather than
representation-specific, so they pass against both the `PtrHashMap` index and
#9756's packed 4-byte cells.

**Three sites remain knowingly uncovered**, on ground neither PR restructures:
`transfer_descriptor_owner` (array-growth ownership transfer),
`install_fresh_accessor_property` and `set_builtin_accessor_descriptor`. No
test reaches those paths, so a missed arm in them would not be caught by this
suite. They are recorded rather than half-covered; rule 2 checks any test that
reaches them, so closing them is a matter of exercising the paths.

**Whole suite under `--profile gcaudit`: 3153 passed on #9755 / 3157 on #9756,
0 failed, no rule-2 violation anywhere.**

(At `codegen-units = 16` two unrelated tests fail — `handle_bound_method_name`'s `'static`-literal identity check, the CGU-duplication artifact its own comment documents for Windows; they pass at `codegen-units = 1`, which is what the profile uses.)

## CI

Three failures on the first push were mine and are fixed here: the missing
`changelog.d/` fragment, `cargo fmt`, and `scripts/check_file_size.sh` (this
change took four files past the 2000-line limit; see the second commit). Also
fixed: `scripts/gc_rekeyed_key_tables.json` follows the moved scanner, and the
two `#[cfg(test)]` transition-cache seams are re-exported.

Green locally on this branch: `cargo fmt --check`, `cargo check --all-targets`
with `RUSTFLAGS=-D warnings`, `cargo test -p perry-runtime --release`
(**3152 passed / 0 failed**, `--test-threads=1`), `check_file_size.sh`,
`gc_rekeyed_key_tables.py` (42 sites, 25 prunes, all classified),
`check_gc_scanner_latches.py` (130 registrations), `gc_gate_wiring_check.py`,
`check_gc_doc_claims.py`, `check_gc_env_knobs.py`, `gc_pin_sites.py`,
`gc_matrix_liveness_check.py --check-registry`.

**Every other red check is pre-existing on `main` at this PR's base commit
`12efed12220e`**, not introduced here — checked by running the same gates
against a clean `origin/main` and by reading main's own runs on that SHA:

| check | evidence it is pre-existing |
|---|---|
| `cargo-test`, `check` (API docs drift), `warnings` (product + all-targets), `gap-suite`, `gc-stress matrix`, `gc-stress`, `main-gate` | main's own CI run [33926006467](https://github.com/PerryTS/perry/actions/runs/33926006467) on `12efed12220e` fails on exactly these steps |
| `self-test-checkers` | `python3 scripts/check_thread_locals.py` fails identically on a clean `origin/main` checkout: two raw `thread_local!` blocks in `gc/census.rs`. Run [33918296710](https://github.com/PerryTS/perry/actions/runs/33918296710) (TLS Budget) is red on `12efed12220e`. Being fixed for the whole repo in #9774 |
| `gc-native-roots-complete`, `gc-root-dominance`, `gc-root-dominance-statepoints`, `gc-ratchet` | red on `12efed12220e` on main: [33918907275](https://github.com/PerryTS/perry/actions/runs/33918907275), [33917989138](https://github.com/PerryTS/perry/actions/runs/33917989138), [33917527174](https://github.com/PerryTS/perry/actions/runs/33917527174) |
| `ext-link` | red on main since 2026-09-04 ([33856617416](https://github.com/PerryTS/perry/actions/runs/33856617416)); it fails linking `js_bun_tcp_listen` out of `perry-ext-net` into `perry-ext-http`, and this PR touches neither crate |
| `native-roots-rs4gc (ubuntu-24.04-arm, aarch64, ELF)` | **step-for-step identical to main.** On this PR it fails on: *Build compiler and static runtime (perry-dev profile), Provider dylib host-boundary GC and Response, Walker agreement (aarch64 hosts), Probe matrix, RS4GC mode, forced evacuation, Both non-default walkers.* Main's run [33918907275](https://github.com/PerryTS/perry/actions/runs/33918907275) on `12efed12220e` fails on that same list, in that order — it dies in the *build* step, before any root scanning runs. The macOS arm is likewise red on main. |
| `pr-gate`, `parity-aggregate` | aggregators that report their dependencies; they go green when the above do |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved minor garbage-collection performance by scanning only relevant runtime data.
  - Reduced unnecessary remembered-set work after collections, especially for large arrays and external buffers.
  - Optimized shape and property lookup bookkeeping to improve access speed and reduce memory overhead.
  - Added a runtime profile to support debugging and validation.

- **Diagnostics**
  - Added optional garbage-collection diagnostics for monitoring scan and coverage activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->






## Rebased onto main `1d63fa91f`+train125 (`c7361c87c`)

Replayed clean on top of the rebased #9755; no conflicts in this commit. The two
reconciliations the rebase needed both belong to #9755 and are described there —
the `gc/roots.rs` split regenerated against main's `get_stack_bottom` bodies so
the landed pthread stack-bounds fix survives, and rule-1 arming restored for
`family_append_fresh`, the third family-append path main added in `0ee491545`
after this branch was written.

The second of those matters here in particular: `family_append_fresh` is the
append `shape_descriptor_intern` uses, and the table it files into is
`shapes.families`, whose sibling `shapes.indices` is what this PR restructures.
An unlogged family is a keys array the minor-scoped rekey scanner never visits.
