### PR TITLE
diag(hir): PERRY_NATIVEINST_DIAG — report every native-instance tag at the two entry points that create them

### DIFF
--- a/changelog.d/9847-nativeinst-registry-diag.md
+++ b/changelog.d/9847-nativeinst-registry-diag.md
@@ -1,0 +1,16 @@
+`PERRY_NATIVEINST_DIAG=1` reports every native-instance tag as it is created.
+
+`register_native_instance` and `push_module_native_instance` are the only two
+entry points through which such a tag can come into existence, so a diagnostic
+on them cannot miss one the way a diagnostic on guessed construction sites can
+— which is why it is placed there. One line per registration:
+
+```
+[nativeinst] REGISTER push_module name="O" -> child_process::Instance
+```
+
+The env var is excluded from the build-level cache, because a cached build
+reuses the finished binary and never lowers HIR, so the report would print
+nothing — and nothing is indistinguishable from "no tag was ever registered".
+
+Off, the cost is one relaxed atomic load per registration.

--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -1461,6 +1461,7 @@ impl LoweringContext {
         module_name: String,
         class_name: String,
     ) -> bool {
+        nativeinst_registry_diag("register", &local_name, &module_name, &class_name);
         // #5137: if the user opted this package into `perry.compilePackages`,
         // its real npm source is being compiled and the binding resolves to
         // the compiled-from-source class. Registering a native instance here
@@ -1679,6 +1680,7 @@ impl LoweringContext {
     /// scans these in reverse (last-match-wins), so the index stores the LAST
     /// pushed entry per name (overwrite).
     pub(crate) fn push_module_native_instance(&mut self, entry: (String, String, String)) {
+        nativeinst_registry_diag("push_module", &entry.0, &entry.1, &entry.2);
         let idx = self.module_native_instances.len();
         self.module_native_instances_index
             .insert(entry.0.clone(), idx);
@@ -1908,4 +1910,37 @@ pub(crate) fn perry_ui_factory_returns_handle(name: &str) -> bool {
     matches!(name, "VStack" | "HStack" | "Button" | "ForEach" | "WebView")
         || perry_dispatch::perry_ui_lookup(name)
             .is_some_and(|row| row.ret == perry_dispatch::ReturnKind::Widget)
+}
+
+/// #9847: report every native-instance tag as it is created.
+///
+/// `register_native_instance` and `push_module_native_instance` are the only
+/// two entry points through which a native-instance tag can come into
+/// existence, so a diagnostic on *them* cannot miss a tag the way one on
+/// guessed construction sites can — which is the whole reason this exists.
+///
+/// What it prints, one line per registration:
+///
+/// ```text
+/// [nativeinst] REGISTER push_module name="O" -> child_process::Instance
+/// ```
+///
+/// The tag table is keyed by identifier TEXT with module-wide scope, so on a
+/// minified single-module bundle the same short name is routinely claimed by
+/// several unrelated native classes and every method call on any local with
+/// that name is lowered as a native-instance call of whichever won. This
+/// report is what makes that visible: on `cli_2.1.112.js` it prints 795 lines
+/// whose most-registered identifiers are `Y`(71), `z`(65), `K`(65), `_`(65),
+/// `A`(54), `O`(52), `w`(37), `q`(35) — every one a single letter.
+///
+/// Enable with `PERRY_NATIVEINST_DIAG=1`. Off, this is one relaxed atomic load
+/// per registration and nothing else.
+pub(crate) fn nativeinst_registry_diag(kind: &str, name: &str, module: &str, class: &str) {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    let on = *ON.get_or_init(
+        || matches!(std::env::var("PERRY_NATIVEINST_DIAG"), Ok(v) if !v.is_empty() && v != "0"),
+    );
+    if on {
+        eprintln!("[nativeinst] REGISTER {kind} name={name:?} -> {module}::{class}");
+    }
 }

--- a/crates/perry/src/commands/compile/build_cache.rs
+++ b/crates/perry/src/commands/compile/build_cache.rs
@@ -841,6 +841,14 @@ fn eligibility(args: &CompileArgs, project_root: &Path) -> Result<(), String> {
     if std::env::var("PERRY_OUTLINE_ENTRY_REPORT").is_ok() {
         return Err("outline-entry-report".to_string());
     }
+    // #9847: same reasoning as `opt-report` above. A cached build reuses the
+    // finished binary and never lowers HIR, so the native-instance report
+    // would print nothing — and nothing is indistinguishable from "no tag was
+    // ever registered", which is the reading this diagnostic exists to make
+    // impossible.
+    if std::env::var("PERRY_NATIVEINST_DIAG").is_ok() {
+        return Err("nativeinst-diag".to_string());
+    }
     if args.verify_native_regions || args.emit_attest || args.emit_sandbox {
         return Err("sidecar-or-verify".to_string());
     }


### PR DESCRIPTION
Two `eprintln`s and a cache exclusion. The whole diff is 43 lines.

## What it prints

```
[nativeinst] REGISTER push_module name="O" -> child_process::Instance
[nativeinst] REGISTER register    name="O" -> readable_stream::ReadableStream
```

One line per native-instance registration, under `PERRY_NATIVEINST_DIAG=1`.

## Why these two functions specifically

`register_native_instance` and `push_module_native_instance` are the **only two
entry points through which a native-instance tag can come into existence**, so
a diagnostic on them cannot miss a tag.

That placement is the point of the change, and it was learned the hard way. An
earlier attempt at the same question instrumented four plausible *construction*
sites — out of the **165** places in `perry-hir` that build
`Expr::NativeMethodCall`, across 47 files — printed zero, and the zero was
uninterpretable: it could equally have meant "nothing tags this" or "you
instrumented a dead path". It was the latter. A diagnostic sited where the data
must pass does not have that failure mode.

## What it found — #9847

The tag table is keyed by identifier **text** with module-wide scope. On a
minified bundle that compiles as one module, the same short name is routinely
claimed by several mutually exclusive native classes, and every method call on
any local with that name lowers as a native-instance call of whichever won.

On claude-code's `cli_2.1.112.js`, 795 registrations. Most-registered
identifiers:

```
71 "Y"   65 "z"   65 "K"   65 "_"   54 "A"   52 "O"   37 "w"   35 "q"
```

Every one a single letter. `O` alone is registered as `stream::Instance`,
`child_process::Instance`, `transform_stream::TransformStream` and
`readable_stream::ReadableStream`. `child_process::Instance` by itself covers
`O`, `w`, `z`, `Y`, `_`, `K`.

Reading that took one 30-second compile. Deriving it from source took a day of
hypotheses, four of which were wrong.

## The cache exclusion is not optional

`PERRY_NATIVEINST_DIAG` is excluded from the build-level cache for the same
reason `PERRY_OPT_REPORT` is: a cached build reuses the finished binary and
never lowers HIR, so the report would come up empty — and empty is
indistinguishable from "no tag was ever registered", which is exactly the
reading this diagnostic exists to make impossible.

## One caveat a reader should not have to reconstruct

In the run that produced the histogram above, the accompanying **control
printed 0** — it used a CJS `require()` in a `.js` file, a form that (as #9847
documents) never creates a tag at all, so the control was void. That does not
undermine the numbers **only because the bundle printed 795 lines**: the
instrument demonstrably fires, so there is no zero to interpret. Had the bundle
also printed 0, the run would have proven nothing. Stating it because a reader
will see the control's 0 and should not have to work out why it is harmless
here.

Also uninvestigated: some `register` lines carry an empty `module::class`
(probably the `shadow_native_instance` tombstone path). The 104 `push_module`
lines and the class-bearing lines are the unambiguous part; the histogram above
is drawn from those.

## Cost

Off, one relaxed atomic load per registration. No emitted byte changes.

Diagnostic only — it fixes nothing. The defect it documents is #9847.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional native-instance registration diagnostic enabled with `PERRY_NATIVEINST_DIAG=1`.
  * When enabled, compilation reports each native-instance tag registration to standard error, including its type and associated module/class information.
  * Diagnostic-enabled builds bypass the build cache so registration details are reliably reported.

* **Documentation**
  * Added documentation covering how to enable the diagnostic, sample output, and its behavior when disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->