### PR TITLE
fix(runtime): materialize error stacks during inspect

### DIFF
--- a/changelog.d/9933-util-inspect-lazy-error-stack.md
+++ b/changelog.d/9933-util-inspect-lazy-error-stack.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Materialize lazy Error stacks when `util.inspect()` formats an Error with a
+  `cause` or an `AggregateError` with `errors`, preserving Node-compatible
+  stack/body layout.

--- a/crates/perry-runtime/src/builtins/formatting/errors.rs
+++ b/crates/perry-runtime/src/builtins/formatting/errors.rs
@@ -49,7 +49,13 @@ unsafe fn format_error_headline(error_ptr: *const crate::error::ErrorHeader) -> 
 }
 
 unsafe fn format_error_stack_frame(error_ptr: *const crate::error::ErrorHeader) -> Option<String> {
-    let stack = string_header_to_string((*error_ptr).stack, "");
+    // #9486 made Error stacks lazy: `ErrorHeader.stack` stays null until the
+    // first observable read materializes the captured frame payload. Inspect
+    // is one of those reads. Looking at the slot directly made Errors with a
+    // cause or AggregateError.errors print a standalone `{` where Node keeps
+    // it attached to the final stack line.
+    let stack_ptr = crate::error::materialize_error_stack(error_ptr.cast_mut());
+    let stack = string_header_to_string(stack_ptr, "");
     stack
         .lines()
         .skip(1)


### PR DESCRIPTION
`util.inspect(new Error("outer", { cause }))` and AggregateError inspection lost their stack/body layout after Error stacks became lazy in #9486. The formatter read `ErrorHeader.stack` directly, saw the pre-materialization null slot, and emitted the property body on a standalone `{` line; the `node-suite/util/inspect/error-cause-and-aggregate` parity row consequently failed.

Route inspection through the shared lazy stack materializer before selecting the displayed frame. This preserves captured frames until inspection actually consumes them and restores Node-compatible formatting for Error causes and AggregateError entries.

Tracked by #9202.

Validation:
- `./run_parity_tests.sh --suite node-suite --module util --filter error-cause-and-aggregate` (1/1)
- `./run_parity_tests.sh --suite node-suite --module util` (88/88)
- `cargo test --profile perry-dev -p perry-runtime -- --test-threads=1` (3,256 passed, 4 ignored; doc tests 8 ignored)
- `./scripts/run_lint_gates.sh` (all 64 local gates passed; 2 CI-only expressions skipped)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed error inspection so lazily generated stack traces are materialized correctly.
  - Improved formatting for errors with causes and aggregate errors, preserving the expected stack and body layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->