### PR TITLE
fix(runtime): mock declared prototype methods

### DIFF
--- a/changelog.d/9913-test-mock-prototype.md
+++ b/changelog.d/9913-test-mock-prototype.md
@@ -1,0 +1,1 @@
+`node:test`'s `mock.method()` now replaces declared class prototype methods for instance dispatch and restores their original behavior, while recording calls and receiver identity like Node.

--- a/crates/perry-runtime/src/node_submodules/test.rs
+++ b/crates/perry-runtime/src/node_submodules/test.rs
@@ -367,6 +367,22 @@ fn set_property_value(target: f64, property: &str, value: f64) {
     }
 }
 
+fn set_method_property_value(target: f64, property: &str, value: f64) {
+    let raw = raw_ptr_from_value(target);
+    if let Some(class_id) = crate::object::class_id_for_decl_prototype_object(raw) {
+        unsafe {
+            crate::object::js_register_prototype_method(
+                class_id,
+                property.as_ptr(),
+                property.len(),
+                value,
+            );
+        }
+    } else {
+        set_property_value(target, property, value);
+    }
+}
+
 fn get_property_value(target: f64, property: &str) -> f64 {
     let raw = raw_ptr_from_value(target);
     if raw >= 0x10000 && crate::closure::is_closure_ptr(raw) {
@@ -691,7 +707,7 @@ fn restore_mock_state(id: i64) {
             target,
             property,
             original,
-        }) => set_property_value(target, &property, original),
+        }) => set_method_property_value(target, &property, original),
         Some(MockRestoreTarget::ObjectAccessor {
             target,
             property,
@@ -1036,7 +1052,7 @@ extern "C" fn mock_method_thunk(
             original,
         },
     );
-    set_property_value(target.get_nanbox_f64(), &property_name, function);
+    set_method_property_value(target.get_nanbox_f64(), &property_name, function);
     function
 }
 

--- a/test-parity/node-suite/test/mock-fn/prototype-method.ts
+++ b/test-parity/node-suite/test/mock-fn/prototype-method.ts
@@ -1,7 +1,10 @@
 import { mock } from "node:test";
 
 class Counter {
-  constructor(public value: number) {}
+  value: number;
+  constructor(value: number) {
+    this.value = value;
+  }
   read() {
     return this.value;
   }


### PR DESCRIPTION
`mock.method(Counter.prototype, "read")` wrote its wrapper only to the materialized prototype object, while instance calls resolve declared methods through the class registry. The call therefore reached the original vtable method and left `method.mock.calls` empty.

Declared class prototype targets now route mock installation and restoration through the runtime's prototype-method registration path, which invalidates direct-call guards and makes the wrapper visible to instance dispatch. The parity fixture also replaces a TypeScript parameter property that Node 26 cannot strip, so Node now executes the intended oracle case.

Validation:

- Corrected prototype-method fixture matches Node 26.5.1 exactly, including receiver identity and restore behavior
- Extended base-class/subclass custom-implementation probe matches Node
- Focused `node_submodules::test` tests: 52 passed
- Full `perry-runtime` suite: 3,242 passed, 4 ignored; doc tests green
- Full `perry-stdlib` suite: 132 passed
- Full `test` node-suite module: 81/90, with the repaired fixture passing and 9 existing unrelated diffs
- `scripts/run_lint_gates.sh`: all 64 gates passed; 2 CI-only commands skipped locally
- No version bump

Fixes #9202


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `node:test` mocking now supports methods declared on class prototypes.
  - Mocked prototype methods correctly intercept instance calls while preserving the original behavior after restoration.
  - Calls and receiver identity are recorded consistently for mocked prototype methods.

- **Tests**
  - Added coverage validating prototype method replacement, restoration, call tracking, and instance behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->