### PR TITLE
fix(ci): track moved RS4GC unit gate

### DIFF
--- a/.github/workflows/llvm-inprocess.yml
+++ b/.github/workflows/llvm-inprocess.yml
@@ -126,7 +126,7 @@ jobs:
           cargo build --profile perry-dev -p perry -p perry-runtime-static \
             -p perry-stdlib-static --features perry/llvm-inprocess
 
-      - name: Unit gates (528 incl. corpus construction + RS4GC pin)
+      - name: Unit gates (including corpus construction + RS4GC pin)
         run: |
           set -euo pipefail
           out=$(cargo test --profile perry-dev -p perry-codegen \
@@ -136,7 +136,9 @@ jobs:
           grep -q "dialect::tests::corpus_spike ... ok" <<<"$out"
           grep -q "dialect::tests::corpus_batch_kernel ... ok" <<<"$out"
           grep -q "dialect::tests::corpus_exception_handling ... ok" <<<"$out"
-          grep -q "inprocess::tests::rs4gc_schedules_in_process ... ok" <<<"$out"
+          # The implementation may move between inprocess submodules; the
+          # unique test name is the stable contract that proves this pin ran.
+          grep -Eq '^test .*::rs4gc_schedules_in_process \.\.\. ok$' <<<"$out"
 
 
       # The tracked `.ll` corpora above are a SNAPSHOT of what the compiler


### PR DESCRIPTION
The scheduled `llvm-inprocess` run passed its full codegen test suite but failed afterward because its non-vacuity assertion still expected `inprocess::tests::rs4gc_schedules_in_process`. The `inprocess.rs` split moved that test to `inprocess::optimize_emit::tests`, so the gate reported failure even though the RS4GC pin ran and passed.

Match the unique test-function suffix instead of its internal module path, and remove the stale hard-coded suite count from the step label. The assertion still requires an explicit `... rs4gc_schedules_in_process ... ok` harness line, so a skipped or missing test cannot make the gate green.

Validation:

- exact workflow unit block: 1,449 passed, 1 ignored, 0 failed; all four corpus/RS4GC non-vacuity assertions matched;
- `actionlint .github/workflows/llvm-inprocess.yml`;
- `scripts/run_lint_gates.sh`: all 64 local gates passed, 2 CI-expression rows skipped; workspace warnings check and Clippy passed.

Closes #9928


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated validation for in-process test results.
  * Test checks now support valid executions across different in-process module paths.
  * Test reporting no longer depends on a hardcoded total test count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->