### PR TITLE
perf(runtime): dispatch String.prototype.codePointAt natively (99k String wrappers per reply)

### DIFF
--- a/changelog.d/9795-string-code-point-at-dispatch.md
+++ b/changelog.d/9795-string-code-point-at-dispatch.md
@@ -1,0 +1,12 @@
+### Runtime
+
+- perf(runtime): `String.prototype.codePointAt` is answered by the native
+  string-method dispatch instead of falling through to the primitive-method
+  fallback. It had a prototype thunk but no dispatch arm, so every call
+  resolved `globalThis.String.prototype.codePointAt`, cloned that closure to
+  rebind `this`, and — the thunk not being registered strict — ran `ToObject`
+  on the receiver, minting a `String` wrapper with an own index property per
+  UTF-16 code unit. Grapheme-aware text measurement calls it once per
+  character: on the compiled claude-code TUI it was the only method name
+  reaching the fallback, at 99,008 calls and 99,008 wrappers per 400-character
+  streamed reply (`PERRY_GC_DIAG=1`, `[gc-primitive-dispatch]`).

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -19,6 +19,8 @@ mod proto_dispatch;
 mod string_methods;
 
 #[cfg(test)]
+mod code_point_at_dispatch_tests;
+#[cfg(test)]
 mod dispatch_arg_coercion_tests;
 #[cfg(test)]
 mod probe_dispatch_tests;

--- a/crates/perry-runtime/src/object/native_call_method/code_point_at_dispatch_tests.rs
+++ b/crates/perry-runtime/src/object/native_call_method/code_point_at_dispatch_tests.rs
@@ -1,0 +1,80 @@
+//! #9761: `String.prototype.codePointAt` must be answered by the native
+//! string-method dispatch, not by the primitive-method FALLBACK.
+//!
+//! The fallback (`call_primitive_builtin_prototype_method`) resolves
+//! `globalThis.String.prototype[<name>]`, clones that closure to rebind `this`,
+//! and — because the resolved thunk is not registered strict — runs `ToObject`
+//! on the receiver, minting a `String` wrapper with an own index property per
+//! UTF-16 code unit. `codePointAt` had a prototype thunk but no dispatch arm,
+//! and grapheme-aware text measurement calls it once per character: on the
+//! compiled claude-code TUI it was the ONLY name reaching the fallback, at
+//! 99,008 calls (and 99,008 wrappers) per 400-character streamed reply.
+//!
+//! The assertion is the wrapper count, not the return value: a test that only
+//! checked the answer would pass with the arm deleted, because the fallback
+//! computes the same number — expensively. `BOXED_PRIMITIVE_PAYLOADS` gains one
+//! entry per wrapper, so "no new boxed primitives" is exactly "the fallback did
+//! not run".
+
+use crate::value::JSValue;
+
+unsafe fn call_string_method(receiver: &str, method: &str, args: &[f64]) -> f64 {
+    let s = crate::string::js_string_from_bytes(receiver.as_ptr(), receiver.len() as u32);
+    let recv = f64::from_bits(JSValue::string_ptr(s).bits());
+    super::js_native_call_method(
+        recv,
+        method.as_ptr() as *const i8,
+        method.len(),
+        if args.is_empty() {
+            std::ptr::null()
+        } else {
+            args.as_ptr()
+        },
+        args.len(),
+    )
+}
+
+#[test]
+fn code_point_at_dispatches_natively_and_boxes_no_receiver() {
+    unsafe {
+        // Warm anything the first dispatch installs, so the delta below is the
+        // method call itself and not one-time globalThis population.
+        let _ = call_string_method("ab", "charCodeAt", &[0.0]);
+        let before = crate::builtins::test_boxed_primitive_payload_count();
+
+        let cp = call_string_method("a", "codePointAt", &[0.0]);
+        assert_eq!(cp, 97.0, "codePointAt(0) of \"a\"");
+        let astral = call_string_method("\u{1F600}b", "codePointAt", &[0.0]);
+        assert_eq!(astral, 128512.0, "an astral pair is one code point");
+        let past_end = call_string_method("a", "codePointAt", &[5.0]);
+        assert!(
+            JSValue::from_bits(past_end.to_bits()).is_undefined(),
+            "out of range is undefined"
+        );
+
+        assert_eq!(
+            crate::builtins::test_boxed_primitive_payload_count(),
+            before,
+            "the native arm must not mint a String wrapper; a non-zero delta \
+             means the call fell through to the primitive-method fallback"
+        );
+    }
+}
+
+/// Positive control for the assertion above: the counter must be able to move,
+/// or "no new boxed primitives" proves nothing. Minting the wrapper the
+/// fallback would have minted is the direct, environment-independent form —
+/// a second dispatch through a name without a native arm cannot serve as the
+/// control here, because the unit-test thread has no populated `globalThis`
+/// and the fallback returns before it boxes.
+#[test]
+fn the_wrapper_counter_moves_when_a_receiver_is_boxed() {
+    let before = crate::builtins::test_boxed_primitive_payload_count();
+    let s = crate::string::js_string_from_bytes(b"abc".as_ptr(), 3);
+    let value = f64::from_bits(JSValue::string_ptr(s).bits());
+    let _wrapper = crate::builtins::js_boxed_string_new(value, 1);
+    assert!(
+        crate::builtins::test_boxed_primitive_payload_count() > before,
+        "if this cannot move, the codePointAt assertion above is vacuous"
+    );
+}

--- a/crates/perry-runtime/src/object/native_call_method/string_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/string_methods.rs
@@ -136,6 +136,20 @@ pub(super) unsafe fn dispatch_string(
                 "charCodeAt" => {
                     return Some(crate::string::js_string_char_code_at(s_ptr, arg_i32(0)));
                 }
+                // #9761: `codePointAt` had a `String.prototype` thunk but no
+                // arm here, so it was the ONE method name the compiled
+                // claude-code TUI drove into the primitive-method FALLBACK:
+                // 99,008 calls per 400-character reply, each of which looked
+                // `globalThis.String` up, cloned the prototype closure to
+                // rebind `this`, and — because the callee is sloppy — ran
+                // `ToObject` on the receiver, minting a `String` wrapper with
+                // its own index property. Grapheme-aware text measurement
+                // calls it once per character, so a missing arm here is a
+                // per-character wrapper. It is the sibling of `charCodeAt`
+                // one line up and reads the same receiver the same way.
+                "codePointAt" => {
+                    return Some(crate::string::js_string_code_point_at(s_ptr, arg_i32(0)));
+                }
                 "slice" => {
                     // Coerce args first (`arg_i32` may run user `valueOf` and move
                     // the receiver under GC), then re-fetch the rooted receiver.


### PR DESCRIPTION
> **REBASED onto `35c36f425` (2026-09-06), new head `3946b5d07`.** #9794 is on
> `main`, so this is no longer stacked: it is a single commit, 4 files,
> +108 lines. The rebase had **no conflicts** — the 8-file conflict recorded
> against this PR was #9794's, not this commit's. Details, plus a base change
> that partly overtakes the numbers below (#9810 made string-wrapper indices
> virtual, and it took the `string_wrappers=` counter's only writer with it),
> are in "Rebased onto `35c36f425`" at the bottom. **The rig table below was
> measured on `main` `12efed1222` and is not a delta against today's `main`.**

Stacked on #9794 (which carries the `[gc-primitive-dispatch]` counter this is
measured with).

## What

`String.prototype.codePointAt` had a `String.prototype` thunk but **no arm in
the native string-method dispatch**, so every call fell through to
`call_primitive_builtin_prototype_method`:

1. resolve `globalThis.String` and then `String.prototype.codePointAt`,
2. clone that closure to rebind `this`,
3. and — the thunk not being registered strict — run `ToObject` on the
   receiver, minting a `String` wrapper whose own index properties are one per
   UTF-16 code unit.

The counter added in #9794 says what that costs on the compiled claude-code
TUI: `codePointAt` is the **only** method name that reaches the fallback at
all, and it reaches it **99,008 times per 400-character streamed reply**, with
99,008 `String` wrappers minted — because grapheme-aware text measurement calls
it once per character.

```
[gc-primitive-dispatch] exit: names=1 calls=99008 receiver_chars=99008
[gc-primitive-dispatch]   calls=99008 receiver_chars=99008 String.prototype.codePointAt
[gc-primitive-dispatch] exit: string_wrappers=99008 index_properties=99008
```

The new arm is the sibling of `charCodeAt` one line above it and reads the
receiver the same way.

## The test asserts the wrapper count, not the answer

The fallback computes the same code point, expensively — so a test that only
checked the return value would pass with the arm deleted. The test asserts that
`BOXED_PRIMITIVE_PAYLOADS` does not grow across the call (one entry per
wrapper), and a positive control pins that the counter can move.

`cargo test -p perry-runtime --release -- --test-threads=1`: 3150 passed,
0 failed.

## Measured — offline mock-API claude-code TUI rig, node arm in the same session

Candidate `cc_gc3` = this PR stack (#9794 + #9795) on `main` 12efed1222, built
by `cc_relink`. All runs serialized through the campaign's measurement lock;
the 400-character footprint column is three repeats (footprint is bimodal
depending on whether a full collection lands in the window).

| arm | 400 cpu s | 400 idle12 cpu s | 3300 cpu s | 3300 idle12 cpu s | typing cpu r2 | echo p90 ms | turn r2 cpu s | FP settled 400 MB | peak RSS 400 MB | FP settled 3300 MB | peak RSS 3300 MB | startup s |
|---|---|---|---|---|---|---|---|---|---|---|---|---|
| `cc_base` (main) | 11.69 | 7.96 | 80.77 | 9.86 | 1.36 | 100 | 1.38 | 692 | 1952 | 1360 | 2227 | 2.19 |
| this stack | **8.22–8.82** | **4.62** | **40.36** | 11.46 | **0.92** | **27** | **0.95** | **356/383/386** | **1876** | **628** | **1938** | **2.03** |
| node (same session) | 0.23–0.31 | 0.02 | 0.51 | 0.01 | 0.14 | 5 | 0.08 | 169–328 | 376 | 211 | 390 | 1.98 |

CPU: 400-char reply −26 %, 3300-char −50 %, post-turn idle −42 %, typing −32 %,
keystroke echo p90 −73 %, short-turn −31 %. Memory: settled footprint after a
400-char turn 692 → 356–386 MB (−45 %), after a 3300-char turn 1360 → 628 MB
(−54 %), peak RSS −4 % / −13 %. Neither metric regresses; node remains the bar
and this does not reach it.

## Mechanism (the counters that had to move)

`PERRY_ALLOC_SITE_SAMPLE=65536`, share of attributed GC-arena bytes in a
400-character reply, before → after this stack:

| allocation category | before | after #9794 | after #9794+#9795 |
|---|---|---|---|
| `String` wrapper (boxed receiver) | 30.7 % | 36.3 % | **absent** |
| `globalThis` builtin name key | 12.7 % | **absent** | **absent** |
| prototype/`constructor` lookup | 7.0 % | **absent** | **absent** |
| to_string / native method call | 8.1 % | 1.5 % | 2.5 % |
| ordinary property set (keys+slot arrays) | 13.8 % | 23.4 % | 43.5 % |
| sampled arena total, streamed turn | 305 MB | 206 MB | **157 MB** |
| sampled arena total, 14 s after the turn | 358 MB | 296 MB | **197 MB** |
| `GC_TYPE_STRING` bytes, streamed turn | 138 MB | 53 MB | **44 MB** |
| `GC_TYPE_OBJECT_META` bytes, streamed turn | 19 MB | 16 MB | **3 MB** |

`[gc-primitive-dispatch]` before: `names=1 calls=99008 receiver_chars=99008`,
`string_wrappers=99008 index_properties=99008`. After: the line is never
emitted — nothing reaches the primitive-method fallback and no `String` wrapper
is minted during a reply.

The category that is now largest (ordinary property set, 43.5 %) is
`Intl.Segmenter`'s per-segment record, which is PR #9769's subject.

Per 400-character reply this removes 99,008 `globalThis` property lookups,
99,008 closure clones and 99,008 `String` wrapper objects. `cargo test -p
perry-runtime --release -- --test-threads=1`: 3150 passed, 0 failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added allocation-site sampling with `PERRY_ALLOC_SITE_SAMPLE`, reporting allocation totals, object types, and top call sites.
  - Expanded `PERRY_GC_DIAG=1` output with collection triggers, full-collection causes, budgeted-cycle metrics, charge attribution, and survival reports.

- **Bug Fixes**
  - `String.prototype.codePointAt` now uses the native string method path.
  - Improved radix formatting for large numbers and fractional rounding.
  - Corrected `String` wrapper index property behavior.

- **Performance**
  - Reduced repeated allocations for common ASCII characters and built-in property names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Rebased onto `35c36f425` (2026-09-06)

`origin/main` moved to **`35c36f425`**, which landed #9794's two commits — the
GC diagnostics (`8c2bcc8ca`) and the primitive-string path (`b87000808`) — as
new commits with different SHAs.

The rebase is `git rebase --onto 35c36f425 5a5eec6b2`: #9794's two commits are
dropped and **only `c7189439b` is replayed**. New head **`3946b5d07`**, a
single commit over `35c36f425`, 4 files, +108 lines. The replayed patch is
**byte-identical** to `c7189439b` — a diff of the two patches differs only in
`index` and `@@` header lines.

### Conflicts: none, and what the 8-file list actually was

The conflict recorded against this PR —
`builtins/formatting/boxed_primitives.rs`, `builtins/mod.rs`,
`gc/diag_sites.rs` (add/add), `gc/mod.rs`, `object/descriptor_state.rs`,
`object/prototype_helpers.rs`, `string/mod.rs`, `value/to_string.rs` — is
**entirely #9794's**: every one of those files is touched by `157afd99a` /
`5a5eec6b2` and by their landed forms on main, and `gc/diag_sites.rs` is the
tell, since an add/add can only happen when both sides create the same new
file. **This PR's own commit touches none of those eight files.** Nothing was
hand-resolved and nothing was dropped.

### Re-derived on the new base

* `dispatch_string`'s `charCodeAt` arm and its `arg_i32` closure
  (`ToIntegerOrInfinity` via `js_string_index_to_i32`) are unchanged on main,
  and **`codePointAt` still has no arm** — the gap this PR closes is still open.
* `crate::string::js_string_code_point_at` is at `string/char_ops.rs:653` with
  the semantics the test asserts: negative or out-of-range index → NaN-boxed
  `undefined`, an index on a surrogate-pair lead → the whole code point, an
  index on the trailing half → the bare unit.
* `crate::builtins::test_boxed_primitive_payload_count` and
  `js_boxed_string_new(value, has_arg)` both still exist, and
  `js_boxed_string_new` still calls `register_boxed_primitive_payload` — so the
  positive control can still move, which is what keeps the main assertion
  non-vacuous.

### A base change that bears on the numbers, stated because it is not visible in the diff

Main now carries **#9810 / #9814 (`5b27cc871`, `0e9ad3476`, `d5019dbdf`):
string-wrapper character indices are VIRTUAL.** At this PR's old base
`js_boxed_string_new` called `install_string_wrapper_indices`, a `for i in
0..len` loop installing one own property per UTF-16 code unit; that call and
that function are gone on main. So the **`index_properties = 99,008` half of
the cost quoted above has already been removed by someone else.** What the
fallback still costs per call, and what this PR still removes, is the
`globalThis.String` → `String.prototype.codePointAt` resolution, the closure
clone to rebind `this`, and the `ToObject` wrapper object itself with its
`BOXED_PRIMITIVE_PAYLOADS` entry — 99,008 of each per 400-character reply. The
test asserts exactly that surviving part (the wrapper count), so it is
unaffected by #9810 and it still fails with the arm deleted.

Two consequences for the evidence in this body:

1. **The rig table was measured on `main` `12efed1222`** — before a ~40-PR
   merge train, before #9810's virtual indices, and before #9857. It is not a
   delta against today's `main` and should not be read as one; it needs
   re-running against a current base before it is quoted as a landed number.
2. **`[gc-primitive-dispatch] …: string_wrappers=… index_properties=…` cannot
   be reproduced on `main` today.** Its only writer was
   `diag_string_wrapper_materialized`, called from inside
   `install_string_wrapper_indices` (`boxed_primitives.rs:236` at the old base);
   #9810 deleted the loop and the writer with it. `STRING_WRAPPERS` survives in
   `gc/diag_sites.rs` as a thread-local that is **read and never written**, so
   the `wrappers > 0` branch in `report_primitive_dispatch` is unreachable. The
   `names=/calls=/receiver_chars=` half of the line is intact — its writer is
   still at `native_call_method.rs:362` — and it is the half that identifies
   `codePointAt` as the one name reaching the fallback. Not this PR's to fix;
   flagged so nobody re-measures against a counter that cannot move.

### Testing after the rebase

Rebased tree, `cargo test -j4 -p perry-runtime --release --lib -- --test-threads=1`
(campaign build lock, `nice -n19`, dev box, load 42–76):

```
test result: ok. 3199 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out
```

Both of this PR's tests pass by name on the new base — including the positive
control, which matters here precisely because #9810 rewrote
`js_boxed_string_new` underneath it:

```
object::native_call_method::code_point_at_dispatch_tests::code_point_at_dispatches_natively_and_boxes_no_receiver ... ok
object::native_call_method::code_point_at_dispatch_tests::the_wrapper_counter_moves_when_a_receiver_is_boxed ... ok
```

`js_boxed_string_new` still calls `register_boxed_primitive_payload`, so
`BOXED_PRIMITIVE_PAYLOADS` still gains one entry per wrapper and the control
still moves — the wrapper assertion is not vacuous on `35c36f425`.

Gates re-run on the rebased tree: `check_test_registration.py` (131/131
rust-test modules registered, so the new test module is accounted for),
`check_thread_locals.py`, `raw_handle_debt.py`, `check_file_size.sh`.
**Not re-run:** `cargo clippy` and the `gcaudit` profile.

https://claude.ai/code/session_014knX724SYDogwzsXybCGxp


---
**Draft as of 2026-09-06 13:05 CEST (campaign coordinator):** headline evidence is stale — the `[gc-primitive-dispatch]` counter it cites has no writer on main since #9810/#9814 (see the linked issue), the `index_properties` half of the claim has already landed through those PRs, and the rig table predates the train and #9857. The remaining claim (wrapper + `globalThis` lookup + closure clone per `codePointAt` call) is being priced on perrymaster as I3 − I2; the PR leaves draft when that number exists.

https://claude.ai/code/session_014knX724SYDogwzsXybCGxp
