### PR TITLE
fix(runtime): render node:test reporter directives

### DIFF
--- a/changelog.d/9914-test-reporter-directives.md
+++ b/changelog.d/9914-test-reporter-directives.md
@@ -1,0 +1,2 @@
+Render `skip` and `todo` directives in the `node:test` spec and TAP reporters,
+including Node-compatible markers and optional directive reasons.

--- a/crates/perry-runtime/src/node_submodules/test_reporters.rs
+++ b/crates/perry-runtime/src/node_submodules/test_reporters.rs
@@ -88,6 +88,48 @@ fn event_data(event: f64) -> f64 {
     object_property(event, b"data").unwrap_or(undefined_value())
 }
 
+fn reporter_directive(data: f64) -> Option<(&'static str, String)> {
+    for (key, label) in [(b"skip".as_slice(), "SKIP"), (b"todo".as_slice(), "TODO")] {
+        let Some(value) = object_property(data, key) else {
+            continue;
+        };
+        if crate::value::js_is_truthy(value) == 0 {
+            continue;
+        }
+        let reason = if JSValue::from_bits(value.to_bits()).is_any_string() {
+            value_to_string(value).unwrap_or_default()
+        } else {
+            String::new()
+        };
+        return Some((label, reason));
+    }
+    None
+}
+
+fn directive_suffix(data: f64) -> String {
+    reporter_directive(data)
+        .map(|(label, reason)| {
+            if reason.is_empty() {
+                format!(" # {label}")
+            } else {
+                format!(" # {label} {reason}")
+            }
+        })
+        .unwrap_or_default()
+}
+
+fn spec_directive_suffix(data: f64) -> String {
+    reporter_directive(data)
+        .map(|(label, reason)| {
+            if reason.is_empty() {
+                format!(" # {label}")
+            } else {
+                format!(" # {reason}")
+            }
+        })
+        .unwrap_or_default()
+}
+
 fn format_reporter_events(kind: i32, events: &[f64]) -> String {
     if kind == REPORTER_LCOV {
         return String::new();
@@ -118,7 +160,15 @@ fn format_reporter_event(kind: i32, event: f64) -> String {
     match kind {
         REPORTER_SPEC => match typ.as_str() {
             "test:pass" => object_string(data, b"name")
-                .map(|name| format!("✔ {name}\n"))
+                .map(|name| {
+                    let marker =
+                        if reporter_directive(data).is_some_and(|(label, _)| label == "SKIP") {
+                            "﹣"
+                        } else {
+                            "✔"
+                        };
+                    format!("{marker} {name}{}\n", spec_directive_suffix(data))
+                })
                 .unwrap_or_default(),
             "test:diagnostic" => object_string(data, b"message")
                 .map(|message| format!("ℹ {message}\n"))
@@ -134,7 +184,10 @@ fn format_reporter_event(kind: i32, event: f64) -> String {
                 let detail_type = object_property(data, b"details")
                     .and_then(|details| object_string(details, b"type"))
                     .unwrap_or_else(|| "test".to_string());
-                format!("ok undefined - {name}\n  ---\n  type: '{detail_type}'\n  ...\n")
+                format!(
+                    "ok undefined - {name}{}\n  ---\n  type: '{detail_type}'\n  ...\n",
+                    directive_suffix(data)
+                )
             }
             "test:diagnostic" => object_string(data, b"message")
                 .map(|message| format!("# {message}\n"))

--- a/test-parity/node-suite/test/reporters/directives.ts
+++ b/test-parity/node-suite/test/reporters/directives.ts
@@ -21,9 +21,21 @@ const events = [
   },
 ];
 
-async function collect(name: string, reporter: any) {
+async function collect(name: string, reporter: any): Promise<void> {
   let output = "";
-  for await (const chunk of reporter(Readable.from(events))) output += String(chunk);
+  const result = reporter(Readable.from(events));
+  if (typeof result.write === "function") {
+    const transform = reporter();
+    transform.on("data", (chunk: unknown) => {
+      output += String(chunk);
+    });
+    await new Promise<void>((resolve) => {
+      transform.on("end", resolve);
+      Readable.from(events).pipe(transform);
+    });
+  } else {
+    for await (const chunk of result) output += String(chunk);
+  }
   console.log(`${name}:`, JSON.stringify(output));
 }
 


### PR DESCRIPTION
The `node:test` spec and TAP reporters ignored `skip` and `todo` metadata on passing test events. As a result, skipped tests appeared as ordinary passes and TAP output omitted the directives consumed by downstream tooling.

Reporter formatting now preserves Node's directive behavior: spec uses the skipped marker, includes string reasons, and retains `SKIP`/`TODO` for boolean directives; TAP always emits the labeled directive and optional reason. The parity fixture now invokes Node 26's reporter transforms correctly, so it exercises the same event stream in Node and Perry.

Validation:

- Directives fixture matches Node 26.5.1 byte for byte, including string and boolean directive forms
- Focused `node_submodules::test` tests: 52 passed
- Full `perry-runtime` suite: 3,242 passed, 4 ignored; doc tests green
- Full `perry-stdlib` suite: 132 passed
- Official `test` node-suite module: 88/90; directives passes, with only the already-submitted prototype-method fix and the separate nested-reporter case remaining
- `scripts/run_lint_gates.sh`: all 64 gates passed; 2 CI-only commands skipped locally
- No version bump

Fixes #9202


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Test reporters now display `skip` and `todo` directives in output.
  - Spec reports use a distinct marker for skipped tests and include optional directive reasons.
  - TAP reports append directive information to passing-test output.
  - Directive formatting supports Node-compatible markers and syntax.

- **Tests**
  - Reporter validation now covers both streaming and asynchronous reporter output formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->