### PR TITLE
fix(module): pad omitted Module parent argument

### DIFF
--- a/changelog.d/9936-module-constructor-parent-arity.md
+++ b/changelog.d/9936-module-constructor-parent-arity.md
@@ -1,0 +1,1 @@
+Fixed `new Module(id)` so an omitted parent is passed as `undefined` instead of reading an uninitialized native argument.

--- a/crates/perry-codegen/src/lower_call/native_table/node_core/module_sea_tls_test.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_core/module_sea_tls_test.rs
@@ -21,7 +21,10 @@ pub(crate) const NODE_CORE_MODULE_SEA_TLS_TEST_ROWS: &[NativeModSig] = &[
         method: "Module",
         class_filter: None,
         runtime: "js_module_module_new",
-        args: &[NA_F64],
+        // The runtime accepts the optional parent as its second argument.
+        // Keep the slot in the native signature so an omitted parent is
+        // explicitly padded with undefined instead of reading a stale register.
+        args: &[NA_F64, NA_F64],
         ret: NR_F64,
     },
     NativeModSig {
@@ -567,6 +570,15 @@ pub(crate) const NODE_CORE_MODULE_SEA_TLS_TEST_ROWS: &[NativeModSig] = &[
 #[cfg(test)]
 mod tests {
     use super::NODE_CORE_MODULE_SEA_TLS_TEST_ROWS;
+
+    #[test]
+    fn module_constructor_keeps_the_optional_parent_argument() {
+        let sig = NODE_CORE_MODULE_SEA_TLS_TEST_ROWS
+            .iter()
+            .find(|sig| sig.module == "module" && sig.method == "Module")
+            .expect("missing module.Module signature");
+        assert_eq!(sig.args.len(), 2, "Module must forward its optional parent");
+    }
 
     #[test]
     fn node_test_mock_accessor_calls_keep_the_options_argument() {


### PR DESCRIPTION
Fixes the `node-suite/module/commonjs/constructor-prototype` row in #9202.

`module.Module` is lowered through `js_module_module_new(id, parent)`, but its native signature declared only the `id` slot. Calling `new Module(id)` could therefore leave the runtime's optional `parent` argument in a stale register; preceding prototype reflection made that register look like an object and produced a spurious read-only `length` error.

Declare both runtime arguments so the existing native lowering pads an omitted parent with JavaScript `undefined`. A focused table test keeps the runtime arity synchronized.

Validation:
- focused codegen regression: 1 passed
- exact parity row: 1/1 passed
- `node-suite/module/commonjs/`: 5/5 passed
- `scripts/run_lint_gates.sh`: all 64 gates passed; 2 CI-only commands skipped
- `cargo fmt --check` and `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `new Module(id)` when the optional parent argument is omitted. The constructor now correctly treats the missing value as `undefined`, preventing incorrect behavior caused by an uninitialized argument.
  - Preserved the optional parent argument in the Node module interface for consistent module construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->