### PR TITLE
fix(compile): put PERRY_SEGVIEW in the cache identity, and clear the segment-view cursor at loop exit

### DIFF
--- a/crates/perry-codegen/src/collectors/segview.rs
+++ b/crates/perry-codegen/src/collectors/segview.rs
@@ -1221,7 +1221,26 @@ fn rewrite_site(list: &mut Vec<Stmt>, i: usize, site: &SegmentForOfSite, fresh: 
             pick(cur, Expr::Undefined, decline_iter),
         ),
     );
-    3
+    // Clear the cursor at loop exit. The cursor local is declared in the
+    // ENCLOSING statement list, not inside the loop, so without this its slot
+    // stays a live GC root until the function returns. A cursor that spans a
+    // minor while the loop runs is promoted, and because it holds the input
+    // string in a traced slot it drags that string into the old generation
+    // with it — one per `open`, and `string-width` is entered thousands of
+    // times per reply. That is a candidate mechanism for I4 settling 45-65 MB
+    // ABOVE I3 after idle despite winning 20-50 MB of peak.
+    //
+    // One unconditional clear covers both paths: on the declined path the
+    // local holds `0.0`, a number, so clearing it is a no-op. `break` reaches
+    // this statement; `return` inside the body pops the frame, which is
+    // equally fine. It does not prevent promotion DURING the loop — nothing
+    // in the compiler can, since the cursor is genuinely live there — it stops
+    // the slot from keeping a dead cursor rooted for the rest of the function.
+    list.insert(
+        i + 5,
+        Stmt::Expr(Expr::LocalSet(cur, Box::new(Expr::Undefined))),
+    );
+    4
 }
 
 fn unwrap_for_mut(s: &mut Stmt) -> &mut Stmt {

--- a/crates/perry-codegen/src/collectors/segview_tests.rs
+++ b/crates/perry-codegen/src/collectors/segview_tests.rs
@@ -509,3 +509,46 @@ fn a_site_with_an_unanswerable_use_stays_on_v1() {
         "v1 does not rewrite uses: {out}"
     );
 }
+
+/// The cursor local is declared in the enclosing statement list, so its slot is
+/// a live GC root until the function returns unless the lowering clears it. A
+/// cursor promoted during the loop holds the input string in a traced slot and
+/// drags it into the old generation; leaving the slot rooted afterwards keeps a
+/// DEAD cursor doing that for the rest of the function.
+#[test]
+fn the_cursor_is_cleared_at_loop_exit() {
+    let mut m = module_with(region(cc_body()));
+    assert_eq!(segview_rewrite_module(&mut m), 1);
+
+    // Structural, not string-matched: the statement AFTER the `For` must be a
+    // `LocalSet(<cursor>, Undefined)`, and the cursor is the local the `For`'s
+    // condition tests against zero.
+    let for_idx = m
+        .init
+        .iter()
+        .position(|s| matches!(s, Stmt::For { .. }))
+        .expect("the rewritten loop");
+    let cursor_id = match &m.init[for_idx] {
+        Stmt::For {
+            condition: Some(Expr::Conditional { condition, .. }),
+            ..
+        } => match condition.as_ref() {
+            Expr::Compare { left, .. } => match left.as_ref() {
+                Expr::LocalGet(id) => *id,
+                other => panic!("expected the cursor guard, got {other:?}"),
+            },
+            other => panic!("expected a compare, got {other:?}"),
+        },
+        _ => unreachable!(),
+    };
+    match m.init.get(for_idx + 1) {
+        Some(Stmt::Expr(Expr::LocalSet(id, v))) => {
+            assert_eq!(*id, cursor_id, "the cleared local must be the cursor");
+            assert!(
+                matches!(v.as_ref(), Expr::Undefined),
+                "the cursor slot must be cleared to undefined, got {v:?}"
+            );
+        }
+        other => panic!("no cursor clear after the loop: {other:?}"),
+    }
+}

--- a/crates/perry/src/commands/compile/build_cache.rs
+++ b/crates/perry/src/commands/compile/build_cache.rs
@@ -866,6 +866,19 @@ fn eligibility(args: &CompileArgs, project_root: &Path) -> Result<(), String> {
     if std::env::var("PERRY_SEGVIEW_DIAG").is_ok() {
         return Err("segview-diag".to_string());
     }
+    // #9843: `PERRY_SEGVIEW` is NOT a diagnostic — it changes the emitted
+    // code. It is not part of the build-cache fingerprint or any object-cache
+    // key, so without this a cached build can hand back a binary compiled with
+    // the OTHER setting: compile a file with the tier on, compile it again
+    // with the tier off, and the second can be served from the first. The
+    // A/B rig's whole shape is "one compiler binary, two compiles of one
+    // source differing only in this variable", which is exactly the collision.
+    // Excluded rather than keyed because the tier is experimental and default
+    // OFF; a cache key is the right fix when it ships on, and then a stale
+    // entry cannot silently become the measurement.
+    if std::env::var("PERRY_SEGVIEW").is_ok() {
+        return Err("segview-lowering".to_string());
+    }
     if args.verify_native_regions || args.emit_attest || args.emit_sandbox {
         return Err("sidecar-or-verify".to_string());
     }


### PR DESCRIPTION
Follow-up to #9843 / #9859. Two commits that were pushed to #9859's branch after
the merge train had already picked it up, so the tier landed on main without
them.

Gates on this branch: `cargo build --release -p perry` with **default features**
rc=0; `cargo test -p perry-codegen --lib segview` **17 passed**.

## 1. `PERRY_SEGVIEW` is not in the cache identity — a present hole on main

**This is a live defect on `main` today, not a historical note.**

`PERRY_SEGVIEW` turns the segment-view lowering on and **changes the emitted
code**. It is in neither the build-cache fingerprint nor any object-cache key,
and `is_cacheable` does not mention it. So two compiles of one source that
differ only in that variable can be served **one binary**: compile with the
tier on, compile again with it off, and the second can come from the first's
cache entry.

The failure mode is not a broken build. It is **two A/B arms that are secretly
the same binary** — a measured difference of zero, or two arms swapped. Silent,
and it looks like a result.

`PERRY_SEGVIEW_DIAG` was already excluded for the much weaker reason that a
cached build prints no report. The switch that changes codegen was not.

**Why the existing rows are still sound, and why that is luck rather than
design.** Every measured view arm so far also carried `PERRY_SEGVIEW_DIAG=1`,
which *was* excluded, so those compiles were never cached; the I5-spec bundle
was a full recompile; and every probe A/B has arms whose timings differ by 2–4×
at identical checksums. No measured pair was the same binary. But that held
because a *diagnostic* flag happened to defeat the cache, not because the cache
was correct.

**Until this lands, every view-arm compile in the rig must carry
`PERRY_SEGVIEW_DIAG=1`.** That is the property currently keeping arms distinct.

Excluded rather than keyed because the tier is default OFF. A cache **key** is
the right fix when it ships on by default — and that is a prerequisite for the
default-flip PR, because flipping the default while the switch is absent from
the cache identity would bake the hole into every build rather than every A/B.

## 2. Clear the segment-view cursor at loop exit

The cursor local is declared in the **enclosing** statement list, not scoped to
the loop:

```
let __segview_recv   = <receiver>
let __segview_input  = <input>
let __segview_cursor = js_segments_view_open(recv, inp)
let __segview_iter   = cur != 0 ? undefined : GetIterator(...)
For { ... }            <- last read of the cursor
```

so without a clear its slot stays a live GC root until the function returns. The
cursor holds the input string in a traced slot, so a promoted cursor drags that
string into the old generation, and leaving the slot rooted afterwards keeps a
**dead** cursor doing it for the rest of the function. `string-width` is entered
thousands of times per reply.

One unconditional `LocalSet(cursor, undefined)` after the loop covers both
paths: on the declined path the local holds `0.0`, a number, so the clear is a
no-op. `break` reaches it; `return` pops the frame.

**Honest scope.** It is **CPU-neutral by construction** — one store after the
loop. It does **not** prevent promotion *during* the loop, and nothing in the
compiler can, since the cursor is genuinely live there; it removes only the
post-loop rooting of a dead cursor. The idle-settle delta that originally
motivated it (I4 settling 45–65 MB above I3) **did not reproduce against main**,
so this is kept on its own merits and not as a fix for that number.

The test is structural rather than string-matched: it locates the rewritten
`For`, reads the cursor's LocalId out of the loop's own guard, and requires the
next statement to be `LocalSet(that id, Undefined)`. It fails if the clear is
removed, clears the wrong local, or is emitted before the loop — a
`contains("Undefined")` check would have passed on all three.

## Not affected

Neither commit changes the measured numbers: the cache fix emits no code, and
the cursor clear emits one store after the loop. The tier's cc rows (−14 % CPU,
−30…−42 MB peak with #9893) are in #9859's body.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory management after segment-view loops by clearing temporary cursor values when loops exit.
  * Prevented build-cache reuse when segment-view compilation settings differ, ensuring builds use the correct generated code.

* **Tests**
  * Added coverage verifying that temporary cursor values are cleared immediately after segment-view loops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->