### PR TITLE
fix(diag): remove dead string-wrapper counter

### DIFF
--- a/changelog.d/9900-dead-string-wrapper-diag.md
+++ b/changelog.d/9900-dead-string-wrapper-diag.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- GC primitive-dispatch diagnostics no longer expose a string-wrapper counter
+  that lost its only writer when boxed string indices became virtual.

--- a/crates/perry-runtime/src/gc/diag_sites.rs
+++ b/crates/perry-runtime/src/gc/diag_sites.rs
@@ -369,22 +369,18 @@ pub(super) fn report_charges(label: &str) {
 // whose method the native dispatch tower does not recognise falls through to
 // `native_call_method::call_primitive_builtin_prototype_method`: it resolves
 // `globalThis.<Builtin>.prototype[<method>]` and, for a SLOPPY callee, boxes
-// the receiver with `ToObject`. For a string that wrapper materialises one own
-// property per UTF-16 code unit. So a single unrecognised method name on a hot
-// render path turns into O(length) allocations per call, and the only way to
-// tell WHICH names those are is to count them at the fork.
+// the receiver with `ToObject`. A string wrapper exposes one virtual own index
+// per UTF-16 code unit, so tracking receiver length shows the scale of the
+// boxed surface alongside the method names that reach this fork.
 
 crate::perry_thread_local! {
     /// `"<Builtin>.prototype.<method>" -> (calls, receiver_utf16_chars)`.
     static PRIMITIVE_DISPATCH: RefCell<HashMap<String, (u64, u64)>> =
         RefCell::new(HashMap::new());
-    /// String wrappers actually materialised: (wrappers, index properties).
-    static STRING_WRAPPERS: Cell<(u64, u64)> = const { Cell::new((0, 0)) };
 }
 
 /// Record one trip through the primitive-method fallback. `recv_chars` is the
-/// receiver's UTF-16 length (0 when the receiver is not a string) — the number
-/// of own index properties a sloppy callee's `ToObject` wrapper costs.
+/// receiver's UTF-16 length (0 when the receiver is not a string).
 pub(crate) fn primitive_dispatch(builtin: &[u8], method: &str, recv_chars: u64) {
     if !gc_diag_enabled() {
         return;
@@ -402,12 +398,6 @@ pub(crate) fn primitive_dispatch(builtin: &[u8], method: &str, recv_chars: u64) 
 pub(super) fn report_primitive_dispatch(label: &str) {
     if !gc_diag_enabled() {
         return;
-    }
-    let (wrappers, indices) = STRING_WRAPPERS.with(Cell::get);
-    if wrappers > 0 {
-        eprintln!(
-            "[gc-primitive-dispatch] {label}: string_wrappers={wrappers} index_properties={indices}"
-        );
     }
     let rows: Vec<(String, (u64, u64))> =
         PRIMITIVE_DISPATCH.with(|m| m.borrow().iter().map(|(k, v)| (k.clone(), *v)).collect());

--- a/scripts/gc_runtime_root_holders.json
+++ b/scripts/gc_runtime_root_holders.json
@@ -342,12 +342,6 @@
       "why": "#9794: per-method primitive-dispatch counts, `HashMap<String, (u64, u64)>`. Rust-owned method-name strings and counters."
     },
     {
-      "file": "crates/perry-runtime/src/gc/diag_sites.rs",
-      "name": "STRING_WRAPPERS",
-      "verdict": "not_a_gc_pointer",
-      "why": "#9794: materialized/elided string-wrapper counts as a `(u64, u64)` pair."
-    },
-    {
       "file": "crates/perry-runtime/src/gc/oldgen_defrag.rs",
       "name": "LAST_IDLE_PREDICTED_RELEASE",
       "verdict": "not_a_gc_pointer",


### PR DESCRIPTION
Boxed string indices became virtual in #9810, which removed the only writer for the `STRING_WRAPPERS` diagnostic while leaving its state and output branch in place. The impossible counter and its stale GC-holder inventory exemption are now removed; the live primitive-method histogram and receiver-length attribution remain unchanged.

Validation:

- Repository-wide scan confirms there is no remaining `STRING_WRAPPERS`, writer alias, or `string_wrappers=` output site
- `gc_runtime_root_holders.py` self-test and inventory check pass: 1,357 declarations scanned, 347 valid inventory entries
- `scripts/run_lint_gates.sh`: all 64 gates passed, 2 CI-only checks skipped locally
- No version bump

Fixes #9874


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated garbage-collection diagnostics to remove outdated string-wrapper counts.
  * Primitive dispatch reports now show only active method-call and receiver-character statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->