### PR TITLE
fix(runtime): unify the three pthread stack-bounds extern declarations

### DIFF
--- a/changelog.d/9776-pthread-extern-signature-clash.md
+++ b/changelog.d/9776-pthread-extern-signature-clash.md
@@ -1,0 +1,18 @@
+**`perry-runtime` compiles again under `-D warnings` on linux-x86_64.** The crate
+declared `pthread_getattr_np`, `pthread_attr_getstack` and `pthread_attr_destroy`
+in three separate `extern "C"` blocks using two different spellings of the
+`pthread_attr_t` buffer — `[u64; 8]` in `gc::roots::get_stack_bottom`, `*mut u8`
+in `gc::roots::stack_maps::fp_chain` and in the Error-stack frame walk. Declaring
+one symbol twice in a crate with different signatures is
+`clashing_extern_declarations`, which `-D warnings` denies, and the crate stopped
+building outright (#9486's frame walk supplied the third copy).
+
+The `*mut u8` spelling was not itself new, but its only previous home was
+`fp_chain`, which is gated to `target_arch = "aarch64"`; on an x86_64 host that
+module is compiled out and the two spellings never met.
+
+All three blocks now use `[u64; 8]`, the spelling the collector has always used.
+That also clears the latent aarch64-linux collision between `fp_chain` and
+`gc::roots`, and replaces a `[u8; 128]` buffer — 128 bytes but aligned to 1 —
+with one that is both large enough for `pthread_attr_t` on every supported
+glibc/musl target (56 bytes on both) and correctly aligned for it.

--- a/crates/perry-runtime/src/error_stack_frames.rs
+++ b/crates/perry-runtime/src/error_stack_frames.rs
@@ -195,25 +195,33 @@ mod walk {
 
     #[cfg(all(target_os = "linux", not(target_vendor = "apple")))]
     fn stack_top_uncached() -> usize {
+        // These signatures must stay identical to the ones in
+        // `gc::roots::get_stack_bottom` and `gc::roots::stack_maps::fp_chain`.
+        // Two `extern "C"` blocks in one crate that declare the same symbol
+        // with different argument types are a hard error under `-D warnings`
+        // (`clashing_extern_declarations`), and `[u64; 8]` — 64 bytes, which
+        // covers `pthread_attr_t` on every supported glibc/musl target — is
+        // the spelling the collector has always used. Unlike a `[u8; N]`
+        // buffer it is also correctly aligned for the attr union.
         unsafe extern "C" {
             fn pthread_self() -> usize;
-            fn pthread_getattr_np(thread: usize, attr: *mut u8) -> i32;
+            fn pthread_getattr_np(thread: usize, attr: *mut [u64; 8]) -> i32;
             fn pthread_attr_getstack(
-                attr: *const u8,
-                stackaddr: *mut *mut core::ffi::c_void,
+                attr: *const [u64; 8],
+                stackaddr: *mut *mut u8,
                 stacksize: *mut usize,
             ) -> i32;
-            fn pthread_attr_destroy(attr: *mut u8) -> i32;
+            fn pthread_attr_destroy(attr: *mut [u64; 8]) -> i32;
         }
-        let mut attr = [0u8; 128];
-        let mut addr: *mut core::ffi::c_void = core::ptr::null_mut();
+        let mut attr = [0u64; 8];
+        let mut addr: *mut u8 = core::ptr::null_mut();
         let mut size: usize = 0;
         unsafe {
-            if pthread_getattr_np(pthread_self(), attr.as_mut_ptr()) != 0 {
+            if pthread_getattr_np(pthread_self(), &mut attr) != 0 {
                 return 0;
             }
-            let ok = pthread_attr_getstack(attr.as_ptr(), &mut addr, &mut size) == 0;
-            pthread_attr_destroy(attr.as_mut_ptr());
+            let ok = pthread_attr_getstack(&attr, &mut addr, &mut size) == 0;
+            pthread_attr_destroy(&mut attr);
             if !ok {
                 return 0;
             }

--- a/crates/perry-runtime/src/gc/roots/stack_maps.rs
+++ b/crates/perry-runtime/src/gc/roots/stack_maps.rs
@@ -1786,27 +1786,31 @@ mod fp_chain {
     /// back to the platform unwinder (fail-closed like every other anomaly).
     #[cfg(target_os = "linux")]
     fn stack_top() -> usize {
+        // Identical to `gc::roots::get_stack_bottom` and the Error-stack
+        // capture in `error_stack_frames.rs`: one crate may not declare the
+        // same `extern "C"` symbol with two different signatures
+        // (`clashing_extern_declarations`, denied via `-D warnings`).
         unsafe extern "C" {
             fn pthread_self() -> usize;
-            fn pthread_getattr_np(thread: usize, attr: *mut u8) -> i32;
+            fn pthread_getattr_np(thread: usize, attr: *mut [u64; 8]) -> i32;
             fn pthread_attr_getstack(
-                attr: *const u8,
-                stackaddr: *mut *mut c_void,
+                attr: *const [u64; 8],
+                stackaddr: *mut *mut u8,
                 stacksize: *mut usize,
             ) -> i32;
-            fn pthread_attr_destroy(attr: *mut u8) -> i32;
+            fn pthread_attr_destroy(attr: *mut [u64; 8]) -> i32;
         }
         // pthread_attr_t is at most 64 bytes on glibc/musl for the supported
-        // targets; over-allocate defensively.
-        let mut attr = [0u8; 128];
-        let mut addr: *mut c_void = std::ptr::null_mut();
+        // targets, and `[u64; 8]` is both that size and correctly aligned.
+        let mut attr = [0u64; 8];
+        let mut addr: *mut u8 = std::ptr::null_mut();
         let mut size: usize = 0;
         unsafe {
-            if pthread_getattr_np(pthread_self(), attr.as_mut_ptr()) != 0 {
+            if pthread_getattr_np(pthread_self(), &mut attr) != 0 {
                 return 0;
             }
-            let ok = pthread_attr_getstack(attr.as_ptr(), &mut addr, &mut size) == 0;
-            pthread_attr_destroy(attr.as_mut_ptr());
+            let ok = pthread_attr_getstack(&attr, &mut addr, &mut size) == 0;
+            pthread_attr_destroy(&mut attr);
             if !ok {
                 return 0;
             }


### PR DESCRIPTION
## The break

`main` cannot compile `perry-runtime` under `-D warnings`, so the **`warnings`** job on
https://github.com/PerryTS/perry/actions/runs/33926006467 (main at `12efed12220e`) fails
with `build failed, waiting for other jobs to finish`:

```
error: `pthread_getattr_np` redeclared with a different signature
   --> crates/perry-runtime/src/gc/roots.rs:761:9
761 |         fn pthread_getattr_np(thread: usize, attr: *mut [u64; 8]) -> i32;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this signature doesn't match the previous declaration
    ::: crates/perry-runtime/src/error_stack_frames.rs:200:13
200 |             fn pthread_getattr_np(thread: usize, attr: *mut u8) -> i32;
    |             ------------------------------------------------------- `pthread_getattr_np` previously declared here
    = note: expected `unsafe extern "C" fn(usize, *mut u8) -> i32`
               found `unsafe extern "C" fn(usize, *mut [u64; 8]) -> i32`
    = note: `-D clashing-extern-declarations` implied by `-D warnings`
error: could not compile `perry-runtime` (lib) due to 3 previous errors
```

Same for `pthread_attr_getstack` and `pthread_attr_destroy`.

## Root cause

`perry-runtime` declares these three libc functions in **three** separate `extern "C"`
blocks, in two different spellings:

| site | attr spelling | cfg |
| --- | --- | --- |
| `gc/roots.rs:757` `get_stack_bottom` | `[u64; 8]` | `target_os = "linux"` |
| `gc/roots/stack_maps.rs:1788` `fp_chain::stack_top` | `*mut u8` | `target_os = "linux"` **and `target_arch = "aarch64"`** |
| `error_stack_frames.rs:197` `stack_top_uncached` | `*mut u8` | `target_os = "linux"` (**no arch gate**) |

The `*mut u8` spelling is not new — but the only site that used it was inside
`mod fp_chain`, which is gated to `target_arch = "aarch64"`. On CI's **linux-x86_64**
host that module is `cfg`'d out, so the two spellings never met and the lint never fired.

**Culprit: `1ebc65e87` — "feat(runtime): real function names in Error stacks — frame-pointer
walk + the existing name registry (#9486) (#9521)" (2026-09-02).** It added a third copy of
the block in `error_stack_frames.rs` gated only on `target_os = "linux"`. With no arch gate
it collides with `gc/roots.rs` on x86_64, and the crate stopped compiling under `-D warnings`.

This is macOS-invisible: every declaration involved is behind `cfg(target_os = "linux")`.

## The fix

All three blocks now use the `[u64; 8]` spelling that `gc::roots::get_stack_bottom` — the
oldest and most-shipped of the three — has always used. This also clears the **latent**
aarch64-linux collision between `fp_chain` and `gc/roots.rs`, which would have broken that
target the moment anyone built it with `-D warnings`.

`[u64; 8]` is 64 bytes: at least the size of `pthread_attr_t` on every supported glibc/musl
target (56 bytes on both), and correctly aligned for it — which the `[u8; 128]` buffer it
replaces, with alignment 1, was not. No behavioural change otherwise; all three functions
compute the same stack-high address they did before.

## Verification

- Minimised standalone repro: the two spellings in one crate produce exactly the two
  `redeclared with a different signature` errors under `-D warnings`; unified, `rustc`
  exits 0.
- `RUSTFLAGS="-D warnings" cargo check -p perry-runtime --all-targets` on a **linux-x86_64**
  host reproduces the 3 errors at `12efed12220e` and passes with this commit.

## Not fixed here

`main` is red for four further, independent reasons — none of them this compile error, and
none of them fixed by this PR. Detailed separately:

- **`check`** — API-docs drift: `Bun.connect`/`Bun.listen` were added to the API manifest by
  `868787448` ("feat(bun): add TCP socket facades") without re-running `scripts/regen_api_docs.sh`.
- **`ext-link`** (red since 2026-09-04) — `js_bun_tcp_listen` calls `perry_ffi::run_pending`,
  and `crates/perry-ext-http/src/test_async_shims.rs` has no `perry_ffi_run_pending` stub.
  Same culprit commit `868787448`.
- **`cargo-test`** — `commands::compile::build_cache::tests::codegen_env_vars_are_build_cache_inputs`.
- **`gc-stress matrix (4/4)`** / **`gap-suite (2)`** — output mismatches in
  `test_gap_repsel_gc_stress`, `test_gap_perfhooks_3088_3008_3010_3011` and
  `test_gap_prop_plan_cache_invalidation`.

`gc-stress` and `main-gate` are aggregator jobs (14s / 3s) and go green once their
dependencies do.

https://claude.ai/code/session_01YPfnmWZmSpSWpmnoXvH8z2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Linux builds with warnings treated as errors.
  - Improved compatibility across supported Linux architectures by aligning system-level stack handling declarations.
  - Corrected buffer alignment and sizing used during thread stack inspection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->