### PR TITLE
fix(gc-ratchet): 10_store_receiver_across_alloc runs no minor collection — give it margin

### DIFF
--- a/benchmarks/gc_ratchet/probes/10_store_receiver_across_alloc.ts
+++ b/benchmarks/gc_ratchet/probes/10_store_receiver_across_alloc.ts
@@ -33,7 +33,41 @@
 declare function gc(): void;
 
 const SLOTS = 1024;
-const ITERATIONS = 200000;
+
+// ITERATIONS EXISTS TO GIVE THIS PROBE MARGIN, NOT TO MAKE IT LONGER.
+//
+// This probe went **inert on main for part of 2026-08-18..09-06** and nobody
+// noticed: `minor_cycles` fell from 1 to 0, so no evacuating minor ran, so the
+// three conditions below could not bite and the probe measured nothing. It
+// still "passed" everything except a gc-ratchet gate that was already red for
+// unrelated reasons (#9829, #9832), which is why it went weeks undetected.
+//
+// The cause was margin, not a bug: at 200,000 iterations the probe allocated
+// just enough to cross the nursery threshold exactly once. #8313 shrank a
+// two-field object from 56 to 40 bytes — a change everyone wants — and that
+// alone dropped the total under the threshold. **A probe that fires exactly one
+// collection is one optimisation away from firing none**, and any future
+// allocation win re-creates this silently.
+//
+// Measured on `main` @ d36a1af0c, 40-byte objects, three repeats each:
+//
+//     ITERATIONS    minor_cycles   wall_ms
+//        200,000          0           26     <- inert, shipped for weeks
+//        600,000          2           47
+//      1,200,000          4           81
+//      2,400,000          9          147
+//
+// 2,400,000 is chosen so the probe still runs several evacuating minors after a
+// further 8x reduction in allocated bytes per object. The cost is ~120 ms on a
+// metric the gate does not band (`wall_ms`), which is the cheapest insurance in
+// the suite.
+//
+// INVARIANT, and please check it if you touch this file: this probe must report
+// `minor_cycles >= 2`. `gc_ratchet.py` refuses to PIN a baseline whose
+// `minor_cycles < 1`, so a fully inert probe cannot be blessed — but it will
+// happily pin `minor_cycles == 1`, which is the marginal state that produced
+// this outage. One is not margin.
+const ITERATIONS = 2400000;
 
 // (1) module-level, so the receiver is loaded from a global handle rather than
 // a shadow slot.

--- a/changelog.d/9833-probe10-margin.md
+++ b/changelog.d/9833-probe10-margin.md
@@ -1,0 +1,29 @@
+**The `10_store_receiver_across_alloc` GC-ratchet probe was running no
+collection at all, and has been given margin** (#9833, fixes #9832).
+
+The probe exists to catch a store receiver held in a register across an
+evacuating minor — the stale-root class of #6970 / #9523 — and its own header
+lists three conditions that must all hold for it to bite, the third being an
+allocating right-hand side. On `main` it reported `minor_cycles = 0`: no minor
+ran, so no evacuation happened, so there was no window and the probe measured
+nothing. `freed_bytes = 0` alongside `copied_objects = 0` rules out "a minor ran
+and found nothing live".
+
+The cause was margin rather than a bug. At 200,000 iterations the probe crossed
+the nursery threshold exactly once, and #8313 — shrinking a two-field object
+from 56 to 40 bytes — put it under. A probe that fires exactly one collection is
+one optimisation away from firing none. It is now 2,400,000 iterations, which
+measured 9 minors and keeps several after a further eightfold reduction in bytes
+per object, for about 120 ms on `wall_ms`, which the gate does not band.
+
+Verified by sabotage rather than by the counter moving: removing the allocating
+RHS returns `minor_cycles=0 copied_objects=0 freed_bytes=0`, the exact signature
+the probe had while broken.
+
+`heap_used_bytes` returns from 464,072 to 244,648 against a pinned baseline of
+220,384 — the +110.57 % that cell showed on `main` was the post-`gc()` residue
+of a run in which nothing was ever collected, not retention.
+
+Five further probes (`01`, `02`, `03`, `09`, `11`) currently sit at
+`minor_cycles == 1` and are one allocation win away from the same silent state;
+that is recorded in #9832 and not addressed here.


### PR DESCRIPTION
Fixes #9832. Unblocks the #9829 re-pin, which cannot be assembled while a probe
is inert.

## The defect

On `main` @ `d36a1af0c`, this probe reports **`minor_cycles = 0`**:

| metric | pinned baseline | main today |
|---|---|---|
| **`minor_cycles`** | **1** | **0** |
| `copied_objects` / `copied_bytes` / `freed_bytes` | 8,160 / 506,200 / 8,930,928 | **0 / 0 / 0** |
| `heap_used_bytes` | 220,384 | 464,072 (+110.57 %) |

`freed_bytes = 0` rules out "a minor ran and found nothing live". No collection
ran. The probe's own header lists three conditions that must all hold for it to
bite, the third being an allocating RHS, and says dropping any one "makes it
silently measure nothing". Without an evacuating minor there is no window, so
the probe cannot catch the class it exists for — stale-root-across-evacuation,
#6970 / #9523, which this project has shipped real bugs in twice.

Reproduced locally on a clean `main` build: `heap_used_bytes = 464,072`,
byte-identical to CI.

## The cause is margin, not a bug

At 200,000 iterations the probe allocated just enough to cross the nursery
threshold **exactly once**. #8313 shrank a two-field object 56 → 40 bytes — a
change we want — and that alone put it under. **A probe that fires exactly one
collection is one optimisation away from firing none**, and any future
allocation win silently re-creates this.

Measured on `main` @ `d36a1af0c`, three repeats each:

| ITERATIONS | `minor_cycles` | `wall_ms` |
|---|---|---|
| 200,000 | **0** | 26 |
| 600,000 | 2 | 47 |
| 1,200,000 | 4 | 81 |
| **2,400,000** | **9** | **147** |

2,400,000 keeps several evacuating minors after a further **8x** reduction in
bytes per object, at a cost of ~120 ms on `wall_ms` — a metric the gate
explicitly does not band. Cheapest insurance in the suite.

## Verified by sabotage, not by the number moving

Restoring `minor_cycles` proves the probe *collects*. It does not prove the
probe *covers the class*. So I removed the allocating RHS — condition (3) in the
probe's own header — and re-measured:

```
sink[i & (SLOTS - 1)] = null;      // was: = { a: i, b: "s" + (i & 7) }
  -> minor_cycles = 0   copied_objects = 0   freed_bytes = 0
```

Exactly the signature the probe had while broken. The biting condition is
load-bearing and observable, so this restores coverage rather than counters.

## After the fix

```
correctness      pass
minor_cycles     9
copied_objects   18,660
copied_bytes     825,520
freed_bytes      88,858,544
heap_used_bytes  244,648
```

**`heap_used_bytes` 464,072 → 244,648, against a pinned baseline of 220,384.**
The +110.57 % this cell showed on `main` was never retention — it was the
post-`gc()` residue of a run in which nothing was collected. Anyone re-pinning
that cell at 464,072 would have blessed an inert probe.

## Why this had to be fixed before the re-pin, not excluded

`gc_ratchet.py` already refuses to pin a baseline whose `minor_cycles < 1`
("baseline pinned a probe that ran no minor collection, so there is no
evacuating-minor behaviour here to ratchet against"), so the #9829 re-pin would
have been **rejected by the tool**. It will, however, happily pin
`minor_cycles == 1` — the marginal state that caused this outage. The header now
records `minor_cycles >= 2` as the invariant, with the table above as its
justification, so the next person re-sizing this probe knows what the number is
for.

## Note for the suite as a whole

This is the third check found tonight that could not fail while looking healthy
— after a unit test that passed under sabotage and a gate whose failures nobody
watched (#9830). Worth asking of the other probes: **how many minors does each
one run, and which are at 1?** A probe at 1 is not covered, it is lucky. I have
not swept that here.

https://claude.ai/code/session_014UZWia6L37DpA93VLtNK9m

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated garbage-collection performance checks to reliably trigger multiple minor collection cycles.
  * Added documented thresholds and validation details for detecting regressions in allocation behavior.

* **Documentation**
  * Recorded the probe’s previous behavior, runtime impact, measured results, and verification status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->