### PR TITLE
fix(tls): preserve dynamic peer certificates

### DIFF
--- a/changelog.d/9911-tls-peer-certificate-dispatch.md
+++ b/changelog.d/9911-tls-peer-certificate-dispatch.md
@@ -1,0 +1,1 @@
+Fix dynamic `TLSSocket.getPeerCertificate()` calls from the native net extension so they return the full negotiated certificate. Certificate inspection now preserves the peer identity across server secure-context rotation.

--- a/crates/perry-ext-net/src/dispatch.rs
+++ b/crates/perry-ext-net/src/dispatch.rs
@@ -180,7 +180,11 @@ fn socket_method_name(prop: &str) -> Option<&'static [u8]> {
         "upgradeToTLS" => Some(b"upgradeToTLS"),
         "getSession" => Some(b"getSession"),
         "isSessionReused" => Some(b"isSessionReused"),
-        "getPeerCertificate" => Some(b"getPeerCertificate"),
+        // The primary stdlib dispatcher owns `getPeerCertificate`: it builds
+        // the complete legacy certificate object from the DER recorded at the
+        // handshake. Claiming it here returned the extension's reduced JSON
+        // facade, whose optional CN is populated only for adopted HTTPS
+        // sockets, so direct `tls.connect()` handles produced `{}`.
         "setDefaultEncoding" => Some(b"setDefaultEncoding"),
         "cork" => Some(b"cork"),
         "uncork" => Some(b"uncork"),
@@ -281,9 +285,6 @@ unsafe fn socket_method(handle: i64, method: &str, args: &[f64]) -> Option<f64> 
         }
         "getSession" => nanbox_ptr(crate::js_ext_net_socket_tls_session(handle)),
         "isSessionReused" => crate::js_ext_net_socket_tls_session_reused(handle),
-        "getPeerCertificate" => {
-            json_str_to_value(crate::js_ext_net_socket_peer_certificate_json(handle))
-        }
         "once" if args.len() >= 2 => {
             crate::js_net_socket_once(handle, unbox_to_i64(args[0]), unbox_to_i64(args[1]));
             nanbox_handle(handle)


### PR DESCRIPTION
When a `TLSSocket` flowed through a callback, dynamic `getPeerCertificate()` dispatch was intercepted by `perry-ext-net`'s reduced HTTPS facade. Direct `tls.connect()` sockets never populate that facade's optional CN field, so both the original and rotated server certificates appeared as `{}` even though the negotiated DER bytes were recorded correctly.

The extension now leaves `getPeerCertificate()` to the primary stdlib handle dispatcher, which builds Node's legacy certificate object from the recorded DER. This preserves the first connection's certificate while a server rotates its secure context and exposes the new certificate to later connections.

Refs #9202.

Validation:
- exact `tls/context/server-context-rotation.ts` output matches Node 26.5.1
- complete TLS node-suite: 100/100 passed
- full `perry-ext-net`: 33 passed
- `cargo check -p perry-stdlib` passed during path isolation
- `./scripts/run_lint_gates.sh`: all 64 gates passed, 2 CI-only skipped


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `TLSSocket.getPeerCertificate()` so it returns the complete negotiated certificate.
  * Certificate inspection now preserves peer identity when a server’s secure context is rotated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->