### PR TITLE
test(runtime): cover for-in visited levels across GC

### DIFF
--- a/test-files/test_issue_9869_for_in_visited_levels_gc.ts
+++ b/test-files/test_issue_9869_for_in_visited_levels_gc.ts
@@ -1,0 +1,22 @@
+// parity-env: PERRY_GC_SCHEDULE_SEED=9869 PERRY_GC_SCHEDULE_RATE=1 PERRY_GC_SCHEDULE_ALLOC_KB=0 PERRY_GC_FORCE_EVACUATE=1 PERRY_GC_VERIFY_EVACUATION=1 PERRY_GC_PROTECT_FROMSPACE=1
+
+// #9869: `for-in` defers building its shadow set until a prototype level has
+// an enumerable key to filter. The retained earlier levels must remain rooted
+// while key-array construction allocates and triggers a moving collection.
+const ancestor = {
+  own: "shadowed",
+  ancestor: "visible",
+};
+const emptyMiddle = Object.create(ancestor);
+const receiver = Object.create(emptyMiddle);
+receiver.own = "receiver";
+
+// Level zero records `receiver`; the empty middle level allocates a key array
+// but keeps the shadow set deferred; the ancestor's keys then trigger a rebuild
+// that reads both retained heap objects after evacuation.
+const keys: string[] = [];
+for (const key in receiver) {
+  keys.push(key);
+}
+
+console.log(keys.join(","));


### PR DESCRIPTION
The runtime fix for #9869 is already on main, but the retained prototype levels had no parity regression that forces collection between recording a level and rebuilding the deferred shadow set. This fixture uses a keyed receiver, an empty middle prototype, and a keyed ancestor: middle-level key-array allocation evacuates the retained receiver, then the ancestor triggers the shadow rebuild and duplicate-key filter.

Validation:

- Exact fixture: 1/1 pass against Node 26.5.1
- Forced schedule completed 11 copying collections and moved 18,887 objects with from-space protection and evacuation verification enabled
- Test registration check passes: 259 files checked, no missing registrations
- `scripts/run_lint_gates.sh`: all 64 gates passed, 2 CI-only checks skipped locally
- Test-only change; no changeset or version bump required

Fixes #9869


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for `for-in` iteration across a multi-level prototype chain.
  - Verifies that enumeration remains correct when garbage collection occurs during key collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->