### PR TITLE
perf(intl): take the view mode's canonicality proof and UTF-8 re-validation off the per-grapheme path

### DIFF
--- a/crates/perry-runtime/src/intl/segments_view.rs
+++ b/crates/perry-runtime/src/intl/segments_view.rs
@@ -52,6 +52,11 @@ static REGEXP_TEST_ACCEPTED: AtomicU64 = AtomicU64::new(0);
 static REGEXP_TEST_DECLINED: AtomicU64 = AtomicU64::new(0);
 
 fn diag_on() -> bool {
+    // Always on under test: a counter nothing increments cannot be asserted on,
+    // and the decline counters exist so a decline names its cause.
+    if cfg!(test) {
+        return true;
+    }
     static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ON.get_or_init(|| std::env::var("PERRY_SEGVIEW_DIAG").is_ok())
 }
@@ -63,29 +68,18 @@ fn bump(c: &AtomicU64) {
     }
 }
 
-/// One line, on demand. A decline that names its own reason is the difference
-/// between "the tier did not fire" and "the tier fired and found nothing".
-pub fn report_segview_counters() {
-    if !diag_on() {
-        return;
-    }
-    eprintln!(
-        "[segview] opens={} declines: not_segmenter={} not_grapheme={} segment_patched={} \
-         not_string={} not_utf8={} empty={} | nexts={} code_point_at={} materialise_segment={} \
-         regexp_test: accepted={} declined={}",
+/// The counters' consumer today is the test suite, which is why there is no
+/// `report_*` function: a printer with no caller is dead code, and the tally
+/// the campaign reads is the COMPILER-side `PERRY_SEGVIEW_DIAG` one. Wire a
+/// runtime-side printer when a rig run needs these numbers, not before.
+#[cfg(test)]
+fn counters() -> [u64; 4] {
+    [
         OPENS.load(Ordering::Relaxed),
-        DECLINE_NOT_SEGMENTER.load(Ordering::Relaxed),
-        DECLINE_NOT_GRAPHEME.load(Ordering::Relaxed),
-        DECLINE_SEGMENT_PATCHED.load(Ordering::Relaxed),
         DECLINE_NOT_STRING.load(Ordering::Relaxed),
-        DECLINE_NOT_UTF8.load(Ordering::Relaxed),
-        DECLINE_EMPTY.load(Ordering::Relaxed),
         NEXTS.load(Ordering::Relaxed),
-        CODE_POINT_ATS.load(Ordering::Relaxed),
-        MATERIALISE_SEGMENT.load(Ordering::Relaxed),
-        REGEXP_TEST_ACCEPTED.load(Ordering::Relaxed),
-        REGEXP_TEST_DECLINED.load(Ordering::Relaxed),
-    );
+        crate::object::regex_proto_thunks::REGEXP_PROTOTYPE_TEST_WALKS.load(Ordering::Relaxed),
+    ]
 }
 
 // --- cursor plumbing --------------------------------------------------------
@@ -119,6 +113,7 @@ fn set_num_field(obj: *mut ObjectHeader, index: u32, value: usize) {
 /// dropped at the end of the call; a short (SSO) string is decoded into the
 /// caller's stack buffer, so neither case allocates and neither case leaks an
 /// address.
+///
 #[inline]
 fn with_input<R>(cursor: *mut ObjectHeader, f: impl FnOnce(&str) -> R) -> Option<R> {
     let value = crate::object::js_object_get_field(cursor, F_INPUT);
@@ -711,6 +706,86 @@ mod view_mode_tests {
             0.0,
             "invalid UTF-8 must decline"
         );
+    }
+
+    /// The canonicality proof must be a LOAD, not a walk: the only by-name
+    /// lookup is the one-time recording at install. If this ever climbs with
+    /// the number of calls, the fast path is not the path being taken — which
+    /// is exactly the failure the counter exists to catch.
+    #[cfg(feature = "regex-engine")]
+    #[test]
+    fn canonicality_proof_walks_once_per_realm_not_once_per_call() {
+        let cursor = js_segments_view_open(grapheme_segmenter(), js_string("abcdef"));
+        assert!(cursor != 0.0);
+        let re = crate::regex::js_regexp_construct(js_string("[a-z]"), js_string(""));
+        let re_v = f64::from_bits(JSValue::pointer(re as *const u8).bits());
+        assert_eq!(js_segments_view_next(cursor), 1.0);
+        let before = counters()[3];
+        for _ in 0..50 {
+            let v = js_segments_view_regexp_test(cursor, re_v);
+            assert!(!is_undefined(v), "a plain regex must keep being accepted");
+        }
+        assert_eq!(
+            counters()[3],
+            before,
+            "50 accepted calls must add ZERO by-name walks"
+        );
+        // A second cursor and a second regex must not add one either: the
+        // recorded site belongs to the realm, not to the call or the receiver.
+        let cursor2 = js_segments_view_open(grapheme_segmenter(), js_string("xy"));
+        assert_eq!(js_segments_view_next(cursor2), 1.0);
+        let re2 = crate::regex::js_regexp_construct(js_string("[x-z]"), js_string(""));
+        let re2_v = f64::from_bits(JSValue::pointer(re2 as *const u8).bits());
+        assert!(!is_undefined(js_segments_view_regexp_test(cursor2, re2_v)));
+        assert_eq!(
+            counters()[3],
+            before,
+            "a second cursor and regex must add no walks either"
+        );
+        // NOT asserted: an absolute bound like `walks <= 1`. The unit harness
+        // resets arenas between tests and builds the prototype tower more than
+        // once in a process, so the per-process total counts REALMS, not calls.
+        // The property that matters — and the one that fails if the fast path
+        // stops being taken — is the delta above.
+    }
+
+    /// SABOTAGE-SHAPED, kept as a test: patching `RegExp.prototype.test` AFTER
+    /// the site is recorded must make the very next call decline.
+    #[cfg(feature = "regex-engine")]
+    #[test]
+    fn a_patched_prototype_test_declines_on_the_next_call() {
+        let cursor = js_segments_view_open(grapheme_segmenter(), js_string("ab"));
+        assert_eq!(js_segments_view_next(cursor), 1.0);
+        let re = crate::regex::js_regexp_construct(js_string("[a-z]"), js_string(""));
+        let re_v = f64::from_bits(JSValue::pointer(re as *const u8).bits());
+        assert!(
+            !is_undefined(js_segments_view_regexp_test(cursor, re_v)),
+            "accepted before the patch"
+        );
+
+        // Replace `RegExp.prototype.test` the way a program would.
+        let proto_ptr = crate::object::regex_proto_thunks::REGEXP_PROTOTYPE_TEST_SITE
+            .load(Ordering::Acquire)
+            & ((1i64 << 48) - 1);
+        assert!(proto_ptr != 0, "the site must have been recorded");
+        let proto = proto_ptr as *mut ObjectHeader;
+        let key = crate::string::js_string_from_bytes(b"test".as_ptr(), 4);
+        let replacement = crate::closure::js_closure_alloc(patched_test_thunk as *const u8, 0);
+        crate::closure::js_register_closure_arity(patched_test_thunk as *const u8, 0);
+        crate::object::js_object_set_field_by_name(
+            proto,
+            key,
+            crate::value::js_nanbox_pointer(replacement as i64),
+        );
+        assert!(
+            is_undefined(js_segments_view_regexp_test(cursor, re_v)),
+            "a replaced `RegExp.prototype.test` must make the view DECLINE, so \
+             the caller materialises and runs the user's function"
+        );
+    }
+
+    extern "C" fn patched_test_thunk(_c: *const crate::closure::ClosureHeader) -> f64 {
+        f64::from_bits(JSValue::bool(true).bits())
     }
 
     /// `_regexp_test` answers the same as the materialised call for a plain

--- a/crates/perry-runtime/src/intl/segments_view.rs
+++ b/crates/perry-runtime/src/intl/segments_view.rs
@@ -114,13 +114,40 @@ fn set_num_field(obj: *mut ObjectHeader, index: u32, value: usize) {
 /// caller's stack buffer, so neither case allocates and neither case leaks an
 /// address.
 ///
+/// **The UTF-8 validation is done ONCE, in `open`, and is not repeated here.**
+/// Re-validating cost 6.2 % of the loop's thread as `core::str::from_utf8`
+/// self, because every entry point re-derives the borrow per call (the §9a
+/// rooting contract) and each derivation walked the whole input again.
+///
+/// The invariant that makes `from_utf8_unchecked` sound here, stated so it can
+/// be checked rather than trusted:
+///
+/// 1. `F_INPUT` is written exactly once, by `js_segments_view_open`, and never
+///    reassigned — no entry point below stores into it.
+/// 2. `open` refuses any input that is not already a string primitive and runs
+///    `std::str::from_utf8` on its bytes before allocating the cursor, so the
+///    value in that slot has been validated.
+/// 3. A collection may MOVE that string but never rewrites its bytes, and the
+///    traced slot is updated to the new address, so the bytes reachable here
+///    are the same bytes `open` validated.
+/// 4. The SSO path decodes the same value into the stack buffer, so it carries
+///    the same guarantee.
+///
+/// A `debug_assert` re-checks it in debug builds, which is where a future
+/// fourth writer to the slot would be caught.
 #[inline]
 fn with_input<R>(cursor: *mut ObjectHeader, f: impl FnOnce(&str) -> R) -> Option<R> {
     let value = crate::object::js_object_get_field(cursor, F_INPUT);
     let mut sso = [0u8; crate::value::SHORT_STRING_MAX_LEN];
     let bytes =
         unsafe { crate::string::js_string_key_bytes(JSValue::from_bits(value.bits()), &mut sso) }?;
-    let text = std::str::from_utf8(bytes).ok()?;
+    debug_assert!(
+        std::str::from_utf8(bytes).is_ok(),
+        "the cursor's input slot is written once, by `open`, from a value it \
+         validated — a failure here means a second writer appeared"
+    );
+    // SAFETY: invariants 1-4 above.
+    let text = unsafe { std::str::from_utf8_unchecked(bytes) };
     Some(f(text))
 }
 

--- a/crates/perry-runtime/src/intl/segments_view.rs
+++ b/crates/perry-runtime/src/intl/segments_view.rs
@@ -791,9 +791,8 @@ mod view_mode_tests {
         );
 
         // Replace `RegExp.prototype.test` the way a program would.
-        let proto_ptr = crate::object::regex_proto_thunks::REGEXP_PROTOTYPE_TEST_SITE
-            .load(Ordering::Acquire)
-            & ((1i64 << 48) - 1);
+        let proto_ptr =
+            crate::object::regex_proto_thunks::REGEXP_PROTOTYPE_PTR.load(Ordering::Acquire);
         assert!(proto_ptr != 0, "the site must have been recorded");
         let proto = proto_ptr as *mut ObjectHeader;
         let key = crate::string::js_string_from_bytes(b"test".as_ptr(), 4);

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -1295,11 +1295,23 @@ pub fn scan_object_cache_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'
         &iterator_prototypes::STRING_ITERATOR_PROTOTYPE_PTR,
         &iterator_prototypes::REGEXP_STRING_ITERATOR_PROTOTYPE_PTR,
         &iterator_prototypes::ITERATOR_HELPER_PROTOTYPE_PTR,
+        // The realm's `RegExp.prototype`, recorded by `regex_proto_thunks` so
+        // the view mode's canonicality proof is three loads instead of a walk.
+        // A recorded address MUST be scanned: unscanned, it is a stale pointer
+        // the first time the collector moves the prototype.
+        #[cfg(feature = "regex-engine")]
+        &regex_proto_thunks::REGEXP_PROTOTYPE_PTR,
     ] {
         slot.with_slot(|slot| {
             visitor.visit_atomic_i64_slot(slot, Ordering::Acquire, Ordering::Release);
         });
     }
+    // The canonical `test` closure is a NaN-boxed word, not a bare address, so
+    // it is visited as one — the collector rewrites the pointer inside it.
+    #[cfg(feature = "regex-engine")]
+    regex_proto_thunks::REGEXP_PROTOTYPE_TEST_CLOSURE.with_slot(|slot| {
+        visitor.visit_atomic_nanbox_u64_slot(slot, Ordering::Acquire, Ordering::Release);
+    });
 }
 
 /// Drive the PRODUCTION shape-cache writer from a test. Deliberately nothing

--- a/crates/perry-runtime/src/object/regex_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/regex_proto_thunks.rs
@@ -317,21 +317,26 @@ fn regex_instance_or_throw(method: &str) -> *const crate::regex::RegExpHeader {
 }
 
 crate::perry_thread_local! {
-    /// The realm's `RegExp.prototype`, and the field index its own `test`
-    /// occupies, packed as `(index << 48) | ptr`. Recorded once when the
-    /// prototype's methods are installed.
-    static REGEXP_PROTOTYPE_TEST_SITE_SLOT: std::sync::atomic::AtomicI64 =
+    /// The realm's `RegExp.prototype`. A raw heap address, so it is a GC ROOT:
+    /// visited in `scan_object_cache_roots_mut` beside the iterator-prototype
+    /// towers, which both marks it and rewrites it when the collector moves the
+    /// object. A recorded address that is not scanned is a stale pointer the
+    /// first time the prototype moves — the #9539/#9445 shape.
+    static REGEXP_PROTOTYPE_PTR_SLOT: std::sync::atomic::AtomicI64 =
         const { std::sync::atomic::AtomicI64::new(0) };
-    /// The canonical `test` closure as a NaN-boxed value, for an
-    /// identity compare against whatever the slot holds now.
-    static REGEXP_PROTOTYPE_TEST_CLOSURE_SLOT: std::sync::atomic::AtomicI64 =
-        const { std::sync::atomic::AtomicI64::new(0) };
+    /// The canonical `test` closure, NaN-boxed. Also a root, visited as a
+    /// nanbox word so the collector rewrites the pointer inside it.
+    static REGEXP_PROTOTYPE_TEST_CLOSURE_SLOT: std::sync::atomic::AtomicU64 =
+        const { std::sync::atomic::AtomicU64::new(0) };
+    /// The field index its own `test` occupies. Not an address, so not a root.
+    static REGEXP_PROTOTYPE_TEST_INDEX_SLOT: std::sync::atomic::AtomicU32 =
+        const { std::sync::atomic::AtomicU32::new(u32::MAX) };
 }
 
-pub(crate) static REGEXP_PROTOTYPE_TEST_SITE: super::RealmAtomicI64 =
-    super::RealmAtomicI64::new(&REGEXP_PROTOTYPE_TEST_SITE_SLOT);
-pub(crate) static REGEXP_PROTOTYPE_TEST_CLOSURE: super::RealmAtomicI64 =
-    super::RealmAtomicI64::new(&REGEXP_PROTOTYPE_TEST_CLOSURE_SLOT);
+pub(crate) static REGEXP_PROTOTYPE_PTR: super::RealmAtomicI64 =
+    super::RealmAtomicI64::new(&REGEXP_PROTOTYPE_PTR_SLOT);
+pub(crate) static REGEXP_PROTOTYPE_TEST_CLOSURE: super::RealmAtomicU64 =
+    super::RealmAtomicU64::new(&REGEXP_PROTOTYPE_TEST_CLOSURE_SLOT);
 
 /// How many by-name walks the canonicality proof has done in this process.
 /// The fast path does none: the only walk is the one-time recording below, so
@@ -339,8 +344,6 @@ pub(crate) static REGEXP_PROTOTYPE_TEST_CLOSURE: super::RealmAtomicI64 =
 /// says the fast path is actually the path being taken.
 pub(crate) static REGEXP_PROTOTYPE_TEST_WALKS: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
-
-const PROTO_PTR_MASK: i64 = (1i64 << 48) - 1;
 
 /// Is `RegExp.prototype.test` still the builtin, for the regex `value`?
 ///
@@ -394,18 +397,19 @@ pub(crate) fn regexp_prototype_test_is_canonical(value: f64) -> bool {
     if super::prototype_chain::object_static_prototype(recv_addr).is_some() {
         return false;
     }
-    let site = REGEXP_PROTOTYPE_TEST_SITE.load(std::sync::atomic::Ordering::Acquire);
+    let proto_ptr = REGEXP_PROTOTYPE_PTR.load(std::sync::atomic::Ordering::Acquire);
     let canonical = REGEXP_PROTOTYPE_TEST_CLOSURE.load(std::sync::atomic::Ordering::Acquire);
-    if site == 0 || canonical == 0 {
+    let index = REGEXP_PROTOTYPE_TEST_INDEX_SLOT
+        .with(|slot| slot.load(std::sync::atomic::Ordering::Acquire));
+    if proto_ptr == 0 || canonical == 0 || index == u32::MAX {
         return false;
     }
-    let proto_obj = (site & PROTO_PTR_MASK) as *mut ObjectHeader;
-    let index = (site >> 48) as u32;
-    if proto_obj.is_null() {
-        return false;
-    }
+    let proto_obj = proto_ptr as *mut ObjectHeader;
+    // Both reads below are of values the collector maintains: the prototype
+    // address is a scanned root, and the recorded closure is a scanned nanbox
+    // word, so a move rewrites both and this compare stays an identity compare.
     let current = crate::object::js_object_get_field(proto_obj, index);
-    if current.bits() != canonical as u64 {
+    if current.bits() != canonical {
         return false;
     }
     // `defineProperty(proto, "test", { get })` leaves the data slot alone and
@@ -453,18 +457,19 @@ fn record_canonical_test_site(proto_obj: *mut ObjectHeader) {
     if crate::object::js_object_get_field(proto_obj, index).bits() != own.to_bits() {
         return;
     }
-    if index as i64 > (i64::MAX >> 48) {
-        return;
-    }
     let addr = proto_obj as i64;
-    if addr & !PROTO_PTR_MASK != 0 {
-        return; // an address that does not fit the packing: stay on the slow path
-    }
-    REGEXP_PROTOTYPE_TEST_CLOSURE.store(own.to_bits() as i64, std::sync::atomic::Ordering::Release);
-    REGEXP_PROTOTYPE_TEST_SITE.store(
-        ((index as i64) << 48) | addr,
-        std::sync::atomic::Ordering::Release,
-    );
+    REGEXP_PROTOTYPE_TEST_INDEX_SLOT
+        .with(|slot| slot.store(index, std::sync::atomic::Ordering::Release));
+    // GC_STORE_AUDIT(ROOT): REGEXP_PROTOTYPE_TEST_CLOSURE is a mutable nanbox
+    // root visited by scan_object_cache_roots_mut.
+    REGEXP_PROTOTYPE_TEST_CLOSURE.with_slot(|slot| {
+        crate::gc::runtime_store_root_atomic_nanbox_u64(
+            slot,
+            own.to_bits(),
+            std::sync::atomic::Ordering::Release,
+        );
+    });
+    REGEXP_PROTOTYPE_PTR.store(addr, std::sync::atomic::Ordering::Release);
 }
 
 /// Install the real (brand-checking) `exec`/`test`/`toString`/`compile`

--- a/crates/perry-runtime/src/object/regex_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/regex_proto_thunks.rs
@@ -316,39 +316,155 @@ fn regex_instance_or_throw(method: &str) -> *const crate::regex::RegExpHeader {
     ))
 }
 
+crate::perry_thread_local! {
+    /// The realm's `RegExp.prototype`, and the field index its own `test`
+    /// occupies, packed as `(index << 48) | ptr`. Recorded once when the
+    /// prototype's methods are installed.
+    static REGEXP_PROTOTYPE_TEST_SITE_SLOT: std::sync::atomic::AtomicI64 =
+        const { std::sync::atomic::AtomicI64::new(0) };
+    /// The canonical `test` closure as a NaN-boxed value, for an
+    /// identity compare against whatever the slot holds now.
+    static REGEXP_PROTOTYPE_TEST_CLOSURE_SLOT: std::sync::atomic::AtomicI64 =
+        const { std::sync::atomic::AtomicI64::new(0) };
+}
+
+pub(crate) static REGEXP_PROTOTYPE_TEST_SITE: super::RealmAtomicI64 =
+    super::RealmAtomicI64::new(&REGEXP_PROTOTYPE_TEST_SITE_SLOT);
+pub(crate) static REGEXP_PROTOTYPE_TEST_CLOSURE: super::RealmAtomicI64 =
+    super::RealmAtomicI64::new(&REGEXP_PROTOTYPE_TEST_CLOSURE_SLOT);
+
+/// How many by-name walks the canonicality proof has done in this process.
+/// The fast path does none: the only walk is the one-time recording below, so
+/// this must read **1 per realm**, not one per call. It is the counter that
+/// says the fast path is actually the path being taken.
+pub(crate) static REGEXP_PROTOTYPE_TEST_WALKS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+const PROTO_PTR_MASK: i64 = (1i64 << 48) - 1;
+
 /// Is `RegExp.prototype.test` still the builtin, for the regex `value`?
 ///
 /// The `Intl.Segmenter` view mode answers `regex.test(segment)` without
 /// materialising the segment, so it must not silently bypass a user
-/// replacement. Same allocation-free proof as
-/// `iterator_prototypes::prototype_next_is_canonical`: the prototype's OWN
-/// `test` slot still holds a closure whose native entry is this module's
-/// thunk, AND no accessor descriptor is recorded for `"test"` (a
-/// `defineProperty(proto, "test", {get})` leaves the old closure in the data
-/// slot). Any other state returns `false` and the caller declines.
+/// replacement — and it asks this question TWICE PER GRAPHEME, so the question
+/// has to be answered in loads.
+///
+/// It used to be answered by `js_object_get_prototype_of` (the general spec
+/// entry: proxy trap, Temporal cell, primitive-wrapper resolution by name) plus
+/// a by-name own-field lookup that hashes `"test"` on every call. Symbolised,
+/// that proof was **~13 % of the loop's thread** —
+/// `get_field_by_name_object_tail` 3.6, `js_object_get_field_by_name` 3.5,
+/// `get_accessor_descriptor` 2.1, `closure_get_dynamic_prop` 1.75,
+/// `RandomState::hash_one<&str>` 1.4, `js_object_get_prototype_of` 1.3 —
+/// against 0.8 % for the match it was guarding.
+///
+/// The property being tested belongs to `RegExp.prototype`, not to the call, so
+/// it is recorded once at install time: the prototype pointer, the FIELD INDEX
+/// its `test` occupies, and the canonical closure value. A call then reads that
+/// one slot by index and compares. Everything this can get wrong, it gets wrong
+/// in the declining direction:
+///
+/// * `test` replaced or deleted -> the slot no longer holds the recorded
+///   closure -> decline;
+/// * the prototype reshaped so the index means a different key -> the slot does
+///   not hold the recorded closure -> decline;
+/// * an accessor installed with `defineProperty(proto,"test",{get})`, which
+///   leaves the old closure in the data slot -> the per-key accessor Bloom bit
+///   catches it, read straight off the meta record;
+/// * the receiver reparented, so the `test` it would resolve is not this one ->
+///   `object_static_prototype` says a prototype was recorded -> decline.
+///
+/// No invalidation hook on any shared write path, which is the alternative
+/// design and the one that would make every property store in the program pay
+/// for this.
 #[cfg(feature = "regex-engine")]
 pub(crate) fn regexp_prototype_test_is_canonical(value: f64) -> bool {
-    let proto = super::js_object_get_prototype_of(value);
-    let jv = crate::value::JSValue::from_bits(proto.to_bits());
-    if !jv.is_pointer() {
+    let jv_recv = crate::value::JSValue::from_bits(value.to_bits());
+    if !jv_recv.is_pointer() {
         return false;
     }
-    let proto_obj = jv.as_pointer::<ObjectHeader>() as *mut ObjectHeader;
+    let recv_addr = jv_recv.as_pointer::<u8>() as usize;
+    if recv_addr == 0 {
+        return false;
+    }
+    // A regex with no recorded prototype still has its class default, which is
+    // the object recorded below. `object_static_prototype` answers from the
+    // object's own meta record, or from an atomic "nothing was ever recorded"
+    // latch — no mutex, no chain walk.
+    if super::prototype_chain::object_static_prototype(recv_addr).is_some() {
+        return false;
+    }
+    let site = REGEXP_PROTOTYPE_TEST_SITE.load(std::sync::atomic::Ordering::Acquire);
+    let canonical = REGEXP_PROTOTYPE_TEST_CLOSURE.load(std::sync::atomic::Ordering::Acquire);
+    if site == 0 || canonical == 0 {
+        return false;
+    }
+    let proto_obj = (site & PROTO_PTR_MASK) as *mut ObjectHeader;
+    let index = (site >> 48) as u32;
     if proto_obj.is_null() {
         return false;
     }
-    let own = super::js_object_get_own_field_or_undef(proto, b"test".as_ptr(), 4);
-    let own_jv = crate::value::JSValue::from_bits(own.to_bits());
-    if !own_jv.is_pointer() {
+    let current = crate::object::js_object_get_field(proto_obj, index);
+    if current.bits() != canonical as u64 {
         return false;
     }
-    let closure = own_jv.as_pointer::<crate::closure::ClosureHeader>();
-    if closure.is_null()
-        || crate::closure::get_valid_func_ptr(closure) != regex_proto_test_thunk as *const u8
-    {
-        return false;
-    }
+    // `defineProperty(proto, "test", { get })` leaves the data slot alone and
+    // records the accessor, so the identity compare above cannot see it.
     !super::descriptor_state::may_have_descriptor_entry(proto_obj as usize, "test", true)
+}
+
+/// Record the prototype, the index of its own `test`, and the canonical
+/// closure. Called once, from the installer below.
+#[cfg(feature = "regex-engine")]
+fn record_canonical_test_site(proto_obj: *mut ObjectHeader) {
+    REGEXP_PROTOTYPE_TEST_WALKS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let proto_value = crate::value::js_nanbox_pointer(proto_obj as i64);
+    let own = super::js_object_get_own_field_or_undef(proto_value, b"test".as_ptr(), 4);
+    let jv = crate::value::JSValue::from_bits(own.to_bits());
+    if !jv.is_pointer() {
+        return;
+    }
+    // The index of the KEY `"test"` in the prototype's keys array IS its field
+    // index. Done once, at install, with the ordinary accessors.
+    let keys = unsafe { super::object_keys_array(proto_obj) };
+    if keys.is_null() {
+        return;
+    }
+    let count = crate::array::js_array_length(keys);
+    let mut found: Option<u32> = None;
+    for i in 0..count {
+        let key = crate::array::js_array_get_f64(keys, i);
+        let matches = unsafe {
+            crate::string::js_string_key_matches_bytes(
+                crate::value::JSValue::from_bits(key.to_bits()),
+                b"test",
+            )
+        };
+        if matches {
+            found = Some(i as u32);
+            break;
+        }
+    }
+    let Some(index) = found else {
+        return;
+    };
+    // The recorded index must actually hold the closure we just read, or the
+    // per-call load would compare the wrong slot.
+    if crate::object::js_object_get_field(proto_obj, index).bits() != own.to_bits() {
+        return;
+    }
+    if index as i64 > (i64::MAX >> 48) {
+        return;
+    }
+    let addr = proto_obj as i64;
+    if addr & !PROTO_PTR_MASK != 0 {
+        return; // an address that does not fit the packing: stay on the slow path
+    }
+    REGEXP_PROTOTYPE_TEST_CLOSURE.store(own.to_bits() as i64, std::sync::atomic::Ordering::Release);
+    REGEXP_PROTOTYPE_TEST_SITE.store(
+        ((index as i64) << 48) | addr,
+        std::sync::atomic::Ordering::Release,
+    );
 }
 
 /// Install the real (brand-checking) `exec`/`test`/`toString`/`compile`
@@ -361,6 +477,8 @@ pub(super) fn install_regex_proto_methods(proto_obj: *mut ObjectHeader) {
     ipm(proto_obj, "exec", regex_proto_exec_thunk as *const u8, 1);
     #[cfg(feature = "regex-engine")]
     ipm(proto_obj, "test", regex_proto_test_thunk as *const u8, 1);
+    #[cfg(feature = "regex-engine")]
+    record_canonical_test_site(proto_obj);
     // Annex B `compile` re-initializes the receiver in place. It needs a real
     // brand check so `RegExp.prototype.compile.call(non-regexp)` throws a
     // `TypeError` (test262 annexB `.../compile/this-{not-object,obj-not-regexp}`).


### PR DESCRIPTION
**On settled footprint, with both measurements on the table.** In the
levers-only pairing above, settled footprint 120 s after the turn read
460 → 481 MB at 3300 — worse, while peak and CPU improved. In the paired
main5 rotation it is **flat** (483 → 479 at 3300, 460 → 463 at 400). Two
different baselines, so they are not in conflict, and the flat one is the row
that describes what lands. The open question it came from is separate and
older — I4 settling 45-65 MB above I3 — and it belongs to the tier, not to
these commits: nothing here has process lifetime (the counters are `u64`s, and
the two realm slots point at `RegExp.prototype` and its `test` closure, which
`globalThis` already holds). If it reappears, the candidate is the **cursor**:
one per `open`, alive for the whole loop — the shape that survives a minor and
gets promoted — holding its input string in a traced slot, with its lifetime
decided by the lowering's rooted local rather than by the runtime. It is cheaply
decidable, because the cursor has its own class id
(`SEGMENTS_CURSOR_CLASS_ID = 0xFFFF_000E`): an old-gen census after idle counts
them directly. Thousands means the cursor's lifetime; ~0 means the retention is
elsewhere.

Two changes to the `Intl.Segmenter` view mode's hot path, one per commit. Both
were found by symbolising the view arm of the string-width probe
(`segview_probe.js`, region B) — not by reading the code — and each is motivated
by a number below.

Nothing here changes behaviour: same answers, same declines, same symbols.

**Depends on: nothing.** These entry points are only called when the compiler's
view tier fires (#9859), so on main today this branch is **inert** — it changes
the cost of a path nothing yet takes, and can land independently and in any
order relative to the lowering.

## Lever 1 — `638b8327f`: answer the canonicality proof in loads, not a walk

`js_segments_view_regexp_test` asks *"is `RegExp.prototype.test` still the
builtin?"* **twice per grapheme**, because `is RegExp` at the call site does not
rule out a patched prototype and a view-mode test must not silently bypass user
code. The proof cost more than the match it guarded:

| symbol | % of the view arm's thread |
|---|---|
| `get_field_by_name_object_tail` | 3.6 |
| `js_object_get_field_by_name` | 3.5 |
| `get_accessor_descriptor` | 2.1 |
| `closure_get_dynamic_prop` | 1.75 |
| `RandomState::hash_one<&str>` | 1.4 — it hashed `"test"` on **every call** |
| `js_object_get_prototype_of` | 1.3 |
| **the proof, together** | **~13 %** |
| `regexp_test_str_bounded` — the actual matching | **0.8** |

An earlier inclusive read of the same arm put the prototype resolution at
**30.6 %** of the thread (`js_segments_view_regexp_test` 40.4 % inclusive, self
0.9 %).

**The design, and why not the invalidation flag.** The property being tested
belongs to `RegExp.prototype`, not to the call, so it is recorded once when the
prototype's methods are installed: the prototype pointer, the **field index** of
its own `test`, and the canonical closure value. A call then reads that slot by
index and compares — three loads — plus the per-key accessor Bloom bit read
straight off the meta record, and `object_static_prototype` to establish that
the receiver has not been reparented (that answers from the object's own meta
record, or from an atomic "nothing was ever recorded" latch — no mutex, no chain
walk).

The alternative — a "pristine" flag invalidated from the property-set /
write-barrier path — was considered and rejected: it makes **every property
store in the program** pay for this one question, and it adds an invalidation
surface whose failure mode is silent (miss a writer, and the view keeps
accepting a patched `test` forever). The recorded-site design hooks no shared
write path, and everything it can get wrong it gets wrong in the **declining**
direction:

* `test` replaced or deleted → the slot no longer holds the recorded closure;
* the prototype reshaped so the index means a different key → likewise;
* `defineProperty(proto, "test", { get })`, which leaves the old closure in the
  data slot → caught by the accessor Bloom bit;
* the receiver reparented → caught by `object_static_prototype`.

## Lever 2 — `ea54f0a3d`: validate the cursor's input once, not on every entry

`core::str::from_utf8` was the **top self symbol at 6.2 %** (6.9 % across the
three entry points). Every entry point re-derives the input `&str` from the
cursor's traced slot per call — that is the §9a rooting contract and it stays —
but each derivation also re-validated the whole input.

`open` already validates: it refuses an input that is not already a string
primitive and runs `from_utf8` on its bytes before allocating the cursor. The
borrow now uses `from_utf8_unchecked`, with the invariant written where the
`unsafe` is, in four checkable parts:

1. `F_INPUT` is written exactly once, by `js_segments_view_open`, and never
   reassigned — no entry point stores into it;
2. `open` refuses a non-string input and validates the bytes before allocating;
3. a collection MOVES the string but never rewrites its bytes, and the traced
   slot is updated to the new address, so the bytes reachable are the bytes
   `open` validated;
4. the SSO path decodes the same value into the stack buffer.

A `debug_assert` re-checks it in debug builds, which is where a future second
writer to the slot would be caught.

## Measured on the probe

`segview_probe.js` at `13fbd8c`, compiled with I5's compiler `af9227369`,
`--enable-wasm-runtime`, min of 5, quiet box (load 1.3-1.5). **Checksums are
61000 in all four variants on region B** — every arm did the same work.

ns per grapheme:

| | spec path | view tier |
|---|---|---|
| **region B** (whole-line), I5 runtime | 1,016 | **1,422** |
| **region B**, this branch | 1,000 | **578** |
| **region A** (per-character — cc's shape), I5 runtime | 8,462 | 2,262 |
| **region A**, this branch | 8,492 | **1,554** |

Four readings, in the order they matter:

1. **Before these levers the view tier was 40 % SLOWER than the spec path it
   replaces on region B** (1,422 against 1,016). That is the probe-level twin of
   the tier measuring +7 % CPU on the cc bundle — the same fact seen through a
   different instrument, which is why the levers were worth building rather than
   arguing about.
2. **The levers take the view arm −59 % on B and −31 % on A.** That is *more*
   than the 30.6 % + 6.2 % the profile attributed to the two symbols: removing
   the work also removed the allocation and cache traffic it was generating, so
   the profile's attribution was a floor on the win, not an estimate of it.
3. **The spec arm is unchanged — 1,016 → 1,000 and 8,462 → 8,492.** That is the
   positive control: these commits touch only the view entry points, and an arm
   that does not take them must not move. It did not.
4. **Against node** (A 1,323, B 109-141), the view arm with these levers is
   **1.17x node on the per-character shape — cc's shape** — and 4-5x on the
   whole-line shape.

One number that is not ours and should not be read as ours: **main's own runtime
halved the spec path on region B against the pre-train tree** (1,938 → 1,016).
That is main's regex/dispatch work. It also means the "before" the view tier has
to beat moved while this was being built.

Raw data: perrymaster `/root/segview4/`.

## `f076656e5` — a correctness fix in its own right

Found by reading the view path for anything with process lifetime, not by a
failure. The fast path records the prototype address and the canonical `test`
closure and reads them on every call, and **neither was being scanned**. An
address held across a collection without being visited is stale the first time
the collector moves the object — the #9539 / #9445 shape. Nothing had failed
because a realm prototype is long-lived and rarely moves, which is luck rather
than a design, and it would have failed as a corrupt read far from here.

The packed word is split so each part is handled correctly:
`REGEXP_PROTOTYPE_PTR` is a raw address visited with `visit_atomic_i64_slot`
beside the iterator-prototype towers; `REGEXP_PROTOTYPE_TEST_CLOSURE` is a
NaN-boxed word visited with `visit_atomic_nanbox_u64_slot` and stored through
`runtime_store_root_atomic_nanbox_u64` with the `GC_STORE_AUDIT(ROOT)` note the
other mutable roots carry; the field index is not an address and stays an
ordinary atomic. Per-call cost is unchanged, and the identity compare stays an
identity compare across a move because both sides are now maintained by the
collector.

This one is worth landing whatever happens to the two levers.

## Sabotages, as tests rather than scratch runs

* **A patched `RegExp.prototype.test` after the site is recorded makes the very
  next call decline** — so the caller materialises and runs the user's function.
* **The walks counter**: 50 accepted calls, plus a second cursor and a second
  regex, add **zero** by-name walks. `REGEXP_PROTOTYPE_TEST_WALKS` counts the
  one-time recording, so it counts realms, not calls.

  **This property is proven by the unit test and NOT by a runtime line.** No
  build prints these counters under `PERRY_SEGVIEW_DIAG=1`: the reporter that
  once existed had no caller and is removed here, and a real runtime line needs
  an exit-funnel hook that does not exist yet. Anyone looking for `[segview]` in
  a rig log will not find one, and should not read its absence as the fast path
  not firing — read the unit test, or the ns/grapheme numbers above.

One of my own assertions failed first and is worth recording: an absolute
`walks <= 1` is wrong under a unit harness that resets arenas and builds the
prototype tower several times per process. The delta property above is what
actually distinguishes "per realm" from "per call", and it is what the test now
asserts.

Also removes `report_segview_counters`, which had no caller. The counters now
have one — the test suite — and a comment says to wire a runtime-side printer
when a rig run needs the numbers, not before.

## Measured on the cc bundle

### The primary row: main vs the tier with these levers, paired

`main5` (`33e2856c5`) bundle against I5's view bundle running this branch's
runtime. 5 x 3300 + 3 x 400, rotated start, load 0.15-0.5, nothing compiling,
output identical. **This is the JOINT figure — the view tier (#9859) *and*
these levers together, against main with neither** — because it is what a user
gets, and because the tier without these levers was a regression.

| round (3300) | main5 | tier + levers |
|---|---|---|
| 1 | 2.72 | **2.39** |
| 2 | 2.67 | **2.35** |
| 3 | 2.69 | **2.33** |
| 4 | 2.72 | **2.32** |
| 5 | 2.75 | **2.30** |
| **min** | **2.67** | **2.30 — −14 %** |
| mean | 2.71 | 2.34 |
| peak RSS MB | 614 / 614 / 614 / 606 / 607 | **578 / 578 / 572 / 576 / 575 — −30…−42 MB, 5/5** |

400-char: 1.00 → 0.90, 0.99 → 0.98, 0.98 → 0.98; peak 533-544 → 510-519
(−14…−34 MB, 3/3). Settled 120 s after the turn: 483 → 479 at 3300 (idle CPU
2.37 → 2.48), 460 → 463 at 400 — **flat**.

Against node in the same rotation: **2.30 s is 4.8-5.3x node, from main5's
5.6-6.3x.**

Raw: perrymaster `/root/rig9831/combM5I7.jsonl`, `idleM5I7.jsonl`.

### The levers alone, paired



`I5-view`'s objects relinked with this branch's runtime — runtime-only, so the
bundle is not recompiled and the two arms differ **only** by these commits.
This isolates the levers from the tier.
5 x 3300 + 2 x 400, quiet box (load 0.3-0.7), `turn_cpu_s`:

| round (3300) | I5-view | I7-view (this branch) |
|---|---|---|
| 1 | 3.07 | **2.34** |
| 2 | 3.05 | **2.35** |
| 3 | 3.11 | **2.23** |
| 4 | 3.11 | **2.34** |
| 5 | 3.10 | **2.27** |
| **min** | **3.05** | **2.23** — **−27 %** |
| mean | 3.09 | 2.31 |
| peak RSS MB | 580-581 | 571-583 (flat) |

400-char: 1.11 → 0.91 and 1.16 → 1.08.

Against `main5` from the I5 rotation an hour earlier — **same quiet box but NOT
paired**, so read it as a bracket rather than a delta: I7-view 2.23-2.35 against
2.65-2.75 (≈ −15 %), peak 571-583 against 608-619 (−35…−45 MB), 400 ≈ flat.

**What that means for the tier as a whole.** The view tier as merged was CPU-
NEGATIVE on cc — +0.14…+0.36 s at 3300 in 7/7 pairs, about +7 % — because
`js_segments_view_regexp_test` was 40.1 % of the whole thread inclusive, nearly
all of it the canonicality proof. With these two commits the same tier is about
**−15 % against main** with the peak-RSS saving kept. The profile said the proof
cost more than the match it guarded; the bundle now says the same thing in
seconds.

**One number that did not improve, stated rather than buried:** settled
footprint 120 s after the turn went **460 → 481 MB** at 3300, even though idle
CPU fell 3.10 → 2.58 s and peak RSS is flat-to-better. Something the view path
allocates survives the turn and the idle reclaimer. Nothing in these two commits
has process lifetime — the counters are `u64`s, and the two realm slots point at
`RegExp.prototype` and its `test` closure, which `globalThis` already holds — so
the candidate is the **cursor**: one per `open`, alive for the whole loop (the
shape that survives a minor and gets promoted), holding its input string in a
traced slot. Its lifetime is decided by the lowering's rooted local, not by the
runtime. It is cheaply decidable: the cursor has its own class id
(`SEGMENTS_CURSOR_CLASS_ID = 0xFFFF_000E`), so an old-gen census after idle can
count them directly — thousands means the cursor's lifetime, ~0 means the
retention is elsewhere. Not fixed here, not claimed as fixed.

## Gates

Run on this branch:

* `cargo test -p perry-runtime --release --lib -- --test-threads=1` — **3,239
  passed, 0 failed** (10 view tests, including the zero-allocation falsifier:
  200 `next` + `code_point_at` steps move `arena_in_use_bytes` by zero with the
  minor-cycle count pinned).

Run on the immediately preceding tree carrying identical gating, and being
re-run on this SHA before this leaves draft:

* `cargo build --release -p perry` with **default features** — the app path,
  where `regex-engine` is OFF. This is the gate whose absence let #9870's
  orphaned-attribute bug through, and it must be its **own** cargo invocation:
  building it together with the `-static` crates unifies the feature back on and
  hides exactly this class of failure.
* `nm -g libperry_runtime.a | grep -c ' T js_regexp_test'` = 1 from the
  `-static` build.

Not run here, queued: the probe on region B before/after with the rebased
compiler, and the relinked cc bundle against this runtime (runtime-only, so no
recompile).

Draft until those land.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved regular expression method handling when built-in behavior is modified, ensuring the appropriate fallback is used.
  - Improved runtime stability during memory management when regular expression functionality is in use.
  - Improved text segment processing consistency for valid UTF-8 input.

- **Performance**
  - Reduced repeated checks when confirming standard regular expression behavior, improving efficiency for repeated operations.

- **Tests**
  - Added coverage for regular expression canonicality checks, modified methods, fallback behavior, and text segmentation diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Additional rows on main `504e180d0` (2026-09-07, perrymaster, paired 5-round rotation)
With the segment-view tier switched on by default (#9912, the same nine sites rewritten): tier alone +0.04…+0.27 s per round vs main (slower 5/5); tier + these levers −0.54…−0.69 s per round (faster 5/5, −17 % at 3300; −4…−8 % at 400), peak RSS −12…−38 MB, settled RSS flat vs main. These levers are what makes the tier a net win; #9912 is ordered after this PR.
