### PR TITLE
fix(runtime): expose module namespace data descriptors

### DIFF
--- a/changelog.d/9899-module-namespace-descriptors.md
+++ b/changelog.d/9899-module-namespace-descriptors.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Dynamic-import namespace exports now report standard data descriptors with
+  their current live-binding values instead of exposing the runtime's internal
+  accessor representation.

--- a/crates/perry-runtime/src/object/descriptors.rs
+++ b/crates/perry-runtime/src/object/descriptors.rs
@@ -964,6 +964,12 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
             return f64::from_bits(crate::value::TAG_UNDEFINED);
         }
 
+        // #9889: Hide the live binding's internal accessor behind the module
+        // namespace exotic object's required data-descriptor shape.
+        if (*obj).class_id == MODULE_NAMESPACE_CLASS_ID {
+            return module_namespace_own_property_descriptor(obj, key_str);
+        }
+
         // Look up descriptor flags (default: all true).
         let attrs = key_rust
             .as_ref()

--- a/crates/perry-runtime/src/object/namespace_create.rs
+++ b/crates/perry-runtime/src/object/namespace_create.rs
@@ -6,6 +6,26 @@ use super::*;
 
 pub(crate) const MODULE_NAMESPACE_CLASS_ID: u32 = 0xFFFF_4E53;
 
+/// #9889: Implement the module namespace exotic object's [[GetOwnProperty]]
+/// result while retaining accessors as the internal representation of live
+/// bindings. The getter can allocate and evacuate both the namespace and key,
+/// so keep them rooted until it returns. `build_data_descriptor` roots the
+/// resulting value before allocating the descriptor object.
+pub(crate) unsafe fn module_namespace_own_property_descriptor(
+    obj: *mut ObjectHeader,
+    key: *const crate::StringHeader,
+) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let obj_handle = scope.root_raw_mut_ptr(obj);
+    let key_handle = scope.root_string_ptr(key);
+    let value = obj_handle.with_mut_ptr::<ObjectHeader, _>(|current_obj| {
+        key_handle.with_const_ptr::<crate::StringHeader, _>(|current_key| {
+            js_object_get_field_by_name(current_obj, current_key)
+        })
+    });
+    super::descriptors::build_data_descriptor(f64::from_bits(value.bits()), true, true, false)
+}
+
 /// Apply the host-defined invariants shared by static and dynamic module
 /// namespace objects.
 #[no_mangle]

--- a/test-files/test_gap_dynamic_import_alias_binding.ts
+++ b/test-files/test_gap_dynamic_import_alias_binding.ts
@@ -3,6 +3,24 @@
 async function main(): Promise<void> {
   const ns = await import("./dynamic_import_alias_binding.ts");
 
+  function logDescriptor(
+    name: "VAR_SET" | "directConst",
+    expected: string,
+  ): void {
+    const descriptor = Object.getOwnPropertyDescriptor(ns, name);
+    console.log(
+      name,
+      descriptor !== undefined,
+      descriptor !== undefined && "value" in descriptor,
+      descriptor?.writable,
+      descriptor?.enumerable,
+      descriptor?.configurable,
+      descriptor?.get === undefined,
+      descriptor?.set === undefined,
+      descriptor !== undefined && ns.checkAlias(descriptor.value, expected),
+    );
+  }
+
   console.log(
     typeof ns.VAR_SET,
     typeof ns.LET_SET,
@@ -16,6 +34,8 @@ async function main(): Promise<void> {
     ns.checkAlias(ns.CONST_SET, "const"),
     ns.checkAlias(ns.directConst, "direct"),
   );
+  logDescriptor("VAR_SET", "var-before");
+  logDescriptor("directConst", "direct");
 
   ns.reassign();
   console.log(
@@ -24,6 +44,7 @@ async function main(): Promise<void> {
     ns.checkAlias(ns.VAR_SET, "var-before"),
     ns.checkAlias(ns.LET_SET, "let-before"),
   );
+  logDescriptor("VAR_SET", "var-after");
 }
 
 main();


### PR DESCRIPTION
Module namespace live exports are stored as accessors so their values track reassignment, which made `Object.getOwnPropertyDescriptor(ns, key)` expose the internal getter instead of the data descriptor required for namespace exotic objects. Namespace own-property reflection now reads the current export through the rooted live-binding path and returns `{ value, writable: true, enumerable: true, configurable: false }` for both live and snapshot exports.

The dynamic-import alias fixture now checks descriptor shape and value before and after reassignment, including its existing forced moving-GC configuration.

Validation:

- Exact dynamic-import alias parity fixture: 1/1 pass against Node 26.5.1 on coherent post-rebase compiler/runtime artifacts; 3 copying collections and 18,908 moved objects in the pre-rebase equivalent run
- `cargo test -p perry-runtime --profile perry-dev -- --test-threads=1`: 3,237 passed, 4 ignored; doc tests green
- `scripts/run_lint_gates.sh`: all 64 gates passed, 2 CI-only checks skipped locally
- No version bump

Fixes #9889


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dynamic-import namespace exports now report standard data property descriptors.
  * Descriptors correctly expose current live-binding values and writable, enumerable, and non-configurable flags.
  * Accessor details are no longer exposed for these exports.
  * Added coverage for descriptors before and after export value updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->