### PR TITLE
fix(hir): a later class accessor replaces an earlier one

### DIFF
--- a/crates/perry-hir/src/lower_decl/class_decl.rs
+++ b/crates/perry-hir/src/lower_decl/class_decl.rs
@@ -194,6 +194,49 @@ pub(crate) fn capture_class_source(
     }
 }
 
+/// Record one class accessor, honouring ECMA-262's "a later definition of the
+/// same key replaces the earlier one".
+///
+/// `ClassDecl::getters` / `::setters` are consumed with `iter().find(...)`, so
+/// the FIRST entry with a given name wins at lookup time. Appending
+/// unconditionally therefore keeps a *shadowed* accessor alive and silently
+/// drops the one the program actually defines last:
+///
+/// ```js
+/// class Spring3 {
+///   get z() { return this.a.z; }   // damping — shadowed
+///   get z() { return this.c.x; }   // displacement — must win
+/// }
+/// ```
+///
+/// Perry returned `this.a.z` here while every other engine returns
+/// `this.c.x`. In Claude-of-Duty that handed the viewmodel rig a spring's
+/// DAMPING COEFFICIENT (0.46) where it wanted a Z displacement, pushing the
+/// weapon 0.88 m behind the camera, where it clipped and drew nothing.
+///
+/// Static and instance accessors are distinct properties (one lives on the
+/// constructor, one on the prototype) and may legally share a name, so the
+/// replacement is keyed on `(name, is_static)` rather than the name alone.
+fn record_class_accessor(
+    list: &mut Vec<(String, Function)>,
+    statics: &mut Vec<bool>,
+    name: String,
+    func: Function,
+    is_static: bool,
+) {
+    let existing = list
+        .iter()
+        .enumerate()
+        .find_map(|(i, (n, _))| (n == &name && statics[i] == is_static).then_some(i));
+    match existing {
+        Some(i) => list[i] = (name, func),
+        None => {
+            list.push((name, func));
+            statics.push(is_static);
+        }
+    }
+}
+
 pub fn lower_class_decl(
     ctx: &mut LoweringContext,
     class_decl: &ast::ClassDecl,
@@ -683,6 +726,10 @@ pub fn lower_class_decl(
     let mut static_methods = Vec::new();
     let mut getters = Vec::new();
     let mut setters = Vec::new();
+    // Parallel staticness, so `record_class_accessor` can tell a static
+    // accessor from an instance one with the same name.
+    let mut getter_statics: Vec<bool> = Vec::new();
+    let mut setter_statics: Vec<bool> = Vec::new();
     let mut static_accessor_names: Vec<String> = Vec::new();
     let mut static_accessor_fn_ids: Vec<FuncId> = Vec::new();
     let mut computed_members = Vec::new();
@@ -778,7 +825,13 @@ pub fn lower_class_decl(
                             static_accessor_names.push(prop_name.clone());
                             static_accessor_fn_ids.push(func.id);
                         }
-                        getters.push((prop_name, func));
+                        record_class_accessor(
+                            &mut getters,
+                            &mut getter_statics,
+                            prop_name,
+                            func,
+                            method.is_static,
+                        );
                     }
                     ast::MethodKind::Setter => {
                         // Setter: takes one parameter
@@ -797,7 +850,13 @@ pub fn lower_class_decl(
                             static_accessor_names.push(prop_name.clone());
                             static_accessor_fn_ids.push(func.id);
                         }
-                        setters.push((prop_name, func));
+                        record_class_accessor(
+                            &mut setters,
+                            &mut setter_statics,
+                            prop_name,
+                            func,
+                            method.is_static,
+                        );
                     }
                     ast::MethodKind::Method => {
                         let mut func = with_static_member_context(ctx, method.is_static, |ctx| {
@@ -915,7 +974,13 @@ pub fn lower_class_decl(
                             static_accessor_names.push(prop_name.clone());
                             static_accessor_fn_ids.push(func.id);
                         }
-                        getters.push((prop_name, func));
+                        record_class_accessor(
+                            &mut getters,
+                            &mut getter_statics,
+                            prop_name,
+                            func,
+                            method.is_static,
+                        );
                     }
                     ast::MethodKind::Setter => {
                         let prop_name = format!("#{}", method.key.name);
@@ -924,7 +989,13 @@ pub fn lower_class_decl(
                             static_accessor_names.push(prop_name.clone());
                             static_accessor_fn_ids.push(func.id);
                         }
-                        setters.push((prop_name, func));
+                        record_class_accessor(
+                            &mut setters,
+                            &mut setter_statics,
+                            prop_name,
+                            func,
+                            method.is_static,
+                        );
                     }
                 }
             }
@@ -1577,6 +1648,10 @@ pub fn lower_class_from_ast(
     let mut static_methods = Vec::new();
     let mut getters = Vec::new();
     let mut setters = Vec::new();
+    // Parallel staticness, so `record_class_accessor` can tell a static
+    // accessor from an instance one with the same name.
+    let mut getter_statics: Vec<bool> = Vec::new();
+    let mut setter_statics: Vec<bool> = Vec::new();
     let mut static_accessor_names: Vec<String> = Vec::new();
     let mut static_accessor_fn_ids: Vec<FuncId> = Vec::new();
     let mut computed_members = Vec::new();
@@ -1663,7 +1738,13 @@ pub fn lower_class_from_ast(
                             static_accessor_names.push(prop_name.clone());
                             static_accessor_fn_ids.push(func.id);
                         }
-                        getters.push((prop_name, func));
+                        record_class_accessor(
+                            &mut getters,
+                            &mut getter_statics,
+                            prop_name,
+                            func,
+                            method.is_static,
+                        );
                     }
                     ast::MethodKind::Setter => {
                         let func = with_static_member_context(ctx, method.is_static, |ctx| {
@@ -1681,7 +1762,13 @@ pub fn lower_class_from_ast(
                             static_accessor_names.push(prop_name.clone());
                             static_accessor_fn_ids.push(func.id);
                         }
-                        setters.push((prop_name, func));
+                        record_class_accessor(
+                            &mut setters,
+                            &mut setter_statics,
+                            prop_name,
+                            func,
+                            method.is_static,
+                        );
                     }
                     ast::MethodKind::Method => {
                         let mut func = with_static_member_context(ctx, method.is_static, |ctx| {
@@ -1779,7 +1866,13 @@ pub fn lower_class_from_ast(
                             static_accessor_names.push(prop_name.clone());
                             static_accessor_fn_ids.push(func.id);
                         }
-                        getters.push((prop_name, func));
+                        record_class_accessor(
+                            &mut getters,
+                            &mut getter_statics,
+                            prop_name,
+                            func,
+                            method.is_static,
+                        );
                     }
                     ast::MethodKind::Setter => {
                         let prop_name = format!("#{}", method.key.name);
@@ -1788,7 +1881,13 @@ pub fn lower_class_from_ast(
                             static_accessor_names.push(prop_name.clone());
                             static_accessor_fn_ids.push(func.id);
                         }
-                        setters.push((prop_name, func));
+                        record_class_accessor(
+                            &mut setters,
+                            &mut setter_statics,
+                            prop_name,
+                            func,
+                            method.is_static,
+                        );
                     }
                 }
             }

--- a/crates/perry/tests/duplicate_class_accessor_last_wins.rs
+++ b/crates/perry/tests/duplicate_class_accessor_last_wins.rs
@@ -1,0 +1,111 @@
+//! End-to-end regression coverage for duplicate class accessors.
+//!
+//! ECMA-262 ClassDefinitionEvaluation installs class elements in source order,
+//! so a later accessor with the same key REPLACES an earlier one. Perry's HIR
+//! appended every accessor to `ClassDecl::getters` / `::setters`, and those are
+//! consumed with `iter().find(...)` — first match wins — so the SHADOWED
+//! definition stayed live and the real one was dropped.
+//!
+//! The shape below is reduced from Claude-of-Duty's `Spring3`, which pairs an
+//! early `set z` (damping) with a later `get z` (displacement). Perry returned
+//! the damping coefficient from the shadowed getter, which put a first-person
+//! weapon 0.88 m behind the camera, where it clipped and rendered nothing.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+#[test]
+fn a_later_class_accessor_replaces_an_earlier_one() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    let output = dir.path().join("main_bin");
+    std::fs::write(
+        &entry,
+        r#"
+class Spring3 {
+  a = 111;
+  c = 222;
+  damping = 0;
+
+  // Reading `.z` must reach the LAST getter; writing `.z` must still reach
+  // this setter, which no later definition replaces.
+  set z(v: number) { this.damping = v; }
+  get z(): number { return this.a; }
+  get z(): number { return this.c; }
+}
+
+// Static and instance accessors are distinct properties and may share a name:
+// replacing on the key alone would collapse them.
+class Split {
+  static _s = "static-first";
+  _i = "instance-first";
+  static get v(): string { return Split._s; }
+  get v(): string { return this._i; }
+  static get v(): string { return "static-last"; }
+  get v(): string { return "instance-last"; }
+}
+
+// A later setter replaces an earlier setter too.
+class Sink {
+  hits: string[] = [];
+  set s(v: string) { this.hits.push("first:" + v); }
+  set s(v: string) { this.hits.push("last:" + v); }
+}
+
+const spring = new Spring3();
+spring.z = 7;
+console.log("spring", spring.z, spring.damping);
+
+console.log("split", new Split().v, Split.v);
+
+const sink = new Sink();
+sink.s = "x";
+console.log("sink", sink.hits.join("|"), sink.hits.length);
+
+// Accessors defined on a class EXPRESSION follow the same rule.
+const Expr = class {
+  p = 1;
+  q = 2;
+  get w(): number { return this.p; }
+  get w(): number { return this.q; }
+};
+console.log("expr", new Expr().w);
+"#,
+    )
+    .expect("write fixture");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-cache")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled fixture");
+    assert!(
+        run.status.success(),
+        "compiled fixture failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+
+    // Matches `node --experimental-strip-types` on the same source.
+    let expected = "spring 222 7\n\
+                    split instance-last static-last\n\
+                    sink last:x 1\n\
+                    expr 2\n";
+    assert_eq!(String::from_utf8_lossy(&run.stdout), expected);
+}


### PR DESCRIPTION
## The bug

ECMA-262 ClassDefinitionEvaluation installs class elements in source order, so a second `get x` / `set x` **replaces** the first. Perry keeps the first.

`ClassDecl::getters` / `::setters` are consumed with `iter().find(...)` — first match wins — but every accessor was appended with `push()`. The shadowed definition stays live and the one the program actually defines last is silently dropped.

## Reproducer

```ts
class Vec {
  a = 111;
  c = 222;
  damped = 0;

  set z(v: number) { this.damped = v; }
  get z(): number { return this.a; }   // shadowed
  get z(): number { return this.c; }   // must win
}

const v = new Vec();
v.z = 7;
console.log(v.z, v.damped);
```

| | output |
|---|---|
| `node --experimental-strip-types` | `222 7` |
| perry (before) | `111 7` |
| perry (after) | `222 7` |

Note the setter still runs in every case: when a later definition supplies only a getter, the earlier setter stays in force. That asymmetry is the point — see below.

## Every accessor shape is affected

Measured against Node on the fixture in the regression test:

| shape | before | expected |
|---|---|---|
| instance getter | `111` | `222` |
| static getter | `static-first` | `static-last` |
| instance getter alongside a static one | `instance-first` | `instance-last` |
| duplicate **setters** | `first:x` | `last:x` |
| accessors on a class **expression** | `1` | `2` |

There is no diagnostic. The program reads a plausible value from the wrong accessor and keeps running.

## How it surfaced

Claude-of-Duty's `Spring3` (`src/weapons/mathx.js`) pairs an early `set z` (damping) with a later `get z` (displacement):

```js
export class Spring3 {
  constructor(f = 12, z = 1) { this.a = new Spring(f, z); /* … */ }
  set z(v) { this.a.z = this.b.z = this.c.z = v; }  // damping in
  get z()  { return this.a.z; }                     // shadowed
  // …
  get z()  { return this.c.x; }                     // displacement out — must win
}
```

Unusual, but legal, and it depends on exactly the read/write asymmetry the spec produces. Perry served the shadowed damping getter, so:

```
lag.z    = 0.4600   ← new Spring3(5.4, 0.46) damping
recPos.z = 0.4200   ← new Spring3(9,   0.42) damping
```

Those are added as displacements, contributing **+0.880 m** to the first-person viewmodel's Z. The rig moved from its authored `hipPos.z = -0.300` (in front of the eye) to `+0.580` (behind it):

```
rig.pos = 0.117, -0.186, +0.580
basePos = 0.118, -0.185, -0.300
```

All 156 viewmodel nodes then sat at camera-space Z ≥ 0 and clipped. The failure was invisible from the renderer's side: the overlay pass ran, the gate passed, all 156 `draw_indexed` calls were issued, and the pass's colour reached the screen — with zero fragments. `lag.x` and `lag.y` were correct throughout, because only `.z` collides with the damping accessor.

## The change

`record_class_accessor` overwrites an existing entry instead of appending.

The replacement is keyed on `(name, is_static)`, not on the name alone: a static and an instance accessor may legally share a name and are distinct properties — one on the constructor, one on the prototype. Deduping on the key alone would trade this bug for another, which is why the regression test includes a class carrying both.

## Verification

- `cargo test --release -p perry-hir` — 620 passed, 0 failed
- `cargo test --release -p perry-codegen` — 1912 passed, 0 failed
- New test `duplicate_class_accessor_last_wins` covers all five shapes above, with expected output taken from Node. Reverting the one-line lowering change fails it on every shape:

```
left:  "spring 111 7\nsplit instance-first static-first\nsink first:x 1\nexpr 1\n"
right: "spring 222 7\nsplit instance-last static-last\nsink last:x 1\nexpr 2\n"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed duplicate class accessors so later getter or setter definitions correctly replace earlier ones.
  - Preserved separate behavior for static and instance accessors with the same name.
  - Applied consistent accessor handling to class declarations and class expressions.

- **Tests**
  - Added regression coverage verifying duplicate accessor resolution and runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->