### PR TITLE
docs: share CLAUDE.md instructions with Codex

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Repository instructions
+
+Before starting work, read `CLAUDE.md` in this directory in full
+and follow its instructions. It is the shared source of truth
+for both Claude Code and Codex.


### PR DESCRIPTION
## Summary

Add a root `AGENTS.md` directing Codex to read `CLAUDE.md` in full, so both agents use the same repository guidance.

## Changes

- Add a five-line wrapper that keeps `CLAUDE.md` as the shared source of truth.

## Related issue

n/a

## Test plan

Documentation-only change. Tests skipped and immediate admin squash merge requested by the maintainer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added repository guidance for AI-assisted development, including instructions to consult the shared project guidance before starting work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->