### PR TITLE
perf(regex): allocate the RegExp header in the nursery, not the malloc arm

### DIFF
--- a/changelog.d/9840-regexp-header-nursery.md
+++ b/changelog.d/9840-regexp-header-nursery.md
@@ -1,0 +1,35 @@
+### Performance
+
+- **A `RegExp` header is allocated in the nursery instead of the malloc arm.**
+  A JS regex literal evaluates to a fresh `RegExp` every time it is reached, and
+  `js_regexp_new` allocated each header with `gc_malloc`. On the claude-code TUI
+  that is, per 400-character reply (`PERRY_GC_TRACE`), **199,873 of 199,926
+  malloc-tracked GC allocations — 100.0 %**, 80 bytes each, 99.2 % of them
+  freed, with the malloc registry swinging **101,929 entries down to 1,689**
+  across a single minor. Every one of those paid a mimalloc allocation, a push
+  onto `MALLOC_STATE.objects`, an insert into the malloc-registry `PtrHashSet`
+  (which rehashes as it grows), and at death a malloc-sweep visit and a free —
+  old-generation prices for an object that overwhelmingly dies young.
+
+  Nothing required the malloc arm. `GC_TYPE_REGEXP` is already declared
+  `ArenaOrMalloc` and movable; `GcMoveHookKind::RegExpSideTables` already rekeys
+  `REGEX_POINTERS`, `REGEX_SOURCE_TABLE` and the expando owner after evacuation,
+  and `GcLayoutSlotKind::RegExpFields` already traces the header's two string
+  edges and its `meta` record. What kept production on `gc_malloc` was
+  finalization: the copying minor's from-space flip runs no per-object finalize
+  hooks, so a nursery header that died young would leak its `Arc` programs and
+  its registry entries. That is now handled exactly as `Map`, `Set` and `Error`
+  handle theirs — `finalize_dead_copied_minor_from_space_regexps` after a copied
+  minor, `collect_dead_registered_regexps_post_trace` at sweep entry for the
+  non-copying cycle kinds, and the ordinary old-generation sweep for a header
+  that has been promoted.
+
+  Every regex program cache (`REGEX_CACHE`, `FANCY_CACHE`,
+  `REPEAT_MATCHER_CACHE`, `VALIDATED_PATTERNS`, the site cache) keys on pattern
+  and flags CONTENT, not on the header address, so a moving header costs them
+  nothing.
+
+  Note that this **changes the collection schedule** rather than only removing
+  work: the `MallocCount` trigger loses essentially all of its input on this
+  workload, while ~16 MB per reply moves into the nursery. The schedule is
+  reported with the change rather than assumed unchanged.

--- a/crates/perry-runtime/src/gc/copying.rs
+++ b/crates/perry-runtime/src/gc/copying.rs
@@ -1908,6 +1908,7 @@ fn finalize_dead_copied_minor_from_space_side_allocations() {
     crate::map::finalize_dead_copied_minor_from_space_maps();
     crate::set::finalize_dead_copied_minor_from_space_sets();
     crate::node_submodules::diagnostics_gc::finalize_dead_copied_minor_from_space_errors();
+    crate::regex::finalize_dead_copied_minor_from_space_regexps();
     // 2026-07-09 GC audit wave 2: the from-space flip runs no per-object
     // finalize hooks, so entries keyed by dead from-space owners in the
     // object-address-keyed side tables are pruned here (headers still intact).

--- a/crates/perry-runtime/src/gc/dead_owner.rs
+++ b/crates/perry-runtime/src/gc/dead_owner.rs
@@ -170,6 +170,13 @@ impl PostTraceProbe {
 /// from-space (eden or the active survivor half) and was neither marked nor
 /// forwarded — every live from-space object was evacuated (FORWARDED) or is
 /// pinned-and-marked by this point. Mirrors `is_dead_copied_minor_from_space_map`.
+/// Crate-visible form for the per-type registry walkers that finalize their
+/// own dead from-space instances after a copied minor (`regex`): is `addr` a
+/// from-space `obj_type` cell that was neither evacuated nor pinned?
+pub(crate) fn owner_is_dead_copied_minor_from_space_of_type(addr: usize, obj_type: u8) -> bool {
+    owner_is_dead_copied_minor_from_space(addr, Some(obj_type))
+}
+
 fn owner_is_dead_copied_minor_from_space(addr: usize, expected_obj_type: Option<u8>) -> bool {
     let space = crate::arena::classify_heap_space(addr);
     if !matches!(space, crate::arena::HeapSpace::NurseryEden)

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -185,6 +185,7 @@ pub(crate) use copying_pointer_set::CopyingPointerSet;
 #[cfg(test)]
 pub(crate) use copying::MAX_YOUNG_MOVE_BYTES;
 mod dead_owner;
+pub(crate) use dead_owner::owner_is_dead_copied_minor_from_space_of_type;
 mod old_free;
 use old_free::*;
 pub(crate) use old_free::{old_free_bytes, old_free_filter_range, old_free_take_exact};

--- a/crates/perry-runtime/src/gc/oldgen.rs
+++ b/crates/perry-runtime/src/gc/oldgen.rs
@@ -1154,6 +1154,7 @@ pub(super) struct IncrementalSweepState {
     subphase: SweepCycleSubphase,
     dead_maps: Vec<usize>,
     dead_sets: Vec<usize>,
+    dead_regexps: Vec<usize>,
     dead_buffers: Vec<usize>,
     dead_typed_arrays: Vec<usize>,
     dead_lazy_arrays: Vec<usize>,
@@ -1177,6 +1178,7 @@ impl IncrementalSweepState {
             subphase: SweepCycleSubphase::Malloc,
             dead_maps: Vec::new(),
             dead_sets: Vec::new(),
+            dead_regexps: Vec::new(),
             dead_buffers: Vec::new(),
             dead_typed_arrays: Vec::new(),
             dead_lazy_arrays: Vec::new(),
@@ -1215,6 +1217,7 @@ impl IncrementalSweepState {
         );
         self.dead_maps = crate::map::collect_dead_registered_maps_post_trace(full_trace);
         self.dead_sets = crate::set::collect_dead_registered_sets_post_trace(full_trace);
+        self.dead_regexps = crate::regex::collect_dead_registered_regexps_post_trace(full_trace);
         self.dead_buffers = crate::buffer::collect_dead_registered_buffers_post_trace(full_trace);
         self.dead_typed_arrays =
             crate::typedarray::collect_dead_registered_typed_arrays_post_trace(full_trace);
@@ -1227,6 +1230,7 @@ impl IncrementalSweepState {
         });
         if !self.dead_maps.is_empty()
             || !self.dead_sets.is_empty()
+            || !self.dead_regexps.is_empty()
             || !self.dead_buffers.is_empty()
             || !self.dead_typed_arrays.is_empty()
             || !self.dead_lazy_arrays.is_empty()
@@ -1245,6 +1249,8 @@ impl IncrementalSweepState {
                         crate::map::finalize_collected_dead_map(addr);
                     } else if let Some(addr) = self.dead_sets.pop() {
                         crate::set::finalize_collected_dead_set(addr);
+                    } else if let Some(addr) = self.dead_regexps.pop() {
+                        crate::regex::finalize_collected_dead_regexp(addr);
                     } else if let Some(addr) = self.dead_buffers.pop() {
                         crate::buffer::finalize_collected_dead_buffer(addr);
                     } else if let Some(addr) = self.dead_typed_arrays.pop() {
@@ -1259,6 +1265,7 @@ impl IncrementalSweepState {
                 }
                 if self.dead_maps.is_empty()
                     && self.dead_sets.is_empty()
+                    && self.dead_regexps.is_empty()
                     && self.dead_buffers.is_empty()
                     && self.dead_typed_arrays.is_empty()
                     && self.dead_lazy_arrays.is_empty()

--- a/crates/perry-runtime/src/gc/tests/copying/survival_and_malloc.rs
+++ b/crates/perry-runtime/src/gc/tests/copying/survival_and_malloc.rs
@@ -891,3 +891,48 @@ fn test_copied_minor_promotable_census_filtered_walk_matches_unfiltered() {
          the equivalence assert above must not be vacuously 0 == 0"
     );
 }
+
+/// #9819 follow-up: `js_regexp_new` allocates the header in the NURSERY. A
+/// header that dies young must be finalized by the copied minor — its `Arc`
+/// program released and its registry entries removed — because the from-space
+/// flip runs no per-object finalize hooks. Without
+/// `finalize_dead_copied_minor_from_space_regexps` the dead address stays in
+/// `REGEX_POINTERS` and the program's strong count never comes back down.
+#[test]
+fn nursery_regexp_that_dies_young_is_finalized_by_the_copied_minor() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+    let dead = crate::regex::test_construct_regexp_and_exec_once("b(?:c)+d-die-young", "g");
+    let live = crate::regex::test_construct_regexp_and_exec_once("b(?:c)+d-die-young", "g");
+    let dead_addr = dead as usize;
+    let live_addr = live as usize;
+    // Premise: production construction is nursery-allocated now.
+    assert!(crate::arena::pointer_in_nursery(dead_addr), "the header must be nursery-allocated");
+    assert!(crate::regex::test_regex_pointer_entry_exists(dead_addr));
+    assert!(crate::regex::test_regex_source_entry_exists(dead_addr));
+    // Both headers share one program through the site cache.
+    let count_before = crate::regex::test_regexp_std_program_strong_count(live);
+    assert!(count_before >= 2);
+
+    // Only `live` is rooted; `dead` is garbage.
+    js_shadow_slot_set(0, ptr_bits(live_addr));
+    let _ = gc_collect_minor();
+
+    let live_new = (js_shadow_slot_get(0) & POINTER_MASK) as usize;
+    assert_ne!(live_new, 0, "the rooted RegExp must survive");
+    assert_ne!(live_new, live_addr, "the rooted RegExp must be evacuated");
+    assert!(crate::regex::regex_header_has_magic(live_new as *const _));
+    assert!(crate::regex::test_regex_pointer_entry_exists(live_new));
+    assert!(crate::regex::test_regex_source_entry_exists(live_new));
+
+    assert!(
+        !crate::regex::test_regex_pointer_entry_exists(dead_addr),
+        "a nursery RegExp that died must be removed from REGEX_POINTERS by the copied minor"
+    );
+    assert!(!crate::regex::test_regex_source_entry_exists(dead_addr));
+    assert_eq!(
+        crate::regex::test_regexp_std_program_strong_count(live_new as *const _),
+        count_before - 1,
+        "the dead header's Arc clone of the shared program must have been dropped"
+    );
+    js_shadow_slot_set(0, 0);
+}

--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -262,6 +262,115 @@ pub(crate) unsafe fn regex_header_finalize_for_gc(re: *mut RegExpHeader) {
     regex_header_clear_dead_for_gc(re as usize);
 }
 
+/// Finalize the RegExp headers that died in from-space during a copied minor.
+///
+/// The copying minor's from-space flip runs no per-object finalize hooks, so
+/// a nursery header that was neither evacuated nor pinned would otherwise keep
+/// its `Arc` programs and its `REGEX_POINTERS` / `REGEX_SOURCE_TABLE` / expando
+/// entries forever. Same shape as `map::finalize_dead_copied_minor_from_space_maps`:
+/// walk the registry after the flip, collect the provably-dead addresses, then
+/// finalize each (the finalizer removes its own registry entries, which is why
+/// the walk and the removal are two passes).
+///
+/// Cost: O(registry) = O(live headers + headers allocated since the last
+/// minor) — the same order as the malloc sweep this replaces, and
+/// proportional to allocation, not to program history.
+pub(crate) fn finalize_dead_copied_minor_from_space_regexps() -> usize {
+    let dead: Vec<usize> = REGEX_POINTERS.with(|table| {
+        table
+            .borrow()
+            .iter()
+            .copied()
+            .filter(|&addr| crate::gc::owner_is_dead_copied_minor_from_space_of_type(addr, crate::gc::GC_TYPE_REGEXP))
+            .collect()
+    });
+    let count = dead.len();
+    for addr in dead {
+        unsafe { regex_header_finalize_for_gc(addr as *mut RegExpHeader) };
+    }
+    count
+}
+
+/// Sweep-entry twin of the above for the non-copying cycle kinds (fallback
+/// minor / full mark-sweep): a dead header in the ACTIVE nursery allocation
+/// block is never object-walked by any sweeper, so it is collected from the
+/// registry right after trace instead (#6010, mirroring Map/Set/Buffer).
+/// Deadness: unmarked ∧ not pinned ∧ not forwarded, and for a minor trace also
+/// not tenured and physically in the nursery.
+pub(crate) fn collect_dead_registered_regexps_post_trace(full_trace: bool) -> Vec<usize> {
+    REGEX_POINTERS.with(|table| {
+        table
+            .borrow()
+            .iter()
+            .copied()
+            .filter(|&addr| unsafe { registered_regexp_is_dead_post_trace(addr, full_trace) })
+            .collect()
+    })
+}
+
+/// Finalize one collected-dead RegExp (budget-chunked by the sweep state).
+pub(crate) fn finalize_collected_dead_regexp(addr: usize) {
+    unsafe { regex_header_finalize_for_gc(addr as *mut RegExpHeader) };
+}
+
+unsafe fn registered_regexp_is_dead_post_trace(addr: usize, full_trace: bool) -> bool {
+    let Some(header) = crate::value::addr_class::try_read_gc_header(addr) else {
+        return false;
+    };
+    if header.obj_type != crate::gc::GC_TYPE_REGEXP {
+        return false;
+    }
+    let flags = header.gc_flags;
+    if flags
+        & (crate::gc::GC_FLAG_MARKED | crate::gc::GC_FLAG_PINNED | crate::gc::GC_FLAG_FORWARDED)
+        != 0
+    {
+        return false;
+    }
+    if full_trace {
+        return true;
+    }
+    if flags & crate::gc::GC_FLAG_TENURED != 0 {
+        return false;
+    }
+    matches!(
+        crate::arena::classify_heap_generation(addr),
+        crate::arena::HeapGeneration::Nursery
+    )
+}
+
+/// Test support: construct a RegExp through the PRODUCTION path
+/// (`js_regexp_new`), run one `test()` so the compiled programs are installed
+/// on the header, and hand the header back unrooted.
+#[cfg(all(test, feature = "regex-engine"))]
+pub(crate) fn test_construct_regexp_and_exec_once(pattern: &str, flags: &str) -> *mut RegExpHeader {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let p = scope.root_string_ptr(js_string_from_str(pattern));
+    let f = scope.root_string_ptr(js_string_from_str(flags));
+    let re = p.with_mut_ptr::<StringHeader, _>(|p| {
+        f.with_mut_ptr::<StringHeader, _>(|f| js_regexp_new(p, f))
+    });
+    let subject = scope.root_string_ptr(js_string_from_str("abc"));
+    subject.with_const_ptr::<StringHeader, _>(|s| {
+        let _ = js_regexp_test(re, s);
+    });
+    re
+}
+
+/// Test support: strong count of the standard program a header holds (the
+/// observer clone taken here is released before returning).
+#[cfg(all(test, feature = "regex-engine"))]
+pub(crate) fn test_regexp_std_program_strong_count(re: *const RegExpHeader) -> usize {
+    unsafe {
+        let raw = (*re).regex_ptr as *const Regex;
+        assert!(!raw.is_null(), "program must be installed");
+        let arc = Arc::from_raw(raw);
+        let n = Arc::strong_count(&arc);
+        std::mem::forget(arc);
+        n
+    }
+}
+
 #[cfg(test)]
 pub(crate) fn test_regex_pointer_entry_exists(addr: usize) -> bool {
     REGEX_POINTERS.with(|table| table.borrow().contains(&addr))
@@ -846,7 +955,7 @@ pub extern "C" fn js_regexp_new(
 ) -> *mut RegExpHeader {
     // ★ `pattern` is a raw `StringHeader*` in a Rust local, and this function
     // allocates twice below (`js_string_from_str` for the canonical flags, then
-    // `gc_malloc` for the header). Either can drive an evacuating minor that
+    // `arena_alloc_gc` for the header). Either can drive an evacuating minor that
     // relocates the pattern string, after which this argument names retired
     // from-space — and it is then *stored into the header* as `pattern_ptr`,
     // so the damage is permanent rather than transient.
@@ -1055,10 +1164,35 @@ pub extern "C" fn js_regexp_new(
     #[allow(unused_variables)]
     let pattern_str: () = ();
 
-    // Allocate the header via gc_malloc so it's tracked by the GC and gets
-    // freed when no longer referenced. Previously this used raw alloc() and
-    // leaked every header, which was a 64-byte-per-call leak on top of the
-    // (now-fixed) regex object leak.
+    // ★ The header is NURSERY-allocated, like an ordinary object.
+    //
+    // It used to be `gc_malloc`'d: raw `alloc()` at first (a 64-byte leak per
+    // construction), then the tracked malloc arm so the sweep could free it.
+    // That arm costs, PER CONSTRUCTION, a mimalloc allocation, a push onto
+    // `MALLOC_STATE.objects`, an insert into the malloc-registry `PtrHashSet`
+    // (which rehashes as it grows), two old→young remembered-set entries for
+    // `pattern_ptr`/`flags_ptr`, and — at death — a malloc-sweep visit, the
+    // finalizer and a free. A JS regex literal constructs a fresh object every
+    // time it is evaluated, so on the claude-code TUI `PERRY_GC_TRACE` counted
+    // **199,873 RegExp headers malloc'd per 400-character reply — 100.0 % of
+    // all malloc allocations** — with the registry swinging 26,690 → 1,689
+    // across one minor: ~94 % of them die young and were paying
+    // old-generation prices to do it.
+    //
+    // `GC_TYPE_REGEXP` has been movable (`GcMoveHookKind::RegExpSideTables`
+    // rekeys `REGEX_POINTERS`, `REGEX_SOURCE_TABLE` and the expando owner
+    // after evacuation; `GcLayoutSlotKind::RegExpFields` traces the two string
+    // edges and `meta`) since the copying collector landed, and
+    // `test_movable_regexp_evacuation_migrates_all_address_owned_state` has
+    // exercised the arena arm all along. What kept production on malloc was
+    // finalization: the copying minor's from-space flip runs no per-object
+    // finalize hooks (`gc::copying`), so a nursery header that dies young
+    // would leak its three `Arc` programs and its registry entries. That is
+    // now handled the way Map/Set/Error handle theirs —
+    // `finalize_dead_copied_minor_from_space_regexps` after a copied minor and
+    // `collect_dead_registered_regexps_post_trace` at sweep entry for the
+    // non-copying cycle kinds — and a tenured header is finalized by the
+    // old-generation sweep's ordinary `gc_type_finalize_unmarked_payload`.
     let header_size = std::mem::size_of::<RegExpHeader>();
     // `flags_ptr` must hold the CANONICAL form, so that `flags_ptr`-keyed
     // lookups (FANCY_CACHE, lookup_fancy_regex) and the GC-survivable source
@@ -1075,12 +1209,12 @@ pub extern "C" fn js_regexp_new(
             scope.root_string_ptr(js_string_from_str(flags_str))
         }
     };
-    // ★ #7341: root the canonical flags string too. The `gc_malloc` below is an
-    // allocation and therefore a collection point, exactly as the comment above
-    // `pattern_root` says — but only the PATTERN was rooted and re-read. The
-    // flags string is created here and stored into the header AFTER that
-    // allocation, so an evacuating minor in `gc_malloc` moved it and the header
-    // kept the pre-collection address. `flags_ptr` is then permanently stale in
+    // ★ #7341: root the canonical flags string too. The header allocation below
+    // is an allocation and therefore a collection point, exactly as the comment
+    // above `pattern_root` says — but only the PATTERN was rooted and re-read.
+    // The flags string is created here and stored into the header AFTER that
+    // allocation, so an evacuating minor in the header allocation moved it and
+    // the header kept the pre-collection address. `flags_ptr` is then permanently stale in
     // a live header: `lookup_fancy_regex` reads it through `string_as_str` and
     // faults on retired from-space, which is 5 of the 31 catches in #7341
     // (four different callers, all reaching that one read).
@@ -1089,7 +1223,11 @@ pub extern "C" fn js_regexp_new(
     // missing is that the value written had to survive the allocation first.
 
     unsafe {
-        let raw = crate::gc::gc_malloc(header_size, crate::gc::GC_TYPE_REGEXP);
+        let raw = crate::arena::arena_alloc_gc(
+            header_size,
+            std::mem::align_of::<RegExpHeader>(),
+            crate::gc::GC_TYPE_REGEXP,
+        );
         if raw.is_null() {
             // #5067 — catchable RangeError instead of aborting on OOM.
             crate::error::throw_allocation_failed();
@@ -1114,19 +1252,24 @@ pub extern "C" fn js_regexp_new(
         (*ptr).pattern_ptr = pattern;
         (*ptr).flags_ptr = canonical_flags_ptr;
         // `pattern_ptr` / `flags_ptr` are GC-managed StringHeaders — the GC scans
-        // this 2-slot payload range via the magic-tagged RegExp layout, and
-        // `canonical_flags_ptr` (js_string_from_str above) is a freshly-allocated
-        // YOUNG string. They are stored into this malloc'd (old-generation) header
-        // by raw writes; without a write barrier the old→young edge is never
-        // remembered, so a copying minor GC sweeps the string while the retained
-        // RegExp still points at it. The evacuation verifier reports this as an
-        // uncovered object→string edge, and it crashes for real when the freed
-        // slot is later scanned/read (a heavy regex workload — e.g. ANSI/emoji
-        // parsing in a terminal UI — hits it within seconds). Remember both edges,
-        // mirroring every other native-header pointer store (closure captures,
-        // object prototype slots, array headers). `runtime_write_barrier_gc_slot`
-        // detects the malloc parent and only remembers genuinely-young children,
-        // so an already-old/interned `pattern` is a harmless no-op.
+        // this 2-slot payload range via the magic-tagged RegExp layout.
+        //
+        // The header is young now, so for a young child the barrier records
+        // nothing; it still has to run, because a header born while a budgeted
+        // cycle is marking is allocated black, and because a header that has
+        // been promoted and then reassigned (`RegExp.prototype.compile`) is a
+        // genuine old→young store. Historically the header was malloc'd, i.e.
+        // old, and this store was THE old→young edge a copying minor would
+        // otherwise miss: the evacuation verifier reported it as an uncovered
+        // object→string edge, and it crashed for real when the freed slot was
+        // later scanned/read (a heavy regex workload — e.g. ANSI/emoji parsing
+        // in a terminal UI — hit it within seconds).
+        //
+        // Remember both edges, mirroring every other native-header pointer
+        // store (closure captures, object prototype slots, array headers).
+        // `runtime_write_barrier_gc_slot` classifies the parent and only
+        // remembers genuinely-young children, so an already-old/interned
+        // `pattern` is a harmless no-op.
         let regexp_parent_addr = ptr as usize;
         if !pattern.is_null() {
             crate::gc::runtime_write_barrier_gc_slot(

--- a/crates/perry-runtime/src/regex/lazy.rs
+++ b/crates/perry-runtime/src/regex/lazy.rs
@@ -38,8 +38,8 @@
 //!   engines refuse);
 //! * `.source` / `.flags` / `.global` / `.sticky` / `lastIndex` are header
 //!   and side-table reads that never touched the compiled program;
-//! * identity is untouched — `js_regexp_new` still `gc_malloc`s a fresh
-//!   header per evaluation.
+//! * identity is untouched — `js_regexp_new` still allocates a fresh header
+//!   per evaluation.
 //!
 //! The build itself happens on the first operation that needs a matcher,
 //! through [`ensure_regex_compiled`], and installs exactly the pointers


### PR DESCRIPTION
> **REBASED onto `35c36f425` (2026-09-06), new head `e076f7793`.** The stack
> this branch carried (#9796, #9801's reconcile, #9819) is now ON MAIN, so the
> PR is a **one-commit, 8-file diff** — the diff it always asked to be reviewed
> as. The rebase had **no conflicts**; details, and the invariants re-derived on
> the new base, are in "Rebased onto `35c36f425`" at the bottom.
>
> **Also at the bottom: the CPU numbers in this body predate #9857 and are
> withdrawn pending a re-run.** #9857 removes the bimodal slow mode this PR's
> "−27 % on means, bimodal → unimodal" was measured against. What this PR is
> accountable for until then is the allocation-arm and memory result
> (`MallocCount` firings 105 → 0, malloc-backed RegExp allocations 1.48 M → 0,
> peak RSS −70…−90 MB).

> **Depends on #9860** — landing order **#9838 → #9860 → this PR**. Do not merge
> it ahead of #9860.
>
> The 400-char settled-footprint regression this PR used to carry (748 MB after
> a 120 s idle window against ~520 for the base arm) is **resolved and
> measured** — see "Memory at 400 — resolved by #9860" below. The cause was
> never the header move: it is a GC policy edge this change lands the heap on
> (the idle compactor's 25 % residue gate declining at 23.7 %, and a freshness
> re-arm that needs a collection it has just declined to make). #9860 supplies
> that re-arm. With it the same workload settles **453 MB against 751** on a
> single isolated turn, and **557–574 MB against a parked 737–752** across a
> four-turn session — in both cases below the base arm's own settled figure.
> The session rows also retire the young-generation follow-up as *likely not
> needed*: when the reclaimer revisits, the young blocks age out and release on
> their own.
> **~~Stacked.~~ No longer stacked — see the rebase note above.** This branch
> used to carry #9796 (3 commits) and #9819 (2 commits) so GitHub showed 6
> commits and 21 files; both are on `main` as of `35c36f425`, and the branch is
> now the single commit `e076f7793` over `35c36f425` (8 files). Its pre-rebase
> isolating A/B pair was `f4bcb1e4d` -> `85bedc396`; the replayed patch is
> byte-identical to `85bedc396`.

## The point of this change is the collection schedule, not only the allocation

*All claude-code numbers below are measured with the `wrap-ansi` / `string-width`
loop as it is today; that subtree is 60-85 % of cc's active CPU, so a change
there will move these absolute figures. The arm-to-arm differences are
same-host, same-binary-per-arm pairs.*

`js_regexp_new` allocated every `RegExpHeader` with `gc_malloc`. This moves it
to the nursery and adds the young-death finalization that was the only thing
keeping it on the malloc arm. A JS regex literal evaluates to a **fresh**
`RegExp` every time it is reached, so on the claude-code TUI that arm is not a
marginal site — **it is the entire arm**:

| capture (sandbox `rx`) | regexp allocs | total malloc-tracked | share | malloc registry peak → after |
|---|---|---|---|---|
| 3300 ×2 | 742,867 / 742,832 | 742,924 / 742,889 | **100.0 %** | **101,893 → 1,597** |
| 400 ×2 | 73,025 / 71,878 | 73,082 / 71,935 | **99.9 %** | 69,618 / 68,454 (no swing) |

80.0 bytes each. The 3300 counter's run-to-run spread is **0.005 %**.

### What removing that arm does, and why the promotion number moves

Per trigger kind, BEFORE arm, one 3300-char turn:

| trigger | n | copied | promoted | eden_live |
|---|---|---|---|---|
| `arena_bytes` | 57 | 225,829 / 20.1 MB | 836,583 / 76.7 MB | 77.1 MB |
| **`malloc_count`** | **48** | **0 / 0.0 MB** | **1,969,158 / 139.6 MB** | 139.6 MB |
| `old_gen_bytes` (fulls) | 6 | 0 | 0 | — |

**A `MallocCount` minor copies nothing and promotes everything** —
`promoted_bytes` equals `eden_live_bytes` exactly, ~2.9 MB per firing. Those 48
cycles carry **70 % of all promoted objects in the turn** (1.97 M of 2.81 M).
This change removes their input, so on a quiet host (perrymaster, load 0.5–0.7)
total promotion falls **6.5 M objects / 403 MB → 4.4 M / 316 MB**. That drop is
not a separate effect to be explained: it *is* those cycles disappearing. Same
mechanism, one number.

### Clean-host result at 3300 (perrymaster, one binary per arm, platform `node`)

* turn CPU: A′ 12.83–19.34 s **bimodal** → **R 10.45–11.58 s, mean 11.08,
  unimodal**; a win in every pair, **−27 % on means** against main + #9838.
* schedule: minors **122 → 25**; `MallocCount` **105 → 0**; `ArenaBytes` 17 → 25;
  `[gc-step]` lines freeing ≤ 1 %: **11 → 0**; arena-finisher sweep 107 MB →
  **1,540 MB**. Fulls 6 → 6, unchanged.
* positive control: `malloc_kinds[regexp].allocated_count` 1,484,765 → **0**;
  total malloc-backed GC allocations 1,484,818 → **53**.
* peak RSS **down 70–90 MB** (VmHWM ~1,123 → ~1,032 MB).

### Memory at 3300: peak down, settled at-or-better — measured

*(400-char settled footprint is a separate and currently NEGATIVE result — see the section below it.)*

perrymaster, 3300 chars, two runs per arm, rotated, load < 0.3, RSS in MB:

| arm | post-turn RSS | **RSS after 120 s idle** | peak VmHWM | CPU burned in the idle window |
|---|---|---|---|---|
| A | 930 / 929 | **554 / 571** | 1108 / 1109 | 22.1 / 19.1 s |
| A' | 911 / 907 | 615 / 669 | 1117 / 1120 | 13.2 / 19.5 s |
| **R** | 1039 / 1032 | **590 / 512** | **1039 / 1036** | 14.1 / 14.4 s |

**The +110 MB R carries at turn end is young-generation headroom, and the idle
collector gives it back.** Settled R is **512-590 MB**, at or below settled A
(554-571) and below A' (615-669); peak VmHWM is **70-80 MB lower** than either.
On the directive's two memory metrics this change improves peak and is
neutral-to-better on settled. Only the instantaneous post-turn reading is
higher, and that is the existing adaptive nursery-cap ladder choosing a larger
Eden in response to churn that moved from malloc into the nursery — reclaimed at
the next collection, as the idle column shows. **This PR changes no threshold
and no pacing knob.**

The mechanism, from the per-kind copy census: R promotes *less* than A
(6.5 M objects / 403 MB -> 4.4 M / 316 MB), so the higher post-turn figure is
not retention and not old-gen growth. Each R minor clears a ~65 MB Eden
(1,299 MB freed + 316 MB promoted over 25 minors) against ~13 MB for A's
`MallocCount` minors; R's high-water *is* its end-of-turn reading, while A peaks
earlier and comes down.

Two caveats travel with the table. **n = 2 per arm.** And the app burns
**13-22 s of CPU inside the 120 s idle window on every arm** — a cc idle-loop
matter, not the collector, and R burns the least of the three — so "settled"
here means "after whatever that loop leaves the idle reclaimer time to do",
not a quiesced heap.

### Settled footprint at 400 characters: a REGRESSION on this branch alone — RESOLVED by #9860 (measured; see "Memory at 400 — resolved by #9860" below)

perrymaster, single isolated 400-char turn, 120 s idle, two rounds per arm,
load < 0.1, RSS in MB:

| arm | turn CPU | post-turn | **after 120 s idle** | fulls | idle-reclaim attempts | idle-compactions |
|---|---|---|---|---|---|---|
| A | 2.18 / 2.21 | 757 / 759 | **512 / 527** | 7 | 3 | 2 |
| **R** | 2.06 / 2.04 | 738 / 742 | **748 / 748** | 3 | 1 | **0** |
| C | 2.04 / 2.04 | 747 / 746 | 746 / 747 | 3 | 1 | 0 |

**R does not settle within 120 s after a single isolated 400-char turn: 748 MB
against A's ~520, +220 MB.** The reclaimer's own diagnostics name the mechanism,
and it is a policy edge rather than the header move:

* R's one idle reclaim ran and was productive (`reclaimed_old=2.1 MB,
  reusable=21.9 MB`), but the compactor's residue gate
  (`idle_compact.rs::compaction_owed`: >= 8 MB **and** >= 25 % of old-gen
  occupancy) **declined at 23.7 %** (21.9 / 92.4) where A passed at 26.0 % and
  released 240 MB.
* Once declined, the idle reclaimer's freshness gate needs a **new collection**
  to re-arm. In A the compaction is that collection; in R
  `external_collections` stays at 9 and the state is parked **1.3 points under
  the gate with no path back** until the next turn allocates.
* The larger half is young, and there is no idle path for it: after R's reclaim
  `[gc-general-reclaim] examined=66 released=0 has_live=39` - **39 of 66 young
  blocks hold a live object and no idle minor exists to evacuate them**, so the
  cap-ladder Eden (~65 MB) stays resident with scattered live objects.

At 3300 the residue is well over 25 %, which is why R settles there. **The move
is what puts the heap at this operating point; the gate constants and the
freshness re-arm are what strand it.** Both are GC policy, not this change.

**Dependency: #9860** (`fix/idle-reclaim-rearm`) fixes the re-arm, and its body
carries the mechanism decomposition — including that the largest single piece
of the ~221 MB is arena *capacity* right-sizing that never gets a second
observation, rather than the young half, and evidence that simply moving the
gate from 25 % to 23 % does not work. **#9860 does not address the young half**
(`has_live=39` of 66 blocks, with no idle minor to evacuate them); the
session-then-settle row below now measures that half, and the answer is that a
separate idle **young evacuation is likely NOT needed** — when the reclaimer
gets a second attempt the young blocks age out and release on their own
(`[gc-general-reclaim] released=32`, `has_live` 50 -> 21). Read the two PRs together: #9860 is based on `644b9d362`
(main + #9838) and likewise shows three commits while asking review of one.

**Landing consequence, stated plainly: this PR claims no memory win at 400 on
its own, and on the directive's rule that neither metric may regress it depends
on #9860.** That dependency is now measured, not asserted: with #9860 the same
single turn settles at **453 MB against 751**, below the base arm's own
512–527 — see "Memory at 400 — resolved by #9860" below, which is also the
row that supersedes the session-then-settle reading in the next subsection. The
3300 settled row above stands unchanged.

**Do not read A -> A' from this table.** Both A rows happened to land in the
18 s mode of the bimodality and both A' rows in the 13 s mode; that column is
the bimodality, not a difference between those two arms.

### Session-then-settle at 400: R settles to A's level when the reclaimer re-arms, and parks when it does not — MEASURED

perrymaster, four 400-char turns in one process, 5 s gaps, then 120 s idle,
arms rotated A/R/R/A, diagnostics on. RSS in MB, CPU in seconds:

| run | per-turn CPU | 4-turn | RSS per turn | **after 120 s** | idle reclaim starts / compactions / fulls / CPU |
|---|---|---|---|---|---|
| A r1 | 2.71 1.95 2.27 2.50 | 8.43 | 835 776 690 857 | **620** | 1 / 1 / 2 / 1.06 s |
| A r2 | 2.71 2.01 2.23 2.50 | 8.45 | 807 774 685 855 | **633** | 1 / 1 / 2 / 0.64 s |
| R r1 | 2.56 1.80 1.66 1.99 | **8.01** | 777 779 716 836 | **616** | 2 / 1 / 3 / 0.92 s |
| R r2 | 2.58 1.74 1.96 2.04 | **8.32** | 780 767 720 903 | **775** | **0 / 0 / 0 / 0.02 s** |

**The single-turn regression does not survive a session, but it does not
disappear cleanly either — it becomes bimodal on one binary.** After a four-turn
session R settles **to A's level (616 vs 620 / 633 MB)** when the idle reclaimer
gets a second attempt inside the window, and **parks at 775 MB when it does
not**: R r2 recorded **zero reclaim starts, zero compactions, zero fulls and
0.02 s of CPU across the whole 120 s** — the loop was completely quiet and
nothing re-armed it. That is the freshness re-arm hole, and **#9860 is the
deciding change**. Its arm has since been measured and it does exactly that —
and it also corrects this table: on a rerun **both** R draws parked (737 / 752
MB), so the 616 MB row here was the lucky draw rather than the typical one. See
"Memory at 400 — resolved by #9860".

Two mechanism details that fall out of the same runs:

* **The young half looks self-solving.** When the reclaimer does revisit, the
  young blocks age out and release on their own — R r1's general reclaim
  reports `released=32` with `has_live` falling **50 -> 21**. So the separate
  idle young evacuation the single-turn section raised as a possible second
  change is **likely not needed**; the missing piece is the revisit, not a new
  evacuation path.
* **Compaction is not what settles it.** In both arms the compaction that ran
  was unproductive (`kept_promise=false`). The settle came from the reclaimer's
  sweep plus general-block aging. This corrects the natural reading of the
  single-turn table above, where A's release sits in the same row as its
  compaction: the compaction is the collection that re-arms the reclaimer, not
  the thing that returns the memory.

**CPU over the same session: R 8.01 / 8.32 against A 8.43 / 8.45 over four
turns (-1.5 to -5 %), with turns 2-4 lower in every pair** and turn 1 -0.13 /
-0.15 in this batch. That is the clean-host counterpart of the dev-box
four-turn row below; the two hosts' numbers are never merged into one table,
and the direction is the same on both.

Raw: `/root/rig9831/multi_idle.jsonl`, `multi_idle_{A,R}_r{1,2}.diag`.

### Memory at 400 — resolved by #9860

perrymaster, same base `644b9d362`, arms rotated, load < 0.3, `PERRY_GC_DIAG=1`.
**R** is this change (`86fa23d97`); **RA** is this change + #9860 (`c9b98b8f0`).

**Single isolated 400-char turn + 120 s idle.** R parks at **751 / 750 MB** on
one reclaim attempt and no compaction; RA settles at **453 / 453 MB** on 8
attempts (4 of them `reason=idle_elapsed`) — **below the base arm's own
512–527**. `arena_capacity` follows, 170.9 / 168.8 → **54.5 / 57.7 MB**, and the
general-block census `has_live` 37–39 of 66 → **2 and 1**. Turn CPU (2.06/2.08
vs 2.05/2.09) and post-turn RSS (742/749 vs 742/748) are unchanged, so the
settle is the only thing that moves.

**Four 400-char turns in one process** (5 s gaps, then 120 s idle, order
R/RA/RA/R, diagnostics on). RSS in MB, CPU in seconds:

| run | per-turn CPU | RSS after each turn | **after 120 s** | reclaim attempts (`idle_elapsed`) / compactions / fulls / idle CPU |
|---|---|---|---|---|
| R #1 | 2.56 1.73 2.04 1.96 | 785 766 721 789 | **737** | 0 (0) / 0 / 0 / 0.02 s — **parked** |
| R #4 | 2.59 1.68 1.95 2.00 | 775 767 721 901 | **752** | 0 (0) / 0 / 0 / 0.02 s — **parked** |
| RA #2 | 2.51 1.69 2.26 1.94 | 779 764 706 778 | **557** | 8 (6) / 2 / 10 / 2.43 s |
| RA #3 | 2.54 1.66 2.54 1.89 | 777 768 701 778 | **574** | 8 (6) / 2 / 10 / 2.18 s |

**Reading, and it corrects the section above.** After a session this change
alone **parks at ~740–750 MB whenever cc's idle loop happens to be quiet — both
R draws did so this time.** The 616 MB settle reported in the
session-then-settle section above was the *lucky* draw, in which the idle loop
produced a collection that re-armed the reclaimer by accident; it is not the
typical case, and this row supersedes it. With #9860 the same session settles at
**557–574 MB, below the base arm's own 620 / 633.** Six of the eight attempts
start on `reason=idle_elapsed`. The reducer converges rather than spinning: its
later `done` lines read `reclaimed_old=0` with reusable ~62 MB against
`old_in_use` ~92 MB (67 %), after which the elapsed arm stops. The price is
**~2.3 s of CPU inside the 120 s window against 0.02 s parked**, level with what
the base arm's own attempts cost.

**The compactor is not what returns the memory.** Every compaction in the RA
runs was unproductive (`released=0`, `kept_promise=false`). What a compaction
supplied in the base arm was the *external collection* that re-armed the
reducer; #9860 supplies that re-arm directly, which is why the release no longer
depends on a compaction being productive.

**Landing consequence: this PR lands after #9860** — order
**#9838 → #9860 → #9845**. Merged ahead of it, the parked case comes back, and
the directive's rule that neither metric may regress forbids that.

Raw: perrymaster `/root/rig9831/idleRA.jsonl`,
`idleRA_{R,RA}_{3300,400}_r{1,2}.diag`, `multi_idle_ra.jsonl`,
`multi_idle_ra_{R,RA}_{1..4}.diag`.

### At 400 characters: cheaper in steady state, and the single-turn reading is fragile

Four consecutive 400-char turns in one process, arms rotated, 3 runs each,
load < 0.3, per-turn CPU in seconds:

| arm | t1 | t2 | t3 | t4 | **4-turn total** |
|---|---|---|---|---|---|
| A (x3) | 2.58-2.65 | 1.52-1.79 | 1.93-2.16 | 2.30-2.57 | **8.67-8.93, mean 8.77** |
| **R (x3)** | 2.67-2.68 | **1.31-1.36** | 1.57-2.11 | 1.96-2.05 | **7.66-8.08, mean 7.90** |

**R is cheaper by 0.87 s over four turns, -10 %.** From turn 2 on it is
0.2-0.5 s cheaper every turn. The steady states differ structurally: **A runs
8-11 `MallocCount` minors per turn plus a rising, run-dependent full count
(8/6/2 across the three runs); R runs 2 `ArenaBytes` minors per turn with a
full schedule that is identical in all three runs (1, 0, 2, 4).** Deterministic
where A is run-dependent. RSS per turn is flat and comparable in both arms, with
no growth trend in either.

**Disclosure, because it is the number a reviewer measuring one turn will see.**
A single 400-char turn from a fresh process **does not have a stable sign on
this change**, and that is the honest statement of it. Across batches of the
same binaries on the same quiet host: one batch measured R **+0.3 s** (about
+15 %) in 3 of 5 pairs, a traced batch measured **+0.35 s** in 3 of 4 runs, and
a later batch measured R **0.10-0.16 s FASTER than A in all 5 pairs**
(A 2.18, R 2.04). The multi-turn runs put turn 1 at +0.07 s, a wash. **Quote no
sign for the single-turn 400 number** - the batch-to-batch variation exceeds
the effect, so a single batch of it is one sample, not a measurement. The
four-turn steady-state result (-10 %, with a schedule that is identical across
all three runs where A's varies) is the robust number and the one this PR rests
on. Structurally, turn 1 is also the one turn that flatters A: it has not yet
accumulated the per-turn `MallocCount` minors this change removes.

An earlier reading attributed the single-turn cost to extra escalated old-gen
fulls. That was wrong and is retracted: with trace and diag captured together,
pacing state is identical across all four R runs (first full at base 48-50 MB,
escalation boundary 96-99 MB, backoff shift 0, live peak 85-86 MB) and **R never
escalated**. The escalation appeared in a single diag-only run and was noise.

### A real inefficiency this exposes, tracked separately

Splitting each single 400-char turn into summed in-turn GC pause and remainder:

| arm | turn CPU | in-turn GC pause (cycles) | mutator remainder |
|---|---|---|---|
| A (x4) | 2.08-2.15 | 1.52-1.58 s (12) | 0.56-0.59 s |
| R (x4) | 2.13-2.48 | **1.18-1.31 s (9-10)** | **0.95-1.24 s** |

**R's collector spends 0.25-0.35 s less per turn and its mutator spends
0.4-0.65 s more** - roughly **2.5 us per RegExp constructed or used**. The
mechanism is not yet named and is being counted separately (registry inserts,
move-hook rekeys, the from-space walk's `examined`, and site-cache
probes/repairs, A vs R). Two candidates are already eliminated by reading:
the from-space walk is **inside** the measured pause (`cycle.rs:625` ->
`copying.rs:1560` -> `copying.rs:1701`), so it cannot be mutator time; and both
young-log arming and the write barrier are *cheaper* in R, because a malloc'd
header's `addr_is_minor_relevant` fell through to a `gc_malloc_header_is_tracked`
hash probe and its two header slots were genuine old->young edges. In steady
state this cost is outweighed several times over by the ~10 minors per turn A
keeps paying, which is why the multi-turn total is negative; it is a follow-up,
not a blocker.

The leading hypothesis is **allocation locality**, and it is worth stating
because it is a tradeoff this codebase has not written down. The malloc arm
recycled a small set of cache-hot 80-byte mimalloc cells; the nursery
bump-allocates ~16 MB of headers per turn through a ~65 MB Eden, so each header
is touched cold and the churn evicts the mutator's working set. That predicts a
cost proportional to *uses* rather than to collections - which is what ~2.5 us
per RegExp against 194,511 `test()` calls per turn looks like - and it is
invisible to every GC counter by construction. Its diagnostic is a nursery-cap
sweep: shrink Eden and the mutator remainder should fall while the collection
saving holds. If that confirms, the general statement is that **the adaptive cap
ladder trades collection count against mutator cache locality and currently
prices only the first**, which would be the first case in this campaign of a GC
policy improving its own metric at the mutator's expense. Neither this PR nor
that follow-up proposes moving a threshold.

**Counters, same sandbox, one 400-char turn, A vs R** (counts, so host load is
irrelevant). These eliminate three of the four candidates outright:

| counter | A | R |
|---|---|---|
| `malloc_kinds[regexp].allocated_count` | 71,878 | **0** |
| total malloc-tracked GC allocations | 71,935 | **57** |
| malloc registry peak | 68,454 | **55** |
| collections / `arena_bytes` / fulls | 49 / 45 / 4 | 43 / 39 / **4** |
| `untraced=true` cycles | 0 | **0** |
| copied bytes per minor | 0.47 MB | 0.66 MB |
| site-cache `site_hit` / `new` | 100,867 / 101,936 | 101,658 / 102,723 |
| `pattern_bytes` | 1.236 GB | 1.247 GB |
| from-space walk | (n/a) | **34 walks, 4,367 examined each, 67.3 % productive** |

* **Site cache is not the cost.** `site_hit`, `new`, `pattern_bytes` and `test`
  all move together by +0.8 %, which is the turn being marginally larger; the
  hit RATIO is 98.95 % against 98.96 %. No extra misses and no repairs, so the
  1.24 GB of pattern memcmp is a cost both arms pay, not a delta.
* **The from-space walk is not the cost.** It examines 4,367 entries per minor,
  not tens of thousands - the walk prunes the registry every minor, so it never
  accumulates - and 67.3 % of what it examines is genuinely dead. It is also
  inside the measured pause, so it cannot be mutator time in any case.
* **Fulls are unchanged, 4 and 4**, independently confirming that the escalated-
  fulls reading retracted above was noise.
* `compiles std/fancy/repeat` 211/88/33 -> 210/88/33: one fewer standard
  compile, against +0.8 % more constructions. The invariant holds.

So the mutator cost survives every counter that exists, which is itself the
evidence for the locality hypothesis: it is the one candidate that is invisible
to all of them by construction.

## Why the malloc arm was never required

`GC_TYPE_REGEXP` has been `ArenaOrMalloc` and `movable = true` all along;
`GcMoveHookKind::RegExpSideTables` already rekeys `REGEX_POINTERS`,
`REGEX_SOURCE_TABLE` and the expando owner, `GcLayoutSlotKind::RegExpFields`
already traces `pattern_ptr`/`flags_ptr`/`meta`, and
`test_movable_regexp_evacuation_migrates_all_address_owned_state` has exercised
the arena arm through a `#[cfg(test)]` allocator. The production comment records
`gc_malloc` as an upgrade from a raw `alloc()` that leaked every header — not as
a rejection of the arena. What actually blocked the switch was finalization of
young death: the copying minor's from-space flip runs no per-object finalize
hooks, so a nursery header dying young would leak its three `Arc` programs and
its registry entries. Handled now exactly as `Map`, `Set` and `Error` handle
theirs — `finalize_dead_copied_minor_from_space_regexps` after a copied minor
(`copying.rs:1560`, after the rewrite pass so the move hook has rekeyed to
to-space, before `clear_marks` so `MARKED`/`FORWARDED` still read true, before
the from-space reset so a dead header is still mapped),
`collect_dead_registered_regexps_post_trace` at sweep entry for the non-copying
cycle kinds, and the existing old-generation sweep for a promoted header.

Deadness reuses the audited `owner_is_dead_copied_minor_from_space` predicate,
which requires `GC_FLAG_ARENA` set and `MARKED|FORWARDED` clear, so an evacuated
header and a still-malloc'd one are both skipped.

**A moving header is safe** because every program cache keys on CONTENT:
`REGEX_CACHE`, `FANCY_CACHE`, `REPEAT_MATCHER_CACHE` and `VALIDATED_PATTERNS` on
`(Arc<str>, Arc<str>)`, the site cache on a fingerprint plus a full compare.
Descriptor `(owner, key)` keys are rekeyed generically by
`scan_descriptor_roots_mut`, and #9754's young-log arming is address-based so a
nursery RegExp owner arms itself. `js_regexp_exec` already roots `re` and
re-reads it (#8428/#8446/#8449, because `lastIndex` coercion can run user JS) —
that rooting, not the malloc arm, is what made the hot path safe, and those
three tests now run against a header that really can move.

### One behaviour change reviewers should look at directly

`untraced` in-place promotion requires `skip_remembering`, which requires
`malloc_registry_empty_at_start`. With ~100 k malloc-registered headers the
registry was never empty, so **that path was unreachable on claude-code and
becomes reachable here for the first time.** It is already guarded —
`retag_young_for_in_place_promotion` runs before the from-space finalize walks,
after which no address classifies as nursery, so every death-pruning pass (Map,
Set, Error and now RegExp, which share one predicate) provably finds nothing,
which is what `copying.rs:1219-1226` already argues. Measured: `untraced=true`
is **0 in every arm at 3300**. The 400 census is what tests it there.

## Testing

`cargo test --profile gcaudit -p perry-runtime -- --test-threads=1` — the only
profile with `debug-assertions = true`, and therefore the only one that
exercises the GC rules this change adds — **3,170 passed, 0 failed, 4 ignored,
0 filtered out**. The four ignored are documented benchmarks and the deliberate
abort-child `pin_latch_sabotage_child`. Passing by name:
`nursery_regexp_that_dies_young_is_finalized_by_the_copied_minor`,
`test_movable_regexp_evacuation_migrates_all_address_owned_state`,
`regexp_finalize_releases_all_header_owned_programs`,
`malloc_finalize_clears_regexp_address_owned_tables`,
`regexp_has_dedicated_gc_kind_and_is_not_a_shaped_object`, and the three
moving-minor-inside-`lastIndex` tests. 101 regex tests green.

`compiles std/fancy/repeat` (`PERRY_REGEX_DIAG`) must be unchanged; on this
sandbox its value is 211/88/33.

## Arms, so no number here is misattributed

Both arms are based on main `d36a1af0c` and carry #9796 (2 commits), #9801's
reconcile and #9819 (2 commits). **Neither carries #9838.** The isolating pair
for this change alone is `f4bcb1e4d` → `85bedc396`, one commit apart with
identical codegen, so both share the relink object cache. perry-b4's clean-host
arms are rebased onto `644b9d362` (main + #9838) and its R is `86fa23d97`;
counters reproduce across both, absolute per-reply volumes do not — they are a
property of the sandbox project, so arms are only ever compared within a host.

---

## Rebased onto `35c36f425` (2026-09-06)

`origin/main` moved to **`35c36f425`** and the merge train landed this branch's
entire stack — #9796 (`17cd15449`), #9801's reconcile (`a800902f7`), #9819
(`56e473c6d`) — together with the **split of
`crates/perry-runtime/src/regex.rs`** under the file-size cap (`a800902f7`,
`0b175c555`, `07e3774dc`).

The rebase is `git rebase --onto 35c36f425 f4bcb1e4d`: the five already-landed
commits are dropped and **only `85bedc396` is replayed**. New head
**`e076f7793`**. The PR is now the one-commit, 8-file diff it always asked to be
reviewed as, instead of six commits and 21 files.

### Conflicts: none — and why the campaign log said otherwise

The conflict that was recorded against this PR was in the *whole-stack* merge:
main carries #9796/#9801/#9819 as **different commits**, so replaying this
branch's own copies of them conflicts with their landed forms. Replaying
`85bedc396` alone produced **zero conflicts**, for a concrete reason worth
stating because it was the open question: **the split did not move a single site
this change touches.** `js_regexp_new`, the `REGEX_POINTERS` /
`REGEX_SOURCE_TABLE` thread-locals, `regex_header_finalize_for_gc` and the
`gc_malloc` call itself are all still in `regex.rs` on main — the split moved
`program_key`, `replace_expand_fancy`, `global_scan`, `class_range_validate` and
the fancy-replacement expander out. Nothing was re-applied by hand, nothing was
dropped, and the diff is byte-identical in intent to `85bedc396`.

### Re-derived on the new base rather than trusted to the clean merge

Per BRIEF_COMMON's "a clean merge is evidence about lines, never about meaning",
the invariants this change establishes were re-checked against `35c36f425`:

* **Finalize coverage is Map's coverage.** `finalize_dead_copied_minor_from_space_maps`
  / `collect_dead_registered_maps_post_trace` / `finalize_collected_dead_map`
  have exactly three call sites on main and no others; the RegExp trio now sits
  on the adjacent line at each of them (`copying.rs:1911`, `oldgen.rs:1220`,
  `oldgen.rs:1253`). A RegExp header therefore cannot die on a cycle kind where a
  Map could not.
* **The ordering the change depends on still holds.**
  `retag_young_for_in_place_promotion` is at `copying.rs:1240`;
  `finalize_dead_copied_minor_from_space_side_allocations` is at
  `copying.rs:1634` — after the rewrite pass, after `run_fromspace_scan` and
  `run_native_stack_scan`, and before `clear_marks` and the from-space reset.
  That is the window the PR argues for, unchanged by the train's +97 lines in
  `copying.rs`.
* **One production allocation site.** `gc_malloc(header_size, GC_TYPE_REGEXP)`
  occurs exactly once on main and it is the line this replaces; the only other
  `arena_alloc_gc` for `GC_TYPE_REGEXP` is the pre-existing `#[cfg(test)]`
  `test_alloc_nursery_regexp_for_move`.
* **The other side added no writer of a contract this change moves.**
  `git diff f4bcb1e4d origin/main -- crates/perry-runtime/src/{object,builtins,string}/`
  contains no RegExp reference at all, and the train's only `gc/malloc.rs` change
  is the `perry_thread_local!` conversion of `MALLOC_STATE`.

Gates re-run on the rebased tree: `raw_handle_debt.py` (955 sites against a 963
baseline, 112 modules within ceilings), `check_thread_locals.py` (400 hot / 272
cold, capacity 768), `check_file_size.sh` (no file over 2,000 lines — `regex.rs`
stays under it after the split plus this change), `check_test_registration.py`.

### The CPU claim in this body PREDATES #9857 and is to be re-priced

Every CPU figure above was measured on binaries that do **not** carry #9857
(native-instance tag keyed by `LocalId` instead of by name). On perrymaster,
#9857 alone takes a 3300-character turn from 13.6–18.2 s to **6.9 s, unimodal
7/7**, by removing the 27 % `__memmove_avx512_unaligned_erms` under
`prune_dead_owner_side_tables_post_trace` — which *is* the bimodal slow mode this
PR's "A′ 12.83–19.34 s bimodal → R 10.45–11.58 s unimodal, −27 % on means" row
was measured against.

**So the slow-mode component of this change's CPU win is gone with #9857, and
the −27 % is not a claim this PR may carry forward until the pair is re-run on a
#9857 base.** What this PR is accountable for now is the **memory and
allocation-arm** result, which is the part that is a count rather than a time:

| quantity | before | after |
|---|---|---|
| `malloc_kinds[regexp].allocated_count` (3300) | 1,484,765 | **0** |
| total malloc-backed GC allocations (3300) | 1,484,818 | **53** |
| `MallocCount` trigger firings (3300) | 105 | **0** |
| malloc registry peak (3300) | 101,893 | 1,597 |
| peak RSS / VmHWM (3300) | ~1,123 MB | ~1,032 MB (**−70 to −90 MB**) |

The first four are counts and are base- and load-independent by construction.
The peak-RSS row is a measurement and was taken pre-#9857, so it should be
re-confirmed on a #9857 base before it is quoted as a landed number — #9857
itself moves peak RSS by −460 MB at 3300, so the two are not additive without
being measured together.

The `#9860` dependency for the 400-character settled footprint is unchanged, as
is the landing order **#9838 → #9860 → this PR** (now also after #9857).

### Testing after the rebase

Rebased tree, `cargo test -j4 -p perry-runtime --release --lib -- --test-threads=1`
(under the campaign build lock, `nice -n19`, dev box, load 28–80):

```
test result: ok. 3198 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out
```

The four ignored are the documented benchmarks and the deliberate abort-child
`pin_latch_sabotage_child`, unchanged. Filtering to `regex`:
**101 passed, 0 failed** — the same 101 the pre-rebase body reports.

Passing by name on the new base:

* `gc::tests::copying::survival_and_malloc::nursery_regexp_that_dies_young_is_finalized_by_the_copied_minor` (this PR's new test)
* `gc::tests::copying::survival_and_malloc::test_movable_regexp_evacuation_migrates_all_address_owned_state`
* `regex::tests::regexp_finalize_releases_all_header_owned_programs`
* `regex::tests::malloc_finalize_clears_regexp_address_owned_tables`
* `regex::tests::regexp_has_dedicated_gc_kind_and_is_not_a_shaped_object`
* the three moving-minor `lastIndex` tests —
  `gc::tests::runtime_roots::regexp_last_index::{regexp_exec_survives_a_moving_minor_inside_the_lastindex_coercion, regexp_exec_materializes_an_owned_snapshot_after_an_alloc_point_minor, string_match_fancy_materializes_an_owned_snapshot_after_an_alloc_point_minor}`

**Not re-run on the rebased tree:** the `gcaudit` profile suite (the
debug-assertions arm, 3,170/0 pre-rebase) and `cargo clippy`. Both need a
separate full build of `perry-runtime` and the box was carrying five other
lanes; the release `--lib` suite above is the arm this rebase was checked with.

https://claude.ai/code/session_014knX724SYDogwzsXybCGxp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved memory management for regular expressions, reducing allocation overhead for short-lived patterns.
  * Optimized regular-expression caching to reduce repeated string processing and unnecessary cache-key allocations.
  * Added an early check that can skip expensive repeat matching when a match is impossible.

* **Bug Fixes**
  * Improved cleanup of unreachable regular expressions during garbage collection, including release of associated compiled data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->