### PR TITLE
test: synchronize stdin lifecycle input with child readiness

### DIFF
--- a/changelog.d/9783-stdin-fixture-handshake.md
+++ b/changelog.d/9783-stdin-fixture-handshake.md
@@ -1,0 +1,3 @@
+Make the stdin lifecycle parity fixture wait for each child to finish its toggle
+and GC churn before sending the second input chunk. Removing the four fixed
+2.5-second waits lets the Node oracle finish within the suite's 10-second budget.

--- a/test-files/test_gap_9676_stdin_unref_ref_keeps_reader.ts
+++ b/test-files/test_gap_9676_stdin_unref_ref_keeps_reader.ts
@@ -76,6 +76,10 @@ function runRole(name: string, onFirst: (s: any) => void, doChurn: boolean): voi
       console.log(name + " phase1: true");
       onFirst(s);
       if (doChurn) console.log(name + " churn: " + (churn(300000) > 0));
+      // The parent sends TWO only after the toggle and all churn complete.
+      // A fixed delay cannot prove this ordering and four sequential 2.5s
+      // waits alone exceed the parity suite's 10s per-process budget (#9783).
+      console.log(name + " ready: true");
     } else if (phase === 1 && text.indexOf("TWO") >= 0) {
       clearInterval(ticker);
       finish(name + " phase2: true");
@@ -110,9 +114,24 @@ if (role === "unref-ref") {
     new Promise<void>((resolve) => {
       const child = spawn(process.execPath, childArgs, {
         env: { ...process.env, [ROLE_ENV]: name },
-        stdio: ["pipe", "inherit", "inherit"],
+        stdio: ["pipe", "pipe", "inherit"],
       });
       let settled = false;
+      let output = "";
+      let sentSecond = false;
+      child.stdout!.on("data", (chunk: any) => {
+        process.stdout.write(chunk);
+        output += String(chunk);
+        // stdout may split the readiness line across arbitrary chunks.
+        if (!sentSecond && output.includes(name + " ready: true\n")) {
+          sentSecond = true;
+          try {
+            child.stdin!.write("TWO\n");
+          } catch {
+            /* child already gone */
+          }
+        }
+      });
       const watchdog = setTimeout(() => {
         if (settled) return;
         settled = true;
@@ -120,7 +139,8 @@ if (role === "unref-ref") {
         child.kill("SIGKILL");
         resolve();
       }, WATCHDOG_MS);
-      child.on("exit", (code) => {
+      // Drain the piped stdout before printing the role's exit summary.
+      child.on("close", (code) => {
         if (settled) return;
         settled = true;
         clearTimeout(watchdog);
@@ -134,14 +154,6 @@ if (role === "unref-ref") {
           /* child already gone */
         }
       }, 120);
-      // Late enough that the churn role has finished collecting first.
-      setTimeout(() => {
-        try {
-          child.stdin!.write("TWO\n");
-        } catch {
-          /* child already gone */
-        }
-      }, 2500);
     });
 
   (async () => {


### PR DESCRIPTION
The stdin lifecycle fixture waits 2.5 seconds for each of four sequential child processes, so its Node oracle exceeds the parity runner's 10-second timeout before Perry is tested.

Have each child signal readiness after its stdin toggle and optional GC churn, then send the second input chunk in response. Buffer the readiness line across stdout chunks and wait for `close` so the child's output is drained before its exit summary. This preserves all four lifecycle cases and explicitly orders the second chunk after the toggle and churn. No timeout increase or version bump.

Closes #9783.

Validation on macOS arm64 using the pinned Node 26.5.1 and the compiler/runtime built from main `c7361c87c` (plus #9805's provider-fixture-only change):
- Original Node fixture: 10.14 seconds. Updated fixture: Node 0.65 seconds, native Perry 5.07 seconds, byte-identical output.
- Canonical `run_parity_tests.sh --filter test_gap_9676_stdin_unref_ref_keeps_reader` with prebuilt compiler/runtime and the default 10-second limit: 1 passed, 0 failed, 0 skipped.
- `git diff --check` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved stdin lifecycle test synchronization by waiting for child readiness before sending subsequent input.
  - Replaced fixed delays with readiness-based coordination, improving reliability and ensuring completion within the test time limit.
- **Documentation**
  - Added a changelog entry describing the stdin fixture synchronization update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->