### PR TITLE
fix(gc): route the census thread-locals through hot TLS

### DIFF
--- a/changelog.d/9781-census-hot-tls.md
+++ b/changelog.d/9781-census-hot-tls.md
@@ -1,0 +1,10 @@
+**The GC census thread-locals no longer pay `_tlv_get_addr`.** `gc::census`
+is compiled unconditionally, so its two ungated `thread_local!` blocks were
+in shipping builds and cost an out-of-line libdyld call per access on Darwin
+— including the `ARMED` flag that gates whether the census does anything at
+all. Both now use `crate::perry_thread_local!`, the same treatment the four
+other recent declarations received; every call site already went through
+`.with()`, so nothing else changed.
+
+This also restores the `self-test-checkers` job, whose thread-local policy
+ratchet (#7469) had been failing on main and on every open PR.

--- a/crates/perry-runtime/src/gc/census.rs
+++ b/crates/perry-runtime/src/gc/census.rs
@@ -43,7 +43,7 @@ static SIGNAL_PENDING: AtomicBool = AtomicBool::new(false);
 static SIGNAL_INSTALLED: AtomicBool = AtomicBool::new(false);
 static MAIN_THREAD: OnceLock<std::thread::ThreadId> = OnceLock::new();
 
-thread_local! {
+crate::perry_thread_local! {
     static ARMED: Cell<bool> = const { Cell::new(false) };
     static SEQ: Cell<u32> = const { Cell::new(0) };
     static LABEL: RefCell<&'static str> = const { RefCell::new("manual") };
@@ -177,7 +177,7 @@ fn census_service_signal() {
     super::js_gc_collect();
 }
 
-thread_local! {
+crate::perry_thread_local! {
     /// Pass-1 snapshot: sorted header addresses that were marked when mark
     /// propagation finished (see the module docs).
     static PASS1_MARKED: RefCell<Option<Vec<usize>>> = const { RefCell::new(None) };


### PR DESCRIPTION
## The break

`scripts/check_thread_locals.py` fails on `main`, which takes the **`self-test-checkers`**
job of the **TLS Budget** workflow down — on main itself (run 33945210479) and on every open
PR, including unrelated ones:

```
thread-local policy check FAILED:

  crates/perry-runtime/src/gc/census.rs: 2 raw `thread_local!` block(s), none allowed.
    Use `crate::perry_thread_local!` — same syntax, same `.with()` at every call site,
    and the address lands in this thread's hot cache instead of costing a
    `_tlv_get_addr` call (#7469).
```

In that workflow the expensive `tls-budget` job passes (13m19s); only this 12-second
hermetic checker fails.

## Why it is a real finding, not just a ratchet

`gc::census` is compiled unconditionally — `crates/perry-runtime/src/gc/mod.rs:247` declares
`pub(crate) mod census;` with no `cfg` — so both blocks are in shipping builds and pay
`_tlv_get_addr` per access on Darwin, which is exactly the cost #7469's policy exists to
prevent. (The census is *runtime*-gated by `PERRY_GC_CENSUS`, but that gate is read through
`ARMED`, one of these very thread-locals.)

The file's third `thread_local!` is `#[cfg(test)]` and is out of scope by construction, as
the checker's own header documents — hence "2 raw blocks", not 3.

This is the same treatment `12efed122` ("perf(runtime): route four recent thread_local
declarations through hot TLS") gave four other recent declarations; `census.rs` was missed.

## The change

Both blocks become `crate::perry_thread_local!`. The macro takes the same syntax — multiple
statics per block, doc comments, `const { … }` initialisers — and yields the same `.with()`
API. All nine call sites of `ARMED` / `SEQ` / `LABEL` / `PASS1_MARKED` already go through
`.with()` (verified: zero non-`.with()` uses), so nothing else changes.

## Verification

Checker, run locally against the tree:

```
before:  thread-local policy check FAILED: ... 2 raw `thread_local!` block(s)   rc=1
after:   thread-local policy OK: 304 hot declarations, 122 raw blocks in
         87 recorded cold files, capacity 768                                   rc=0
```

Compile, on linux-x86_64 — `cargo check -p perry-runtime --all-targets`:

```
ASSERT converted: 2 (expect 2)
RC=0
real check of perry-runtime: 1        # a genuine `Checking perry-runtime v…`, not a cache hit
census.rs diagnostics: 0
Finished `dev` profile in 30.68s
```

Note: with `RUSTFLAGS=-D warnings` this branch does **not** build, but for an unrelated
reason — the three `clashing_extern_declarations` errors fixed by **#9776**, none of which
come from `census.rs`. That is why the compile check above is run without `-D warnings`;
once #9776 lands, both hold together.

## Scope

One of several independent breakages on `main`, which is currently red across six workflows.
Also open from this sweep: **#9776** (`warnings`), **#9777** (`cargo-test`), **#9780**
(`check` + `ext-link`).

https://claude.ai/code/session_01YPfnmWZmSpSWpmnoXvH8z2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced runtime overhead for garbage-collection census tracking, particularly on Apple platforms.

* **Reliability**
  * Restored automated checks that help detect thread-local storage regressions before release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->