### PR TITLE
perf(gc): skip the element-shape table when neither address of a move advertises a proof

### DIFF
--- a/changelog.d/9808-element-shape-transfer-gate.md
+++ b/changelog.d/9808-element-shape-transfer-gate.md
@@ -1,0 +1,25 @@
+**A relocated array whose element-shape proof does not exist no longer takes
+the side table to find that out** (#9792).
+
+`transfer_element_shape` runs from `layout_transfer` for every relocated
+array — growth forwarding, a copying minor, an old-gen defrag. It already
+computes `had_bit` for free from two header words it has read anyway, and
+then took `ELEMENT_SHAPES`' `RefCell` and hashed both addresses regardless,
+for two removes that on the overwhelmingly common path remove nothing. It now
+returns when neither address advertises a proof.
+
+The gate has exactly one safe shape and both halves are pinned by
+`a_transfer_skips_the_table_only_when_neither_address_advertises_a_proof`.
+Skipping on `!had_bit` alone would be wrong: a destination that still
+advertises a proof describes storage the move has just replaced, so that case
+keeps the full fail-closed path.
+
+What skipping leaves behind is a record at an address whose bit is clear, and
+that state was already part of the design rather than new: the bit is the sole
+authority for a read (`element_shape_proof` returns `None` before touching the
+table, and `note_element_store` is gated on the same bit), and `establish`
+draws every identity from `ELEMENT_SHAPE_PROOF_SEQ` rather than from whatever
+record sits at the address — precisely so a survivor cannot donate its epoch
+to the next array proven there. `prune_dead_element_shape_owners` drops it on
+the next collection, the same footprint-only guarantee a fail-closed transfer
+already relied on. The test asserts both defences directly.

--- a/crates/perry-runtime/src/array/element_shape.rs
+++ b/crates/perry-runtime/src/array/element_shape.rs
@@ -672,6 +672,25 @@ pub(crate) fn transfer_element_shape(old_user: usize, new_user: usize) {
         // exactly the versioning a consumer guards on.
         let had_bit = array_gc_header(old_user as *const ArrayHeader)
             .is_some_and(|old_header| header_has_bit(old_header));
+        // #9792: neither address advertises a proof, so there is nothing to
+        // move and nothing to fail closed about — the `clear_bit` below would
+        // clear a bit that is already clear. Skipping is what the siblings in
+        // `gc::layout_tables` do with their emptiness flag, decided here from
+        // the header words this function has already read rather than from a
+        // side-table probe.
+        //
+        // What it leaves behind is a record at an address whose bit is clear,
+        // and that state is already part of the design: the bit is the sole
+        // authority for a read (`element_shape_proof` returns `None` without
+        // touching the table), and `establish` draws every identity from
+        // `ELEMENT_SHAPE_PROOF_SEQ` rather than from whatever record sits at
+        // the address, precisely so a survivor cannot donate its epoch to the
+        // next array established there. `prune_dead_element_shape_owners`
+        // drops it on the next collection, which is the same footprint-only
+        // guarantee a fail-closed transfer already relied on.
+        if !had_bit && !header_has_bit(new_header) {
+            return;
+        }
         let moved = ELEMENT_SHAPES.with(|m| {
             let mut map = m.borrow_mut();
             map.remove(&new_user);
@@ -793,6 +812,16 @@ pub(crate) fn test_exact_shape_store_hits() -> u64 {
 #[cfg(test)]
 pub(crate) unsafe fn test_element_shape_bit_set(arr: *const ArrayHeader) -> bool {
     array_gc_header(arr).is_some_and(|header| header_has_bit(header))
+}
+
+/// Clear the advertising bit and leave the record in the table — the survivor
+/// state a skipped [`transfer_element_shape`] produces, and the one the
+/// bit-is-authority rule has to hold up under.
+#[cfg(test)]
+pub(crate) unsafe fn test_clear_element_shape_bit_only(arr: *mut ArrayHeader) {
+    if let Some(header) = array_gc_header(arr) {
+        clear_bit(header);
+    }
 }
 
 #[cfg(test)]

--- a/crates/perry-runtime/src/array/element_shape_tests.rs
+++ b/crates/perry-runtime/src/array/element_shape_tests.rs
@@ -541,6 +541,71 @@ fn a_fail_closed_transfer_leaves_no_record_for_the_next_array_to_inherit() {
     );
 }
 
+#[test]
+fn a_transfer_skips_the_table_only_when_neither_address_advertises_a_proof() {
+    // #9792: `transfer_element_shape` runs for every relocated array, and its
+    // `had_bit` verdict is free — two header words it has already read. When
+    // neither address advertises a proof it takes the side table anyway, for
+    // two removes that can only remove what no reader could reach. The gate
+    // that skips that has exactly ONE safe shape, and this pins both halves.
+    //
+    // Arm 1 — neither bit set: skipping is correct, and the record it leaves
+    // behind stays unreadable and cannot donate its identity.
+    // Arm 2 — the DESTINATION still advertises one: skipping would leave a
+    // live proof describing storage that has just been overwritten, so the
+    // gate must NOT fire on `!had_bit` alone.
+    let _serialized = test_serialize();
+
+    // Arm 1.
+    let src = built_from_pushes(CLASS_A, 2);
+    let dst = built_from_pushes(CLASS_A, 2);
+    let survivor = proof(dst).expect("proven").epoch;
+    unsafe { clear_element_shape(src) };
+    unsafe { test_clear_element_shape_bit_only(dst) };
+    assert!(
+        test_element_shape_record_exists(dst as usize),
+        "the fixture must actually leave a record behind the cleared bit"
+    );
+
+    transfer_element_shape(src as usize, dst as usize);
+
+    assert!(
+        proof(dst).is_none(),
+        "the bit is the sole authority for a read, so a record behind a \
+         cleared bit must not read as a proof"
+    );
+    let reproven = unsafe { ensure_element_shape(dst) }.expect("still homogeneous");
+    assert_ne!(
+        reproven.epoch, survivor,
+        "establishing draws a fresh identity from ELEMENT_SHAPE_PROOF_SEQ, so \
+         a survivor record can never donate its epoch"
+    );
+
+    // Arm 2: source proves nothing, destination still advertises a proof.
+    let src2 = built_from_pushes(CLASS_A, 2);
+    let dst2 = built_from_pushes(CLASS_A, 2);
+    unsafe { clear_element_shape(src2) };
+    assert!(
+        unsafe { test_element_shape_bit_set(dst2) },
+        "the fixture must leave the destination advertising a proof"
+    );
+
+    transfer_element_shape(src2 as usize, dst2 as usize);
+
+    unsafe {
+        assert!(
+            !test_element_shape_bit_set(dst2),
+            "a transfer whose source proved nothing must still fail the \
+             destination closed — gating on `!had_bit` alone would leave a \
+             live proof over storage the move has just replaced"
+        );
+    }
+    assert!(
+        !test_element_shape_record_exists(dst2 as usize),
+        "and it must take the destination's record with it"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Lifecycle hooks — what stops a recycled address inheriting a stale identity
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes part of #9792. Independent of #9807 (different table, different file);
they were measured in one binary and can land in either order.

## The change

`transfer_element_shape` runs from `layout_transfer` for **every relocated
array** — growth forwarding, a copying minor, an old-gen defrag. It already
computes `had_bit` for free from two header words it has read anyway, then took
`ELEMENT_SHAPES`' `RefCell` and hashed both addresses regardless, for two
`remove`s that on the common path remove nothing.

It now returns before the table when **neither address advertises a proof**.

## Why the gate has exactly one safe shape

Gating on `!had_bit` alone would be wrong. A destination that still advertises
a proof is describing storage the move has just replaced, so that case must
keep the full fail-closed path — the existing test
`a_fail_closed_transfer_leaves_no_record_for_the_next_array_to_inherit` fails
under exactly that sabotage, and so does the new test, on its named assertion:

```
a transfer whose source proved nothing must still fail the destination closed —
gating on `!had_bit` alone would leave a live proof over storage the move has
just replaced
```

(Verified by making that edit and running the suite: 2 failures, then restored.)

## The safety case for what skipping leaves behind

Skipping leaves a record in `ELEMENT_SHAPES` at an address whose bit is clear.
That state is not new — it is one the design already names and defends against,
in three independent places:

* **The bit is the sole authority for a read.** `element_shape_proof` returns
  `None` on a clear bit before it touches the table; `note_element_store_with_bit`
  is gated on the same bit before its `record_for`. Those are the only two
  callers of `record_for`, and both check first. So a record behind a clear bit
  is unreachable, not merely stale.
* **`establish` draws every identity from `ELEMENT_SHAPE_PROOF_SEQ`**, never
  from the record at the address — its doc comment says this exists precisely
  so "a survivor record — left by a fail-closed transfer, a dead array whose
  prune has not run yet — can never donate its identity to the array
  established here next".
* **`prune_dead_element_shape_owners` drops it on the next collection**, which
  is the same footprint-only guarantee a fail-closed transfer already relied on
  ("a stale record can never be *read*, because a recycled allocation's fresh
  `_reserved` is zero").

The new test asserts the first two directly rather than arguing them: it builds
the survivor state (record present, bit cleared), runs the transfer, asserts no
proof reads back, then establishes at that very address and asserts the epoch
is not the survivor's.

## Numbers

Rig: the offline mock-API harness, `cc_relink/cc_base_new` (main `1d63fa91f`,
this PR's base) as the before arm, node measured in the same session. The
candidate is a full compile of the claude-code bundle carrying **both #9807 and
#9808** — they land independently but were measured in one binary. Runtime-only
diff, so both binaries come from the same codegen.

**400-character streamed reply — quiet box (1-min load 4.2–5.9), 4 paired runs,
arm order alternated each pair:**

| metric | before | after | node |
|---|---|---|---|
| turn CPU (s) | 7.52 / 6.07 / 6.34 / 6.39 | 8.09 / 6.26 / 6.19 / 5.98 | 0.25 / 0.26 / 0.25 / 0.25 |
| turn CPU median / min | 6.37 / 6.07 | **6.22 / 5.98** | 0.25 / 0.25 |
| settled footprint (MB) | 449 / 452 / 489 / 493 | **436 / 428 / 448 / 450** | 171 / 328 / 172 / 329 |
| footprint end-of-turn (MB) | 540 / 540 / 545 / 543 | 524 / 537 / 542 / 543 | 171 / 327 / 172 / 328 |
| peak RSS (MB) | 650 / 653 / 649 / 653 | 662 / 650 / 649 / 647 | 369 / 370 / 369 / 372 |
| CPU in the next 12 s (s) | 5.76 / 4.87 / 4.87 / 4.71 | 7.24 / 6.85 / 4.49 / 4.27 | 0.02 / 0.02 / 0.01 / 0.03 |

**3300-character streamed reply — quiet subset (load 6.4–10.0), 3 paired runs:**

| metric | before | after | node |
|---|---|---|---|
| turn CPU (s) | 74.95 / 75.24 / 79.31 | **71.84 / 74.91 / 51.62** | 0.54 / 0.56 |
| peak RSS (MB) | 1308 / 1299 / 1294 | 1297 / 1310 / 1356 | 402 / 407 |

**`timed_turn` (37 keystrokes then two short turns), taken at load 35–50 and so
reported for completeness only:** startup 4.80 s before vs 2.60 / 1.80 s after;
typing CPU r2 1.56 vs 1.49 / 0.87 s; echo p90 66 vs 48 / 28 ms; turn r2 CPU
0.92 vs 1.03 / 1.06 s. The before arm lost one of its two runs, so one side is
n=1.

### Reading, stated plainly

The CPU win is **modest and inside the run-to-run spread**: −2 % on the
400-char median, −4 % on the 3300-char median, and the before arm wins two of
the four paired 400-char comparisons. The one consistent directional result is
**settled footprint, lower in 4 of 4 paired 400-char runs (median 470 → 442 MB,
−6 %)** — which is what removing 50 MB of per-turn `Vec` allocation should look
like. Peak RSS is flat.

The row that reads *worse* after is `CPU in the next 12 s` (median 4.87 →
5.67 s), and four pairs do not resolve it: the after arm's own spread there is
4.27–7.24 s against the before arm's 4.71–5.76 s.

This is the size of result that was predicted before the run — the prune costs
one walk of the live keys per collection, and removing two of three walks is a
small share of a turn in which the collector is doing much more elsewhere.
**Neither metric regresses, which is the bar.**

### A first reading was wrong and is withdrawn

Measured at 1-min load 17–58, the candidate looked **40–58 % slower** on the
3300-char arm. Repeating the same pairs on a quiet box inverted it (−4.1 %,
−0.4 %, −35 %), and the before arm's own samples for one unchanged binary
ranged 52–79 s across those loads. No CPU number taken above ~12 load on this
box is usable, and the footprint column is bimodal exactly as the campaign's
invariant 0 says (676–706 vs 1113–1134 MB in the same pair set, decided by
whether a full collection fell in the window).

## Binary provenance, and the one thing the measured binary does not carry

The measured candidate is a full compile (no object-cache reuse) of the bundle
carrying this diff *and* #9807 on top of `1d63fa91f`, which is exactly `cc_base_new`'s commit,
so the two arms differ only by the runtime change — the diff touches no
`perry-codegen`/`perry-hir` file, so both binaries carry the same emitted JS.

The branch has since been rebased onto current main. The only thing the rebase
adds is the changelog fragment's rename to `9808-…`, which is what the `lint`
job requires to count it as a fragment at all. Nothing in `element_shape.rs`
changed, so the measured binary matches this diff.

## What this leaves behind, and what would falsify the safety case

Skipping leaves a record in `ELEMENT_SHAPES` at an address whose bit is clear
where the old unconditional `remove` would have swept it. That is a real
change in table occupancy, not only in correctness, and it deserves naming: the
records that used to be cleared opportunistically by *any* later move touching
that address are now cleared only by `prune_dead_element_shape_owners`. That
prune runs once per collection — `PERRY_GC_DIAG` and `PERRY_LAYOUT_DIAG` on
the same 400-character reply show 40 copying minors plus 6 full cycles against
46 prunes — so the extra occupancy is bounded by one collection's array churn,
not unbounded.

**The measurement that would falsify this** is peak RSS and settled footprint:
an accumulating table shows up there first. Both are flat-or-better in the
table above (peak RSS 649 → 649 MB median at 400 chars, 1300 → 1310 MB at
3300; settled footprint down 6 %). The census does not currently break out
`ELEMENT_SHAPES`, so this is an indirect answer rather than a direct count —
adding that row is the cheap way to make it direct, and is worth doing whether
or not this lands.

## Tests

New: `a_transfer_skips_the_table_only_when_neither_address_advertises_a_proof`,
covering both arms of the gate's boundary. Plus a `#[cfg(test)]`
`test_clear_element_shape_bit_only` helper to construct the survivor state.

`cargo test --release -p perry-runtime --lib -- --test-threads=1`: **3,143
passed, 0 failed** (54 under `array::element_shape`). `cargo clippy
-p perry-runtime` clean.

The `run-extended-tests` label is on this PR so the GC gates actually run
rather than showing `skipping`. Reading notes: #9782 is open (full mark-sweep
`gc-stress` arms), and `gc-root-dominance` red with `violations: 0` is the
corpus floor ("checked 5,625 function(s), need at least 6,000"), which a
runtime-only diff cannot move.

https://claude.ai/code/session_014UZWia6L37DpA93VLtNK9m


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved runtime efficiency when transferring array element-shape information by skipping unnecessary bookkeeping when no active shape proof is present.

* **Bug Fixes**
  * Preserved fail-safe handling when destination shape information remains active, ensuring stale or invalid metadata cannot be treated as valid proof.

* **Tests**
  * Added coverage for both optimized transfer paths and safety behavior around retained metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->