### PR TITLE
feat(codegen): turn the segment-view lowering on by default

### DIFF
--- a/crates/perry-codegen/src/collectors/segview.rs
+++ b/crates/perry-codegen/src/collectors/segview.rs
@@ -958,10 +958,17 @@ fn describe(v: &SegViewVerdict) -> String {
 // labels correct and avoids duplicating any closure the body contains — a
 // duplicated `Expr::Closure` would carry a duplicate `FuncId`.
 
-/// `PERRY_SEGVIEW=1`. **Default OFF**: the runtime's view entry points do not
-/// exist yet, so an on-by-default rewrite would emit calls that fail to link.
+/// **Default ON.** `PERRY_SEGVIEW=0` opts out.
+///
+/// It shipped default OFF because the runtime's view entry points did not
+/// exist; #9870 landed them on main, and on claude-code the tier with #9893's
+/// levers is -14 % CPU and -30…-42 MB peak RSS with identical output.
+///
+/// The opt-out stays: a program whose loops the tier declines pays nothing,
+/// but a switch that changes emitted code needs an off position that does not
+/// require a rebuild of the compiler.
 pub fn segview_lowering_enabled() -> bool {
-    matches!(std::env::var("PERRY_SEGVIEW"), Ok(v) if !v.is_empty() && v != "0")
+    !matches!(std::env::var("PERRY_SEGVIEW"), Ok(v) if v == "0")
 }
 
 fn extern_call(name: &str, args: Vec<Expr>) -> Expr {

--- a/crates/perry-codegen/src/collectors/segview_tests.rs
+++ b/crates/perry-codegen/src/collectors/segview_tests.rs
@@ -552,3 +552,27 @@ fn the_cursor_is_cleared_at_loop_exit() {
         other => panic!("no cursor clear after the loop: {other:?}"),
     }
 }
+
+/// The default is ON, and `PERRY_SEGVIEW=0` is the opt-out.
+///
+/// Asserted rather than assumed because the switch is read through the
+/// environment: a typo in the predicate that made it always-false would leave
+/// every test above passing (they call the rewrite directly) while the tier
+/// silently never fired in a real compile — the #9824 shape.
+#[test]
+fn the_lowering_is_on_by_default_and_zero_opts_out() {
+    use super::segview::segview_lowering_enabled;
+    // These mutate process-wide state, so they live in one test rather than
+    // three; `cargo test` runs test fns concurrently and separate tests would
+    // race on the same variable.
+    std::env::remove_var("PERRY_SEGVIEW");
+    assert!(
+        segview_lowering_enabled(),
+        "unset must mean ON — that is what 'default on' means"
+    );
+    std::env::set_var("PERRY_SEGVIEW", "0");
+    assert!(!segview_lowering_enabled(), "`0` is the opt-out");
+    std::env::set_var("PERRY_SEGVIEW", "1");
+    assert!(segview_lowering_enabled(), "`1` stays on");
+    std::env::remove_var("PERRY_SEGVIEW");
+}


### PR DESCRIPTION
**DRAFT. Gated on two things, neither of which is done:**

1. **#9910 must land first.** It puts `PERRY_SEGVIEW` into the build-cache
   identity. Flipping the default while the switch is absent from that identity
   would bake the hole into *every* build rather than every A/B — a cached
   binary could be served for a source compiled under the other setting. #9910
   is also the parent of this branch, so this diff is the one-line flip on top
   of it.
2. **A main-vs-default-on rotation on perrymaster.** Everything measured so far
   set `PERRY_SEGVIEW=1` explicitly. Default-on is a different configuration —
   it is what every compile in the tree does, including ones nobody chose it
   for — and it has not been rotated. Until that row exists this is unmeasured
   in the form it would ship.

## The change

One line, plus the doc comment it invalidates:

```rust
-pub fn segview_lowering_enabled() -> bool {
-    matches!(std::env::var("PERRY_SEGVIEW"), Ok(v) if !v.is_empty() && v != "0")
+pub fn segview_lowering_enabled() -> bool {
+    !matches!(std::env::var("PERRY_SEGVIEW"), Ok(v) if v == "0")
 }
```

`PERRY_SEGVIEW=0` becomes the opt-out. It stays because a switch that changes
emitted code needs an off position that does not require rebuilding the
compiler; a program whose loops the tier declines pays nothing either way.

## Why the default should move, once gated

On claude-code, with #9893's levers, paired against main on a quiet box:
**−14 % CPU MIN (5/5 faster), −30…−42 MB peak RSS (5/5), settled RSS flat,
output identical**; 4.8–5.3× node from main's 5.6–6.3×. On the probe's region A
— cc's per-`.segment()`-call shape — 2,262 → 1,554 ns/grapheme against node's
1,323, i.e. **1.17× node**. Rows and their provenance are in #9859.

Without #9893's levers the same tier **costs** +15 % CPU, which is why the
gating on it is not a formality.

## The test

Asserts the default through the same environment read the compiler uses: unset
⇒ on, `0` ⇒ off, `1` ⇒ on. Every other segview test calls the rewrite directly,
so a predicate that was accidentally always-false would leave all of them
passing while the tier silently never fired in a real compile — the #9824
shape, and the reason this assertion is worth its three lines.

18 segview tests pass on this branch.

## Default-on gate on main `504e180d0` (perrymaster, cc 3300-char reply, 5-round interleaved rotation; paired deltas)
Identity from the artefacts: with `PERRY_SEGVIEW` unset and no diag, the branch rewrites the same nine sites as the opt-in build (view call sites next/open 20/10 vs 0/0 on main), so the flip does exactly what the env switch did.

| arm | turn CPU s min / mean | Δ vs main (per round) | peak RSS Δ | settled 120 s |
|---|---|---|---|---|
| main | 3.56 / 3.61 | | | 494 |
| **default-on alone** | 3.67 / 3.80 | **+0.27, +0.22, +0.22, +0.27, +0.04 (slower 5/5)** | −28…−39 MB | 456 / 488 |
| default-on + #9893 levers | 2.92 / 3.00 | **−0.54, −0.69, −0.54, −0.62, −0.61 (faster 5/5, −17 %)** | −12…−38 MB | 480 / 494 (flat) |

400-char turn: default-on alone +0.09…+0.20 s (3/3 slower), with the levers −0.05…−0.11 s (3/3 faster); peak −9…−35 MB either way.

**Consequence**: this flip must land together with or after #9893. On its own it fails the campaign's CPU rule (+3…+5 % at 3300, +7…+14 % at 400) while buying peak RSS; with the levers it is the I7-view result on the current base. Absolute numbers on this host currently carry a ~35 % shift from a foreign service; the pairs above are interleaved and hold. Raw: `combDO.jsonl`, `idleDO.jsonl`.

## Rebased onto main (2026-09-07)
The base PRs this branch was stacked on landed on main via merge train #9922, so the branch was rebased onto current main: head `9b9aedda2` → `e495a1e24`, replay patch-identical (only this branch's own commits remain above main). The measurements above were taken on the pre-rebase head with the same code; CI on this head is the remaining gate.

Local gates on the rebased head (macOS arm64, 2026-09-09): perry-codegen tests 1,45x passed / 0 failed; runtime lib suite one thread 3,26x passed / 0 failed / 4 ignored; `cargo build --release -p perry-runtime --features wasm-host` ok. Un-drafted under the local-verification rule (GitHub runners unavailable); the Linux ladder on perrymaster follows as confirmation.

https://claude.ai/code/session_011dhBmdn4vGgNibjo3oZqTo
