### PR TITLE
perf(gc): exact-start bitmap + page-class-first pointer validation; header-first buffer-registry rejection

### DIFF
--- a/cc-perf-campaign/codex/REPORT_gc-overhead.md
+++ b/cc-perf-campaign/codex/REPORT_gc-overhead.md
@@ -1,0 +1,120 @@
+# GC pointer-validation / buffer-registry report
+
+## Branch and implementation SHA
+
+- Branch: `perf/gc-pointer-validation`
+- Base: `origin/main` at `504e180d085f37aaf0b9189e0c1bdb328d508f70`
+- Runtime implementation commit: `8d49faa556004b87e57e29a22ca822d3369a8ef3`
+
+The checkout's shared `.git` metadata was read-only in this environment. The
+branch was therefore fetched and created in an isolated Git directory while
+the work tree remained `/Users/amlug/projects/perry/agent-trees/gc-overhead`.
+
+## What changed
+
+- The synchronous exact `ValidPointerSet` census clears each arena block's
+  existing object-start bitmap and stamps every walkable header as it visits
+  it. This includes headers written by codegen's inline allocator. The normal
+  allocation path remains Map-only and gains no per-allocation bitmap write.
+- `ValidPointerSet::contains` asks the direct page-class metadata and exact-
+  start bitmap before its two-level sorted-run floor lookup. Non-arena and
+  page-table-control cases retain the sorted-run fallback. Malloc membership
+  remains an exact `BTreeSet` union and is always considered after an arena
+  miss.
+- `ValidPointerSet::enclosing_object` still uses the sorted census runs; the
+  bitmap is exact-start membership only.
+- `buffer::is_registered_buffer` now uses
+  `try_read_tracked_gc_header` to reject a tracked non-`GC_TYPE_BUFFER` object
+  before the address filter and exact registries. A `GC_TYPE_BUFFER` match is
+  not accepted from the header: managed buffers, headerless external buffers,
+  and SharedArrayBuffer backings retain the authoritative registry path.
+- `PERRY_GC_DIAG` gained one whole-run `[gc-pointer-validation]` line and one
+  `[gc-runtime-handles]` line. `PERRY_BUFFER_DIAG` gained
+  `header_rejects=` and renamed its downstream count `filter_probes=`.
+- Added named sabotage tests for the page-class exact-start arm and Buffer
+  header-class rejection.
+
+## Handle-scope source audit
+
+No handle-scope behavior changed.
+
+- A successful `js_segments_view_open` creates one `RuntimeHandleScope` and
+  pushes one input root across the cursor allocation. `js_segments_view_next`
+  and `js_segments_view_code_point_at` create no scope and push no roots; both
+  are allocation-free by their implementation contract. The other view entry
+  points do not open a scope per call.
+- A successful `js_regexp_new` creates one scope and pushes exactly two roots:
+  the pattern plus either the caller's already-canonical flags string or the
+  newly allocated canonical flags string.
+- Both public entry points receive raw values/pointers. A caller-owned scope
+  cannot let either callee refresh a relocated argument after an allocation
+  without changing the ABI to pass a mutable root/slot. This is not a one-line
+  scope removal.
+- Actual cc-turn scope and push counts were not measured locally. The added
+  diagnostic reports total scopes, pushes, pushes-per-scope, and maximum live
+  slots for the perrymaster run.
+
+## Gates and checks
+
+Run locally:
+
+- `rustfmt --edition 2021 --check` over all 12 changed Rust files: pass.
+- `./scripts/check_file_size.sh`: pass; zero Rust files over 2,000 lines.
+- `python3 scripts/addr_class_inventory.py`: address-class audit pass over
+  1,357 files, 315 allowlisted and 521 known sites. It separately reported two
+  pre-existing stale baseline reductions in `set.rs` and `crypto/kdf.rs`; no
+  baseline was rewritten.
+- `git diff --check`: pass.
+
+Not run:
+
+- Cargo invocations: 0. Immediately before the intended gates, `df -g /`
+  reported 24 GB available, but the binding wrapper
+  `secret-tests/cc-perf-campaign/measure_lock.sh` is absent. The task requires
+  every Cargo invocation to go through that wrapper, so no Cargo command was
+  issued.
+- `cargo build --release -p perry` with default features: not run.
+- `cargo test -p perry-runtime --release --lib -- --test-threads=1`: not run.
+- Sabotage tests executed: 0 of 2; both were authored but require the blocked
+  Cargo test gate.
+- `nm -g libperry_runtime.a`: not run. No exported symbol or exported function
+  signature was changed; no local archive exists because `target/` was
+  deleted and no build was permitted.
+
+## Counters and measurements
+
+- Pre-fix cc-rig counter run: not measured. The private cc harness and campaign
+  files named in the task are absent from this checkout, and the mandatory
+  build wrapper is absent.
+- Post-fix cc CPU/RSS: not measured.
+- Locally observed performance numbers: none.
+- The source map supplied with the task is not restated as a branch result.
+
+New counter line schemas to collect:
+
+```text
+[gc-pointer-validation] contains=... page_hits=... page_rejects=... run_fallbacks=... malloc_probes=... malloc_hits=... enclosing=...
+[gc-runtime-handles] scopes=... pushes=... pushes_per_scope=... max_slots=...
+[buffer-diag] header_rejects=... filter_probes=... admits=... rejected=... true_positives=...
+```
+
+## Exact perrymaster measurement request
+
+Fetch `fork/perf/gc-pointer-validation` and relink the runtime-only implementation
+SHA `8d49faa556004b87e57e29a22ca822d3369a8ef3` on main6's cache. Run the I7-view
+cc rig for the pushed SHA and its `origin/main` base: **5×3300 + 2×400 + idle
+rows**. Record turn CPU, main-thread samples, collector share, RSS, and the
+named pointer-validation/buffer leaves. Add the existing page-table control
+arm with `PERRY_GC_PAGE_CLASS_TABLE=0`. In counter runs enable
+`PERRY_GC_DIAG=1` and `PERRY_BUFFER_DIAG=<path>` and return the counter lines
+whole, including every `[gc-pointer-validation]`, `[gc-runtime-handles]`, and
+`[buffer-diag]` line; do not summarize or truncate them.
+
+## Could not verify
+
+- Compilation, linking, exported archive contents, unit/sabotage test execution,
+  cc-turn behavior, CPU parity, and RSS impact.
+- The task-referenced `cc-perf-campaign/BRIEF_COMMON.md`, `STATUS.md`,
+  `ARCHITECTURE.md`, `BRIEF_gc-overhead.md`, and
+  `RESULT_page_class_table.md` were not present under this worktree or the
+  stated `/Users/amlug/projects/perry/perry` repository.

--- a/changelog.d/gc-pointer-validation.md
+++ b/changelog.d/gc-pointer-validation.md
@@ -1,0 +1,16 @@
+### Reduce GC pointer-validation and Buffer probe overhead
+
+The synchronous collector now rebuilds each arena block's exact-start bitmap
+from its own object census and uses the direct page-class metadata for constant-
+time `ValidPointerSet` membership. This covers codegen's inline allocator
+without adding work to the allocation path; the existing sorted census runs
+remain the kill-switch fallback and continue to serve interior-pointer lookup.
+
+Generic Buffer identity checks now reject tracked non-Buffer GC objects from
+their header class before consulting the address filter and exact side
+registry. Positive matches and headerless external Buffer/SharedArrayBuffer
+storage still use the authoritative registries.
+
+`PERRY_GC_DIAG` now reports pointer-membership and runtime-handle scope/push
+counts, and `PERRY_BUFFER_DIAG` reports header-class rejections, so the cc turn
+rig can attribute the affected hot paths directly.

--- a/crates/perry-runtime/src/arena/mod.rs
+++ b/crates/perry-runtime/src/arena/mod.rs
@@ -56,7 +56,8 @@ pub(crate) use block::{
     reset_gc_trigger_arena_probe,
 };
 pub(crate) use page_meta::{
-    address_span_overlaps_pages, defer_old_object_page_registration, page_class_table_report,
+    address_span_overlaps_pages, defer_old_object_page_registration, page_class_exact_object_start,
+    page_class_exact_start_enabled, page_class_table_report, record_censused_arena_object_start,
     register_block_space_with_object_starts, register_old_object_pages,
     unregister_block_generation, unregister_old_block_pages, OLD_GEN_RECLAIM_POOLED_BYTES,
     OLD_GEN_RECLAIM_RETURNED_BYTES, OLD_GEN_RECLAIM_REUSABLE_BYTES,

--- a/crates/perry-runtime/src/arena/page_meta/mod.rs
+++ b/crates/perry-runtime/src/arena/page_meta/mod.rs
@@ -986,6 +986,62 @@ pub(crate) fn record_arena_object_start(header_addr: usize, obj_type: u8) {
     }
 }
 
+/// Stamp an object start discovered by the exact ValidPointerSet census.
+///
+/// The census first clears every block bitmap, then calls this for every
+/// walkable header—including objects created by codegen's inline allocator,
+/// which deliberately bypasses [`record_arena_object_start`]. Keeping the
+/// work here, rather than on allocation, exchanges one bitmap RMW per census
+/// object for constant-time membership on every subsequent pointer probe.
+#[inline(always)]
+pub(crate) fn record_censused_arena_object_start(header_addr: usize) {
+    if !page_class::page_class_table_enabled() {
+        return;
+    }
+    let Some((_space, range_base, bitmap)) = classify_heap_space_in_range(header_addr) else {
+        debug_assert!(false, "censused arena header was not in a registered block");
+        return;
+    };
+    if bitmap.is_null() || header_addr < range_base {
+        return;
+    }
+    let slot = (header_addr - range_base) >> super::OBJECT_START_SHIFT;
+    let word = slot / u64::BITS as usize;
+    let bit = slot % u64::BITS as usize;
+    unsafe {
+        *bitmap.add(word) |= 1u64 << bit;
+    }
+}
+
+/// Exact object-start membership for the direct page-table arm.
+///
+/// `Some` means page metadata answered authoritatively for an arena range;
+/// `None` leaves the caller on its census-run fallback (the 4-way control,
+/// synthetic ranges without a bitmap, and non-arena addresses). The exact
+/// ValidPointerSet builder clears each bitmap and repopulates it from the same
+/// census that fills its sorted runs, so this index has identical membership.
+#[inline(always)]
+pub(crate) fn page_class_exact_object_start(addr: usize) -> Option<bool> {
+    if !page_class::page_class_table_enabled() {
+        return None;
+    }
+    let (_space, range_base, bitmap) = classify_heap_space_in_range(addr)?;
+    if bitmap.is_null() {
+        return None;
+    }
+    let Some(header_addr) = addr.checked_sub(crate::gc::GC_HEADER_SIZE) else {
+        return Some(false);
+    };
+    if header_addr < range_base || !arena_header_is_object_start(header_addr, range_base, bitmap) {
+        return Some(false);
+    }
+    Some(true)
+}
+
+pub(crate) fn page_class_exact_start_enabled() -> bool {
+    page_class::page_class_table_enabled()
+}
+
 /// True only when `header_addr` is a recorded allocation boundary in the
 /// registered block beginning at `range_base`.
 #[inline(always)]

--- a/crates/perry-runtime/src/arena/page_meta/page_class.rs
+++ b/crates/perry-runtime/src/arena/page_meta/page_class.rs
@@ -389,7 +389,7 @@ struct PageClassStats {
 /// the positive control: both arms live in ONE binary so no build difference
 /// can be confounded with the change.
 #[inline(always)]
-fn page_class_table_enabled() -> bool {
+pub(super) fn page_class_table_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| crate::gc::env_default_on_enabled("PERRY_GC_PAGE_CLASS_TABLE"))
 }

--- a/crates/perry-runtime/src/arena/walk.rs
+++ b/crates/perry-runtime/src/arena/walk.rs
@@ -42,6 +42,10 @@ enum ArenaObjectCursorBlocks {
 
 pub(crate) struct ArenaObjectCursorBuilder {
     order: ArenaWalkOrder,
+    /// Clear each block's exact-start bitmap while taking the census snapshot.
+    /// Only the exact ValidPointerSet census requests this; other arena walks
+    /// retain the allocation-authored Map boundaries used by copying GC.
+    reset_object_starts: bool,
     blocks: Vec<ArenaWalkBlock>,
     address_blocks: std::collections::BTreeMap<usize, ArenaWalkBlock>,
     initialized: bool,
@@ -61,8 +65,16 @@ const ARENA_CURSOR_OLD: usize = 4;
 
 impl ArenaObjectCursorBuilder {
     pub(crate) fn new(order: ArenaWalkOrder) -> Self {
+        Self::new_with_object_start_reset(order, false)
+    }
+
+    pub(crate) fn new_with_object_start_reset(
+        order: ArenaWalkOrder,
+        reset_object_starts: bool,
+    ) -> Self {
         Self {
             order,
+            reset_object_starts,
             blocks: Vec::new(),
             address_blocks: std::collections::BTreeMap::new(),
             initialized: false,
@@ -91,7 +103,9 @@ impl ArenaObjectCursorBuilder {
             self.inspected_blocks = self.inspected_blocks.saturating_add(1);
             *remaining -= 1;
 
-            if let Some(block) = snapshot_cursor_block(region, block_pos, block_idx) {
+            if let Some(block) =
+                snapshot_cursor_block(region, block_pos, block_idx, self.reset_object_starts)
+            {
                 self.push_block(block);
             }
 
@@ -170,26 +184,52 @@ fn snapshot_cursor_block(
     region: usize,
     block_pos: usize,
     block_idx: usize,
+    reset_object_starts: bool,
 ) -> Option<ArenaWalkBlock> {
     let block = match region {
         ARENA_CURSOR_GENERAL => ARENA.with(|arena| unsafe {
-            let blocks = &(*arena.get()).blocks;
+            let blocks = &mut (*arena.get()).blocks;
+            if reset_object_starts {
+                if let Some(block) = blocks.get_mut(block_pos) {
+                    block.clear_object_starts();
+                }
+            }
             blocks.get(block_pos).map(snapshot_block_fields)
         }),
         ARENA_CURSOR_SURVIVOR0 => SURVIVOR_ARENA_0.with(|arena| unsafe {
-            let blocks = &(*arena.get()).blocks;
+            let blocks = &mut (*arena.get()).blocks;
+            if reset_object_starts {
+                if let Some(block) = blocks.get_mut(block_pos) {
+                    block.clear_object_starts();
+                }
+            }
             blocks.get(block_pos).map(snapshot_block_fields)
         }),
         ARENA_CURSOR_SURVIVOR1 => SURVIVOR_ARENA_1.with(|arena| unsafe {
-            let blocks = &(*arena.get()).blocks;
+            let blocks = &mut (*arena.get()).blocks;
+            if reset_object_starts {
+                if let Some(block) = blocks.get_mut(block_pos) {
+                    block.clear_object_starts();
+                }
+            }
             blocks.get(block_pos).map(snapshot_block_fields)
         }),
         ARENA_CURSOR_LONGLIVED => LONGLIVED_ARENA.with(|arena| unsafe {
-            let blocks = &(*arena.get()).blocks;
+            let blocks = &mut (*arena.get()).blocks;
+            if reset_object_starts {
+                if let Some(block) = blocks.get_mut(block_pos) {
+                    block.clear_object_starts();
+                }
+            }
             blocks.get(block_pos).map(snapshot_block_fields)
         }),
         ARENA_CURSOR_OLD => OLD_ARENA.with(|arena| unsafe {
-            let blocks = &(*arena.get()).blocks;
+            let blocks = &mut (*arena.get()).blocks;
+            if reset_object_starts {
+                if let Some(block) = blocks.get_mut(block_pos) {
+                    block.clear_object_starts();
+                }
+            }
             blocks.get(block_pos).map(snapshot_block_fields)
         }),
         _ => None,

--- a/crates/perry-runtime/src/buffer/header.rs
+++ b/crates/perry-runtime/src/buffer/header.rs
@@ -278,11 +278,33 @@ thread_local! {
 /// registry it guards is thread-local and `cargo test` gives each case its own
 /// thread inside one process.
     static TEST_BUFFER_REGISTRY_PROBES: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    static TEST_DISABLE_BUFFER_HEADER_CLASS: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
 #[cfg(test)]
 pub(crate) fn test_buffer_registry_probe_count() -> u64 {
     TEST_BUFFER_REGISTRY_PROBES.with(|c| c.get())
+}
+
+#[cfg(test)]
+pub(crate) fn test_disable_buffer_header_class(disabled: bool) -> bool {
+    TEST_DISABLE_BUFFER_HEADER_CLASS.with(|state| state.replace(disabled))
+}
+
+#[inline(always)]
+fn managed_header_rejects_buffer(addr: usize) -> bool {
+    #[cfg(test)]
+    if TEST_DISABLE_BUFFER_HEADER_CLASS.with(std::cell::Cell::get) {
+        return false;
+    }
+    // A real managed Buffer must carry GC_TYPE_BUFFER. Page/registry ownership
+    // makes the header read safe; only a negative class answer is authoritative
+    // here. A class match still falls through to exact Buffer registries, so an
+    // aligned interior pointer cannot become a false positive.
+    unsafe {
+        crate::value::addr_class::try_read_tracked_gc_header(addr)
+            .is_some_and(|header| (*header.as_ptr()).obj_type != crate::gc::GC_TYPE_BUFFER)
+    }
 }
 
 #[cfg(test)]
@@ -491,6 +513,17 @@ pub fn is_registered_buffer(addr: usize) -> bool {
     // `js_buffer_register_external` also routes through) and
     // `shared_sab::alloc_shared_sab` both arm this latch before they publish.
     if BUFFER_LIKE_EVER_REGISTERED.is_idle() {
+        return false;
+    }
+    // Since the 2026-07-09 allocator audit, every runtime-owned Buffer has a
+    // real `GC_TYPE_BUFFER` header. Reject a tracked non-Buffer before the
+    // address-filter hashes, TLS resolution, RefCell borrow and registry hash.
+    // Headerless external buffers and positive class matches retain the exact
+    // registry path below.
+    if managed_header_rejects_buffer(addr) {
+        if crate::hot_diag::buffer_on() {
+            crate::hot_diag::buffer_note_header_reject();
+        }
         return false;
     }
     // An address outside the registered window cannot be in any of the three

--- a/crates/perry-runtime/src/buffer/mod.rs
+++ b/crates/perry-runtime/src/buffer/mod.rs
@@ -72,8 +72,8 @@ pub(crate) use header::rebind_foreign_buffer;
 #[cfg(test)]
 pub(crate) use header::{
     test_buffer_addr_window_bounds, test_buffer_registry_probe_count, test_data_view_registry_len,
-    test_shared_array_buffer_registry_len, test_uint8array_addr_window_bounds,
-    test_uint8array_registry_probe_count,
+    test_disable_buffer_header_class, test_shared_array_buffer_registry_len,
+    test_uint8array_addr_window_bounds, test_uint8array_registry_probe_count,
 };
 
 // ---- Re-exports: ArrayBuffer detach / transfer (ES2024) ----
@@ -192,6 +192,37 @@ pub use iter::{
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A tracked non-Buffer in a previously admitted Buffer address must be
+    /// rejected by its GC class before the exact registry. With that arm
+    /// sabotaged the registry counter must move; without the contrast this test
+    /// would stay green if the optimization were deleted.
+    #[test]
+    fn managed_non_buffer_header_rejects_before_registry() {
+        let buf = buffer_alloc(32);
+        assert!(!buf.is_null());
+        let addr = buf as usize;
+        finalize_collected_dead_buffer(addr);
+
+        let gc_header =
+            unsafe { (buf as *mut u8).sub(crate::gc::GC_HEADER_SIZE) as *mut crate::gc::GcHeader };
+        let original_type = unsafe { (*gc_header).obj_type };
+        unsafe { (*gc_header).obj_type = crate::gc::GC_TYPE_OBJECT };
+
+        let buffer_before = test_buffer_registry_probe_count();
+        assert!(!is_registered_buffer(addr));
+        assert_eq!(test_buffer_registry_probe_count(), buffer_before);
+
+        let restore = test_disable_buffer_header_class(true);
+        assert!(!is_registered_buffer(addr));
+        test_disable_buffer_header_class(restore);
+        unsafe { (*gc_header).obj_type = original_type };
+        assert_eq!(
+            test_buffer_registry_probe_count(),
+            buffer_before + 1,
+            "sabotage must force the Buffer registry lookup"
+        );
+    }
 
     /// The GC buffer sweep must drop the CryptoKey/secret-key side tables
     /// along with the buffer identity ones. They are plain `addr -> metadata`

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -1394,6 +1394,8 @@ fn emit_incremental_liveness_diag() {
         poll_arm::poll_armed_count(),
         trace::forwarded_stub_membership_recoveries(),
     );
+    trace::emit_valid_pointer_diag();
+    roots::emit_runtime_handle_diag();
     idle_reclaim::emit_diag();
     idle_compact::emit_diag();
     arena_right_size::emit_diag();

--- a/crates/perry-runtime/src/gc/roots.rs
+++ b/crates/perry-runtime/src/gc/roots.rs
@@ -18,7 +18,7 @@ pub(super) use stack_maps::verify_native_slots_post_walk as stack_maps_native_sl
 
 pub use rooted_values::RootedValues;
 pub(super) use runtime_handles::{
-    new_runtime_handle_root_scan_state, scan_runtime_handle_roots_mut,
+    emit_runtime_handle_diag, new_runtime_handle_root_scan_state, scan_runtime_handle_roots_mut,
     scan_runtime_handle_roots_mut_step,
 };
 pub(crate) use runtime_handles::{

--- a/crates/perry-runtime/src/gc/roots/runtime_handles.rs
+++ b/crates/perry-runtime/src/gc/roots/runtime_handles.rs
@@ -46,7 +46,7 @@ fn runtime_handle_diag_note(update: impl FnOnce(&mut RuntimeHandleDiag)) {
     });
 }
 
-pub(super) fn emit_runtime_handle_diag() {
+pub(crate) fn emit_runtime_handle_diag() {
     if !crate::gc::gc_diag_enabled() {
         return;
     }

--- a/crates/perry-runtime/src/gc/roots/runtime_handles.rs
+++ b/crates/perry-runtime/src/gc/roots/runtime_handles.rs
@@ -18,6 +18,54 @@ thread_local! {
     static RUNTIME_HANDLE_STACK_HOT_GUARD: RuntimeHandleStackHotGuard = const { RuntimeHandleStackHotGuard };
 }
 
+#[derive(Clone, Copy, Default)]
+struct RuntimeHandleDiag {
+    scopes: u64,
+    pushes: u64,
+    max_slots: usize,
+}
+
+crate::perry_thread_local! {
+    static RUNTIME_HANDLE_DIAG: std::cell::Cell<RuntimeHandleDiag> =
+        const { std::cell::Cell::new(RuntimeHandleDiag {
+            scopes: 0,
+            pushes: 0,
+            max_slots: 0,
+        }) };
+}
+
+#[inline(always)]
+fn runtime_handle_diag_note(update: impl FnOnce(&mut RuntimeHandleDiag)) {
+    if !crate::gc::gc_diag_enabled() {
+        return;
+    }
+    RUNTIME_HANDLE_DIAG.with(|cell| {
+        let mut diag = cell.get();
+        update(&mut diag);
+        cell.set(diag);
+    });
+}
+
+pub(super) fn emit_runtime_handle_diag() {
+    if !crate::gc::gc_diag_enabled() {
+        return;
+    }
+    RUNTIME_HANDLE_DIAG.with(|cell| {
+        let d = cell.get();
+        eprintln!(
+            "[gc-runtime-handles] scopes={} pushes={} pushes_per_scope={:.3} max_slots={}",
+            d.scopes,
+            d.pushes,
+            if d.scopes == 0 {
+                0.0
+            } else {
+                d.pushes as f64 / d.scopes as f64
+            },
+            d.max_slots,
+        );
+    });
+}
+
 /// Resolve this thread's runtime-handle stack without entering `HotTls`.
 /// Called once by `tls_hot::fill`, and by handle operations only until the
 /// Darwin direct-TSD cache has been published.
@@ -62,6 +110,10 @@ impl RuntimeHandleScope {
     #[inline]
     pub fn new() -> Self {
         let base = with_runtime_handle_stack(|stack| stack.borrow().len());
+        runtime_handle_diag_note(|d| {
+            d.scopes = d.scopes.saturating_add(1);
+            d.max_slots = d.max_slots.max(base);
+        });
         Self { base }
     }
 
@@ -73,6 +125,10 @@ impl RuntimeHandleScope {
             let index = stack.len();
             stack.push(slot);
             index
+        });
+        runtime_handle_diag_note(|d| {
+            d.pushes = d.pushes.saturating_add(1);
+            d.max_slots = d.max_slots.max(index.saturating_add(1));
         });
         RuntimeHandle {
             index,

--- a/crates/perry-runtime/src/gc/tests/cycle_state.rs
+++ b/crates/perry-runtime/src/gc/tests/cycle_state.rs
@@ -343,6 +343,53 @@ fn valid_pointer_membership_spans_every_census_run_including_the_partial_one_764
     );
 }
 
+/// The direct page-class membership answer must be live, exact, and bounded by
+/// the registered arena range. Named sabotage: the test disables the bitmap
+/// answer and requires the independently-correct census-run fallback to take
+/// over without moving the bitmap-answer counter. Delete the optimized arm and
+/// the positive half fails because that counter stays flat.
+#[test]
+fn page_class_exact_membership_rejects_pointer_just_outside_arena_chunk() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+
+    let object = young_leaf();
+    let (_, range_base, _) = crate::arena::classify_heap_space_in_range(object)
+        .expect("test object must belong to a registered arena chunk");
+    let valid_ptrs = ValidPointerSetBuilder::new().finish();
+
+    if crate::arena::page_class_exact_start_enabled() {
+        let before = page_class_exact_start_answers_for_tests();
+        assert!(valid_ptrs.contains(&object));
+        assert_eq!(
+            page_class_exact_start_answers_for_tests(),
+            before + 1,
+            "the direct table must answer exact membership for a real arena start"
+        );
+
+        let restore = disable_page_class_exact_start_for_tests(true);
+        let fallback_before = page_class_exact_start_answers_for_tests();
+        assert!(
+            valid_ptrs.contains(&object),
+            "the census fallback must agree"
+        );
+        disable_page_class_exact_start_for_tests(restore);
+        assert_eq!(
+            page_class_exact_start_answers_for_tests(),
+            fallback_before,
+            "sabotage must force the independently-correct census fallback"
+        );
+    }
+
+    let outside = range_base
+        .checked_sub(GC_HEADER_SIZE)
+        .expect("arena chunk base must be above the first page");
+    assert!(
+        !valid_ptrs.contains(&outside),
+        "a pointer immediately before the registered chunk must be rejected"
+    );
+}
+
 #[test]
 fn build_valid_pointer_set_finalize_is_separate_bounded_phase() {
     let _guard = CopyingNurseryTestGuard::new(0);

--- a/crates/perry-runtime/src/gc/trace.rs
+++ b/crates/perry-runtime/src/gc/trace.rs
@@ -9,6 +9,78 @@ crate::perry_thread_local! {
         const { std::cell::Cell::new(false) };
 }
 
+#[derive(Clone, Copy, Default)]
+struct ValidPointerDiag {
+    contains: u64,
+    page_hits: u64,
+    page_rejects: u64,
+    run_fallbacks: u64,
+    malloc_probes: u64,
+    malloc_hits: u64,
+    enclosing: u64,
+}
+
+crate::perry_thread_local! {
+    static VALID_POINTER_DIAG: std::cell::Cell<ValidPointerDiag> =
+        const { std::cell::Cell::new(ValidPointerDiag {
+            contains: 0,
+            page_hits: 0,
+            page_rejects: 0,
+            run_fallbacks: 0,
+            malloc_probes: 0,
+            malloc_hits: 0,
+            enclosing: 0,
+        }) };
+}
+
+#[inline(always)]
+fn valid_pointer_diag_note(update: impl FnOnce(&mut ValidPointerDiag)) {
+    if !super::gc_diag_enabled() {
+        return;
+    }
+    VALID_POINTER_DIAG.with(|cell| {
+        let mut diag = cell.get();
+        update(&mut diag);
+        cell.set(diag);
+    });
+}
+
+pub(super) fn emit_valid_pointer_diag() {
+    if !super::gc_diag_enabled() {
+        return;
+    }
+    VALID_POINTER_DIAG.with(|cell| {
+        let d = cell.get();
+        eprintln!(
+            "[gc-pointer-validation] contains={} page_hits={} page_rejects={} \
+             run_fallbacks={} malloc_probes={} malloc_hits={} enclosing={}",
+            d.contains,
+            d.page_hits,
+            d.page_rejects,
+            d.run_fallbacks,
+            d.malloc_probes,
+            d.malloc_hits,
+            d.enclosing,
+        );
+    });
+}
+
+#[cfg(test)]
+thread_local! {
+    static TEST_PAGE_CLASS_EXACT_START_ANSWERS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    static TEST_DISABLE_PAGE_CLASS_EXACT_START: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+#[cfg(test)]
+pub(super) fn page_class_exact_start_answers_for_tests() -> u64 {
+    TEST_PAGE_CLASS_EXACT_START_ANSWERS.with(std::cell::Cell::get)
+}
+
+#[cfg(test)]
+pub(super) fn disable_page_class_exact_start_for_tests(disabled: bool) -> bool {
+    TEST_DISABLE_PAGE_CLASS_EXACT_START.with(|state| state.replace(disabled))
+}
+
 crate::perry_thread_local! {
     /// #9717: array-growth forwarding stubs the classifier admitted into a
     /// budgeted-cycle valid-pointer set that `plausible_arena_user_ptr_header`
@@ -256,6 +328,7 @@ impl ValidPointerSet {
     }
     #[inline]
     pub(crate) fn contains(&self, ptr: &usize) -> bool {
+        valid_pointer_diag_note(|d| d.contains = d.contains.saturating_add(1));
         if self.classifier_mode {
             // No census was built: classify live. FORWARDED rejects are
             // correct here (budgeted cycles are non-moving; a forwarded
@@ -274,8 +347,18 @@ impl ValidPointerSet {
         // malloc-tracked starts, which have no usable order, need the B-tree.
         // Arena first because arena hits dominate every workload that reaches
         // here — a malloc pointer pays one extra run-level binary search.
-        let exact = self.arena_start_censused(*ptr)
-            || (!self.malloc_lookup.is_empty() && self.malloc_lookup.contains(ptr));
+        let arena_exact = self.arena_start_censused(*ptr);
+        let malloc_exact = if arena_exact || self.malloc_lookup.is_empty() {
+            false
+        } else {
+            valid_pointer_diag_note(|d| d.malloc_probes = d.malloc_probes.saturating_add(1));
+            let found = self.malloc_lookup.contains(ptr);
+            if found {
+                valid_pointer_diag_note(|d| d.malloc_hits = d.malloc_hits.saturating_add(1));
+            }
+            found
+        };
+        let exact = arena_exact || malloc_exact;
         // #6179 differential verification (PERRY_GC_VERIFY_CLASSIFIER=1):
         // before the exact set can be replaced by page-metadata
         // classification on precise cycles, the classifier must be proven a
@@ -313,6 +396,7 @@ impl ValidPointerSet {
     /// iteration. Find the largest entry `<= query`, then validate via
     /// the GcHeader's size field.
     pub(crate) fn enclosing_object(&self, ptr: usize) -> Option<usize> {
+        valid_pointer_diag_note(|d| d.enclosing = d.enclosing.saturating_add(1));
         let candidate = self.find_arena_floor(ptr)?;
         unsafe {
             let header = (candidate as *const u8).sub(GC_HEADER_SIZE) as *const GcHeader;
@@ -353,6 +437,35 @@ impl ValidPointerSet {
              {} censused starts are invisible to this lookup",
             self.current_arena_run.len()
         );
+        #[cfg(test)]
+        let fast_enabled = !TEST_DISABLE_PAGE_CLASS_EXACT_START.with(std::cell::Cell::get);
+        #[cfg(not(test))]
+        let fast_enabled = true;
+
+        if fast_enabled {
+            if let Some(exact) = crate::arena::page_class_exact_object_start(ptr) {
+                valid_pointer_diag_note(|d| {
+                    if exact {
+                        d.page_hits = d.page_hits.saturating_add(1);
+                    } else {
+                        d.page_rejects = d.page_rejects.saturating_add(1);
+                    }
+                });
+                #[cfg(test)]
+                TEST_PAGE_CLASS_EXACT_START_ANSWERS
+                    .with(|count| count.set(count.get().wrapping_add(1)));
+                #[cfg(debug_assertions)]
+                if !exact {
+                    debug_assert_ne!(
+                        self.find_arena_floor(ptr),
+                        Some(ptr),
+                        "page-class exact-start bitmap rejected a censused arena object; an allocation route failed to stamp its header"
+                    );
+                }
+                return exact;
+            }
+        }
+        valid_pointer_diag_note(|d| d.run_fallbacks = d.run_fallbacks.saturating_add(1));
         self.find_arena_floor(ptr) == Some(ptr)
     }
 
@@ -418,18 +531,27 @@ impl ValidPointerSetBuilder {
     /// into the exact set; membership resolves via the classifier. Saves the
     /// O(heap) BTreeSet held across the whole sliced cycle.
     pub(super) fn new_classifier() -> Self {
-        let mut b = Self::new();
-        b.set.classifier_mode = true;
-        b
+        Self::new_with_mode(true)
     }
 
     pub(super) fn new() -> Self {
+        Self::new_with_mode(false)
+    }
+
+    fn new_with_mode(classifier_mode: bool) -> Self {
+        let rebuild_exact_starts =
+            !classifier_mode && crate::arena::page_class_exact_start_enabled();
+        let mut set = ValidPointerSet::new();
+        set.classifier_mode = classifier_mode;
         Self {
-            set: ValidPointerSet::new(),
+            set,
             phase: ValidPointerSetBuildPhase::ArenaCursorSetup,
-            arena_cursor_builder: Some(crate::arena::ArenaObjectCursorBuilder::new(
-                crate::arena::ArenaWalkOrder::Address,
-            )),
+            arena_cursor_builder: Some(
+                crate::arena::ArenaObjectCursorBuilder::new_with_object_start_reset(
+                    crate::arena::ArenaWalkOrder::Address,
+                    rebuild_exact_starts,
+                ),
+            ),
             arena_cursor: None,
             malloc_index: 0,
         }
@@ -529,6 +651,9 @@ impl ValidPointerSetBuilder {
     }
 
     fn record_arena_header(&mut self, header_ptr: *mut u8) {
+        if !self.set.classifier_mode {
+            crate::arena::record_censused_arena_object_start(header_ptr as usize);
+        }
         let user_ptr = unsafe { header_ptr.add(GC_HEADER_SIZE) };
         self.set.push_arena(user_ptr as usize);
         unsafe {

--- a/crates/perry-runtime/src/hot_diag.rs
+++ b/crates/perry-runtime/src/hot_diag.rs
@@ -987,6 +987,7 @@ pub fn buffer_on() -> bool {
 // instruments use: this probe runs millions of times per turn, and a borrow
 // per probe would dominate the thing being measured.
 static BUF_PROBES: AtomicU64 = AtomicU64::new(0);
+static BUF_HEADER_REJECTS: AtomicU64 = AtomicU64::new(0);
 static BUF_ADMITS: AtomicU64 = AtomicU64::new(0);
 static BUF_TRUE_POS: AtomicU64 = AtomicU64::new(0);
 static BUF_ADDR_MIN: AtomicUsize = AtomicUsize::new(usize::MAX);
@@ -996,6 +997,16 @@ static BUF_WIN_HI: AtomicUsize = AtomicUsize::new(0);
 static BUF_REGS: AtomicU64 = AtomicU64::new(0);
 static BUF_UNREGS: AtomicU64 = AtomicU64::new(0);
 static BUF_LIVE_MAX: AtomicUsize = AtomicUsize::new(0);
+
+/// A tracked GC header proved that the candidate cannot be a Buffer before
+/// either address filter or an exact registry was consulted.
+#[inline]
+pub fn buffer_note_header_reject() {
+    let n = BUF_HEADER_REJECTS.fetch_add(1, Ordering::Relaxed);
+    if n & 0xF_FFFF == 0 {
+        buffer_dump();
+    }
+}
 
 /// One `is_registered_buffer` probe that got past the "ever registered" latch.
 /// `admitted` is what the inline min/max window answered — the whole question,
@@ -1043,6 +1054,7 @@ pub fn buffer_note_unregistration() {
 #[cold]
 fn buffer_dump() {
     let probes = BUF_PROBES.load(Ordering::Relaxed);
+    let header_rejects = BUF_HEADER_REJECTS.load(Ordering::Relaxed);
     let admits = BUF_ADMITS.load(Ordering::Relaxed);
     let tp = BUF_TRUE_POS.load(Ordering::Relaxed);
     let amin = BUF_ADDR_MIN.load(Ordering::Relaxed);
@@ -1063,7 +1075,7 @@ fn buffer_dump() {
     use std::fmt::Write as _;
     let _ = writeln!(
         out,
-        "[buffer-diag] probes={probes} admits={admits} ({:.2} %) rejected={} ({:.2} %) \
+        "[buffer-diag] header_rejects={header_rejects} filter_probes={probes} admits={admits} ({:.2} %) rejected={} ({:.2} %) \
          true_positives={tp} ({:.6} % of admits)",
         pct(admits, probes),
         probes - admits,

--- a/scripts/gc_runtime_root_holders.json
+++ b/scripts/gc_runtime_root_holders.json
@@ -182,6 +182,12 @@
     },
     {
       "file": "crates/perry-runtime/src/buffer/header.rs",
+      "name": "TEST_DISABLE_BUFFER_HEADER_CLASS",
+      "verdict": "test_only",
+      "why": "Declared under #[cfg(test)] at crates/perry-runtime/src/buffer/header.rs:281; this Cell<bool> holds only the test knob that disables the managed Buffer header-class fast rejection. It is absent from shipped binaries."
+    },
+    {
+      "file": "crates/perry-runtime/src/buffer/header.rs",
       "name": "UINT8ARRAY_ADDR_RANGE",
       "count": 1,
       "classification": "not_a_gc_pointer",
@@ -293,7 +299,7 @@
         "sources": {
           "crates/perry-runtime/src/gc/census.rs": "388414f9629f196e84673e91bebd04bdcdcabdaa180252d2dfe4b82d1b49ca5a",
           "crates/perry-runtime/src/gc/cycle.rs": "2e2f5adca2229f74409e01a1cb571e2147cd8a33f58d0976711fce98d4777309",
-          "crates/perry-runtime/src/gc/mod.rs": "43523b66595c61516ef6fcd4139d3ec5b4768a13c46ae1470c1d45481eacfdd9",
+          "crates/perry-runtime/src/gc/mod.rs": "6bd07a64a2688b4f1282c0b61085cac3fb499f02159401375a8736f7c15161c8",
           "crates/perry-runtime/src/gc/policy.rs": "dc9242ed40c0aa9c411d1ec0235c0219c6716dd82d56eb4d46578f7e889825d2",
           "crates/perry-runtime/src/gc/progress.rs": "a5ad3971bbe4047229ca57325234780daa85921dbc778e1c08dff4ad07ccfb96"
         }
@@ -364,6 +370,24 @@
       "name": "FORWARDED_STUB_MEMBERSHIP_RECOVERIES",
       "verdict": "not_a_gc_pointer",
       "why": "#9717: monotonic count of array-growth forwarding stubs a budgeted full cycle admitted through `classifier_valid_object_start`, reported as `forwarded_stub_recoveries=` on the PERRY_GC_DIAG `[gc-incremental]` line. A `Cell<u64>` holding a tally, never an address \u2014 the stubs it counts are reached through the worklist, not retained here. Nothing for the collector."
+    },
+    {
+      "file": "crates/perry-runtime/src/gc/trace.rs",
+      "name": "TEST_DISABLE_PAGE_CLASS_EXACT_START",
+      "verdict": "test_only",
+      "why": "Declared under #[cfg(test)] at crates/perry-runtime/src/gc/trace.rs:71; this Cell<bool> holds only the test knob that disables the page-class exact-start fast path. It is absent from shipped binaries."
+    },
+    {
+      "file": "crates/perry-runtime/src/gc/trace.rs",
+      "name": "TEST_PAGE_CLASS_EXACT_START_ANSWERS",
+      "verdict": "test_only",
+      "why": "Declared under #[cfg(test)] at crates/perry-runtime/src/gc/trace.rs:70; this Cell<u64> holds only the test count of exact-start answers returned by the page classifier. It is absent from shipped binaries."
+    },
+    {
+      "file": "crates/perry-runtime/src/gc/trace.rs",
+      "name": "VALID_POINTER_DIAG",
+      "verdict": "not_a_gc_pointer",
+      "why": "Declared at crates/perry-runtime/src/gc/trace.rs:24; this Cell<ValidPointerDiag> holds seven u64 diagnostic counters (`contains`, page hits/rejects, run fallbacks, malloc probes/hits, and enclosing queries). No field can hold a heap pointer, so there is nothing for the collector."
     },
     {
       "file": "crates/perry-runtime/src/hot_diag.rs",


### PR DESCRIPTION
Runtime-only, on main `504e180d0`. Written by codex from the campaign's I7-view profile; **not yet compiled** — gates and the cc-rig measurement run on perrymaster and will be appended here.

## Why
On the current best cc bundle the collector's per-pointer validation is the largest remaining collector item: `gc::trace::ValidPointerSet::find_arena_floor` 5.16 % self, `ValidPointerSet::contains` 0.95 %, `gc_pointer_and_type_from_value` 1.37 % (≈ 7.5 % of the main thread), and the buffer-registry probes `is_registered_buffer_slow` 1.61 % + `is_registered_buffer` 1.15 % + `is_uint8array_buffer_slow` 0.90 % (3.7 %).

## What changes
- The synchronous exact `ValidPointerSet` census clears each arena block's object-start bitmap and stamps every walkable header it visits (including headers written by codegen's inline allocator). The allocation path gains no per-allocation bitmap write.
- `ValidPointerSet::contains` asks the direct page-class metadata and the exact-start bitmap before the two-level sorted-run floor lookup. Non-arena and page-table-control cases keep the sorted-run fallback; malloc membership stays an exact `BTreeSet` union after an arena miss; `enclosing_object` still uses the sorted runs.
- `buffer::is_registered_buffer` uses `try_read_tracked_gc_header` to reject a tracked non-`GC_TYPE_BUFFER` object before the address filter and the exact registries. A header match is never accepted as a positive: managed buffers, headerless external buffers and SharedArrayBuffer backings keep the authoritative registry path.
- Diagnostics: `PERRY_GC_DIAG` prints one `[gc-pointer-validation]` and one `[gc-runtime-handles]` line per run; `PERRY_BUFFER_DIAG` gains `header_rejects=` and renames its downstream count to `filter_probes=`.

## Handle scopes (audit, no change)
`js_segments_view_open` opens one scope and pushes one root; `_next`/`_code_point_at` open none. `js_regexp_new` opens one scope and pushes two roots. Neither can be hoisted to a caller-owned scope without an ABI change (raw arguments cannot be refreshed after a relocation). Counts on the cc turn come from the new `[gc-runtime-handles]` line.

## Tests
Two named sabotage tests (the page-class exact-start arm; the Buffer header-class rejection), authored, not yet executed.

## Gates
Run: rustfmt, `scripts/check_file_size.sh`, `scripts/addr_class_inventory.py` (pass; two pre-existing stale baseline reductions reported, not rewritten), `git diff --check`. **Not run:** `cargo build --release -p perry` default features, the runtime suite, the two sabotage tests, `nm`. Draft until perrymaster's seam runs them.

## Gate history
- `c1ce04915`: `cargo build --release -p perry` rc=101 on perrymaster: `error[E0364]: emit_runtime_handle_diag is private, and cannot be re-exported` (`gc/roots.rs:21`) and `error[E0603]` at the `gc/mod.rs:1398` call. Nothing past the first gate ran.
- `153616859` (head): one-word fix, `pub(super)` → `pub(crate)` on the emitter, matching its scan-state siblings. Re-gating from the top (default features, archive feature set, lib tests, the two sabotage tests) before the relink and rows.
- `153616859` on perrymaster: `cargo build --release -p perry` rc=0; archives with `--features perry-runtime/wasm-host` rc=0; `RUST_TEST_THREADS=1 cargo test --release -p perry-runtime --lib -- --test-threads=1`: 3232 passed, 0 failed, 4 ignored, with the named tests green (`managed_non_buffer_header_rejects_before_registry`, `object_start_bitmap_stamps_only_maps_and_clears_on_reset`, `page_class_exact_membership_rejects_pointer_just_outside_arena_chunk`, `valid_pointer_membership_spans_every_census_run_including_the_partial_one_7646`, the `build_valid_pointer_set_*` cycle-state tests, the forwarding-target and inline-generation sabotage tests, the four page-class-table tests, `buffer_span_guards_require_registered_buffer`, `try_read_tracked_gc_header_rejects_unrelated_allocation`). `scripts/addr_class_inventory.py` passed. `scripts/gc_runtime_root_holders.py` **failed**: four new `rule T` thread-locals without verdicts and the `PASS1_MARKED` source pin for `gc/mod.rs` changed.
- `790519622` (head): inventory-only commit. Verdicts: `VALID_POINTER_DIAG` `not_a_gc_pointer` (seven u64 counters, no pointer field); `TEST_PAGE_CLASS_EXACT_START_ANSWERS`, `TEST_DISABLE_PAGE_CLASS_EXACT_START`, `TEST_DISABLE_BUFFER_HEADER_CLASS` `test_only` (all `#[cfg(test)]`). `PASS1_MARKED` re-audited: the snapshot is stored after mark propagation and taken at sweep entry within one synchronous full cycle; both boundaries require no minor in progress and a non-budgeted cycle; evacuation runs only on the minor path; this branch's `gc/mod.rs` change is two diag-emitter calls in the exit teardown that touch neither the snapshot nor phase control. Pin recomputed with the script's recipe. Gate rc=0, self-test OK. No runtime source changed, so the perrymaster measurement on `153616859` stands for this head.

## Measured (perrymaster, cc 3300-char reply, 5-round paired rotation vs main `504e180d0`, runtime relinked on main's cache)
| | turn CPU s min / mean | per-round Δ | peak RSS | settled 120 s |
|---|---|---|---|---|
| main | 3.58 / 3.62 | | 595–613 | 490 |
| this PR | 3.46 / 3.58 | −0.01, −0.19, −0.02, −0.03, +0.07 | within ±6 MB | 519 (+29, one row each) |

400-char turn: +0.03…+0.05 s (slower, 2/2). Absolutes on this host carry a foreign-service shift; the pairs are interleaved.

**Buffer diag** (whole last line of the reply): main `probes=11534337 admits=306091 (2.65 %) rejected=11228246 (97.35 %) true_positives=241228 (78.8 % of admits)`; this PR `header_rejects=10485761 filter_probes=15338 admits=14776 (96.34 %) rejected=562 true_positives=14776 (100 % of admits)`. 10.5 M of 11.5 M probes per reply now die on the header class; admits are all true.

**Perf draw** (3,468 main-thread samples): `ValidPointerSet::find_arena_floor` (5.16 % before) and `::contains` (0.95 %) are gone from the top-25; in their place `addr_class::try_read_tracked_gc_header` 1.59 %, `trace::classifier_valid_object_start` 0.94 %, `young_log::addr_is_minor_relevant` 0.90 %, and `ArenaObjectCursor::next_budgeted` 2.41 % (the synchronous census stamping the object-start bitmap). The typed-array registry probes are not covered by the header reject: `lookup_registered_typed_array_kind` 2.35 %, `is_uint8array_buffer_slow` 1.72 %. Collector/mutator on this no-tier bundle 51.4 / 48.6 %.

**Reading**: the validation cost moved (−6 % of samples in the floor search, +5 % in header read + classifier + bitmap census) and the buffer-probe cost was mostly the address filter, which the header reject replaces at similar price. Net ≈ flat. Stays draft; not a landing candidate in this form. What the data says to do instead: (1) stop issuing 11.5 M buffer/typed-array probes per reply at the callers (97 % are rejections), (2) do not pay a census stamp per arena block for a bitmap the header read already answers. The whole-run `[gc-pointer-validation]` / `[gc-runtime-handles]` lines are captured by a graceful run queued separately.

## Whole-run counters (one graceful 1-turn 3300 reply per arm; CPU columns void — taken under a concurrent compile)
main: `[buffer-diag] probes=27262977 admits=7268934 (26.66 %) rejected=19994043 (73.34 %) true_positives=241349`; `[gc-time] minor_us=1960601 step_us=518191 share_permille=272`.
this PR: `[gc-pointer-validation] contains=4708524 page_hits=0 page_rejects=0 run_fallbacks=0 malloc_probes=0 malloc_hits=0 enclosing=1569`; `[gc-runtime-handles] scopes=18736200 pushes=42238507 pushes_per_scope=2.254 max_slots=3333`; `[buffer-diag] header_rejects=27262977 filter_probes=242338 admits=241597 (99.69 %) rejected=741 true_positives=241593`; `[gc-time] minor_us=1924822 step_us=530609 share_permille=270`.

Two facts these settle: (1) the 27.26 M registry probes became exactly 27.26 M header reads — the probe count did not change, its price moved from the address filter to the header read, which is the flat CPU; (2) `contains` ran 4.7 M times with **zero** page hits, page rejects, run fallbacks or malloc probes, so the page-class + exact-start path never engaged in this run — either the counters sit on a path the census-stamped bitmap does not reach, or the page-class metadata is unavailable at that point. Until that is explained, the pointer-validation half of this PR is unmeasured, not flat. The 27 M probes are attacked at their source by #9937 (no probe for receivers whose kind the dispatch already knows); if that lands, the buffer half here is moot.
