### PR TITLE
Fix gc-native-roots failures on ARM Linux and macOS

### DIFF
--- a/.github/workflows/gc-native-roots.yml
+++ b/.github/workflows/gc-native-roots.yml
@@ -673,7 +673,9 @@ jobs:
           export PERRY_RUNTIME_DIR="$PWD/target/perry-dev"
           export PERRY_NO_AUTO_OPTIMIZE=1
           unset PERRY_LLVM_OPT PERRY_LLVM_CLANG
-          export LLVM_SYS_221_PREFIX="$(brew --prefix llvm)"
+          # Keep LLVM_SYS_221_PREFIX from setup-llvm22. The stock-toolchain
+          # assertion removes the external opt/clang overrides; the in-process
+          # backend itself still has to link the LLVM 22 ABI used by llvm-sys.
           export RUSTFLAGS="-C force-frame-pointers=yes -C force-unwind-tables=yes"
           cargo build --profile perry-dev -p perry -p perry-runtime-static \
             -p perry-stdlib-static --features perry-codegen/llvm-inprocess

--- a/changelog.d/9920-gc-native-roots-platforms.md
+++ b/changelog.d/9920-gc-native-roots-platforms.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Restore the scheduled native-roots gate on ARM Linux and macOS by handling
+  libyaml's target-specific `c_char` signedness and retaining its configured
+  LLVM 22 prefix for the in-process backend.

--- a/crates/perry-runtime/src/bun_compat/cli_utils.rs
+++ b/crates/perry-runtime/src/bun_compat/cli_utils.rs
@@ -947,7 +947,7 @@ fn yaml_parse(input: f64) -> f64 {
                 let problem = if parser.problem.is_null() {
                     "invalid YAML".to_string()
                 } else {
-                    std::ffi::CStr::from_ptr(parser.problem)
+                    std::ffi::CStr::from_ptr(parser.problem.cast::<std::ffi::c_char>())
                         .to_string_lossy()
                         .into_owned()
                 };


### PR DESCRIPTION
The scheduled `gc-native-roots` gate fails for two platform-specific reasons: Ubuntu ARM cannot compile the libyaml diagnostic pointer on targets where Rust's `c_char` is unsigned, and the macOS stock-toolchain step overwrites the LLVM 22 prefix with Homebrew's unversioned LLVM 23 before invoking the LLVM 22 in-process backend.

This casts libyaml's problem pointer through the target `std::ffi::c_char` type and preserves the `LLVM_SYS_221_PREFIX` exported by `setup-llvm22`. The stock-toolchain assertion still removes the external `opt` and `clang` overrides, while the in-process backend remains linked to the ABI required by `llvm-sys` 221.

Validation:
- ARM Linux target compile of the changed `unsafe-libyaml` diagnostic expression
- invalid `Bun.YAML.parse` compiled probe, including the full `SyntaxError` diagnostic
- corrected in-process RS4GC probe under LLVM 22: compact map present, raw stackmaps removed, output equal to the shadow-stack control, 75 copying minors and 15,391 objects moved, 12/12 functions reported as RS4GC
- `perry-runtime`: 3,242 passed, 4 ignored; doc tests: 8 ignored
- `perry-stdlib`: 132 passed
- all 64 local lint and compile gates passed; 2 CI-expression-only commands skipped
- actionlint reports one fewer finding than `origin/main`, with the remaining findings unchanged

Fixes #9915


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restored scheduled native-roots validation on ARM Linux and macOS.
  - Improved platform-specific YAML parsing compatibility and error handling.
  - Ensured in-process LLVM builds use the configured LLVM 22 toolchain consistently.

- **Documentation**
  - Added changelog coverage for native-roots validation across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->