### PR TITLE
perf(gc): swap-remove for keys-array descriptor families, with a spill index — removes up to 848 GB of memmove per turn

### DIFF
--- a/changelog.d/9879-gc-family-list-swap-remove.md
+++ b/changelog.d/9879-gc-family-list-swap-remove.md
@@ -1,0 +1,29 @@
+### Fixed
+
+- **gc:** a keys-array family's descriptor list no longer memmoves its whole
+  tail on every removal, and no longer scans linearly to find an id.
+
+  `IdList::remove` was `Vec::remove(pos)`, which shifts everything past the
+  removed position. Measured on the compiled claude-code TUI, one 3300-char
+  reply, ten draws across two hosts: the removals sit at position **~0.31** of
+  the list — i.e. essentially always the front — and the longest list reaches
+  **514,030** entries, so the same ~3.7 M removals memmove up to **848 GB** in
+  a single turn. The removals come from the dead-owner prune
+  (`prune_dead_owner_side_tables_post_trace`).
+
+  No claim is made that this explains the turn's bimodal CPU: one draw moved
+  335 GB and was as fast as one that moved 16 GB, so bytes moved is necessary
+  but not sufficient for the slow mode. What is removed here is unambiguously
+  wasted work; how much time that is worth is for the A/B to say.
+
+  A spilled list now carries an `id -> index` map, built once it passes 32
+  entries, and `families` removes through a swap-remove that moves one element
+  regardless of position. `by_facts` keeps the order-preserving removal it
+  needs (its first entry is the canonical answer for exact-facts interning) and
+  is unaffected — measured at max length **1**, so it never builds an index.
+
+  The same index also removes the linear membership scan in
+  `family_push_back`, previously **6.2 %** of main-thread leaf samples.
+
+  This does not address why one family reaches half a million descriptors,
+  which is a separate defect and a separate change.

--- a/crates/perry-runtime/src/gc/copying.rs
+++ b/crates/perry-runtime/src/gc/copying.rs
@@ -1896,6 +1896,7 @@ pub(super) fn run_copied_minor_attempt(
     }
     crate::arena::alloc_sample::report("minor");
     super::diag_sites::report_primitive_dispatch("minor");
+    crate::object::shapes::id_list_report();
     report_forwarding_refusals("copying_minor");
     super::scanner_profile::report_and_reset("copying_minor");
     CopiedMinorAttempt::Done(Some(CopiedMinorFastPathOutcome {

--- a/crates/perry-runtime/src/object/shapes.rs
+++ b/crates/perry-runtime/src/object/shapes.rs
@@ -264,6 +264,15 @@ struct ShapeTableInner {
 
 const SHAPE_YOUNG_LOG_NAME: &str = "shapes.families+indices";
 
+/// Re-export of the id-list operation counters' report, so the collector does
+/// not have to name a private sibling module. One `[gc-idlist]` line per
+/// copying minor under `PERRY_GC_DIAG=1`; `elems_moved` is the falsifier for
+/// the swap-remove change.
+#[inline]
+pub(crate) fn id_list_report() {
+    shapes_store::id_list_report();
+}
+
 impl ShapeTableInner {
     /// Rule 1 of `gc/young_log.rs`: log a keys address BEFORE a family or a
     /// slot index is published under it, when the keys array is not old.
@@ -305,7 +314,14 @@ impl ShapeTableInner {
         let Some(ids) = self.families.get_mut(&keys) else {
             return false;
         };
-        let removed = ids.remove(id);
+        // UNORDERED: a family's readers are set-valued (see `IdList`'s type
+        // doc), and the ordered removal was memmoving the whole tail of a list
+        // measured at up to 514,030 entries, from position ~0.31, 3.7 M times
+        // per 3300-char reply. The dominant caller is the dead-owner prune
+        // (`prune_dead_owner_side_tables_post_trace` ->
+        // `remove_descriptor_indexed_under`); `retire_owned_shape_siblings`
+        // never sees a family longer than 16.
+        let removed = ids.remove_unordered(id);
         if ids.is_empty() {
             self.families.remove(&keys);
         }
@@ -334,7 +350,11 @@ impl ShapeTableInner {
         let Some(ids) = self.by_facts.get_mut(&facts) else {
             return false;
         };
-        let removed = ids.remove(id);
+        // ORDERED, and it must stay ordered: `facts_push_front` is how an
+        // installed process-global id becomes the canonical answer ahead of an
+        // equivalent local one, and this list is read first-wins. Measured at
+        // max length 1 on cc, so the order costs nothing to keep.
+        let removed = ids.remove_ordered(id);
         if ids.is_empty() {
             self.by_facts.remove(&facts);
         }

--- a/crates/perry-runtime/src/object/shapes_store.rs
+++ b/crates/perry-runtime/src/object/shapes_store.rs
@@ -467,23 +467,225 @@ impl ShapeSlab {
     }
 }
 
-/// A compact list of descriptor ids: up to three inline, then a spilled
-/// `Vec`. Sized so a family-index bucket is `(u64, IdList)` = 24 bytes.
+/// MEASUREMENT that this structure is judged on, and the test's instrument.
 ///
-/// Order is meaningful: [`IdList::push_front`] is how an installed
-/// process-global id becomes the canonical answer for exact-facts interning
-/// ahead of an equivalent local id (`install_external_shape_id`).
+/// Two counters on the id-list mutation path, kept unconditionally because the
+/// rig falsifier and the unit guard both read them and a `cfg(test)` counter
+/// can only prove the test's own arithmetic. Deliberately a THREE-field struct
+/// in one `Cell`: a thread-local `Cell<T>` get/set copies `T` on every
+/// operation, and this path runs millions of times per turn, so the width of
+/// this type is itself a cost.
+#[derive(Default, Clone, Copy)]
+pub(crate) struct IdListOpStats {
+    /// Removals that found their id.
+    pub(crate) removals: u64,
+    /// Elements shifted by a removal. Bytes = this x 4. Swap-remove moves
+    /// none; `Vec::remove` moves the whole tail past the removed position.
+    pub(crate) elems_moved: u64,
+    /// Entries touched by a linear membership or position scan. The other
+    /// half of the same defect: the index removes this too.
+    pub(crate) positions_scanned: u64,
+}
+
+thread_local! {
+    pub(crate) static ID_LIST_OP_STATS: std::cell::Cell<IdListOpStats> =
+        const {
+            std::cell::Cell::new(IdListOpStats {
+                removals: 0,
+                elems_moved: 0,
+                positions_scanned: 0,
+            })
+        };
+}
+
+#[inline]
+fn note_scan(entries: usize) {
+    ID_LIST_OP_STATS.with(|c| {
+        let mut st = c.get();
+        st.positions_scanned += entries as u64;
+        c.set(st);
+    });
+}
+
+#[inline]
+fn note_removal(elems_moved: usize) {
+    ID_LIST_OP_STATS.with(|c| {
+        let mut st = c.get();
+        st.removals += 1;
+        st.elems_moved += elems_moved as u64;
+        c.set(st);
+    });
+}
+
+/// One `[gc-idlist]` line per copying minor under `PERRY_GC_DIAG=1`,
+/// cumulative. `elems_moved` is the rig falsifier for this change.
+pub(crate) fn id_list_report() {
+    if !crate::gc::gc_diag_enabled() {
+        return;
+    }
+    let st = ID_LIST_OP_STATS.with(std::cell::Cell::get);
+    if st.removals == 0 {
+        return;
+    }
+    eprintln!(
+        "[gc-idlist] removals={} elems_moved={} bytes_moved={} positions_scanned={}",
+        st.removals,
+        st.elems_moved,
+        st.elems_moved * 4,
+        st.positions_scanned,
+    );
+}
+
+/// A spilled id list: the ids, plus an `id -> index` map built once the list
+/// is large enough for a linear scan to cost more than a hash probe.
+///
+/// The index is what makes `remove_unordered`, `contains` and `position` O(1)
+/// on the lists that actually get long. Below [`SPILL_INDEX_MIN`] it stays
+/// empty and every operation is the linear scan it always was, because for a
+/// handful of entries the scan is a single cache line and the map is not.
+#[derive(Clone, Debug, Default)]
+pub(super) struct SpillList {
+    ids: Vec<u32>,
+    /// Empty while `ids.len() < SPILL_INDEX_MIN`; complete above it.
+    ///
+    /// `PtrHasher` (#8125) is the right hasher here for the same reason it is
+    /// on the maps around it: shape ids come from a monotonic counter, so the
+    /// key is a small dense integer and the avalanche step is what keeps every
+    /// one of them off bucket 0.
+    pos: crate::fast_hash::PtrHashMap<u32, u32>,
+}
+
+/// Where the index starts paying. Measured shape of the problem: `families`
+/// lists reach 514,030 entries on a claude-code reply while `by_facts` lists
+/// are length 1, so anything in the low tens is far below the case that hurts
+/// and far above the case where the map would be pure overhead.
+const SPILL_INDEX_MIN: usize = 32;
+
+impl SpillList {
+    #[inline]
+    fn indexed(&self) -> bool {
+        !self.pos.is_empty()
+    }
+
+    /// Build the index if the list has just crossed the threshold. Called
+    /// after every growth, so the map exists from the first entry past it.
+    #[inline]
+    fn maybe_build_index(&mut self) {
+        if self.pos.is_empty() && self.ids.len() >= SPILL_INDEX_MIN {
+            self.pos.reserve(self.ids.len());
+            for (i, &id) in self.ids.iter().enumerate() {
+                self.pos.insert(id, i as u32);
+            }
+        }
+    }
+
+    /// Position of `id`, O(1) when indexed and a counted linear scan below the
+    /// threshold.
+    #[inline]
+    fn position(&self, id: u32) -> Option<usize> {
+        if self.indexed() {
+            return self.pos.get(&id).map(|&i| i as usize);
+        }
+        note_scan(self.ids.len());
+        self.ids.iter().position(|&x| x == id)
+    }
+
+    #[inline]
+    fn push(&mut self, id: u32) {
+        let i = self.ids.len();
+        self.ids.push(id);
+        if self.indexed() {
+            self.pos.insert(id, i as u32);
+        } else {
+            self.maybe_build_index();
+        }
+    }
+
+    /// ORDER-PRESERVING removal, for a list whose order is load-bearing.
+    /// O(n) in the tail by construction — that is what "preserve the order"
+    /// costs — and it reindexes the shifted suffix.
+    fn remove_ordered(&mut self, id: u32) -> Option<usize> {
+        let pos = self.position(id)?;
+        let moved = self.ids.len() - 1 - pos;
+        note_removal(moved);
+        self.ids.remove(pos);
+        if self.indexed() {
+            self.pos.remove(&id);
+            for (i, &other) in self.ids.iter().enumerate().skip(pos) {
+                self.pos.insert(other, i as u32);
+            }
+        }
+        Some(pos)
+    }
+
+    /// UNORDERED removal: the last element takes the removed one's slot.
+    /// Moves ONE element regardless of position, which is the whole point —
+    /// the measured removals sit at position ~0.31 of a list up to 514,030
+    /// long, so `Vec::remove` was shifting essentially the entire list every
+    /// time.
+    ///
+    /// What this does NOT claim: that the memmove explains the bimodal turn
+    /// CPU. On perrymaster one draw moved 335 GB and was as fast as a draw
+    /// that moved 16 GB, so bytes moved is necessary but not sufficient for
+    /// the slow mode. This removes work that is unambiguously wasted; how much
+    /// TIME it removes is the A/B's to say.
+    fn remove_unordered(&mut self, id: u32) -> Option<usize> {
+        let pos = self.position(id)?;
+        note_removal(if pos + 1 == self.ids.len() { 0 } else { 1 });
+        let last = self.ids.len() - 1;
+        self.ids.swap_remove(pos);
+        if self.indexed() {
+            self.pos.remove(&id);
+            if pos != last {
+                // The element that was last now lives at `pos`.
+                self.pos.insert(self.ids[pos], pos as u32);
+            }
+        }
+        Some(pos)
+    }
+
+    #[inline]
+    fn replace(&mut self, old: u32, new: u32) -> bool {
+        let Some(pos) = self.position(old) else {
+            return false;
+        };
+        self.ids[pos] = new;
+        if self.indexed() {
+            self.pos.remove(&old);
+            self.pos.insert(new, pos as u32);
+        }
+        true
+    }
+}
+
+/// A compact list of descriptor ids: up to three inline, then a spilled
+/// `Vec` with an `id -> index` map (see [`SpillList`]). Sized so a family-index
+/// bucket is `(u64, IdList)` = 24 bytes.
+///
+/// # Order
+/// Order is meaningful **for `by_facts` only**: [`IdList::push_front`] is how
+/// an installed process-global id becomes the canonical answer for exact-facts
+/// interning ahead of an equivalent local id (`install_external_shape_id`), and
+/// that list is read first-wins. `families` is NOT order-sensitive: its only
+/// order-touching reader is the "one descriptor stands for the family" choice
+/// in the two rekey walks, which breaks on the first carrier and otherwise
+/// takes any present member — and the chosen descriptor feeds exactly one
+/// expression, `old_carrier || cache_carrier`, whose value is the same for
+/// every carrier and the same for every non-carrier. The outcome is a function
+/// of the SET, not of the order.
+///
+/// That asymmetry is why removal comes in two flavours:
+/// [`IdList::remove_ordered`] for `by_facts` and [`IdList::remove_unordered`]
+/// for `families`. **The caller declares the contract**, because the caller is
+/// the one that knows whether its order is load-bearing; a single `remove` that
+/// guessed would be the bug.
 #[derive(Clone, Debug)]
 pub(super) enum IdList {
-    Inline {
-        len: u8,
-        ids: [u32; 3],
-    },
-    // The `Box` is the point: an inline `Vec` is 24 bytes and would make every
-    // bucket 32; the spill is the rare case, so its extra indirection is
-    // cheaper than eight bytes on every family.
-    #[allow(clippy::box_collection)]
-    Spill(Box<Vec<u32>>),
+    Inline { len: u8, ids: [u32; 3] },
+    // The `Box` is the point: an inline `SpillList` is far wider and would make
+    // every bucket pay for it; the spill is the rare case, so its extra
+    // indirection is cheaper than those bytes on every family.
+    Spill(Box<SpillList>),
 }
 
 const _: () = assert!(std::mem::size_of::<IdList>() == 16);
@@ -502,7 +704,7 @@ impl IdList {
     pub(super) fn as_slice(&self) -> &[u32] {
         match self {
             IdList::Inline { len, ids } => &ids[..*len as usize],
-            IdList::Spill(v) => v.as_slice(),
+            IdList::Spill(v) => v.ids.as_slice(),
         }
     }
 
@@ -518,12 +720,18 @@ impl IdList {
 
     #[inline]
     pub(super) fn contains(&self, id: u32) -> bool {
-        self.as_slice().contains(&id)
+        match self {
+            IdList::Inline { len, ids } => ids[..*len as usize].contains(&id),
+            IdList::Spill(v) => v.position(id).is_some(),
+        }
     }
 
-    fn spill(&mut self) -> &mut Vec<u32> {
+    fn spill(&mut self) -> &mut SpillList {
         if let IdList::Inline { len, ids } = self {
-            let v = ids[..*len as usize].to_vec();
+            let v = SpillList {
+                ids: ids[..*len as usize].to_vec(),
+                pos: crate::fast_hash::new_ptr_hash_map(),
+            };
             *self = IdList::Spill(Box::new(v));
         }
         match self {
@@ -554,6 +762,11 @@ impl IdList {
     /// main-thread leaf samples on a claude-code streamed reply, 95 % of it
     /// under `ShapeTableInner::family_push_back`.
     ///
+    /// The spill index now removes that scan for the callers that cannot use
+    /// this entry point, which is why `contains` is O(1) above
+    /// [`SPILL_INDEX_MIN`]. This function stays because skipping the probe
+    /// entirely is still cheaper than performing it.
+    ///
     /// Callers that re-file an EXISTING id (the metadata rekey when a keys
     /// array moves) must keep using [`push_back`]: those ids can already be in
     /// the destination list.
@@ -567,7 +780,9 @@ impl IdList {
         }
     }
 
-    /// Prepend `id` unless already present.
+    /// Prepend `id` unless already present. Order-preserving by definition, so
+    /// it stays O(n) on a spilled list; only `by_facts` and the external-id
+    /// install use it, and neither is on a hot path.
     pub(super) fn push_front(&mut self, id: u32) {
         if self.contains(id) {
             return;
@@ -578,31 +793,53 @@ impl IdList {
                 ids[0] = id;
                 *len += 1;
             }
-            _ => self.spill().insert(0, id),
+            _ => {
+                let v = self.spill();
+                v.ids.insert(0, id);
+                if v.indexed() {
+                    v.pos.clear();
+                }
+                v.maybe_build_index();
+            }
         }
     }
 
-    /// Drop `id` if present; returns whether it was.
-    pub(super) fn remove(&mut self, id: u32) -> bool {
+    /// Drop `id` if present, PRESERVING the order of what remains; returns
+    /// whether it was there. For a list whose order is load-bearing —
+    /// `by_facts`, where the first entry is the canonical answer.
+    pub(super) fn remove_ordered(&mut self, id: u32) -> bool {
         match self {
-            IdList::Inline { len, ids } => {
-                let n = *len as usize;
-                let Some(pos) = ids[..n].iter().position(|&x| x == id) else {
-                    return false;
-                };
-                ids.copy_within(pos + 1..n, pos);
-                ids[n - 1] = 0;
-                *len -= 1;
-                true
-            }
-            IdList::Spill(v) => {
-                let Some(pos) = v.iter().position(|&x| x == id) else {
-                    return false;
-                };
-                v.remove(pos);
-                true
-            }
+            IdList::Inline { len, ids } => Self::remove_inline(len, ids, id),
+            IdList::Spill(v) => v.remove_ordered(id).is_some(),
         }
+    }
+
+    /// Drop `id` if present, WITHOUT preserving order; returns whether it was
+    /// there. For `families`, whose readers are set-valued (see the type doc).
+    ///
+    /// This is the change: on a spilled list it moves ONE element instead of
+    /// the whole tail.
+    pub(super) fn remove_unordered(&mut self, id: u32) -> bool {
+        match self {
+            // Three entries: the inline shift is a single register move and
+            // there is nothing to gain from disturbing the order.
+            IdList::Inline { len, ids } => Self::remove_inline(len, ids, id),
+            IdList::Spill(v) => v.remove_unordered(id).is_some(),
+        }
+    }
+
+    #[inline]
+    fn remove_inline(len: &mut u8, ids: &mut [u32; 3], id: u32) -> bool {
+        let n = *len as usize;
+        note_scan(n);
+        let Some(pos) = ids[..n].iter().position(|&x| x == id) else {
+            return false;
+        };
+        note_removal(n - 1 - pos);
+        ids.copy_within(pos + 1..n, pos);
+        ids[n - 1] = 0;
+        *len -= 1;
+        true
     }
 
     /// Replace `old` with `new` in place (keeps its position); returns
@@ -611,6 +848,7 @@ impl IdList {
         match self {
             IdList::Inline { len, ids } => {
                 let n = *len as usize;
+                note_scan(n);
                 match ids[..n].iter().position(|&x| x == old) {
                     Some(pos) => {
                         ids[pos] = new;
@@ -619,21 +857,20 @@ impl IdList {
                     None => false,
                 }
             }
-            IdList::Spill(v) => match v.iter().position(|&x| x == old) {
-                Some(pos) => {
-                    v[pos] = new;
-                    true
-                }
-                None => false,
-            },
+            IdList::Spill(v) => v.replace(old, new),
         }
     }
 
-    /// Bytes held outside the containing bucket.
     pub(super) fn heap_bytes(&self) -> usize {
         match self {
             IdList::Inline { .. } => 0,
-            IdList::Spill(v) => std::mem::size_of::<Vec<u32>>() + v.capacity() * 4,
+            IdList::Spill(v) => {
+                std::mem::size_of::<SpillList>()
+                    + v.ids.capacity() * 4
+                    // The index is the structure's memory cost and is reported
+                    // rather than hidden: it exists only above SPILL_INDEX_MIN.
+                    + v.pos.capacity() * (std::mem::size_of::<(u32, u32)>() + 1)
+            }
         }
     }
 }
@@ -782,8 +1019,10 @@ mod tests {
         assert_eq!(list.as_slice(), &[1, 2, 3, 4]);
         list.push_front(0);
         assert_eq!(list.as_slice(), &[0, 1, 2, 3, 4]);
-        assert!(list.remove(2));
-        assert!(!list.remove(2));
+        // The ORDERED removal keeps this list's order, which is what
+        // `by_facts` depends on.
+        assert!(list.remove_ordered(2));
+        assert!(!list.remove_ordered(2));
         assert_eq!(list.as_slice(), &[0, 1, 3, 4]);
         assert!(list.replace(3, 30));
         assert!(!list.replace(3, 300));
@@ -794,13 +1033,136 @@ mod tests {
         inline.push_back(7);
         inline.push_back(8);
         inline.push_back(9);
-        assert!(inline.remove(8));
+        assert!(inline.remove_ordered(8));
         assert_eq!(inline.as_slice(), &[7, 9]);
         assert!(inline.replace(9, 10));
         assert_eq!(inline.as_slice(), &[7, 10]);
-        assert!(inline.remove(7));
-        assert!(inline.remove(10));
+        assert!(inline.remove_ordered(7));
+        assert!(inline.remove_ordered(10));
         assert!(inline.is_empty());
         assert_eq!(inline.heap_bytes(), 0);
+    }
+
+    /// THE GUARD for this change, and it is an asymmetric one: the unordered
+    /// removal must move O(1) elements per call, and the ordered one is
+    /// allowed to move O(n) because that is what preserving the order costs.
+    ///
+    /// Front removal is the measured shape of the defect — removals sit at
+    /// position ~0.31 of a list up to 514,030 long — so the test removes from
+    /// the front, which is the worst case for `Vec::remove` and the best case
+    /// for nothing.
+    ///
+    /// **Sabotage: point `remove_unordered` at `remove_ordered`.** The bound
+    /// below is `4 * N`; the O(n) path moves `N * (N - 1) / 2` = 1,999,000
+    /// elements for N = 2,000, i.e. 250x the bound, and this fails. A bound
+    /// expressed as a MULTIPLE of N rather than an absolute is what makes the
+    /// assertion about the complexity class instead of about one N.
+    #[test]
+    fn unordered_removal_moves_o1_elements_and_scans_o1_entries() {
+        const N: u32 = 2_000;
+
+        let baseline = ID_LIST_OP_STATS.with(std::cell::Cell::get);
+        let mut list = IdList::default();
+        for id in 1..=N {
+            // The interning sites' entry point: no membership probe.
+            list.append_unchecked(id);
+        }
+        assert_eq!(list.len(), N as usize);
+        assert!(matches!(list, IdList::Spill(_)));
+
+        // Remove every id from the FRONT of the list, in insertion order.
+        for id in 1..=N {
+            assert!(list.remove_unordered(id), "id {id} was not present");
+        }
+        assert!(list.is_empty());
+
+        let after = ID_LIST_OP_STATS.with(std::cell::Cell::get);
+        let moved = after.elems_moved - baseline.elems_moved;
+        let scanned = after.positions_scanned - baseline.positions_scanned;
+        let removals = after.removals - baseline.removals;
+        assert_eq!(removals, u64::from(N));
+
+        // O(1) per removal, with room for the swap itself.
+        assert!(
+            moved <= 4 * u64::from(N),
+            "unordered removal moved {moved} elements for {N} removals — that \
+             is the O(n) tail shift this structure exists to remove \
+             (the ordered path would move {})",
+            u64::from(N) * (u64::from(N) - 1) / 2
+        );
+        // The index answers `position`, so no linear scan may be charged for
+        // a list this long. Sabotage: raise SPILL_INDEX_MIN above N and this
+        // fails with ~N*N/2 scanned entries.
+        assert!(
+            scanned <= 4 * u64::from(N),
+            "unordered removal scanned {scanned} entries for {N} removals — \
+             the spill index is not answering `position`"
+        );
+    }
+
+    /// The index must agree with the vector after every operation, including
+    /// the swap that moves a third element nobody named. Checked exhaustively
+    /// against a plain `Vec` oracle, because an index that drifts is a wrong
+    /// ANSWER (a descriptor that cannot be found, or one found under the wrong
+    /// id), not a slow one.
+    ///
+    /// Sabotage: drop the `self.pos.insert(self.ids[pos], pos as u32)` fixup
+    /// in `remove_unordered` — the element the swap relocated keeps a stale
+    /// index and the `contains` check below fails.
+    #[test]
+    fn the_spill_index_agrees_with_the_vector_after_every_operation() {
+        let mut list = IdList::default();
+        let mut oracle: Vec<u32> = Vec::new();
+        for id in 1..=200u32 {
+            list.append_unchecked(id);
+            oracle.push(id);
+        }
+        // Remove a scattered third of them, front, middle and back.
+        for &id in &[1u32, 2, 3, 100, 101, 199, 200, 50, 150, 7] {
+            assert!(list.remove_unordered(id));
+            oracle.retain(|&x| x != id);
+        }
+        // Same SET, whatever the order.
+        let mut got = list.as_slice().to_vec();
+        got.sort_unstable();
+        let mut want = oracle.clone();
+        want.sort_unstable();
+        assert_eq!(got, want);
+        // And every survivor is still findable through the index.
+        for &id in &want {
+            assert!(list.contains(id), "id {id} lost its index entry");
+        }
+        for &id in &[1u32, 2, 3, 100, 101, 199, 200, 50, 150, 7] {
+            assert!(!list.contains(id), "removed id {id} is still findable");
+        }
+        // `replace` must keep the index coherent too.
+        let survivor = want[0];
+        assert!(list.replace(survivor, 9_999));
+        assert!(!list.contains(survivor));
+        assert!(list.contains(9_999));
+    }
+
+    /// A list that never reaches `SPILL_INDEX_MIN` must not allocate an index
+    /// — the map is the structure's memory cost and it is only worth paying
+    /// where the scan hurts. `by_facts` lists, measured at length 1 on cc,
+    /// live entirely in this regime.
+    #[test]
+    fn a_short_spilled_list_builds_no_index() {
+        let mut list = IdList::default();
+        for id in 1..=8u32 {
+            list.append_unchecked(id);
+        }
+        assert!(matches!(list, IdList::Spill(_)));
+        match &list {
+            IdList::Spill(v) => assert!(
+                !v.indexed(),
+                "a list of 8 built an index; SPILL_INDEX_MIN is {SPILL_INDEX_MIN}"
+            ),
+            IdList::Inline { .. } => unreachable!(),
+        }
+        // Still correct without one.
+        assert!(list.remove_unordered(4));
+        assert!(!list.contains(4));
+        assert!(list.contains(8));
     }
 }

--- a/crates/perry-runtime/src/object/shapes_tests.rs
+++ b/crates/perry-runtime/src/object/shapes_tests.rs
@@ -777,8 +777,9 @@ mod descriptor_tests_8067 {
             .expect("shape range unexpectedly exhausted");
         let unrelated = shape_descriptor_ensure(unrelated_keys as *const ArrayHeader, 1, 1)
             .expect("shape range unexpectedly exhausted");
-        // Before retirement every version is resolvable and the family lists
-        // them in mint order.
+        // Before retirement every version is resolvable. Adds append, so the
+        // family happens to be in mint order here; that is a property of the
+        // ADD path, not a contract (see the retirement assertion below).
         assert_eq!(
             test_shape_ids_for_keys(keys),
             vec![stale_a, stale_b, cached, current]
@@ -795,7 +796,26 @@ mod descriptor_tests_8067 {
         );
         assert!(shape_descriptor_by_id(current).is_some());
         assert!(shape_descriptor_by_id(unrelated).is_some());
-        assert_eq!(test_shape_ids_for_keys(keys), vec![cached, current]);
+        // MEMBERSHIP, not order. #9706's contract is "the growth history is
+        // retired behind the version its owner now carries, except one an
+        // optimization cache permanently owns" — a statement about WHICH ids
+        // survive. The order they survive in is not part of it, and no
+        // production reader of `families` depends on it: every one either
+        // filters the whole list, snapshots the whole list, aggregates it, or
+        // (the two rekey walks) picks "a carrier if the family has one, else
+        // any present member" and feeds that single choice to exactly one
+        // expression, `old_carrier || cache_carrier`, whose value is the same
+        // for every carrier and the same for every non-carrier. The two
+        // helpers this test uses are `#[cfg(test)]` renderings of the list.
+        //
+        // This assertion compared against a `Vec` because the helper returns
+        // one, which pinned mint order by accident; `families` now removes by
+        // swapping the last element into the hole, so a survivor can move.
+        let mut survivors = test_shape_ids_for_keys(keys);
+        survivors.sort_unstable();
+        let mut expected = vec![cached, current];
+        expected.sort_unstable();
+        assert_eq!(survivors, expected);
         // Retired facts re-intern as FRESH ids: nothing can resolve the old ones.
         let reminted = shape_descriptor_ensure(keys as *const ArrayHeader, 1, 1)
             .expect("shape range unexpectedly exhausted");


### PR DESCRIPTION
> **DRAFT, pending one paired row.** At `PERRY_GC_TENURING_SURVIVALS=1`, over
> four turns on the landing base, this change is **≈ 0 on every column** against
> main5 pinned the same way. The earlier "+4 % / worse in 5 of 5 pairs" reading
> came from **single-turn** rows, where main's own turn-1 tenuring excursion
> (`S = 4 → 2 → 1`) dominates — this change was not the variable. What is still
> unmeasured is the **adaptive (knob-unset) configuration over four turns**; that
> row (TN2) or the arena lane's fix to the excursion itself is what takes this
> out of draft. See "On the landing base".
>
> **The runtime lib suite is green** and is not what is blocking: `cargo test
> --release -p perry-runtime --lib -- --test-threads=1`, cold build, macOS dev
> box, **3200 passed / 0 failed / 4 ignored / 0 filtered**. The measurement
> host's Linux run was 3192 total; the gap is exactly the 12 `target_os =
> "macos"` test items in this crate (3204 = 3192 + 12), so the suites agree. The
> one earlier failure —
> `owned_key_count_versions_are_retired_behind_the_current_one`, which asserted
> the family's ORDER after a retirement — over-specified and is now a membership
> comparison; see "Was the order really free?".

## The defect

`IdList::remove` was `Vec::remove(pos)`, which shifts every element past the
removed position. The removals that matter come from the dead-owner prune —
`prune_dead_owner_side_tables_post_trace` → `remove_descriptor_indexed_under` —
against a **`families`** list, i.e. the descriptor ids indexed under one
keys-array address.

Measured on the compiled claude-code TUI, single 3300-char replies, two hosts,
fourteen draws:

* the removals sit at **position ~0.31** of the list — essentially always the
  **front**, which is the worst case for a tail shift;
* **one owned-keys array per process** grows its family to **404 k–514 k** while
  every other list stays small;
* so the same **~3.7 M removals memmove up to 848 GB in a single turn**;
* **100.000 % of those bytes are in `families`.** `by_facts` moves **zero** —
  its longest list is **1** in every draw, exactly as its doc claims;
* `retire_owned_shape_siblings` is **not** involved: it never sees a family
  longer than **16**.

## What actually happens, per minor — measured with final counters

A second instrumented arm, 4 single-turn 3300 draws on the measurement host,
`--graceful --exit-wait 45` so **`exited=true` on all four and these are final
counters, not a truncated cumulative line**. Load 2.3–4.0, so the CPU column is
inflated and only the *modes* are read from it.

| draw | CPU | mode | biggest family | removals from it | elements moved | bytes | minors that removed from it (of ~125) |
|---|---|---|---|---|---|---|---|
| 1 | 20.26 | slow | `0x58e9a055278` | 704,240 | 149.77 G | **599 GB** | **2**: 512,685 then 191,555 |
| 2 | 16.92 | slow | `0x3a16a093d58` | 404,890 | 81.97 G | **328 GB** | **1**: 404,890 |
| 3 | 15.27 | **fast** | **none — no key ever reaches 100 k** | **0** | **0** | **0** | — |
| 4 | 20.26 | slow | `0x3bc7fe9fa80` | 707,010 | 150.31 G | **601 GB** | **2**: 512,693 then 194,317 |

Per-removal tail histogram, draw 1 — the distribution is what makes this a
structural defect rather than a slow constant:

| tail moved | 0 | 1 | 2–15 | 16–255 | 256–4k | 4k–64k | **64k–1M** | 1M+ |
|---|---|---|---|---|---|---|---|---|
| removals | 1,258,074 | 2,774,737 | 2,240,229 | 5,339 | 36,968 | 192,522 | **871,094** | 0 |

**Three readings.**

1. **The whole slow-mode cost is one or two minors per turn**, each bulk
   front-removing a ~512 k family — 340–870 k removals apiece, most of them
   moving between 64 k and 1 M elements. The other ~123 minors remove nothing
   from that family at all. This is not a cost smeared across the turn; it is
   two enormous prunes.
2. **The family's only key is `"0"`** — the crossing lines report
   `names=len=1 [0]` every time. It is half a million objects with a single own
   property named `0`, all sharing one keys array, each minting its own
   descriptor.
3. **The fast draw is not the same family pruned cheaply — it is the family
   never growing past 100 k.** The 10 k → 100 k crossing, and its *re*-crossing
   after the prune, occur only in slow draws (`site=0` for the first 10 k,
   `site=1` after). So the mode is decided by whether a minor lands and prunes
   the family before the allocation burst finishes, and the burst recurs twice
   per turn. That is why it is per-process, and why unrelated *schedule* changes
   were also observed to remove it.

**What this means for the fix, and it is the reason no growth issue is filed.**
A program that allocates half a million same-shape single-key objects in a burst
is doing nothing wrong. The defect is that removal was **O(family)**, so a bulk
prune of that family cost O(n²). This change makes the bulk prune **O(removals)**.
On claude-code specifically, #9857 removes the source of this particular family
— which is why cc's own number is expected to be unchanged on the landing base,
and why this fix is for **any** workload that builds a large family.

*Reconciliation with an earlier reading of mine.* I previously reported that
bytes moved was "necessary but not sufficient", from a draw that moved 335 GB
and stayed fast. That capture had `exited=false`, so its counters were truncated
before the turn tail. In this series — the only one with final counters — the
correlation is clean: the fast draw moved **zero** bytes from the big family and
every slow draw moved 328–601 GB. I am not claiming the memmove accounts for
every millisecond of the 4.5 s, but the earlier counter-example does not stand.

## The order question, which is what makes a swap-remove available at all

The answer differs per index, so removal becomes two entry points:

* **`by_facts` is ordered.** `facts_push_front` installs a process-global id as
  the canonical answer ahead of an equivalent local one, and the list is read
  first-wins. It keeps the order-preserving removal — which costs nothing, since
  it is length 1.
* **`families` is not.** Its only order-touching reader is the "one descriptor
  stands for the family" choice in the two rekey walks
  (`scan_shape_table_rekey_mut`, `scan_shape_keys_address`): break on the first
  `old_carrier || cache_carrier`, else take any present member. The chosen
  descriptor then feeds **exactly one expression** — `old_carrier ||
  cache_carrier` — whose value is the same for every carrier and the same for
  every non-carrier. **The outcome is a function of the set, not the order**, as
  the code's own comment says ("else any present member").

**The caller declares the contract**, because the caller is the one that knows
whether its order is load-bearing. A single `remove()` that guessed which index
it was on would be the bug.

## The structure

A spilled list gains an `id → index` map, built once it passes
`SPILL_INDEX_MIN` (32) and empty below it, where a scan of a few entries is one
cache line and a hash probe is not. That makes `position`, `contains` and
removal O(1) on the lists that get long — which also removes the **linear
membership scan in `family_push_back`**, recorded at this file's own
`append_unchecked` as **6.2 % of main-thread leaf samples, 95 % of it under that
one caller**.

## Measured (perrymaster, 8 single-turn 3300 draws, load 0.93–1.37)

Built from this change's tree and relinked against the pre-fix binary's object
cache; the pre-fix arm ("A") is the same base without it.

| | A (pre-fix) | this change |
|---|---|---|
| turn CPU | fast ~14.5–14.7, slow ~19.1–19.2 | **14.02–14.34** |
| **slow draws** | **35 % of 34 draws** | **0 of 8** |
| `[gc-idlist]` removals | — | 20.7–21.9 M |
| `elems_moved` | — | 4.42–4.46 M |
| **bytes moved** | 5.6–16 GB (fast draws), **335–848 GB** (slow) | **17.7 MB, every draw** |
| positions scanned | — | 28.0–29.5 M |
| minors / fulls / steps | 122–123 / 5 / 11 | **122–123 / 5 / 11** |

**Schedule unchanged** (minors 122–123, 17–18/105, fulls 5, steps 11, tiny-parse
11 — identical to A), so this is not a pacing change wearing a structure's
clothes. **Fast-mode CPU is unchanged**: 14.0–14.3 with these counters compiled
in, against 14.5–14.7 for the instrumented pre-fix arm's fast draws and 13.6
uninstrumented. On A's distribution the expected saving is a **mean −1.6 s**
(35 % × 4.5 s) with no fast-mode cost.

**Caveat that travels with the table:** `exited=false` on all 8 draws (the
script waits 10 s), so the quoted `[gc-idlist]` line is the last cumulative one
before `SIGKILL` — up to roughly one second of turn tail is unaccounted for. The
counters are cumulative and load-independent, so this bounds their completeness,
not their meaning.

Raw: `/root/rig9831/swap_{1..8}.diag`, `swap.jsonl`.

### What the mode statement is, precisely

This **removes the slow mode on the pre-#9857 binary**: 0 slow draws in 8, where
the same base without it is slow in 35 % of 34. The fix is for **any workload
that builds a large family**, and cc is simply the workload that exposed it.

**What used to follow this sentence was a prediction, and its status has moved
twice.** It read: *"on the landing base #9857 stops cc from creating that family,
so cc's own number is expected to be unchanged"*. Single-turn rows appeared to
falsify it (worse in 5 of 5 pairs) and it was retracted here; four-turn rows at
`S=1` then showed this change **≈ 0 on every column**, and the single-turn deltas
to be main's own turn-1 tenuring excursion. Both the claim and the retraction
rested on data that did not isolate the variable. See "On the landing base"
below — the adaptive configuration still has no paired four-turn row.

The mechanism section above says why the mode exists at all (one or two minors bulk-pruning a 512 k
family, versus a draw where it never grows that far), which is also why it is
per-process rather than a property of the binary.


## Measured on the mini (pre-#9857 binary), tenuring pinned

A second quiet host (macOS, the shipped platform), 8 runs, **`exited=true` on
all of them**, load 1.70, zero interference from other work. Four 3300-char
turns in one process then a 120 s idle window, with the tenuring survival
threshold pinned at `=1` and `=2`. **Two different controls appear below and
each comparison names which one it uses** — a same-sandbox control built from
the same tree without this change (n=2, `=2` only), and an earlier five-draw
series on the same binary family.

### Idle CPU at `=2`: the 23 s mode is gone

| arm | idle CPU |
|---|---|
| **this change, `=2`** | **3.94 / 4.18 / 3.79** — a 0.39 s band |
| this change, `=1` | 1.86 / 1.93 / 1.85 |
| control, five-draw series, `=2` | 4.41 / **23.52 / 23.33 / 23.34** / 4.38 |
| control, same sandbox, `=2` | 4.40 / 4.41 |

The 23–24 s mode occurs in **no draw**. Stated with its power: the prior
high-mode rate was 3 of 5, so 0 of 3 is **p ≈ 0.064** under "unchanged" —
suggestive on this data alone and convincing beside the mechanism and the
per-minor counters above, but n = 3 cannot exclude a rarer high mode. **The
same-sandbox control's two draws both landed in the low mode**, so it does not
independently re-demonstrate the bimodality; that evidence is the five-draw
series.

**What is not claimed:** idle CPU does not fall to the `=1` range. It lands at
3.79–4.18 s, about **2× `=1`'s 1.85–1.93**. This change removed the ~19 s high
mode; a residual ~2 s of `=2`-specific idle CPU remains and is **not** the prune
memmove.

### Four-turn CPU: the spread collapses

| arm | n | 4-turn totals | min | spread |
|---|---|---|---|---|
| **this change, `=1`** | 3 | **73.9 / 74.4 / 74.3** | 73.9 | **0.5 s** |
| control, five-draw series, `=1` | 5 | 131.6 / 99.6 / 97.6 / 95.1 / 91.5 | 91.5 | **40.1 s** |
| **this change, `=2`** | 3 | **80.9 / 83.2 / 83.4** | 80.9 | **2.5 s** |
| control, same sandbox, `=2` | 2 | 108.5 / 129.2 | 108.5 | 20.7 s |
| control, five-draw series, `=2` | 5 | 175.2 / 127.0 / 109.5 / 86.0 / 104.3 | 86.0 | **89.2 s** |

* `=1`: **−19 % on minima** against the five-draw series, spread **40.1 → 0.5 s**.
* `=2`: **−25 % on minima against the same-sandbox control** (80.9 vs 108.5);
  spread **89.2 → 2.5 s** against the five-draw series — 36×.

Two named prior behaviours are absent from every draw: the **turn-1 split at
`=2`** (this change 15.0/16.7/16.9 against the control's 34.6/37.0) and the
**long tail** (to 46 s previously, 48.4 s in the same-sandbox control).

That one change removes the idle burn, the turn-1 split and the CPU tail
together is the "one mechanism, three sides" prediction, and it is met.

### Observation, not a claim: peak RSS at pinned `=2` moved UP

| arm | peak RSS |
|---|---|
| **this change, `=2`** | **2521 / 2355 / 2343** |
| control, same sandbox, `=2` | 2229 / 2239 |
| control, five-draw series, `=2` | 2231 / 2233 / 2236 / 2235 / 2242 |
| this change, `=1` | 1389 / 1439 / 1432 — **unchanged** |

Every `=2` draw of this change exceeds every prior `=2` draw from either source
— **+114 MB at the minimum**, ranges disjoint — and the same-sandbox control
rules out sandbox and protocol. It is visible in the arena: at `=2` capacity
reaches **541–566 MB** where `=1` stays at **278–289 MB**, doubling **inside**
turn 2.

**Reported as a surprise, and deliberately not defended.** `=1` peak is
unchanged, and **pinned `=2` is not a landing configuration** — it is a
tenuring experiment's arm. The tenuring arms on the landing base will be run
with this change included, which is where that interaction belongs.

**And one hypothesis is refuted directly by the same data:** the natural reading
— that the arena regrows at the start of turn 2 — is wrong. Capacity is
**253–254 MB at the end of turn 1 and 255–256 MB at the start of turn 2**, i.e.
continuous across the boundary. The doubling happens *within* turn 2, not at its
edge.

Raw on the mini under `~/ccperf/logs/`; `MINI_9881.tsv`, `p9881_an.py` and
`RESULT_9881_mini.md` in the campaign directory.


## On the landing base — and this falsifies a prediction made above

**Everything above was measured on the pre-#9857 base.** On the landing base
(main5 `33e2856c5`, bundle vs the same bundle relinked with this change),
perrymaster, 5×3300 + 1×400, load 0.9–5.6:

| 3300 turn CPU, per round | main5 | + this change (knob unset) | + this change, `PERRY_GC_TENURING_SURVIVALS=1` |
|---|---|---|---|
| 1 | 2.81 | 2.83 | **2.42** |
| 2 | 4.12 | 4.38 | **4.01** |
| 3 | 3.43 | 4.43 | **3.25** |
| 4 | 3.83 | 4.47 | **3.07** |
| 5 | 2.71 | 3.09 | **2.55** |
| **min** | **2.71** | **2.83 (+4 %)** | **2.42 (−11 %)** |
| mean | 3.38 | 3.84 | 3.06 |
| pairs | — | **worse in 5/5** | **better in 5/5** |

| other metrics | main5 | unset | `S=1` |
|---|---|---|---|
| 400 turn CPU | 0.99 | 1.01 | **0.71 (−28 %)** |
| peak RSS | — | +3…+23 MB | +9…+22 MB |
| settled RSS after 120 s idle, 3300 | 473 | **492 (+19 MB)** | — |
| settled RSS, 400 | 455 | 466 | — |
| idle CPU | — | equal | equal |

**The prediction this falsifies is mine.** The "mode statement" above says cc's
own number is *expected to be unchanged* on the landing base, because #9857
removes the family that made the prune expensive. Measured, it is **not**
unchanged: with the tenuring knob unset this change **costs** 4 % on minima and
is worse in **5 of 5 pairs**, with **+19 MB settled**. That expectation was
wrong and is retracted rather than reworded.

**The sign depends on the tenuring policy's state, not on this diff alone.** The
same binary, with `S` pinned to 1, **beats main5 by 11 % at 3300 and 28 % at
400**, better in 5 of 5 pairs. perry-b4's reading, which the tenuring arms will
test: on this tree the adaptive lock no longer settles at `S=1`, because the
swap-remove removed the churn its schedule was reading — so "unset" runs in the
`S ≥ 2` regime the mini priced, which is exactly where the mini also saw
**+114 MB peak**. Two hosts, two configurations, one consistent story: this
change is a clear win in the `S=1` regime and a cost in the `S ≥ 2` regime, and
which regime a run lands in is decided by a policy this diff does not touch but
does perturb.

**So this PR is back to DRAFT and no code changes until the tenuring arms
read.** They run four env arms on main5 + this change + the lock — `s1`, unset,
`s2`, and main5 itself at `S=1` as the control that was missing — with an
S-histogram, lock transitions and promotion per arm.

The pre-#9857 results above (perrymaster's 0/8 slow draws, the mini's spread
collapse and idle-mode removal) **stand as measured**; they are results about a
binary whose family this change makes cheap to prune. What is now open is
whether the landing base wants it before the tenuring policy is settled.

Raw: `/root/rig9831/combTN0.jsonl`, `idleTN0.jsonl`.


### What TN0 actually measured — and it was not this change

TN, four arms on the landing base (main5 + this change + the lock), **2 rounds ×
four-turn 3300 + 400**, load ≤ 1. The arm TN0 was missing is the first column:
**main5 itself pinned to `S=1`**.

| pinned `S=1`, 4-turn | m5s1 (main5) | s1 (main5 + this change) |
|---|---|---|
| turn-1 CPU | 2.93 / 3.05 | 3.02 / 2.95 |
| Σ turns 2–4 | 6.33 / 6.36 | 6.35 / 6.41 |
| promoted | 39.7 / 38.0 MB | 39.0 / 39.0 MB |
| peak (vmhwm) | 657 / 651 MB | 655 / 656 MB |
| idle CPU | 0.74 / 0.80 | 0.78 / 1.49 (one outlier) |
| S-histogram | `S1:27` | `S1:27` |

**Equal on every column.** So at `S=1`, over four turns, this change is **≈ 0** —
which is what the body originally claimed for the landing base.

**TN0's ±4–14 % was main's own adaptive policy, not this diff.** With the knob
unset, main takes a turn-1 excursion — `S = 4 → 2 → 1` — worth **+0.35–0.45 s at
3300 and +50 % of turn 1 at 400**. TN0's rows were **single-turn**, i.e. 100 %
turn 1, so that excursion dominated every one of them and this change was never
the variable being measured. That is this campaign's own named trap — *a
single-turn measurement can invert a verdict* — and it caught both of my
statements in turn: the original "unchanged on the landing base" and the
retraction I published when TN0 appeared to falsify it. **Neither was
supported by data that isolated the variable.** The four-turn `S=1` rows are the
first that do.

**Two rows are still missing, and this stays draft until one of them lands:**

1. **TN2** — main5-unset vs main5 + this change-unset, over four turns, so the
   *adaptive* configuration gets its own paired row. Queued as a 3-round relink
   stage.
2. **The excursion fix itself** — the arena lane is repairing the turn-1
   `S = 4 → 2 → 1` startup claim, after which the question is moot.

## Tests, with the sabotage named at each

| test | what it pins | sabotage that fails it |
|---|---|---|
| `unordered_removal_moves_o1_elements_and_scans_o1_entries` | 2,000 front removals move ≤ 4N elements and scan ≤ 4N entries | point `remove_unordered` at `remove_ordered` — the ordered path moves N(N−1)/2 = **1,999,000**, 250× the bound; raising `SPILL_INDEX_MIN` above N fails the scan half |
| `the_spill_index_agrees_with_the_vector_after_every_operation` | index vs a plain `Vec` oracle after front, middle and back removals, plus `replace` | drop the `pos.insert(ids[pos], pos)` fixup for the element the swap relocated |
| `a_short_spilled_list_builds_no_index` | a list below the threshold allocates no map | lower `SPILL_INDEX_MIN` |

The bound is asserted as a **multiple of N**, not as an absolute, so the
assertion is about the complexity class rather than about one N. The oracle test
exists because a drifting index is a **wrong answer** — a descriptor that cannot
be found — not a slow one.

`[gc-idlist]` under `PERRY_GC_DIAG=1` reports removals, elements moved and
positions scanned.

## Base and scope

Rebased onto main `35c36f425`. Main moved 60 commits under these files since the
measured base (`644b9d362`) — including #9756's `SlotIndex` — but **`IdList`
itself is byte-identical on both**, and the only conflict was an additive one in
`copying.rs` where main and this change each append a diag call at the same
point (both kept). Verified after the rebase that the **only two `IdList`
removal call sites** are `family_remove` → unordered and `facts_remove` →
ordered, so no writer main added is left unrouted.

## Was the order really free? — the one test that said otherwise

The first full-suite run failed exactly one test, and it was the right one to
fail: `owned_key_count_versions_are_retired_behind_the_current_one` asserted
`test_shape_ids_for_keys(keys) == vec![cached, current]` after a retirement, and
swap-removing the two stale versions moved `current` in front of `cached`.

So the claim above was re-checked against that test's subject, by enumerating
**every** production reader of `families` on this base:

| reader | what it takes | order? |
|---|---|---|
| `retire_owned_shape_siblings` | filter, all but `keep` | set |
| `prune_dead_shape_keys_young` | snapshot, remove all | set |
| `scan_shape_table_rekey_mut` | first carrier else any member | set |
| `move_shape_family` | wholesale remove + re-insert | n/a |
| `relevant_shape_keys` | the KEYS, then `sort_unstable` + `dedup` | normalised |
| `scan_shape_keys_address` | first carrier else any member | set |
| census (`heap_bytes`, `len`, max) | aggregates | n/a |
| `retire_owned_shape_siblings`' slot-list twins (×2) | filter, all but one | set |
| `IdList::replace` caller | replaces in place | position-preserving |

The two rekey walks are the only order-**touching** readers, and what they take
is a single choice fed to exactly one expression — `old_carrier ||
cache_carrier` — whose value is the same for every carrier and the same for
every non-carrier. Nothing reads a position.

And the helper the failing assertion used is `#[cfg(test)]`:
`test_shape_ids_for_keys` renders `families.as_slice().to_vec()` for tests only,
and its `.first()` sibling is likewise `#[cfg(test)]` and is only ever called on
families the caller seeded with one descriptor. **#9706's contract is about
which ids survive a same-address retirement, not the order they survive in**;
the assertion compared against a `Vec` because the helper returns one.

The assertion is now a sorted comparison with that reasoning written at it. The
*pre*-retirement assertion is deliberately left alone — no removal has happened
there, so it legitimately documents that adds append — with a comment saying
that is a property of the add path and not a contract.

Corroborating, and it is the part that would have caught a real order
dependency: the suite ran **3192 with exactly one failure**, so no other test in
the tree asserts a family's order across a removal.

**Not addressed:** why one family reaches half a million descriptors. That is a
separate defect, still being measured, and will be a separate change.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved performance when managing large object shape families, with faster lookups and removals.
  - Reduced unnecessary movement and scanning during garbage collection and runtime updates.
  - Improved memory accounting for larger shape collections.

- **Reliability**
  - Preserved canonical ordering for fact-based lookups while allowing efficient unordered updates where ordering is not required.

- **Diagnostics**
  - Added runtime reporting to help monitor shape-list operations and garbage-collection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



