### PR TITLE
perf(shapes): append a freshly allocated descriptor id without the family membership scan

### DIFF
--- a/changelog.d/keystroke-shape-family-append.md
+++ b/changelog.d/keystroke-shape-family-append.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- Interning a shape descriptor no longer scans the keys array's whole
+  descriptor history. `ShapeTableInner::family_push_back` / `facts_push_back`
+  answer "is this id already here?" with a linear scan of the family, and a
+  family accumulates every descriptor ever created for one keys array — so
+  interning the *n*-th descriptor for a keys array cost O(n) and a render that
+  keeps bumping a shape's semantic generation paid quadratic time. The two
+  interning sites append ids that `alloc_shape_id` has just handed out, and
+  that allocator never reuses a value, so the scan was provably dead work:
+  they now use `IdList::append_unchecked`. On the compiled claude-code TUI
+  `IdList::contains` was 6.2 % of main-thread leaf samples during a streamed
+  reply and 5.9 % in the window after it, 95 % of it under
+  `family_push_back`.

--- a/crates/perry-runtime/src/object/shapes.rs
+++ b/crates/perry-runtime/src/object/shapes.rs
@@ -264,6 +264,15 @@ impl ShapeTableInner {
         self.families.entry(keys).or_default().push_back(id);
     }
 
+    /// Append a FRESHLY allocated id (see [`IdList::append_unchecked`]): the
+    /// id came from `alloc_shape_id`, which never reuses a value, so the
+    /// membership scan `family_push_back` would run is dead work that is
+    /// linear in the number of descriptors this keys array has ever had.
+    #[inline]
+    fn family_append_fresh(&mut self, keys: u64, id: u32) {
+        self.families.entry(keys).or_default().append_unchecked(id);
+    }
+
     #[inline]
     fn family_push_front(&mut self, keys: u64, id: u32) {
         self.families.entry(keys).or_default().push_front(id);
@@ -285,6 +294,12 @@ impl ShapeTableInner {
     #[inline]
     fn facts_push_back(&mut self, facts: u64, id: u32) {
         self.by_facts.entry(facts).or_default().push_back(id);
+    }
+
+    /// Fresh-id twin of [`ShapeTableInner::facts_push_back`]; same argument.
+    #[inline]
+    fn facts_append_fresh(&mut self, facts: u64, id: u32) {
+        self.by_facts.entry(facts).or_default().append_unchecked(id);
     }
 
     #[inline]
@@ -507,8 +522,12 @@ pub(crate) fn shape_descriptor_ensure_with_holes(
     // complete descriptor.
     // SAFETY: no slab reference is held; `slab()` above went out of scope.
     unsafe { table.slab_mut().insert(id, record) };
-    inner.facts_push_back(facts, id);
-    inner.family_push_back(keys_id, id);
+    // `id` was just handed out by `alloc_shape_id`, which never reuses a
+    // value, so neither accelerator can already hold it: append without the
+    // membership scan, whose cost is linear in this keys array's descriptor
+    // history (see `IdList::append_unchecked`).
+    inner.facts_append_fresh(facts, id);
+    inner.family_append_fresh(keys_id, id);
     Ok(id)
 }
 

--- a/crates/perry-runtime/src/object/shapes_slot_list.rs
+++ b/crates/perry-runtime/src/object/shapes_slot_list.rs
@@ -401,7 +401,9 @@ pub(crate) unsafe fn rekey_stable_tombstone_shape_after_squeeze(
         .get_mut(&record.keys)
         .is_some_and(|ids| ids.replace(old_id, new_id));
     if !replaced {
-        inner.family_push_back(record.keys, new_id);
+        // `new_id` came from `alloc_shape_id` a few lines above and is in no
+        // list yet (see `IdList::append_unchecked`).
+        inner.family_append_fresh(record.keys, new_id);
     }
     inner.indices.remove(&(record.keys as usize));
     drop(inner);

--- a/crates/perry-runtime/src/object/shapes_store.rs
+++ b/crates/perry-runtime/src/object/shapes_store.rs
@@ -537,6 +537,27 @@ impl IdList {
         if self.contains(id) {
             return;
         }
+        self.append_unchecked(id);
+    }
+
+    /// Append an id the caller knows is not in this list.
+    ///
+    /// `alloc_shape_id` hands out a strictly increasing counter that is never
+    /// reused (it parks at `SHAPE_ID_END` rather than wrapping), so an id that
+    /// was allocated after this list was built cannot be in it, in this family
+    /// or in any other. The membership scan in [`push_back`] is therefore dead
+    /// work at the two interning sites, and it is not O(1) dead work: a family
+    /// holds every descriptor ever created for one keys array, so the scan is
+    /// linear in the history of that keys array and interning the *n*-th
+    /// descriptor for it costs O(n) — quadratic over a render that keeps
+    /// bumping a shape's semantic generation. `IdList::contains` was 6.2 % of
+    /// main-thread leaf samples on a claude-code streamed reply, 95 % of it
+    /// under `ShapeTableInner::family_push_back`.
+    ///
+    /// Callers that re-file an EXISTING id (the metadata rekey when a keys
+    /// array moves) must keep using [`push_back`]: those ids can already be in
+    /// the destination list.
+    pub(super) fn append_unchecked(&mut self, id: u32) {
         match self {
             IdList::Inline { len, ids } if (*len as usize) < ids.len() => {
                 ids[*len as usize] = id;

--- a/crates/perry-runtime/src/object/shapes_tests.rs
+++ b/crates/perry-runtime/src/object/shapes_tests.rs
@@ -552,6 +552,43 @@ mod descriptor_tests_8067 {
     }
 
     #[test]
+    fn interning_appends_each_new_descriptor_to_the_family_exactly_once() {
+        // `shape_descriptor_ensure` appends a FRESHLY allocated id with
+        // `IdList::append_unchecked`, skipping the membership scan whose cost
+        // is linear in the family's history. The scan is skippable only
+        // because `alloc_shape_id` never reuses a value; this pins the
+        // observable consequence — every distinct descriptor for one keys
+        // array appears in its family exactly once, in birth order — so a
+        // later change that feeds a recycled id through the fresh path fails
+        // here instead of silently duplicating a family entry.
+        let _lock = crate::gc::global_side_table_test_lock();
+        let keys = 0x8067_0000_0000_2900usize;
+        let mut born = Vec::new();
+        for n in 1..=6u32 {
+            born.push(
+                shape_descriptor_ensure(keys as *const ArrayHeader, n, n)
+                    .expect("shape range unexpectedly exhausted"),
+            );
+        }
+        assert_eq!(
+            test_shape_ids_for_keys(keys),
+            born,
+            "each new descriptor is appended once, in birth order"
+        );
+        // Re-interning the same facts must hit the accelerator and add nothing.
+        for (i, n) in (1..=6u32).enumerate() {
+            assert_eq!(
+                shape_descriptor_ensure(keys as *const ArrayHeader, n, n).unwrap(),
+                born[i],
+                "an existing descriptor must be reused, not re-appended"
+            );
+        }
+        assert_eq!(test_shape_ids_for_keys(keys), born);
+
+        test_drop_shape_descriptors(keys);
+    }
+
+    #[test]
     fn a_foreign_agent_id_misses_instead_of_aliasing_same_address() {
         let _lock = crate::gc::global_side_table_test_lock();
         let fake_keys = 0x8067_0000_0000_1000usize;


### PR DESCRIPTION
## What

`shape_descriptor_ensure_with_holes` — the interning funnel every object shape
goes through — ends with

```rust
inner.facts_push_back(facts, id);
inner.family_push_back(keys_id, id);
```

and both helpers answer "is this id already in the list?" with a **linear scan**
(`IdList::contains`). The family under a keys array holds *every descriptor ever
created for that keys array* (that is what it is for: the shapes a keys array has
had). So interning the *n*-th descriptor for a keys array cost O(n), and a
program that keeps bumping a shape's semantic generation — a TUI re-rendering the
same component tree — pays quadratic time in the history of each keys array.

The scan is dead work at both sites: `id` was handed out by `alloc_shape_id` two
statements earlier, and that allocator is a strictly increasing counter that
never reuses a value (on exhaustion it parks at `SHAPE_ID_END` rather than
wrapping, precisely so an id can never alias). An id allocated after a list was
built cannot be in it — in that family or any other.

## The change

* `IdList::append_unchecked` — append without the membership scan, documented
  with the invariant that licenses it.
* `ShapeTableInner::family_append_fresh` / `facts_append_fresh` use it, and the
  two sites that append a just-allocated id (`shape_descriptor_ensure_with_holes`
  and the id move in `shapes_slot_list`) call those.
* Every other caller keeps `push_back`: the metadata rekey that re-files
  **existing** ids under a moved keys address can legitimately meet an id the
  destination list already holds.

## What is claimed

**This is a complexity fix, not a CPU win.** Interning a shape descriptor is now
O(1) in the number of descriptors the keys array has ever had, instead of O(n) —
a cost that grows with process lifetime and therefore does not show its true size
in any short measurement. That is the whole claim.

Proof that the scan is gone (macOS `sample`, main thread, leaf samples, 400-char
streamed reply on the claude-code TUI, `cc_ks2` = the same branch without this
commit):

| leaf | before (`cc_ks2`) | after (`cc_ks4`) |
|---|---|---|
| `IdList::contains` | 681 (**6.19 %**) | 3 (**0.02 %**) |
| of which under `family_push_back` | 647 (95 %) | — |

200x fewer samples. `shape_descriptor_ensure` itself stays at 0.36 %, i.e.
interning still happens, it just no longer walks the family. On `main` the same
symbol reads 95 samples (0.79 %) in that window — it grows as the shape table
does, which is exactly the point.

**End to end it is flat, and I am explicitly not claiming otherwise.** Same
session, same `measure_lock.sh`, 400-character reply
(`stream_scale.py --mem --idle 12`):

| arm | turn CPU | idle-12 CPU | peak RSS | FP settled |
|---|---|---|---|---|
| `cc_ks2` (without this PR) | 7.09 s | 3.96 s | 659 MB | 634 MB |
| `cc_ks4` (with this PR + #9769) | 6.98 s | 3.90 s | 658 MB | 651 MB |
| node 2.1.112 | 0.29 s | 0.02 s | 375 MB | 175 MB |

0.11 s on a 7 s turn is inside the run-to-run spread. It is not a CPU win and
must not be counted as one. (A 3300-character arm of the same candidate came in
at 37.95 s against 51.8 s previously recorded for `cc_ks2` — the direction this
predicts, longer run ⇒ longer families ⇒ more scan removed — but the two numbers
are from different sessions and I am not treating that gap as measured either.)

## Correctness

New test `interning_appends_each_new_descriptor_to_the_family_exactly_once` pins
the observable consequence — six distinct descriptors for one keys array appear
in its family exactly once each, in birth order, and re-interning the same facts
reuses the existing id and appends nothing — so a later change that routes a
recycled id through the fresh path fails here instead of silently duplicating a
family entry. Verified running, not merely present.
