### PR TITLE
fix: complete 868787448's Bun TCP landing (API docs drift + ext-link shim)

### DIFF
--- a/changelog.d/9780-bun-tcp-landing-followups.md
+++ b/changelog.d/9780-bun-tcp-landing-followups.md
@@ -1,0 +1,15 @@
+**`Bun.listen` / `Bun.connect` are documented, and `perry-ext-http`'s unit
+tests link again.** #9514's TCP socket facades added both methods to the
+compile-time API manifest without regenerating the derived docs, so
+`docs/src/api/reference.md` and `docs/api/perry.d.ts` had been stale since
+2026-09-03 and the API-docs drift check failed on every run. They now list
+both entries (3046 → 3048).
+
+Separately, `js_bun_tcp_listen` drives the shared async runtime from its
+bind-poll loop via `perry_ffi::run_pending`. `perry-ext-net` stubs that
+symbol only under `#[cfg(test)]`, which does not apply when it is linked as
+an ordinary dependency into `perry-ext-http`'s test binary, so release-linking
+that crate failed with `undefined symbol: perry_ffi_run_pending`.
+`perry-ext-http`'s test shim now provides it, alongside the
+`perry_ffi_spawn_async` stub that exists for the same transitive reason.
+`perry-ext-ws` was checked and does not need it.

--- a/crates/perry-ext-http/src/test_async_shims.rs
+++ b/crates/perry-ext-http/src/test_async_shims.rs
@@ -64,3 +64,9 @@ pub extern "C" fn perry_ffi_spawn_blocking_with_reactor(
 // host stdlib archive, which unit-test binaries do not link.
 #[no_mangle]
 pub extern "C" fn perry_ffi_spawn_async(_ctx: *mut c_void) {}
+
+// Same story: `js_bun_tcp_listen` drives the shared runtime from its bind-poll
+// loop (`perry_ffi::run_pending`), so linking perry-ext-net's object code into
+// this crate's test binaries pulls the extern in with it.
+#[no_mangle]
+pub extern "C" fn perry_ffi_run_pending(_budget_ms: u64) {}

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 2089 entries across 136 modules
+// Coverage: 2091 entries across 136 modules
 
 type PerryI8 = number & { readonly __perryI8?: never };
 type PerryI16 = number & { readonly __perryI16?: never };
@@ -375,6 +375,8 @@ declare module "bun" {
   /** stdlib */
   export function build(...args: any[]): any;
   /** stdlib */
+  export function connect(...args: any[]): any;
+  /** stdlib */
   export function deepEquals(...args: any[]): any;
   /** stdlib */
   export function file(...args: any[]): any;
@@ -386,6 +388,8 @@ declare module "bun" {
   export function generateHeapSnapshot(...args: any[]): any;
   /** stdlib */
   export function hash(...args: any[]): any;
+  /** stdlib */
+  export function listen(...args: any[]): any;
   /** stdlib */
   export function pathToFileURL(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 3046 entries across 138 modules.
+Total: 3048 entries across 138 modules.
 
 ## Modules
 
@@ -429,12 +429,14 @@ Total: 3046 entries across 138 modules.
 - `Terminal` — module
 - `Transpiler` — module
 - `build` — module
+- `connect` — module
 - `deepEquals` — module
 - `file` — module
 - `fileURLToPath` — module
 - `gc` — module
 - `generateHeapSnapshot` — module
 - `hash` — module
+- `listen` — module
 - `pathToFileURL` — module
 - `scan` — instance *(class: `Transpiler`)*
 - `scanImports` — instance *(class: `Transpiler`)*


### PR DESCRIPTION
Two red CI jobs, one cause. **`868787448` "feat(bun): add TCP socket facades"** (2026-09-03 22:42)
added `Bun.listen` / `Bun.connect` but left two derived things un-updated. Both are that
commit's loose ends, so they are fixed together here.

## 1. `check` — API docs drift

`868787448` added to `crates/perry-api-manifest/src/entries/part_4.rs`:

```rust
method("bun", "listen", false, None),
method("bun", "connect", false, None),
```

and touched **zero** files under `docs/`. The `check` job's "Check for API docs drift" step
regenerates the docs and diffs, so it has failed ever since:

```
-Total: 3046 entries across 138 modules.
+Total: 3048 entries across 138 modules.
+- `connect` — module
+- `listen` — module
```

Regenerated with `scripts/regen_api_docs.sh`'s own commands off a release build
(`perry --print-api-manifest=markdown` / `=dts`). The resulting diff is exactly the two
entries CI reported — `3046 → 3048`, nothing else. The manifest crate has no target `cfg`s
(only `cfg(test)`) and `check` runs on `ubuntu-latest`, so this Linux-generated output is
byte-for-byte what CI regenerates.

## 2. `ext-link` — undefined symbol, red since 2026-09-04

The reported symbol is `js_bun_tcp_listen`, but that is a red herring — it is defined
unconditionally at `crates/perry-ext-net/src/bun_tcp.rs:275`. The actual error is what it
*calls*:

```
error: linking with `cc` failed: exit status: 1
  = note: rust-lld: error: undefined symbol: perry_ffi_run_pending
error: could not compile `perry-ext-http` (lib test) due to 1 previous error
```

`js_bun_tcp_listen` drives the shared runtime from its bind-poll loop
(`perry_ffi::run_pending(2)`, `bun_tcp.rs:324`). `perry-ext-net` supplies a
`perry_ffi_run_pending` stub in its own `test_async_shims.rs` — but that module is
`#[cfg(test)]`, so it exists only when `perry-ext-net` is itself the crate under test, not
when it is linked as an ordinary dependency into **`perry-ext-http`'s** test binary.
`perry-ext-http`'s shim already covers `perry_ffi_spawn_async` for exactly this transitive
reason; `perry_ffi_run_pending` is the same situation one call deeper.

Note this is *not* the same bug as `6dcd1a598` (#9719), which fixed the analogous
`web-fetch`-gated HTTP bridge symbols in `perry-stdlib` and left the TCP path alone.

## Verification (linux-x86_64, real builds)

`cargo test --release --no-run -p perry-ext-http`, with the shim file swapped between main's
version and this one, sharing a target dir so the second run genuinely relinks:

```
BEFORE (main's shim):  rc=101   Compiling perry-ext-http: 1
    rust-lld: error: undefined symbol: perry_ffi_run_pending
    error: could not compile `perry-ext-http` (lib test) due to 1 previous error

AFTER  (this commit):  rc=0     0 errors
    Executable unittests src/lib.rs (.../perry_ext_http-69d8d87496af011d)
```

I also linked the `ws` feature group to check whether `perry-ext-ws` — which also depends on
`perry-ext-net` and also lacks the stub — needs the same fix. It does **not**; both it and
`perry-ext-fastify` produce executables cleanly, so the fix is deliberately scoped to
`perry-ext-http` alone rather than added defensively.

## Scope

This is one of several independent breakages on main. Also open from the same sweep:
**#9776** (`warnings` — a `clashing_extern_declarations` compile error, culprit `1ebc65e87`)
and **#9777** (`cargo-test` — an unkeyed build-cache env var, culprit `0b68a25cf`).

https://claude.ai/code/session_01YPfnmWZmSpSWpmnoXvH8z2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the API reference and type declarations to include the `Bun.connect` and `Bun.listen` methods.
  - Corrected API coverage totals so the published documentation accurately reflects the available Bun networking APIs.

- **Bug Fixes**
  - Resolved an issue that prevented the HTTP extension’s test suite from linking successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->