### PR TITLE
fix(node:v8): require new for class exports

### DIFF
--- a/changelog.d/9876-v8-constructor-validation.md
+++ b/changelog.d/9876-v8-constructor-validation.md
@@ -1,0 +1,1 @@
+Make the `node:v8` class exports throw Node-compatible `TypeError` values when called without `new`, including the expected `ERR_CONSTRUCT_CALL_REQUIRED` code for `Serializer` and `Deserializer`.

--- a/crates/perry-runtime/src/object/native_module_dispatch/dispatch_v_z.rs
+++ b/crates/perry-runtime/src/object/native_module_dispatch/dispatch_v_z.rs
@@ -39,6 +39,14 @@ pub(crate) unsafe fn nm_dispatch_v8(ctx: &NmCtx, module_name: &str, method_name:
         typed_kind
     );
     match (module_name, method_name) {
+        ("v8", name @ ("Serializer" | "Deserializer")) => {
+            let message = format!("Class constructor {name} cannot be invoked without 'new'");
+            crate::fs::validate::throw_type_error_with_code(&message, "ERR_CONSTRUCT_CALL_REQUIRED")
+        }
+        ("v8", name @ ("DefaultSerializer" | "DefaultDeserializer" | "GCProfiler")) => {
+            let message = format!("Class constructor {name} cannot be invoked without 'new'");
+            crate::node_submodules::diagnostics::throw_type_error_no_code(message.as_bytes())
+        }
         ("v8", "serialize") => crate::node_v8::js_v8_serialize(arg(0)),
         ("v8", "deserialize") => crate::node_v8::js_v8_deserialize(arg(0)),
         ("v8", "getHeapStatistics") => crate::node_v8::js_v8_get_heap_statistics(),


### PR DESCRIPTION
Calling several class exports from `node:v8` as ordinary functions currently returns `undefined`, while Node throws a `TypeError`. This change rejects direct calls to `Serializer`, `Deserializer`, `DefaultSerializer`, `DefaultDeserializer`, and `GCProfiler`, preserving Node's distinction between the coded serializer errors and the uncoded default/profiler errors. Construction with `new` continues through the existing dedicated code-generation paths.

Relates to #9202.

Validation:
- `node-suite/v8/classes/constructor-validation`: 1/1 parity pass
- V8 class family: constructor and receiver-validation fixtures pass; two unrelated existing prototype/inheritance fixtures remain mismatched
- `cargo test -p perry-runtime --lib -- --test-threads=1`: 3,197 passed, 4 ignored
- `scripts/run_lint_gates.sh`: 60 passed, 2 CI-only commands skipped; the two existing `gc_runtime_root_holders.py` source-pin failures from current main remain
- workspace `cargo check --all-targets` with warnings denied and workspace Clippy passed

No version bump.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `node:v8` constructor validation.
  * Calling `Serializer` or `Deserializer` without `new` now returns the expected `TypeError` with the appropriate error code.
  * Calling other affected constructors without `new` now consistently returns a `TypeError` explaining that `new` is required.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->