### PR TITLE
Merge train: #9899, #9900, #9902

### DIFF
--- a/changelog.d/9899-module-namespace-descriptors.md
+++ b/changelog.d/9899-module-namespace-descriptors.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Dynamic-import namespace exports now report standard data descriptors with
+  their current live-binding values instead of exposing the runtime's internal
+  accessor representation.

--- a/changelog.d/9900-dead-string-wrapper-diag.md
+++ b/changelog.d/9900-dead-string-wrapper-diag.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- GC primitive-dispatch diagnostics no longer expose a string-wrapper counter
+  that lost its only writer when boxed string indices became virtual.

--- a/crates/perry-runtime/src/gc/diag_sites.rs
+++ b/crates/perry-runtime/src/gc/diag_sites.rs
@@ -369,22 +369,18 @@ pub(super) fn report_charges(label: &str) {
 // whose method the native dispatch tower does not recognise falls through to
 // `native_call_method::call_primitive_builtin_prototype_method`: it resolves
 // `globalThis.<Builtin>.prototype[<method>]` and, for a SLOPPY callee, boxes
-// the receiver with `ToObject`. For a string that wrapper materialises one own
-// property per UTF-16 code unit. So a single unrecognised method name on a hot
-// render path turns into O(length) allocations per call, and the only way to
-// tell WHICH names those are is to count them at the fork.
+// the receiver with `ToObject`. A string wrapper exposes one virtual own index
+// per UTF-16 code unit, so tracking receiver length shows the scale of the
+// boxed surface alongside the method names that reach this fork.
 
 crate::perry_thread_local! {
     /// `"<Builtin>.prototype.<method>" -> (calls, receiver_utf16_chars)`.
     static PRIMITIVE_DISPATCH: RefCell<HashMap<String, (u64, u64)>> =
         RefCell::new(HashMap::new());
-    /// String wrappers actually materialised: (wrappers, index properties).
-    static STRING_WRAPPERS: Cell<(u64, u64)> = const { Cell::new((0, 0)) };
 }
 
 /// Record one trip through the primitive-method fallback. `recv_chars` is the
-/// receiver's UTF-16 length (0 when the receiver is not a string) — the number
-/// of own index properties a sloppy callee's `ToObject` wrapper costs.
+/// receiver's UTF-16 length (0 when the receiver is not a string).
 pub(crate) fn primitive_dispatch(builtin: &[u8], method: &str, recv_chars: u64) {
     if !gc_diag_enabled() {
         return;
@@ -402,12 +398,6 @@ pub(crate) fn primitive_dispatch(builtin: &[u8], method: &str, recv_chars: u64) 
 pub(super) fn report_primitive_dispatch(label: &str) {
     if !gc_diag_enabled() {
         return;
-    }
-    let (wrappers, indices) = STRING_WRAPPERS.with(Cell::get);
-    if wrappers > 0 {
-        eprintln!(
-            "[gc-primitive-dispatch] {label}: string_wrappers={wrappers} index_properties={indices}"
-        );
     }
     let rows: Vec<(String, (u64, u64))> =
         PRIMITIVE_DISPATCH.with(|m| m.borrow().iter().map(|(k, v)| (k.clone(), *v)).collect());

--- a/crates/perry-runtime/src/object/descriptors.rs
+++ b/crates/perry-runtime/src/object/descriptors.rs
@@ -964,6 +964,12 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
             return f64::from_bits(crate::value::TAG_UNDEFINED);
         }
 
+        // #9889: Hide the live binding's internal accessor behind the module
+        // namespace exotic object's required data-descriptor shape.
+        if (*obj).class_id == MODULE_NAMESPACE_CLASS_ID {
+            return module_namespace_own_property_descriptor(obj, key_str);
+        }
+
         // Look up descriptor flags (default: all true).
         let attrs = key_rust
             .as_ref()

--- a/crates/perry-runtime/src/object/namespace_create.rs
+++ b/crates/perry-runtime/src/object/namespace_create.rs
@@ -6,6 +6,26 @@ use super::*;
 
 pub(crate) const MODULE_NAMESPACE_CLASS_ID: u32 = 0xFFFF_4E53;
 
+/// #9889: Implement the module namespace exotic object's [[GetOwnProperty]]
+/// result while retaining accessors as the internal representation of live
+/// bindings. The getter can allocate and evacuate both the namespace and key,
+/// so keep them rooted until it returns. `build_data_descriptor` roots the
+/// resulting value before allocating the descriptor object.
+pub(crate) unsafe fn module_namespace_own_property_descriptor(
+    obj: *mut ObjectHeader,
+    key: *const crate::StringHeader,
+) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let obj_handle = scope.root_raw_mut_ptr(obj);
+    let key_handle = scope.root_string_ptr(key);
+    let value = obj_handle.with_mut_ptr::<ObjectHeader, _>(|current_obj| {
+        key_handle.with_const_ptr::<crate::StringHeader, _>(|current_key| {
+            js_object_get_field_by_name(current_obj, current_key)
+        })
+    });
+    super::descriptors::build_data_descriptor(f64::from_bits(value.bits()), true, true, false)
+}
+
 /// Apply the host-defined invariants shared by static and dynamic module
 /// namespace objects.
 #[no_mangle]

--- a/scripts/gc_runtime_root_holders.json
+++ b/scripts/gc_runtime_root_holders.json
@@ -342,12 +342,6 @@
       "why": "#9794: per-method primitive-dispatch counts, `HashMap<String, (u64, u64)>`. Rust-owned method-name strings and counters."
     },
     {
-      "file": "crates/perry-runtime/src/gc/diag_sites.rs",
-      "name": "STRING_WRAPPERS",
-      "verdict": "not_a_gc_pointer",
-      "why": "#9794: materialized/elided string-wrapper counts as a `(u64, u64)` pair."
-    },
-    {
       "file": "crates/perry-runtime/src/gc/oldgen_defrag.rs",
       "name": "LAST_IDLE_PREDICTED_RELEASE",
       "verdict": "not_a_gc_pointer",

--- a/test-files/test_gap_dynamic_import_alias_binding.ts
+++ b/test-files/test_gap_dynamic_import_alias_binding.ts
@@ -3,6 +3,24 @@
 async function main(): Promise<void> {
   const ns = await import("./dynamic_import_alias_binding.ts");
 
+  function logDescriptor(
+    name: "VAR_SET" | "directConst",
+    expected: string,
+  ): void {
+    const descriptor = Object.getOwnPropertyDescriptor(ns, name);
+    console.log(
+      name,
+      descriptor !== undefined,
+      descriptor !== undefined && "value" in descriptor,
+      descriptor?.writable,
+      descriptor?.enumerable,
+      descriptor?.configurable,
+      descriptor?.get === undefined,
+      descriptor?.set === undefined,
+      descriptor !== undefined && ns.checkAlias(descriptor.value, expected),
+    );
+  }
+
   console.log(
     typeof ns.VAR_SET,
     typeof ns.LET_SET,
@@ -16,6 +34,8 @@ async function main(): Promise<void> {
     ns.checkAlias(ns.CONST_SET, "const"),
     ns.checkAlias(ns.directConst, "direct"),
   );
+  logDescriptor("VAR_SET", "var-before");
+  logDescriptor("directConst", "direct");
 
   ns.reassign();
   console.log(
@@ -24,6 +44,7 @@ async function main(): Promise<void> {
     ns.checkAlias(ns.VAR_SET, "var-before"),
     ns.checkAlias(ns.LET_SET, "let-before"),
   );
+  logDescriptor("VAR_SET", "var-after");
 }
 
 main();

--- a/test-files/test_issue_9869_for_in_visited_levels_gc.ts
+++ b/test-files/test_issue_9869_for_in_visited_levels_gc.ts
@@ -1,0 +1,22 @@
+// parity-env: PERRY_GC_SCHEDULE_SEED=9869 PERRY_GC_SCHEDULE_RATE=1 PERRY_GC_SCHEDULE_ALLOC_KB=0 PERRY_GC_FORCE_EVACUATE=1 PERRY_GC_VERIFY_EVACUATION=1 PERRY_GC_PROTECT_FROMSPACE=1
+
+// #9869: `for-in` defers building its shadow set until a prototype level has
+// an enumerable key to filter. The retained earlier levels must remain rooted
+// while key-array construction allocates and triggers a moving collection.
+const ancestor = {
+  own: "shadowed",
+  ancestor: "visible",
+};
+const emptyMiddle = Object.create(ancestor);
+const receiver = Object.create(emptyMiddle);
+receiver.own = "receiver";
+
+// Level zero records `receiver`; the empty middle level allocates a key array
+// but keeps the shadow set deferred; the ancestor's keys then trigger a rebuild
+// that reads both retained heap objects after evacuation.
+const keys: string[] = [];
+for (const key in receiver) {
+  keys.push(key);
+}
+
+console.log(keys.join(","));


### PR DESCRIPTION
Merge train: **#9899, #9900, #9902**.

Two of these close issues filed while auditing earlier trains.

## #9899 — module namespace data descriptors (#9889)

#9879 made aliased dynamic-import bindings live, and implemented that by installing them as **accessor** properties, so `Object.getOwnPropertyDescriptor(ns, "x")` reported `get`/`set` where ECMA-262 §10.4.6.5 and Node report a data descriptor. #9899 takes the option that keeps both: accessors remain the internal representation of the live binding, and the namespace's `[[GetOwnProperty]]` synthesises `{ value, writable: true, enumerable: true, configurable: false }` over it.

The rooting is right — namespace and key are held across `js_object_get_field_by_name`, which runs the getter and can allocate and evacuate — and the doc comment says so.

Its new gap-test assertions cover exactly what the issue named: `"value" in descriptor`, all three attributes, `get`/`set` both `undefined`, and the value still live across a reassignment. Being a gap test, Node is the oracle for the shape.

## #9902 — for-in visited levels across GC (#9869)

The regression fixture #9869 was left open for: a three-level prototype chain where the middle level contributes no enumerable keys, so the shadow set stays deferred and `build_shadow_set` reads both retained levels after the key-array allocations have moved them. Runs under `PERRY_GC_SCHEDULE_RATE=1` with forced evacuation, evacuation verification and from-space protection.

One note for the maintainer, not changed here: the fixture is named `test_issue_9869_…`, and the per-PR `gap-suite` shards select on the substring `test_gap_`, so this runs in the nightly `full` tier only. That matches the convention of the other 380 `test_issue_*` files, so it is not a defect in this PR — but a GC rooting regression is the case where per-PR coverage is worth most, since the whole failure mode is staying invisible until much later. Renaming it `test_gap_issue_9869_…` would move it into the per-PR gate; that is a test-tier policy call rather than a merge blocker.

## #9900 — dead string-wrapper counter

`STRING_WRAPPERS` was declared and read but never incremented, so it always reported zero behind an `if wrappers > 0` guard that never fired. Removed along with its holder-inventory entry — the paired change the gate requires, since a stale entry fails it. The surrounding comment also stops claiming the diagnostic counts "wrappers actually materialised", which it never did.

## Validation

`run_lint_gates: all 64 gates passed; 2 CI-only skipped`

| suite | passed | failed |
|---|---|---|
| perry-runtime | 3248 | 0 |
| perry-codegen | 1938 | 0 |
| perry-hir | 626 | 0 |
| perry-stdlib | 132 | 0 |
