### PR TITLE
fix(compile): key the build cache on PERRY_CONCAT_SITE_CACHE

### DIFF
--- a/changelog.d/9777-build-cache-concat-site-cache.md
+++ b/changelog.d/9777-build-cache-concat-site-cache.md
@@ -1,0 +1,10 @@
+**`PERRY_CONCAT_SITE_CACHE` is now a build-cache input.** #9514's per-site
+concat cache reads the variable as a build-time kill switch — setting it to
+`0` removes the lowering lane entirely — but it was registered neither in
+`BUILD_CACHE_ENV_VARS` nor as a justified exclusion. A build with the switch
+flipped could therefore be served a cached object produced with it in the
+other state.
+
+`codegen_env_vars_are_build_cache_inputs` caught this by scanning
+`crates/perry-codegen/src` for every `env::var("PERRY_…")`, which is why the
+check scans the source instead of trusting a hand-maintained list.

--- a/crates/perry/src/commands/compile/build_cache.rs
+++ b/crates/perry/src/commands/compile/build_cache.rs
@@ -94,6 +94,11 @@ const BUILD_CACHE_ENV_VARS: &[&str] = &[
     // #9026: gates the once-per-closure-entry resolution of read-only boxed
     // capture cells — flipping it changes every closure body that qualifies.
     "PERRY_BOX_CAPTURE_ENTRY_CELLS",
+    // #9514: gates the per-site concat cache. `PERRY_CONCAT_SITE_CACHE=0`
+    // removes the lane at build time, so a qualifying `"literal" + value`
+    // site lowers to a different sequence with it on and off and a cached
+    // object from one setting must not serve the other.
+    "PERRY_CONCAT_SITE_CACHE",
     // The guarded-preinline IR-size ceiling: functions on either side of the
     // budget inline differently, so a run with a raised ceiling must not be
     // served objects a default run produced (same rule as the RS4GC budget


### PR DESCRIPTION
## The break

The **`cargo-test`** job on main is red — one test out of 1074:

```
test commands::compile::build_cache::tests::codegen_env_vars_are_build_cache_inputs ... FAILED
thread '...' panicked at crates/perry/src/commands/compile/build_cache.rs:410:9
these codegen env vars key neither the build cache nor an exclusion
(#6394's rule): ["PERRY_CONCAT_SITE_CACHE"]
test result: FAILED. 1073 passed; 1 failed
```

Failing run: https://github.com/PerryTS/perry/actions/runs/33926006467 (main at `12efed12220e`).

## Root cause

`codegen_env_vars_are_build_cache_inputs` scans `crates/perry-codegen/src` for every
`env::var("PERRY_…")` and requires each to appear in `BUILD_CACHE_ENV_VARS` or in
`BUILD_CACHE_ENV_EXCLUSIONS`. Its own doc comment explains why it scans rather than trusting
a hand-maintained list: *"the list rotted once already and did so silently."*

It has rotted again. **`0b68a25cf` — "perf(strings): per-site concat cache for `"literal"` +
proven-small value (#9514)"** added `std::env::var("PERRY_CONCAT_SITE_CACHE")` at
`crates/perry-codegen/src/concat_site_cache.rs:78` and registered it in neither list.

## This is the guard working, not a stale test

`PERRY_CONCAT_SITE_CACHE` is a **build-time** kill switch, not a diagnostic:

- `concat_site_cache.rs:52` (module doc): *"`PERRY_CONCAT_SITE_CACHE=0` removes the lane at
  build time."*
- `crates/perry/tests/concat_site_cache.rs:243` compiles a fixture with
  `("PERRY_CONCAT_SITE_CACHE", "0")` and asserts the emitted code differs.

So it demonstrably changes generated code, which makes it a cache **input** rather than an
exclusion. Until it is one, a build with the switch flipped can be served a stale cached
object produced with it in the other state — a real cache-correctness hole, which is exactly
what #6394's rule exists to prevent. Added with a comment in the same form as its neighbours.

## Verification

The test is a pure source scan — no compilation semantics — so its logic can be replicated
exactly. Re-running all three of its assertions over the tree with this change applied:

```
scanned: 72   BUILD_CACHE_ENV_VARS: 88   EXCLUSIONS: 11
assert found.len() > 20      : PASS
assert missing.is_empty()    : PASS   (was FAIL ["PERRY_CONCAT_SITE_CACHE"])
assert no stale exclusions   : PASS
```

## Scope

This fixes `cargo-test` only. `main` is red for four further independent reasons, tracked
separately — the `warnings` compile error is #9776; `check` (API-docs drift) and `ext-link`
both trace to `868787448` "feat(bun): add TCP socket facades"; and `gc-stress matrix (4/4)` /
`gap-suite (2)` are older, deterministic output mismatches.

https://claude.ai/code/session_01YPfnmWZmSpSWpmnoXvH8z2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Build caching now correctly distinguishes builds using different `PERRY_CONCAT_SITE_CACHE` settings, preventing incompatible cached objects from being reused.

- **Documentation**
  - Added documentation explaining the build-cache input and how environment-variable checks identify code-generation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->