### PR TITLE
perf(gc): one pass over the per-object layout tables per prune, and a filter that admits when it is outgrown

### DIFF
--- a/changelog.d/9807-layout-prune-single-pass.md
+++ b/changelog.d/9807-layout-prune-single-pass.md
@@ -1,0 +1,33 @@
+**The per-object layout death-prune walks its tables once instead of three
+times, and no longer allocates a `Vec` of every live key** — 50.6 MB of a
+compiled claude-code turn's 304 MB in the layout tables (#9792).
+
+`prune_dead_per_object_layout_owners` visited every surviving key three times
+per collection: `retain` to drop the dead owners, then
+`layout_addr_filter_rebuild` — which first collected all of them into a
+`Vec<usize>` — and then `recount_young_layout_records` to re-derive the
+nursery-key count. The last two want exactly the survivor set `retain` is
+already walking, so both fold into its closure. The `Vec` is gone from the
+rebuild's other caller too.
+
+The measurement that prompted it also found the accelerator these tables sit
+behind unable to do its job. `layout_addr_filter_may_hold` is a 4,096-bit
+one-hash sketch documented for "one or two entries, ~0.05 % false positives";
+a new `PERRY_LAYOUT_DIAG` instrument reports **162,258 live keys and 4,096 of
+4,096 bits set** on one 400-character claude-code reply. Every probe answers
+"may hold", so the early returns in `transfer_per_object_descriptor` and
+`transfer_per_object_slot_mask` never fire, and each rebuild was an O(live
+keys) walk restoring the all-ones state it started from. Past four times the
+bit count — 16,384 keys, where the false-positive rate is already 98.2 % — the
+rebuild now sets all ones directly, the same conservative answer reached in
+O(1); below that the filter keeps exactly the selectivity it has today. The
+instrument says so out loud rather than leaving it to be inferred. Widening the sketch is not available
+from the runtime: its geometry and hash are mirrored in `perry-codegen`'s
+`emit_gated_forget_object_layout`, and discriminating at 162k keys would take
+~190 KB of inline thread-local storage per thread.
+
+`transfer_per_object_descriptor` also gained the emptiness test its shared
+flag cannot express: the flag and the filter are common to both per-object
+tables, so a full slot-mask table drags every relocation into the typed-layout
+map as well — which on cc is permanently empty (typed=0, masks=162,258). One
+`len` load replaces two hashes per evacuated object.

--- a/crates/perry-runtime/src/gc/layout_tables.rs
+++ b/crates/perry-runtime/src/gc/layout_tables.rs
@@ -168,21 +168,11 @@ fn note_new_layout_record(user_ptr: usize) {
     }
 }
 
-/// Re-derive this thread's young-record count from the live keys and publish
-/// the delta. Runs after every death prune (all cycle kinds) and whenever the
-/// tables empty, so promotion (a key moving to an old page) and death both
-/// bring the count back down.
-fn recount_young_layout_records() {
-    let live = {
-        let masks = hot_layout_slot_masks().borrow();
-        let typed = hot_typed_layouts().borrow();
-        masks
-            .keys()
-            .chain(typed.keys())
-            .filter(|key| layout_key_may_be_nursery(**key))
-            .count()
-    };
-    let live = u32::try_from(live).unwrap_or(u32::MAX);
+/// Publish this thread's young-record count and the delta to the process
+/// total. The count itself is derived by the death prune's single pass over
+/// the live keys (all cycle kinds), so promotion (a key moving to an old page)
+/// and death both bring it back down without a walk of their own.
+fn publish_young_layout_records(live: u32) {
     let prev = hot_per_object_layout_hint().young_records.replace(live);
     use std::sync::atomic::Ordering::SeqCst;
     if live > prev {
@@ -204,26 +194,95 @@ pub(in crate::gc) fn prune_dead_per_object_layout_owners(is_dead_owner: &dyn Fn(
     if !per_object_layouts_maybe_nonempty() {
         return;
     }
+    // ONE pass over each table, not three. The old shape visited every live
+    // key three times per collection — `retain`, then
+    // `layout_addr_filter_rebuild` (which first collected them all into a
+    // `Vec<usize>`), then `recount_young_layout_records` — and the survivor
+    // set the last two want is exactly what `retain` is already walking. On cc
+    // that was 162k keys x 47 prunes per 400-character reply, with the `Vec`
+    // alone allocating 50.6 MB of the turn's 304 MB (#9792).
+    let hint = hot_per_object_layout_hint();
+    // A filter this occupancy has outgrown is not worth rebuilding: see
+    // [`layout_addr_filter_saturating_occupancy`]. Decide from the pre-prune
+    // size, which bounds the survivor count from above, so the decision is one
+    // branch captured by the closure rather than a test per key.
+    let occupancy = hot_layout_slot_masks().borrow().len() + hot_typed_layouts().borrow().len();
+    let rebuild_filter = occupancy <= layout_addr_filter_saturating_occupancy();
+    if rebuild_filter {
+        // Cleared FIRST so the bits set below describe survivors only — a key
+        // that dies in this pass must leave no bit behind, which is the whole
+        // point of rebuilding.
+        layout_addr_filter_clear();
+    } else {
+        layout_addr_filter_saturate();
+    }
+    let mut young: u32 = 0;
+    let mut keep = |key: usize| {
+        if is_dead_owner(key) {
+            return false;
+        }
+        if rebuild_filter {
+            let (word, bit) = layout_addr_filter_slot(key);
+            // SAFETY: the filter is a plain `UnsafeCell` in this thread's own
+            // hot slot and nothing else holds a reference to it here. This is
+            // the same single-threaded access every probe makes; the tables
+            // borrowed around it are different thread-locals.
+            unsafe {
+                (*hint.filter.get())[word] |= bit;
+            }
+        }
+        if layout_key_may_be_nursery(key) {
+            young = young.saturating_add(1);
+        }
+        true
+    };
     let masks_emptied = {
         let mut masks = hot_layout_slot_masks().borrow_mut();
         let had = !masks.is_empty();
-        masks.retain(|key, _| !is_dead_owner(*key));
+        masks.retain(|key, _| keep(*key));
         had && masks.is_empty()
     };
     let typed_emptied = {
         let mut typed = hot_typed_layouts().borrow_mut();
         let had = !typed.is_empty();
-        typed.retain(|key, _| !is_dead_owner(*key));
+        typed.retain(|key, _| keep(*key));
         had && typed.is_empty()
     };
+    publish_young_layout_records(young);
+    // Runs last: when it finds both tables empty it disarms the flag, zeroes
+    // the young count published above and clears the filter, which is the
+    // correct end state whichever branch the pass took.
     refresh_per_object_layouts_flag(masks_emptied || typed_emptied);
-    if per_object_layouts_maybe_nonempty() {
-        // Stale filter bits are what the pruned keys leave behind; rebuilding
-        // from the survivors keeps the runtime probes as selective as the
-        // tables really are.
-        layout_addr_filter_rebuild();
-        recount_young_layout_records();
+    if crate::hot_diag::layout_on() {
+        layout_diag_note_prune(rebuild_filter);
     }
+}
+
+/// `PERRY_LAYOUT_DIAG`'s per-prune sample. Out of line and behind
+/// [`crate::hot_diag::layout_on`] so an unarmed build pays one relaxed load.
+#[cold]
+fn layout_diag_note_prune(rebuilt_filter: bool) {
+    let (typed_len, masks_len) = (
+        hot_typed_layouts().borrow().len(),
+        hot_layout_slot_masks().borrow().len(),
+    );
+    let hint = hot_per_object_layout_hint();
+    // SAFETY: as in the pass above — this thread's own filter, no other
+    // reference live.
+    let set = unsafe {
+        (*hint.filter.get())
+            .iter()
+            .map(|w| w.count_ones() as usize)
+            .sum::<usize>()
+    };
+    crate::hot_diag::layout_note_prune(
+        typed_len,
+        masks_len,
+        set,
+        LAYOUT_ADDR_FILTER_BITS,
+        rebuilt_filter,
+        layout_addr_filter_saturating_occupancy(),
+    );
 }
 
 #[cfg(test)]
@@ -366,18 +425,74 @@ pub(in crate::gc) fn layout_addr_filter_note(user_ptr: usize) {
 /// their own (two keys may share one), so this is what keeps a workload that
 /// genuinely churns per-object records from saturating the filter forever.
 fn layout_addr_filter_rebuild() {
+    let occupancy = hot_layout_slot_masks().borrow().len() + hot_typed_layouts().borrow().len();
+    if occupancy > layout_addr_filter_saturating_occupancy() {
+        // Walking the keys would set almost every bit, so this is where the
+        // rebuild lands anyway — reached in O(1) instead of O(live keys).
+        layout_addr_filter_saturate();
+        return;
+    }
     layout_addr_filter_clear();
-    let keys: Vec<usize> = {
-        let masks = hot_layout_slot_masks().borrow();
-        let typed = hot_typed_layouts().borrow();
-        masks.keys().copied().chain(typed.keys().copied()).collect()
-    };
     let hint = hot_per_object_layout_hint();
-    for k in keys {
+    // Straight from the tables: the `Vec<usize>` of every live key that used
+    // to buffer this walk allocated 50.6 MB per 400-character cc reply, and
+    // bought nothing — no borrow held here conflicts with the filter, which
+    // lives in a different thread-local.
+    let set_bit = |k: usize| {
         let (word, bit) = layout_addr_filter_slot(k);
+        // SAFETY: this thread's own filter, no other reference live; the
+        // tables borrowed around it are different thread-locals.
         unsafe {
             (*hint.filter.get())[word] |= bit;
         }
+    };
+    for k in hot_layout_slot_masks().borrow().keys() {
+        set_bit(*k);
+    }
+    for k in hot_typed_layouts().borrow().keys() {
+        set_bit(*k);
+    }
+    hint.sets.set(0);
+}
+
+/// Live keys past which the 4,096-bit sketch stops being an accelerator.
+///
+/// The filter is a one-hash bitmap, so `n` live keys leave it answering
+/// "may hold" for about `1 - e^(-n/4096)` of all addresses: 12 % at 512 keys,
+/// 63 % at 4,096, and indistinguishable from "always yes" past ~16k. cc holds
+/// **162,258** (`PERRY_LAYOUT_DIAG`, one 400-character reply), i.e. every bit
+/// set, every probe positive, and every rebuild an O(live keys) walk that
+/// restores exactly the all-ones state it started from.
+///
+/// Sizing the filter up is not available here: the geometry and hash are
+/// mirrored in generated code (`perry-codegen`'s
+/// `emit_gated_forget_object_layout`), so widening it is a codegen change, and
+/// a sketch that discriminated at 162k keys would need ~1.5 Mbit — 190 KB of
+/// inline thread-local storage on every thread, to serve a workload that has
+/// already lost the fast path. What is available is to stop *paying* for a
+/// gate that cannot pay back: past this occupancy the filter is set to all
+/// ones, which is the conservative answer it would have reached anyway, and
+/// the walk is skipped. Nothing downstream changes behaviour — `may_hold` is
+/// a hint whose `true` every caller already handles.
+///
+/// Four times the bit count is deliberately far past the point where the
+/// filter merely *degrades*: at 16,384 keys its false-positive rate is 98.2 %,
+/// so a rebuilt filter still proves absence for under one address in fifty
+/// while costing a walk of every live key. Below that the filter is left
+/// exactly as it was — a workload holding a few thousand records keeps the
+/// selectivity it has today, and this branch never fires for it.
+#[inline]
+fn layout_addr_filter_saturating_occupancy() -> usize {
+    LAYOUT_ADDR_FILTER_BITS * 4
+}
+
+/// Set every bit: "may hold" for any address. Conservative by construction —
+/// the filter's `false` is the only load-bearing answer.
+fn layout_addr_filter_saturate() {
+    let hint = hot_per_object_layout_hint();
+    // SAFETY: this thread's own filter, no other reference live.
+    unsafe {
+        (*hint.filter.get()).fill(u64::MAX);
     }
     hint.sets.set(0);
 }
@@ -809,6 +924,15 @@ pub(in crate::gc) fn transfer_per_object_descriptor(old_user: usize, new_user: u
         return false;
     }
     let mut typed = hot_typed_layouts().borrow_mut();
+    // The flag and the filter above are shared with `LAYOUT_SLOT_MASKS`, so a
+    // full mask table drags every relocation in here even when this map is
+    // empty — which is cc's steady state (`PERRY_LAYOUT_DIAG`: typed=0,
+    // masks=162,258). An empty map has nothing to remove at either address, so
+    // the two hashes below are pure loss; the `len` test that proves it is one
+    // load. #9792.
+    if typed.is_empty() {
+        return false;
+    }
     typed.remove(&new_user);
     match typed.remove(&old_user) {
         Some(layout) => {

--- a/crates/perry-runtime/src/hot_diag.rs
+++ b/crates/perry-runtime/src/hot_diag.rs
@@ -324,6 +324,154 @@ fn ic_sink() -> &'static Option<Sink> {
     })
 }
 
+// ---------------------------------------------------------------------------
+// Per-object layout tables: occupancy vs the address filter that gates them
+// ---------------------------------------------------------------------------
+
+static LAYOUT_SINK: OnceLock<Option<Sink>> = OnceLock::new();
+static LAYOUT_ON: AtomicBool = AtomicBool::new(false);
+
+fn layout_sink() -> &'static Option<Sink> {
+    LAYOUT_SINK.get_or_init(|| {
+        let sink = sink_from_env("PERRY_LAYOUT_DIAG");
+        LAYOUT_ON.store(sink.is_some(), Ordering::Relaxed);
+        sink
+    })
+}
+
+/// Is the per-object-layout occupancy instrument armed?
+#[inline]
+pub fn layout_on() -> bool {
+    if LAYOUT_SINK.get().is_none() {
+        layout_sink();
+    }
+    LAYOUT_ON.load(Ordering::Relaxed)
+}
+
+/// One collection's view of the per-object layout tables and the 4096-bit
+/// address filter that is supposed to keep evacuation off them.
+///
+/// The question this exists to settle: `layout_addr_filter_may_hold` is
+/// documented for "one or two entries … ~0.05 % false-positive rate", and
+/// `transfer_per_object_descriptor` / `transfer_per_object_slot_mask` return
+/// early only when it says no. If the tables hold far more keys than the
+/// filter has bits, it answers "maybe" for every address, both early returns
+/// stop firing, and every evacuated object pays the full two-map hash path —
+/// while nothing in the system says so out loud.
+///
+/// `keys` is also what a filter rebuild used to cost: one `Vec<usize>` of
+/// every live key per prune, plus a second full walk to recount the young
+/// records.
+#[derive(Default)]
+pub struct LayoutDiag {
+    prunes: u64,
+    typed_len: usize,
+    masks_len: usize,
+    typed_max: usize,
+    masks_max: usize,
+    /// Set bits in the address filter, and its capacity in bits.
+    filter_bits_set: usize,
+    filter_bits_total: usize,
+    filter_bits_set_max: usize,
+    /// Live keys past which a rebuild stops producing a selective filter.
+    useful_keys: usize,
+    /// Prunes that rebuilt the filter from the survivors, and prunes that
+    /// found it already outgrown and skipped the walk.
+    rebuilt: u64,
+    outgrown: u64,
+    /// Keys visited by prunes that DID rebuild — the walk that is still paid.
+    rebuilt_keys: u64,
+}
+
+crate::perry_thread_local! {
+    static LAYOUT_DIAG: RefCell<LayoutDiag> = RefCell::new(LayoutDiag::default());
+}
+
+/// Record one death-prune's occupancy. `rebuilt_filter` says whether this
+/// prune rebuilt the address filter from its survivors, or found the tables
+/// too full for a 4,096-bit sketch to discriminate and saturated it instead.
+pub fn layout_note_prune(
+    typed_len: usize,
+    masks_len: usize,
+    filter_bits_set: usize,
+    filter_bits_total: usize,
+    rebuilt_filter: bool,
+    useful_keys: usize,
+) {
+    LAYOUT_DIAG.with(|d| {
+        let mut d = d.borrow_mut();
+        d.prunes += 1;
+        d.typed_len = typed_len;
+        d.masks_len = masks_len;
+        d.typed_max = d.typed_max.max(typed_len);
+        d.masks_max = d.masks_max.max(masks_len);
+        d.filter_bits_set = filter_bits_set;
+        d.filter_bits_total = filter_bits_total;
+        d.filter_bits_set_max = d.filter_bits_set_max.max(filter_bits_set);
+        d.useful_keys = useful_keys;
+        if rebuilt_filter {
+            d.rebuilt += 1;
+            d.rebuilt_keys += (typed_len + masks_len) as u64;
+        } else {
+            d.outgrown += 1;
+        }
+        let text = d.render();
+        if let Some(sink) = layout_sink() {
+            write_sink(sink, &text);
+        }
+    });
+}
+
+impl LayoutDiag {
+    fn render(&self) -> String {
+        use std::fmt::Write as _;
+        let mut out = String::with_capacity(512);
+        let pct = |n: usize, d: usize| {
+            if d == 0 {
+                0.0
+            } else {
+                100.0 * n as f64 / d as f64
+            }
+        };
+        let keys = self.typed_len + self.masks_len;
+        let _ = writeln!(
+            out,
+            "[layout-diag] prunes={} keys_now={} (typed={} masks={}) keys_max={} \
+             (typed={} masks={})",
+            self.prunes,
+            keys,
+            self.typed_len,
+            self.masks_len,
+            self.typed_max + self.masks_max,
+            self.typed_max,
+            self.masks_max
+        );
+        let _ = writeln!(
+            out,
+            "  filter: {}/{} bits set ({:.1} %), max {}/{} ({:.1} %); selective up to \
+             {} keys, so this table is {}",
+            self.filter_bits_set,
+            self.filter_bits_total,
+            pct(self.filter_bits_set, self.filter_bits_total),
+            self.filter_bits_set_max,
+            self.filter_bits_total,
+            pct(self.filter_bits_set_max, self.filter_bits_total),
+            self.useful_keys,
+            if keys > self.useful_keys {
+                "OUTGROWN it -- every probe answers `may hold`"
+            } else {
+                "within it"
+            }
+        );
+        let _ = writeln!(
+            out,
+            "  filter rebuilds={} over {} keys walked; outgrown-and-skipped={}",
+            self.rebuilt, self.rebuilt_keys, self.outgrown
+        );
+        out
+    }
+}
+
 /// Is the IC-miss instrument armed? One relaxed load once initialised.
 #[inline]
 pub fn ic_on() -> bool {


### PR DESCRIPTION
Closes part of #9792.

## The measurement this rests on

`PERRY_LAYOUT_DIAG=<path>` (added here) samples the per-object layout tables
and the address filter that gates them, at the one per-collection hook that
already holds both. One 400-character streamed reply through the offline rig,
compiled claude-code:

```
[layout-diag] prunes=47 keys_now=161934 (typed=0 masks=161934)
  filter: 4096/4096 bits set (100.0 %) at every prune
  filter rebuilds=47  Vec<usize> elements=6,607,450 = 50.4 MB allocated
```

The falsifier was stated on #9792 before the run: **>= ~10,000 live keys and a
filter >= 90 % ones**, or the hypothesis is wrong and the issue's unattributed
185 MB has to be re-attributed first. It came back at 161,934 keys and 100 %
of bits, at every one of the 47 prunes, and the 50.4 MB agrees with the
independent `PERRY_ALLOC_CENSUS` figure of ~45 MB/turn for this function.

`layout_addr_filter_may_hold`'s own doc comment sizes it for "one or two
entries, ~0.05 % false positives".

Two details from the same instrument that were **not** predicted:

* `typed=0` — `TYPED_LAYOUTS` is empty for the whole turn. The emptiness flag
  and the filter are *shared* between the two per-object tables, so a full
  slot-mask table drags every evacuated object into an empty map as well.
  That is what change 3 below removes.
* The prune is **not** confined to full cycles. In the same run
  `PERRY_GC_DIAG` reports 40 copying minors and the layout instrument reports
  46-47 prunes, i.e. one per collection of either kind. Every one of them was
  walking the live keys three times.

## What changes

**1. The death prune walks each table once instead of three times.**
`prune_dead_per_object_layout_owners` ran `retain` to drop dead owners, then
`layout_addr_filter_rebuild` (which first collected every live key into a
`Vec<usize>`), then `recount_young_layout_records` to re-derive the nursery-key
count. The last two want exactly the survivor set `retain` is already visiting,
so the filter bit and the young-record test move into its closure and the `Vec`
disappears. `layout_addr_filter_rebuild`'s other caller — the amortised rebuild
inside `layout_addr_filter_add` — loses the `Vec` too, iterating the tables
directly; nothing it borrows conflicts with the filter, which lives in a
different thread-local.

**2. A rebuild past the filter's useful occupancy costs O(1), not O(live
keys).** The filter is a one-hash bitmap, so `n` live keys leave it answering
"may hold" for about `1 - e^(-n/4096)` of all addresses: 12 % at 512 keys, 63 %
at 4,096, **98.2 % at 16,384**. At 162,000 a rebuild is an O(live keys) walk
that restores exactly the all-ones state it started from. Past four times the
bit count the filter is now set to all ones directly — the same conservative
answer, and `may_hold`'s `true` is a hint every caller already handles; only
its `false` is load-bearing.

The threshold is deliberately far past the point where the filter merely
*degrades*, so this cannot cost a workload that still has something to gain: at
16,384 keys a rebuilt filter proves absence for under one address in fifty
while walking every live key. Below it, nothing changes — a workload holding a
few thousand records keeps exactly the selectivity it has today, and this
branch never fires for it.

Widening the sketch is deliberately *not* attempted here. Its geometry and hash
are mirrored in `perry-codegen`'s `emit_gated_forget_object_layout`, so
resizing is a codegen change rather than a runtime one, and discriminating at
162k keys would take ~1.5 Mbit — ~190 KB of inline thread-local storage on
every thread — to serve a workload that has already lost the fast path.

**3. `transfer_per_object_descriptor` gets the emptiness test its shared flag
cannot express.** The `PER_OBJECT_LAYOUTS_NONEMPTY` flag and the address filter
are common to both per-object tables, so a full slot-mask table drags every
evacuated object into `TYPED_LAYOUTS` as well — which the instrument shows is
empty for the whole turn (`typed=0`). One `len` load now replaces two hashes
per evacuated object. Unlike the flag, this cannot go stale: it is the map's
own length, read under the borrow that would do the removes.

## Mechanism proof

The instrument was built to make the saturation visible instead of inferred,
so it is also the proof the change does what it says. Both arms below are the
same 400-character reply through the offline rig, in one session; the "before"
arm is a binary carrying the instrument and none of the fix.

| `PERRY_LAYOUT_DIAG`, one 400-char reply | before | after |
|---|---|---|
| prunes | 47 | 46 |
| live keys at the last prune | 161,934 (typed=0) | 161,630 (typed=0) |
| address filter | 4,096/4,096 bits set (100 %) | 4,096/4,096 bits set (100 %) |
| filter rebuilds | **47** | **0** |
| keys walked by those rebuilds | **6,607,450**, buffered through a `Vec<usize>` = **50.4 MB** | **0** |
| outgrown-and-skipped | — | **46** |

`rebuilds=47` becomes `outgrown-and-skipped=46`: every prune now recognises
that a 4,096-bit sketch holding 162k keys is already at the answer a rebuild
would produce, and reaches it without the walk or the `Vec`.

## Numbers

Rig: the offline mock-API harness, `cc_relink/cc_base_new` (main `1d63fa91f`,
this PR's base) as the before arm, node measured in the same session. The
candidate is a full compile of the claude-code bundle carrying **both #9807 and
#9808** — they land independently but were measured in one binary. Runtime-only
diff, so both binaries come from the same codegen.

**400-character streamed reply — quiet box (1-min load 4.2–5.9), 4 paired runs,
arm order alternated each pair:**

| metric | before | after | node |
|---|---|---|---|
| turn CPU (s) | 7.52 / 6.07 / 6.34 / 6.39 | 8.09 / 6.26 / 6.19 / 5.98 | 0.25 / 0.26 / 0.25 / 0.25 |
| turn CPU median / min | 6.37 / 6.07 | **6.22 / 5.98** | 0.25 / 0.25 |
| settled footprint (MB) | 449 / 452 / 489 / 493 | **436 / 428 / 448 / 450** | 171 / 328 / 172 / 329 |
| footprint end-of-turn (MB) | 540 / 540 / 545 / 543 | 524 / 537 / 542 / 543 | 171 / 327 / 172 / 328 |
| peak RSS (MB) | 650 / 653 / 649 / 653 | 662 / 650 / 649 / 647 | 369 / 370 / 369 / 372 |
| CPU in the next 12 s (s) | 5.76 / 4.87 / 4.87 / 4.71 | 7.24 / 6.85 / 4.49 / 4.27 | 0.02 / 0.02 / 0.01 / 0.03 |

**3300-character streamed reply — quiet subset (load 6.4–10.0), 3 paired runs:**

| metric | before | after | node |
|---|---|---|---|
| turn CPU (s) | 74.95 / 75.24 / 79.31 | **71.84 / 74.91 / 51.62** | 0.54 / 0.56 |
| peak RSS (MB) | 1308 / 1299 / 1294 | 1297 / 1310 / 1356 | 402 / 407 |

**`timed_turn` (37 keystrokes then two short turns), taken at load 35–50 and so
reported for completeness only:** startup 4.80 s before vs 2.60 / 1.80 s after;
typing CPU r2 1.56 vs 1.49 / 0.87 s; echo p90 66 vs 48 / 28 ms; turn r2 CPU
0.92 vs 1.03 / 1.06 s. The before arm lost one of its two runs, so one side is
n=1.

### Reading, stated plainly

The CPU win is **modest and inside the run-to-run spread**: −2 % on the
400-char median, −4 % on the 3300-char median, and the before arm wins two of
the four paired 400-char comparisons. The one consistent directional result is
**settled footprint, lower in 4 of 4 paired 400-char runs (median 470 → 442 MB,
−6 %)** — which is what removing 50 MB of per-turn `Vec` allocation should look
like. Peak RSS is flat.

The row that reads *worse* after is `CPU in the next 12 s` (median 4.87 →
5.67 s), and four pairs do not resolve it: the after arm's own spread there is
4.27–7.24 s against the before arm's 4.71–5.76 s.

This is the size of result that was predicted before the run — the prune costs
one walk of the live keys per collection, and removing two of three walks is a
small share of a turn in which the collector is doing much more elsewhere.
**Neither metric regresses, which is the bar.**

### A first reading was wrong and is withdrawn

Measured at 1-min load 17–58, the candidate looked **40–58 % slower** on the
3300-char arm. Repeating the same pairs on a quiet box inverted it (−4.1 %,
−0.4 %, −35 %), and the before arm's own samples for one unchanged binary
ranged 52–79 s across those loads. No CPU number taken above ~12 load on this
box is usable, and the footprint column is bimodal exactly as the campaign's
invariant 0 says (676–706 vs 1113–1134 MB in the same pair set, decided by
whether a full collection fell in the window).

## Binary provenance, and the one thing the measured binary does not carry

The measured candidate is a full compile (no object-cache reuse) of the bundle
from this diff on top of `1d63fa91f`, which is exactly `cc_base_new`'s commit,
so the two arms differ only by the runtime change — the diff touches no
`perry-codegen`/`perry-hir` file, so both binaries carry the same emitted JS.

The branch has since been rebased onto current main. The rebase adds nothing to
the diff except one token: `LAYOUT_DIAG` is now declared with
`crate::perry_thread_local!` rather than `thread_local!`, because
`scripts/check_thread_locals.py` rejects a new raw declaration (it passes now;
it did not before). That declaration is reached only from the `#[cold]` sampler
behind `PERRY_LAYOUT_DIAG`, i.e. never in an unarmed build, so it cannot move
any number in the table above.

## Invariants

* Cost proportional to live data: the prune's per-collection work drops from
  three walks of the surviving keys to one, and the filter rebuild from
  O(live keys) to O(1) once the table has outgrown it. The remaining O(table)
  term is the young-record recount's page classification per survivor, which is
  now folded into the walk that was happening anyway rather than added to it.
* No knob-tuning: the one new constant is the occupancy at which a one-hash
  bitmap's false-positive rate passes ~12 %, derived from the filter's own
  geometry, not fitted to cc.
* Behaviour: `may_hold` becomes *less* selective in the saturated regime, which
  is the direction that is always safe — a `false` is a proof of absence and is
  never manufactured; a `true` is a hint every caller already handles by
  re-testing the map.
* `PERRY_LAYOUT_DIAG` costs one relaxed load when unarmed; the sample itself is
  `#[cold]` and out of line.

## What this does not fix

Worth saying plainly, because the headline number is smaller than the diagnosis
suggests: **the durable value here is the diagnosis and the instrument**, not
the CPU delta. Before this PR nothing in the system said out loud that an
emptiness proof documented for "one or two entries" was answering "may hold"
to every probe on a real workload; it had to be inferred from an allocation
census. `PERRY_LAYOUT_DIAG` now reports occupancy, filter population and
whether the gate is inside or past its useful range, so the next person meets a
number instead of an inference.

**The structural fix is still open.** This PR stops *paying* for a gate that
cannot pay back; it does not restore the gate. Sizing the filter from live
occupancy — with a counter that reports saturation rather than a constant that
tolerates it — is the change that would make the early returns fire again, and
it needs the codegen side (`emit_gated_forget_object_layout` mirrors the
geometry and the hash) to move with it. Until then every evacuated object on a
cc-sized workload still pays the slot-mask hash, which is the larger half of
#9792's 304 MB.

## Tests

`cargo test --release -p perry-runtime --lib -- --test-threads=1`: **3,143
passed, 0 failed** (1,037 of them under `gc::`). `cargo clippy -p perry-runtime`
clean.

The `run-extended-tests` label is on this PR, so the GC gates actually run
rather than showing `skipping` — a quiet gate column proves nothing. Two
reading notes: #9782 is open (full mark-sweep `gc-stress` arms failing), so a
green gc-stress here would not settle much either way; and `gc-root-dominance`
reporting red with `violations: 0` is the corpus floor ("checked 5,625
function(s), need at least 6,000"), which a runtime-only diff cannot move.

https://claude.ai/code/session_014UZWia6L37DpA93VLtNK9m


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved garbage-collection layout cleanup by reducing repeated processing and temporary memory use.
  - Optimized relocation handling for cases with no typed layout entries.
  - Improved performance for heavily populated layout metadata by avoiding unnecessary filtering work.

- **Diagnostics**
  - Added an optional `PERRY_LAYOUT_DIAG` diagnostic report showing layout occupancy, filter saturation, and cleanup activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->