### PR TITLE
perf(runtime): classify native-call receivers from the tracked header; no Buffer/typed-array registry probe for known kinds

### DIFF
--- a/cc-perf-campaign/codex/REPORT_native_call_receiver.md
+++ b/cc-perf-campaign/codex/REPORT_native_call_receiver.md
@@ -1,0 +1,73 @@
+# Native-call receiver registry cut
+
+## Pushed code
+
+- Branch: `fork/perf/native-call-receiver-class`
+- Before-counter commit: `8ad6e0777c0104910c6db66e5e4b16862c95f6b0`
+- Runtime implementation through: `72b713b99abdaf54b07a06b8fe29c177d2a47ff5`
+- Base: `87dc33492`
+- This is runtime-only. No codegen file changed. Re-measurement needs a relink against the I7-view tree's existing bundle cache; it does not need a bundle recompile.
+
+## Source map and old need for the distinction
+
+- `crates/perry-runtime/src/object/native_call_method.rs:1160`: `gc_pointer_and_type_from_value` returns `Option<(*const u8, u8)>`: the normalized receiver address plus its runtime `GC_TYPE_*`. It returns `None` for an invalid/unowned pointer and for Symbol, Map, Set, and RegExp cells, because those have dedicated dispatch paths.
+- `crates/perry-runtime/src/object/native_call_method/handle_methods.rs:55`: native method dispatch needs Buffer versus TypedArray to select different method families. Buffer receivers enter `dispatch_buffer_method` (`object/buffer_dispatch.rs:371`), which owns Node Buffer numeric reads/writes, encoding/toString, compare/copy/fill/search/swap, slice/subarray, ArrayBuffer transfer, DataView accessors, and Buffer/ArrayBuffer/SAB-specific brands. TypedArray receivers enter `dispatch_typed_array_method` (`object/native_call_method/typed_array.rs:40`), which owns element-kind-aware `at`, callback methods, sort/reduce, set/subarray/slice, joins/searches, and the Array-only-method rejection behavior.
+- Buffer, Uint8Array, ArrayBuffer, and SharedArrayBuffer cannot be flattened to one method-table answer. Perry represents ordinary managed Buffer/Uint8Array/ArrayBuffer cells with `GC_TYPE_BUFFER`, then preserves the finer brand registries inside buffer dispatch. Multi-byte typed arrays use `GC_TYPE_TYPED_ARRAY` plus `TypedArrayHeader.kind` (`typedarray/mod.rs:163`).
+- The header tag alone cannot classify every valid receiver. `js_buffer_register_external` registers an embedder-owned `BufferHeader` with no Perry GC header (`buffer/header.rs:597`). `shared_sab::alloc_shared_sab` allocates the process-global SAB backing directly with `alloc_zeroed` and never gives it a GC header (`shared_sab.rs:60`). Native-arena typed views can likewise be headerless. These cases must retain registry fallback after an allocator-tracked-header miss.
+- Managed buffers are different: `buffer_alloc` creates an old-arena `GC_TYPE_BUFFER` allocation (`buffer/header.rs:982`), and foreign-backed wrappers still have a managed `GC_TYPE_BUFFER` wrapper (`buffer/header.rs:1005`). Those do not need a Buffer registry question to establish storage kind.
+
+## Callers from the profile
+
+- `gc_pointer_and_type_from_value`: now reads one allocator-proven header first and asks Buffer/typed-array registries only when no tracked header exists (`native_call_method.rs:1160`).
+- `class_vtable_fast_guard`: consumes the already-computed `NativeReceiverClass`; `Gc(GC_TYPE_OBJECT)` makes Buffer/typed-array impossible before the vtable/object loads (`native_call_method.rs:243`).
+- `js_native_call_method`: classifies once at the call boundary and carries the answer into class and handle dispatch (`native_call_method.rs:1381`, `:2122`). Typed feedback now forwards its `site_id` instead of dropping it (`typed_feedback/guards.rs:853`).
+- `object_static_prototype`: `meta_capable_object` now requires allocator ownership and `GC_TYPE_OBJECT`; headerless cells go to the residual prototype map without a Buffer probe (`object/prototype_chain.rs:140`, `:302`). Proven ordinary objects and validated RegExps have separate no-classification accessors (`:333`, `:347`).
+- `js_object_get_field_by_name` and `get_field_by_name_object_tail`: managed typed-array kind comes from the header/payload (`typedarray_props.rs:55`, `field_get_set/get_field_by_name.rs:647`); the tail resolves one tracked type and only asks registries when it is absent. The Promise brand check also uses tracked ownership rather than speculative header bytes plus two exclusion probes.
+- `js_object_get_field_ic_miss`: the Buffer/TypedArray diversion now switches on a tracked GC type, with registry fallback only for headerless storage (`object/field_get_set/ic_miss.rs:686`).
+- `dispatch_primitive`: its remaining typed-array registry question is confined to the residual untagged/raw-pointer arm (`object/native_call_method/primitive_methods.rs:4`, `:914`). Tagged strings, numbers, booleans, bigint, null, and undefined are classified as `Primitive` before any byte-storage registry (`native_call_method.rs:138`).
+- `js_array_get_f64`: it has its own array/collection receiver classifier (`array/indexing.rs:450`) and was not changed in this runtime-receiver patch. Its remaining typed-array and Buffer probes are not native-call receiver probes.
+- `js_segments_view_next`, `_segment`, and `_regexp_test`: `cursor_ptr` now requires POINTER_TAG, current arena membership, `GC_TYPE_OBJECT`, and fixed class id `0xFFFF_000E` (`intl/segments_view.rs:88`). External/headerless storage cannot pass the arena check. `_regexp_test` still validates its varying RegExp argument once at the exported boundary (`:380`, `:391`); `regexp_test_str_bounded` no longer repeats that validation (`regex.rs:1472`). The RegExp is not checked at view-open time because the expression is a call argument and can change on each loop iteration.
+
+## Mechanism changed
+
+- `NativeReceiverClass` separates primitives, managed GC kinds, headerless Buffer, headerless TypedArray, and other pointers (`native_call_method.rs:55`).
+- Primitive tags return immediately. Managed addresses are admitted only by `try_read_tracked_gc_header`; the GC type is authoritative, and `ObjectHeader.class_id` is read only for `GC_TYPE_OBJECT` (`native_call_method.rs:138`). A 64-slot thread-local site cache stores only `(site_id, gc_type, class_id)`, never a raw GC pointer (`:92`). Every hit revalidates current type and class id. Headerless answers are not cached, so external/native registry lifecycle cannot leave a stale positive entry.
+- `dispatch_handle` consumes the classification and no longer calls either registry for managed receivers. The redundant Buffer retry at the end of Map/Set dispatch was removed (`object/native_call_method/collection_methods.rs:302`).
+- General prototype and named-field paths use the same allocator-proven type decision. Registry fallback remains only after a tracked-header miss or for a finer Buffer/Uint8Array/ArrayBuffer/SAB brand that actually affects the requested operation.
+
+These are code facts, not address-distribution assumptions: plain objects, boxed primitive wrappers, segment cursors, and RegExp cells are Perry allocator-owned allocations with explicit GC types; a segment cursor additionally has the fixed class id. External buffers and SAB backing blocks are allocator-untracked and therefore take the residual path.
+
+## Diagnostics and sabotage tests
+
+The before commit appends one whole `[native-call-diag]` line to the existing Buffer diagnostic, split into Buffer and typed-array counts for `native_receiver`, `view_cursor`, `object_static_prototype`, `field_by_name`, `field_tail`, `dispatch_primitive`, and `other` (`hot_diag.rs:1189`). It is deliberately a separate pre-fix SHA so perrymaster can obtain the caller split without mixing in the cut.
+
+Named load-bearing tests added:
+
+- `cached_plain_object_receiver_probes_zero_buffer_registries`: arms both registries, warms one site, asserts a second plain-object call moves neither registry counter, and asserts the site cache hit counter did move (`receiver_class_tests.rs:42`). The object has an own property literally named `buffer`.
+- `cached_site_revalidates_when_plain_receiver_becomes_buffer`: substitutes a real `Buffer.from("A")` result at the same site and requires Buffer `toString` to return `A` with zero managed-receiver registry probes (`receiver_class_tests.rs:108`).
+- `buffer_uint8array_and_arraybuffer_keep_their_method_paths`: checks the Uint8Array-branded Buffer representation and ArrayBuffer `slice` result brand (`receiver_class_tests.rs:138`).
+- `external_buffer_and_sab_backed_view_keep_native_dispatch`: checks a headerless registered external Buffer and an Int32Array view over a process-global SAB (`receiver_class_tests.rs:161`).
+- `cached_receiver_kind_does_not_hide_reassigned_prototype`: changes the receiver prototype after warming the site and requires the next call to invoke the new method (`receiver_class_tests.rs:215`).
+- `primitive_receiver_tag_skips_byte_storage_registries`: arms both registries and requires a tagged-string call to move neither counter (`receiver_class_tests.rs:81`).
+- `view_cursor_brand_is_a_class_load_with_zero_registry_probes`: requires zero registry-counter delta, corrupts only the cursor class id, requires immediate decline, restores it, and requires advance (`intl/segments_view.rs:799`).
+- `view_regexp_pointer_is_validated_exactly_once_per_call`: requires the RegExp validation counter delta to be exactly one; restoring the duplicate makes it two and deleting the boundary check makes it zero (`intl/segments_view.rs:836`).
+
+## Local gates
+
+- `cargo build --release -p perry-runtime --features wasm-host -j4`: 2 compiler runs. First reached the changed code and failed with four mechanical pointer/unsafe compile errors. After fixes, the retry passed: `Finished release profile ... in 1m 57s`.
+- `cargo test -p perry-runtime --release --lib -j4 -- --test-threads=1`: 1 compile attempt, 0 tests executed. It found that the test fixture could not reach the already-public `js_buffer_register_external` through the private `buffer::header` module. The function was then re-exported from `buffer/mod.rs`. The gate was not rerun because `df -g /` reported 11 GB free, below the binding 12 GB cutoff.
+- `cargo build --release -p perry -j4`: not run; prohibited by the same 11 GB disk cutoff.
+- Archive symbol check: Apple `/usr/bin/nm -g` could not parse Rust's LLVM 23 object attributes. The toolchain-matching `llvm-nm -g target/release/libperry_runtime.rlib` found `_js_buffer_register_external`, `_js_native_call_method`, `_js_object_get_field_by_name`, `_js_segments_view_next`, `_js_segments_view_segment`, `_js_segments_view_regexp_test`, and `_js_typed_feedback_native_call_method`.
+- No local cc run was made. No real `HOME` was used.
+- The final field-IC residual gate commit `72b713b99` was made after the successful archive build and was not cargo-compiled locally because the disk cutoff was already active. It is a header-directed replacement of the two registry conditions at `ic_miss.rs:686`.
+
+## Exact perrymaster request and falsifiers
+
+This is runtime-only: relink the I7-view tree against the branch runtime/archive using the existing bundle cache. Do not recompile the bundle for this patch.
+
+1. Relink/run the before-counter SHA `8ad6e0777c0104910c6db66e5e4b16862c95f6b0` with `PERRY_BUFFER_DIAG=1`. For one 3300-character reply, retain the complete `[buffer-diag]` and `[native-call-diag]` lines, including every Buffer and typed-array caller bucket.
+2. Relink/run code SHA `72b713b99abdaf54b07a06b8fe29c177d2a47ff5` identically. Prediction: `[buffer-diag] probes` falls from about 11.5 million to about **0.8 million** (hard falsifier: must be `<= 1,000,000`); `rejected` is predicted below **100,000** and should be near zero relative to the old 11.2 million. Remaining native-call diagnostic counts should be zero for managed `native_receiver`, `view_cursor`, `object_static_prototype`, and managed field paths; nonzero residuals must correspond to headerless external/SAB/native-view questions.
+3. Perf the same I7-view main-thread reply at 999 Hz. The named buffer/typed registry group must move from 125/2373 self samples (5.27%) toward `<= 1%`; `js_native_call_method` inclusive samples must decrease. Report raw samples and denominator, not only percentages.
+4. Run 5 paired 3300-character turns against `main` and this runtime, alternating order. Report each turn CPU, paired ratios, median ratio, and RSS. Expected RSS is unchanged; the allowed acceptance envelope is +1–10%, but any repeatable allocation growth is evidence against this mechanism because the cache stores 64 fixed, pointer-free entries per runtime thread.
+
+Failure of the probe ceiling, near-zero rejection prediction, class/prototype substitution tests, view class sabotage, or exact-one RegExp validation delta falsifies the change.

--- a/cc-perf-campaign/codex/REPORT_native_recv_fix.md
+++ b/cc-perf-campaign/codex/REPORT_native_recv_fix.md
@@ -1,0 +1,103 @@
+# Native-call receiver test fix
+
+## Pushed implementation
+
+- SHA: `e02fb408b20114670b8330a07eefe9cf2d059c4d`
+- Remote verification:
+
+  ```text
+  e02fb408b20114670b8330a07eefe9cf2d059c4d	refs/heads/perf/native-call-receiver-class
+  ```
+
+## Root causes and changes
+
+1. `intl::segments_view::view_mode_tests::view_regexp_pointer_is_validated_exactly_once_per_call`
+
+   `js_segments_view_regexp_test` performs the required exported-boundary brand
+   validation at `crates/perry-runtime/src/intl/segments_view.rs:391`. On the
+   first match, `regexp_test_str_bounded` reaches `ensure_regex_compiled`, whose
+   cold `build_and_install_programs` path repeated `is_valid_regex_ptr`. That
+   made a cold exported call count two validations. The duplicate cold-builder
+   check was removed at `crates/perry-runtime/src/regex/lazy.rs:224`; the
+   boundary check remains authoritative and the assertion was not changed.
+
+2. `object::native_call_method::receiver_class_tests::cached_plain_object_receiver_probes_zero_buffer_registries`
+
+   The native-call boundary correctly classified the receiver from its tracked
+   `GC_TYPE_OBJECT`, but later Object-brand and defensive header-safety helpers
+   bypassed `NativeReceiverClass`. In particular,
+   `typedarray::is_offheap_sidetable_alloc` unconditionally entered both byte
+   storage registries, and `Object.prototype.toString` independently probed the
+   Buffer and typed-array registries while determining the brand. Temporary
+   counters reproduced 30 typed-array registry calls during the one measured
+   cached call; the native-call diagnostic buckets stayed at zero, confirming
+   the traffic bypassed the classified native-call sites. Buffer counter
+   admission is allocator-window-dependent (perrymaster observed 37).
+
+   `crates/perry-runtime/src/typedarray/mod.rs:535` now proves tracked GC
+   storage first and consults side tables only after a tracked-header miss.
+   `crates/perry-runtime/src/object/to_string_tag.rs:80` and `:158` similarly
+   derive managed Buffer/TypedArray identity (and typed-array kind) from the GC
+   type/payload, reserving registry fallback for headerless storage.
+
+3. `object::native_call_method::receiver_class_tests::cached_site_revalidates_when_plain_receiver_becomes_buffer`
+
+   The receiver cache did revalidate the replacement as `GC_TYPE_BUFFER`, but
+   pre-dispatch brand/header-safety checks still called
+   `is_offheap_sidetable_alloc`, which treated every Buffer as legacy raw
+   storage and entered its side registry (seven admitted probes in
+   perrymaster's run). The tracked-header-first guard at
+   `crates/perry-runtime/src/typedarray/mod.rs:541` now rejects every managed
+   allocation before either registry. Headerless external Buffer/SAB/native
+   typed views retain the old registry fallback at line 544. The test assertion
+   was not changed.
+
+## Verification
+
+The first permitted exact diagnostic run started with 16 GB free and used the
+campaign build lock, release mode, `-j4`, a non-real `HOME`, and one test
+thread. It ran before the receiver-storage fixes, with temporary caller
+instrumentation, and reproduced the failure:
+
+```text
+test object::native_call_method::receiver_class_tests::cached_plain_object_receiver_probes_zero_buffer_registries ... FAILED
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 3267 filtered out; finished in 0.01s
+```
+
+After that compile, `df -g /` was below 12 GB. It was polled every 60 seconds
+for the full 30-minute recovery window (05:54-06:24 CEST). The final poll was:
+
+```text
+/dev/disk3s1s1       926   15         0    96%  458726 7505000    6%   /
+```
+
+Per the task's disk rule, no further Cargo invocation was made. Post-fix test
+verdicts are therefore:
+
+```text
+intl::segments_view::view_mode_tests::view_regexp_pointer_is_validated_exactly_once_per_call — NOT RUN (disk gate)
+object::native_call_method::receiver_class_tests::cached_plain_object_receiver_probes_zero_buffer_registries — NOT RUN (disk gate)
+object::native_call_method::receiver_class_tests::cached_site_revalidates_when_plain_receiver_becomes_buffer — NOT RUN (disk gate)
+object::native_call_method::receiver_class_tests::buffer_uint8array_and_arraybuffer_keep_their_method_paths — NOT RUN (disk gate)
+object::native_call_method::receiver_class_tests::external_buffer_and_sab_backed_view_keep_native_dispatch — NOT RUN (disk gate)
+object::native_call_method::receiver_class_tests::cached_receiver_kind_does_not_hide_reassigned_prototype — NOT RUN (disk gate)
+object::native_call_method::receiver_class_tests::primitive_receiver_tag_skips_byte_storage_registries — NOT RUN (disk gate)
+intl::segments_view::view_mode_tests::view_cursor_brand_is_a_class_load_with_zero_registry_probes — NOT RUN (disk gate)
+```
+
+Non-Cargo checks completed:
+
+```text
+rustfmt --edition 2021 --check [three changed Rust files] — exit 0
+git diff --check — exit 0
+```
+
+## Not verified
+
+- Full `cargo test -p perry-runtime --release --lib -- --test-threads=1`
+- `cargo build --release -p perry-runtime --features wasm-host`
+- `cargo build --release -p perry`
+
+All temporary tracing was removed. The recoverable in-worktree `target`
+directory created by the diagnostic compile was deleted after the disk reached
+0 GB so Git could create and push the required commit.

--- a/cc-perf-campaign/codex/REPORT_native_recv_fix2.md
+++ b/cc-perf-campaign/codex/REPORT_native_recv_fix2.md
@@ -1,0 +1,140 @@
+# Native-call receiver follow-up 2
+
+## Implementation
+
+- Code SHA: `bf1d91892cf5434641a53aed7256c4d4bb4c96b9`
+- Branch: `fork/perf/native-call-receiver-class`
+- The code SHA was confirmed remotely with:
+
+  ```text
+  bf1d91892cf5434641a53aed7256c4d4bb4c96b9	refs/heads/perf/native-call-receiver-class
+  ```
+
+## Exact remaining probe path
+
+The site cache was not stale. `js_native_call_method_at_site` classifies the
+boxed receiver at `crates/perry-runtime/src/object/native_call_method.rs:1410`;
+`classify_native_receiver` reads the tracked `GC_TYPE_OBJECT` and validates the
+site-cache hit at `:151-160`. Its headerless Buffer and typed-array fallbacks at
+`:170` and `:174` are therefore unreachable for this receiver.
+
+The residual probe was an internal Array element read downstream of that hit:
+
+```text
+js_native_call_method_at_site
+  -> try_url_search_params_dynamic_dispatch       native_call_method.rs:1708
+  -> shape_is_url_search_params                    search_params.rs:1135
+  -> js_array_get_f64(keys_arr, 0)                 search_params.rs:1026
+  -> byte-storage redispatch                       array/indexing.rs
+
+and later:
+
+js_native_call_method_at_site
+  -> own method-name scan                          native_call_method.rs:2383
+  -> js_array_get(keys, i)                         native_call_method.rs:2384
+  -> js_array_get_f64                              array/jsvalue_api.rs:17
+  -> byte-storage redispatch                       array/indexing.rs
+```
+
+At parent SHA `4f257d3b4`, `js_array_get_f64` called
+`lookup_typed_array_kind` unconditionally at
+`crates/perry-runtime/src/array/indexing.rs:579`, then called
+`is_registered_buffer` unconditionally at `:586`, after `clean_arr_ptr` had
+already returned a validated internal `GC_TYPE_ARRAY`. The exact Buffer
+registry admission is the test-counter increment at
+`crates/perry-runtime/src/buffer/header.rs:531` followed by
+`is_registered_buffer_slow` at `:532`. The typed-array equivalent increments at
+`crates/perry-runtime/src/typedarray/mod.rs:459` and can reach
+`lookup_registered_typed_array_kind` at `:501`.
+
+The 5-8 Buffer increments are repeated reads of managed internal arrays during
+the URLSearchParams shape/backing probes and subsequent generic method and
+prototype resolution. The varying count is address-window and cache-state
+dependent; all of the admitted managed addresses are already classifiable from
+GC metadata.
+
+The receiver's own property named `buffer` cannot require a Buffer registry
+question. The receiver is a tracked `GC_TYPE_OBJECT`; its property-name store
+is a tracked `GC_TYPE_ARRAY`; and the field value is the number `17`. The string
+`"buffer"` is only compared with the requested method name `"toString"`; the
+value is not loaded because the names do not match. A property spelling never
+changes either allocation's storage layout or GC type.
+
+## Complete byte-storage call audit on the cached-hit route
+
+- `canonicalize_bare_gc_receiver` returns at
+  `object/native_call_method/bare_receiver.rs:114-115` for this NaN-boxed
+  receiver. Consequently the calls to `is_registered_buffer`,
+  `is_uint8array_buffer`, and `lookup_typed_array_kind` at `:175-178` do not run.
+- The receiver classifier's `is_registered_buffer` and
+  `lookup_typed_array_kind` calls at `object/native_call_method.rs:170` and
+  `:174` do not run because the tracked header and cached `(site, GC type,
+  class id)` answer at `:151-160` succeeds.
+- The remaining calls that did run were the `js_array_get_f64` redispatches
+  identified above: old `array/indexing.rs:579` and `:586`. Their slow callees
+  are `typedarray/mod.rs:501` and `buffer/header.rs:532`, respectively.
+- `get_field_by_name_object_tail` has syntactic registry fallbacks at
+  `object/field_get_set/get_field_by_name_tail.rs:282` and `:453`, but its
+  tracked type at `:270-271` is `GC_TYPE_OBJECT`, so neither executes.
+- Date/Temporal/Promise defensive checks can call
+  `typedarray::is_offheap_sidetable_alloc`; that helper returns on the tracked
+  header at `typedarray/mod.rs:541-542`, before its
+  `lookup_typed_array_kind` / `is_registered_buffer` pair at `:544`.
+- The final Object brand derives `tracked_type` at
+  `object/to_string_tag.rs:158-160`. Its `is_registered_buffer` fallback at
+  `:208` and `lookup_typed_array_kind` fallback at `:245` both require
+  `tracked_type.is_none()`, so neither executes for the plain object.
+- `Object.prototype.toString` reads `@@toStringTag` with
+  `symbol::own_symbol_property` and `symbol::inherited_symbol_property`; those
+  helpers do not call a byte-storage registry. The general symbol getter's
+  Buffer/typed-array fallback is not used by this route.
+- No `is_uint8array_buffer` or `is_uint8array_buffer_slow` call executes on the
+  cached plain-object route. The only syntactic one in the entry funnel is the
+  unreachable bare-receiver call noted above.
+
+## Change
+
+`crates/perry-runtime/src/array/indexing.rs:584-600` now reads the resolved
+array address's allocator-tracked GC header once. A managed
+`GC_TYPE_TYPED_ARRAY` or `GC_TYPE_BUFFER` is dispatched directly from that
+type; every other tracked type is an authoritative negative. Only a
+tracked-header miss may consult the typed-array or Buffer side registry, which
+preserves headerless external Buffer, SAB backing, and native-view behavior.
+
+For the object's internal keys arrays, `tracked_type == GC_TYPE_ARRAY`, so both
+registry expressions short-circuit. The assertion and its fixture were not
+changed, and no temporary counters or caller instrumentation remain.
+
+## Verification
+
+Immediately before the Cargo decision:
+
+```text
+Filesystem     1G-blocks Used Available Capacity
+/dev/disk3s1s1       926   15         0    98%
+```
+
+This is below the binding 12 GB floor. No Cargo command was invoked and no wait
+for disk recovery was performed.
+
+Completed non-Cargo checks:
+
+```text
+rustfmt --edition 2021 crates/perry-runtime/src/array/indexing.rs — exit 0
+git diff --check — exit 0
+```
+
+`python3 scripts/addr_class_inventory.py` was also run. It failed on existing
+branch findings outside this patch: the frozen count in
+`object/to_string_tag.rs` is 11 versus 10, and
+`intl/segments_view.rs:101` has an allowlist-unregistered GcHeader cast. This
+patch changes only `array/indexing.rs` and introduced neither finding.
+
+Not run because of the disk gate:
+
+- `cargo test -p perry-runtime --release --lib -- --test-threads=1`
+- the archive feature-set build (`cargo build --release -p perry-runtime --features wasm-host`)
+- `cargo build --release -p perry`
+
+In particular, the post-fix exact test and full release suite were not run
+locally; verification here is static.

--- a/cc-perf-campaign/codex/REPORT_native_recv_fix3.md
+++ b/cc-perf-campaign/codex/REPORT_native_recv_fix3.md
@@ -1,0 +1,211 @@
+# Native-call receiver follow-up 3
+
+## Implementation
+
+- Code SHA: `6870b1db3eb85db3ae8c30fa6c79a814c162bcdc`
+- Branch: `fork/perf/native-call-receiver-class`
+- The code SHA was confirmed remotely with:
+
+  ```text
+  6870b1db3eb85db3ae8c30fa6c79a814c162bcdc	refs/heads/perf/native-call-receiver-class
+  ```
+
+## Exact remaining probe path
+
+At parent SHA `80c58182d`, the one remaining Buffer probe was the call at
+`crates/perry-runtime/src/object/map_set_subclass.rs:71`:
+
+```text
+buffer::header::is_registered_buffer
+  <- object::map_set_subclass::instance_object_ptr
+  <- object::native_call_method::collection_methods::dispatch_map_set
+  <- object::native_call_method::js_native_call_method_at_site
+  <- cached_plain_object_receiver_probes_zero_buffer_registries
+```
+
+`js_native_call_method_at_site` classified the receiver correctly and got a
+site-cache hit, but it then entered `dispatch_map_set` unconditionally.
+`dispatch_map_set` asked `subclass_backing_of`, whose `instance_object_ptr`
+excluded Map, Set, Buffer, and typed-array storage by querying all four side
+registries before trying to interpret the receiver as an ObjectHeader. Thus an
+allocator-tracked plain object paid exactly one Buffer-registry admission.
+
+The first `toString` call paid the same unconditional probe. The test snapshots
+the counters only after that first call, so the assertion exposed only the
+second call's identical +1 hit-path probe (`338` versus `337`), rather than two
+probes.
+
+There is no executed Buffer/typed-array registry call left on the tested
+cached-hit path. The residual source call is now
+`crates/perry-runtime/src/object/map_set_subclass.rs:81`, but it is reachable
+only after `try_read_tracked_gc_header` misses at `:67`. A tracked
+`GC_TYPE_OBJECT` returns directly from `instance_object_ptr` and never reaches
+that side-table fallback.
+
+## Complete byte-storage call audit on the cached plain-object `toString` path
+
+This is a static enumeration, cross-checked by the exact counter test.
+
+1. **Bare-receiver canonicalization.** The receiver is already NaN-boxed, so
+   `canonicalize_bare_gc_receiver` returns at
+   `object/native_call_method/bare_receiver.rs:114-115`. Its headerless-owner
+   probes (`is_registered_buffer`, `is_any_array_buffer`,
+   `is_uint8array_buffer`, and `lookup_typed_array_kind`) at `:175-178` are not
+   reached. Consequently neither `is_registered_buffer_slow` nor
+   `is_uint8array_buffer_slow` can be reached from this funnel.
+
+2. **Site-cache revalidation.** `classify_native_receiver` reads the
+   allocator-tracked header and `ObjectHeader.class_id` at
+   `object/native_call_method.rs:176-182`; `receiver_kind_cache_lookup` at
+   `:183` revalidates all of `(site_id, GC type, class id)`. The cache hit
+   returns `NativeReceiverClass::GcObject(class_id)`. The classifier's
+   `is_registered_buffer` and `lookup_typed_array_kind` calls at `:199` and the
+   following typed-array fallback execute only after a tracked-header miss, so
+   the cache revalidation itself performs no registry probe.
+
+3. **Class-vtable fast guard.** `class_vtable_fast_guard_classified` consumes
+   the already-computed receiver class at `native_call_method.rs:282-320`; it
+   does not reclassify. This fixture has class id zero, so it returns at
+   `:318-319`, before the own-key scan. There is no Buffer or typed-array call
+   in this guard.
+
+4. **Early dispatch and handle checks.** The only typed-array registry call in
+   `dispatch_primitive` is the raw, untagged-pointer arm at
+   `object/native_call_method/primitive_methods.rs:907-926`; a NaN-boxed object
+   cannot enter it. `dispatch_handle` at
+   `object/native_call_method/handle_methods.rs:55-171` now selects its Buffer
+   and typed-array arms solely from `NativeReceiverClass`; `GcObject(0)` selects
+   neither. `dispatch_raw_pointer` likewise rejects a NaN-boxed receiver at
+   `object/native_call_method/collection_methods.rs:350`. The Buffer calls in
+   `common_methods.rs:143` and `:268` belong only to the `hasOwnProperty` and
+   `propertyIsEnumerable` match arms; the requested method is `toString`.
+
+5. **Map/Set dispatch (the measured defect).** The boundary preserves class id
+   in `GcObject(u32)`. At `native_call_method.rs:2166`,
+   `may_dispatch_map_set` checks the tracked class ancestry first. For this
+   receiver `is_map_set_subclass_class_id(0)` returns false at
+   `object/map_set_subclass.rs:97-98`, so `dispatch_map_set` is not entered.
+   Genuine `GC_TYPE_MAP`/`GC_TYPE_SET`, class ids descending from the reserved
+   Map/Set ids, and legacy headerless pointers retain their respective paths.
+   Inside the subclass unwrap, tracked headers are authoritative at
+   `map_set_subclass.rs:67-75`; its Map/Set/Buffer/typed side-table sequence at
+   `:79-82` is now only the tracked-header-miss fallback.
+
+6. **Own-method lookup.** The object has one own key, `buffer`, so the method
+   scan calls `js_array_get` for its internal keys array at
+   `native_call_method.rs:2416`. `js_array_get_f64` classifies the resolved
+   internal array from its tracked header at `array/indexing.rs:584-600`.
+   Its `lookup_typed_array_kind` and `is_registered_buffer` expressions at
+   `:591` and `:600` require a tracked-header miss; `GC_TYPE_ARRAY` therefore
+   executes neither. The spelling `buffer` is only compared with `toString`;
+   it cannot change the storage class.
+
+7. **Prototype method lookup.** `resolve_inherited_field` at
+   `native_call_method.rs:2459` first checks the recorded per-object prototype;
+   the fixture has none. `ordinary_object_prototype_property_value` at `:2467`
+   then obtains the cached Object.prototype address and reads `toString` through
+   `js_object_get_field_by_name` (`field_get_set/accessors.rs:203-212` and
+   `:219-272`). A field IC hit bypasses the object tail. On an IC miss, the tail
+   reads Object.prototype's tracked header at
+   `field_get_set/get_field_by_name_tail.rs:270-271`; its Buffer fallback at
+   `:282` and typed-array lookup at `:453` both require no tracked header and do
+   not run for Object.prototype's `GC_TYPE_OBJECT` allocation. No
+   `is_array_buffer`, `is_shared_array_buffer`, or Uint8Array probe is reached
+   because the enclosing `is_buffer` branch is false.
+
+8. **Built-in thunk and brand derivation.** The resolved built-in is
+   `object_prototype_to_string_thunk` at
+   `object/global_this/array_error.rs:175-185`, which calls
+   `js_object_to_string`. Brand derivation reads the receiver's tracked GC type
+   at `object/to_string_tag.rs:158-160`. Its Buffer fallback at `:205-208` and
+   typed-array lookup at `:242-247` are restricted to `tracked_type.is_none()`.
+   Because the plain receiver is `GC_TYPE_OBJECT`, `is_array_buffer` and
+   `is_shared_array_buffer` at `:212-215` are also unreachable inside the false
+   Buffer branch. `@@toStringTag` lookup uses symbol property/prototype tables,
+   not any byte-storage registry. The final `[object Object]` construction at
+   `:470-476` calls only `js_string_from_bytes` and has no registry probe.
+
+The private `lookup_registered_typed_array_kind` slow lookup is reachable only
+through `lookup_typed_array_kind`; every such call named above is skipped for
+the tracked plain receiver. Likewise the Buffer and Uint8Array slow functions
+are reachable only through their public admission functions, none of which
+executes on this path.
+
+## Change
+
+- `NativeReceiverClass` now retains `ObjectHeader.class_id` as
+  `GcObject(u32)`, including on a site-cache hit.
+- `dispatch_map_set` is called only for real Map/Set GC types, class ids whose
+  parent chain reaches Map/Set, or the residual headerless pointer class.
+  Tracked subclass instances may unwrap their hidden backing; a tracked object
+  with no backing cannot fall into raw collection registries.
+- `instance_object_ptr` now classifies allocator-tracked storage first and
+  consults the legacy Map/Set/Buffer/typed registries only after a tracked-header
+  miss.
+- The neighboring hot `set_prototype_of -> get_prototype_of -> is_node_buffer`
+  route received the same treatment at `buffer/exotic_view.rs:76-84`: a tracked
+  header answers Buffer identity, and `is_registered_buffer` is only the
+  headerless fallback. A tracked plain object short-circuits before the
+  ArrayBuffer/DataView/Uint8Array subtype checks.
+- The assertion and fixture were not changed.
+
+## Verification
+
+Final-tree checks:
+
+```text
+cargo test -j4 -p perry-runtime --release --lib \
+  object::native_call_method::receiver_class_tests::cached_plain_object_receiver_probes_zero_buffer_registries \
+  -- --exact --test-threads=1
+  PASS: 1 passed; 0 failed; 3267 filtered out
+
+direct rebuilt test binary: object::native_call_method::receiver_class_tests
+  PASS: 6 passed; 0 failed
+direct rebuilt test binary: object::map_set_subclass::tests
+  PASS: 4 passed; 0 failed
+direct rebuilt test binary: buffer::exotic_view_tests
+  PASS: 17 passed; 0 failed
+
+cargo build -j4 --release -p perry-runtime --features wasm-host
+  PASS
+
+rustfmt --edition 2021 (four changed Rust files)
+  PASS
+git diff --check
+  PASS
+```
+
+All Cargo invocations above ran through
+`/Users/amlug/projects/perry/secret-tests/cc-perf-campaign/measure_lock.sh --build`.
+Disk checks showed 25 GB free before the final exact test and 15 GB before the
+final archive feature build.
+
+The full single-threaded runtime suite was attempted before the last
+compatibility-preserving adjustment to the headerless fallback. It exited 101
+with SIGSEGV in
+`async_hooks::test_support::tests::native_async_resource_accepts_string_and_symbol_expandos`,
+before reaching the receiver-class tests. That async-hooks test passed 1/1 when
+rerun exactly, so the failure is order/global-state sensitive rather than a
+failure of the changed path. The final-tree exact and focused tests listed
+above passed.
+
+A preliminary `cargo build -j4 --release -p perry` passed before that final
+fallback adjustment. Immediately before a final-tree rerun, the mandatory disk
+check was:
+
+```text
+Filesystem     1G-blocks Used Available Capacity
+/dev/disk3s1s1       926   15        11    58%
+```
+
+Because 11 GB is below the binding 12 GB floor, no further Cargo command was
+invoked and no wait for disk recovery was performed. Thus the full suite and
+top-level `perry` build did not complete as final-tree gates.
+
+`python3 scripts/addr_class_inventory.py` was run and failed only on existing
+branch findings outside this patch: `object/to_string_tag.rs` has 11 frozen
+handle-floor sites versus 10 allowed, and `intl/segments_view.rs:101` has an
+allowlist-unregistered GcHeader cast. `scripts/check_file_size.sh` likewise
+reported the existing 2004-line
+`object/field_get_set/get_field_by_name_tail.rs`. This patch changes none of
+those files.

--- a/changelog.d/native-call-receiver-class.md
+++ b/changelog.d/native-call-receiver-class.md
@@ -1,0 +1,4 @@
+### Performance
+
+- Native method dispatch now classifies managed receivers from their NaN-box tag and allocator-proven GC type instead of consulting the Buffer and typed-array registries for every call. Typed-feedback sites retain a small class/type cache, while external buffers, shared backings, and headerless native typed views keep registry fallback semantics.
+- `Intl.Segmenter` view entry points validate their fixed cursor brand with an arena/type/class-id load, and the RegExp view test no longer repeats a pointer validation already performed at the exported boundary.

--- a/crates/perry-runtime/src/array/indexing.rs
+++ b/crates/perry-runtime/src/array/indexing.rs
@@ -575,15 +575,30 @@ pub extern "C" fn js_array_get_f64(arr: *const ArrayHeader, index: u32) -> f64 {
         return f64::NAN;
     }
     let arr = cleaned;
-    // Check if this is actually a TypedArray — dispatch through typed array helper
-    if crate::typedarray::lookup_typed_array_kind(arr as usize).is_some() {
+    // `clean_arr_ptr` has already resolved the live receiver. Classify that
+    // address from allocator-owned metadata before asking either byte-storage
+    // side table: an internal keys array remains GC_TYPE_ARRAY no matter what
+    // property names it stores (including an own key spelled `buffer`). Only a
+    // tracked-header miss can be one of the legacy/headerless layouts whose
+    // identity lives exclusively in a registry.
+    let tracked_type = unsafe {
+        crate::value::addr_class::try_read_tracked_gc_header(arr as usize)
+            .map(|header| (*header.as_ptr()).obj_type)
+    };
+    // Check if this is actually a TypedArray — dispatch through typed array helper.
+    let is_typed_array = tracked_type == Some(crate::gc::GC_TYPE_TYPED_ARRAY)
+        || (tracked_type.is_none()
+            && crate::typedarray::lookup_typed_array_kind(arr as usize).is_some());
+    if is_typed_array {
         return crate::typedarray::js_typed_array_get(
             arr as *const crate::typedarray::TypedArrayHeader,
             index as i32,
         );
     }
     // Check if this is actually a buffer (Uint8Array) — read individual bytes
-    if crate::buffer::is_registered_buffer(arr as usize) {
+    let is_buffer = tracked_type == Some(crate::gc::GC_TYPE_BUFFER)
+        || (tracked_type.is_none() && crate::buffer::is_registered_buffer(arr as usize));
+    if is_buffer {
         let byte_val =
             crate::buffer::js_buffer_get(arr as *const crate::buffer::BufferHeader, index as i32);
         return byte_val as f64;

--- a/crates/perry-runtime/src/buffer/exotic_view.rs
+++ b/crates/perry-runtime/src/buffer/exotic_view.rs
@@ -74,7 +74,11 @@ pub fn is_non_indexed_buffer_view(addr: usize) -> bool {
 /// because none of them carries the Uint8Array-constructor marker.
 #[inline]
 pub fn is_node_buffer(addr: usize) -> bool {
-    super::is_registered_buffer(addr)
+    let registered = match unsafe { crate::value::addr_class::try_read_tracked_gc_header(addr) } {
+        Some(header) => unsafe { (*header.as_ptr()).obj_type == crate::gc::GC_TYPE_BUFFER },
+        None => super::is_registered_buffer(addr),
+    };
+    registered
         && !super::is_any_array_buffer(addr)
         && !super::is_data_view(addr)
         && !super::is_uint8array_buffer(addr)

--- a/crates/perry-runtime/src/buffer/mod.rs
+++ b/crates/perry-runtime/src/buffer/mod.rs
@@ -57,10 +57,10 @@ pub use header::{
     asymmetric_key_meta, buffer_ab_alias, buffer_alloc, buffer_backing_array_buffer,
     buffer_byte_offset, buffer_data, buffer_data_mut, crypto_key_meta, ensure_buffer_ab_alias,
     is_any_array_buffer, is_array_buffer, is_data_view, is_registered_buffer, is_secret_key,
-    is_shared_array_buffer, is_uint8array_buffer, js_set_crypto_key_death_hook,
-    mark_as_array_buffer, mark_as_asymmetric_key, mark_as_crypto_key, mark_as_data_view,
-    mark_as_secret_key, mark_as_shared_array_buffer, mark_as_uint8array, register_buffer,
-    resolve_buffer_ab_alias, set_buffer_ab_alias, CryptoKeyDeathHookFn,
+    is_shared_array_buffer, is_uint8array_buffer, js_buffer_register_external,
+    js_set_crypto_key_death_hook, mark_as_array_buffer, mark_as_asymmetric_key, mark_as_crypto_key,
+    mark_as_data_view, mark_as_secret_key, mark_as_shared_array_buffer, mark_as_uint8array,
+    register_buffer, resolve_buffer_ab_alias, set_buffer_ab_alias, CryptoKeyDeathHookFn,
 };
 pub(crate) use header::{
     buffer_alloc_foreign, collect_dead_registered_buffers_post_trace,

--- a/crates/perry-runtime/src/hot_diag.rs
+++ b/crates/perry-runtime/src/hot_diag.rs
@@ -1075,6 +1075,37 @@ static BUF_REGS: AtomicU64 = AtomicU64::new(0);
 static BUF_UNREGS: AtomicU64 = AtomicU64::new(0);
 static BUF_LIVE_MAX: AtomicUsize = AtomicUsize::new(0);
 
+#[derive(Clone, Copy)]
+pub(crate) enum NativeProbeCaller {
+    NativeReceiver,
+    ViewCursor,
+    ObjectStaticPrototype,
+    ObjectFieldByName,
+    ObjectFieldTail,
+    DispatchPrimitive,
+    Other,
+}
+
+const NATIVE_PROBE_CALLERS: usize = 7;
+static NATIVE_BUFFER_PROBES: [AtomicU64; NATIVE_PROBE_CALLERS] =
+    [const { AtomicU64::new(0) }; NATIVE_PROBE_CALLERS];
+static NATIVE_TYPED_ARRAY_PROBES: [AtomicU64; NATIVE_PROBE_CALLERS] =
+    [const { AtomicU64::new(0) }; NATIVE_PROBE_CALLERS];
+
+#[inline]
+pub(crate) fn native_note_buffer_probe(caller: NativeProbeCaller) {
+    if buffer_on() {
+        NATIVE_BUFFER_PROBES[caller as usize].fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+#[inline]
+pub(crate) fn native_note_typed_array_probe(caller: NativeProbeCaller) {
+    if buffer_on() {
+        NATIVE_TYPED_ARRAY_PROBES[caller as usize].fetch_add(1, Ordering::Relaxed);
+    }
+}
+
 /// One `is_registered_buffer` probe that got past the "ever registered" latch.
 /// `admitted` is what the inline min/max window answered — the whole question,
 /// because only an admitted address pays the out-of-line call.
@@ -1147,6 +1178,22 @@ fn buffer_dump() {
         probes - admits,
         pct(probes - admits, probes),
         pct(tp, admits)
+    );
+    let b =
+        |caller: NativeProbeCaller| NATIVE_BUFFER_PROBES[caller as usize].load(Ordering::Relaxed);
+    let t = |caller: NativeProbeCaller| {
+        NATIVE_TYPED_ARRAY_PROBES[caller as usize].load(Ordering::Relaxed)
+    };
+    let _ = writeln!(
+        out,
+        "[native-call-diag] buffer native_receiver={} view_cursor={} object_static_prototype={} field_by_name={} field_tail={} dispatch_primitive={} other={} typed_array native_receiver={} view_cursor={} object_static_prototype={} field_by_name={} field_tail={} dispatch_primitive={} other={}",
+        b(NativeProbeCaller::NativeReceiver), b(NativeProbeCaller::ViewCursor),
+        b(NativeProbeCaller::ObjectStaticPrototype), b(NativeProbeCaller::ObjectFieldByName),
+        b(NativeProbeCaller::ObjectFieldTail), b(NativeProbeCaller::DispatchPrimitive),
+        b(NativeProbeCaller::Other), t(NativeProbeCaller::NativeReceiver),
+        t(NativeProbeCaller::ViewCursor), t(NativeProbeCaller::ObjectStaticPrototype),
+        t(NativeProbeCaller::ObjectFieldByName), t(NativeProbeCaller::ObjectFieldTail),
+        t(NativeProbeCaller::DispatchPrimitive), t(NativeProbeCaller::Other),
     );
     let _ = writeln!(
         out,

--- a/crates/perry-runtime/src/intl/segments_view.rs
+++ b/crates/perry-runtime/src/intl/segments_view.rs
@@ -86,7 +86,7 @@ fn counters() -> [u64; 4] {
 
 #[inline(always)]
 fn cursor_ptr(value: f64) -> Option<*mut ObjectHeader> {
-    let obj = unsafe { crate::object::object_ptr_from_value(value) }? as *mut ObjectHeader;
+    let obj = unsafe { crate::object::object_ptr_from_value_for_view(value) }? as *mut ObjectHeader;
     if unsafe { (*obj).class_id } != SEGMENTS_CURSOR_CLASS_ID {
         return None;
     }

--- a/crates/perry-runtime/src/intl/segments_view.rs
+++ b/crates/perry-runtime/src/intl/segments_view.rs
@@ -86,11 +86,26 @@ fn counters() -> [u64; 4] {
 
 #[inline(always)]
 fn cursor_ptr(value: f64) -> Option<*mut ObjectHeader> {
-    let obj = unsafe { crate::object::object_ptr_from_value_for_view(value) }? as *mut ObjectHeader;
-    if unsafe { (*obj).class_id } != SEGMENTS_CURSOR_CLASS_ID {
+    let jv = JSValue::from_bits(value.to_bits());
+    if !jv.is_pointer() {
         return None;
     }
-    Some(obj)
+    let obj = jv.as_pointer::<ObjectHeader>();
+    let addr = obj as usize;
+    if !crate::value::addr_class::is_above_handle_band(addr)
+        || crate::arena::classify_heap_generation(addr) == crate::arena::HeapGeneration::Unknown
+    {
+        return None;
+    }
+    let header =
+        unsafe { (obj as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader };
+    if unsafe {
+        (*header).obj_type != crate::gc::GC_TYPE_OBJECT
+            || (*obj).class_id != SEGMENTS_CURSOR_CLASS_ID
+    } {
+        return None;
+    }
+    Some(obj as *mut ObjectHeader)
 }
 
 #[inline(always)]
@@ -774,6 +789,62 @@ mod view_mode_tests {
         // once in a process, so the per-process total counts REALMS, not calls.
         // The property that matters — and the one that fails if the fast path
         // stops being taken — is the delta above.
+    }
+
+    /// Sabotage case three: the fixed cursor class id is the entire per-call
+    /// brand check. With both byte-storage registries armed, a valid cursor
+    /// advances without entering either. Changing only its class id must make
+    /// the next call decline, proving the compare is load-bearing.
+    #[test]
+    fn view_cursor_brand_is_a_class_load_with_zero_registry_probes() {
+        let _buffer = crate::buffer::js_buffer_alloc(1, 0);
+        let _typed =
+            crate::typedarray::js_typed_array_new_empty(crate::typedarray::KIND_INT16 as i32, 1);
+        let cursor = js_segments_view_open(grapheme_segmenter(), js_string("ab"));
+        let c = cursor_ptr(cursor).expect("test premise: open returned a cursor");
+        let buffer_before = crate::buffer::test_buffer_registry_probe_count();
+        let typed_before = crate::typedarray::test_typed_array_registry_probe_count();
+
+        assert_eq!(js_segments_view_next(cursor), 1.0);
+        assert_eq!(
+            crate::buffer::test_buffer_registry_probe_count(),
+            buffer_before,
+            "view cursor validation must not enter the Buffer registry"
+        );
+        assert_eq!(
+            crate::typedarray::test_typed_array_registry_probe_count(),
+            typed_before,
+            "view cursor validation must not enter the typed-array registry"
+        );
+
+        let saved = unsafe { (*c).class_id };
+        unsafe { (*c).class_id = saved ^ 1 };
+        assert_eq!(
+            js_segments_view_next(cursor),
+            0.0,
+            "sabotage: a wrong class id must be rejected by the next entry"
+        );
+        unsafe { (*c).class_id = saved };
+        assert_eq!(js_segments_view_next(cursor), 1.0);
+    }
+
+    /// The view entry validates its RegExp argument once. Restoring the inner
+    /// helper's duplicate validation makes this delta two; deleting the entry
+    /// validation makes it zero.
+    #[cfg(feature = "regex-engine")]
+    #[test]
+    fn view_regexp_pointer_is_validated_exactly_once_per_call() {
+        let cursor = js_segments_view_open(grapheme_segmenter(), js_string("a"));
+        assert_eq!(js_segments_view_next(cursor), 1.0);
+        let re = crate::regex::js_regexp_construct(js_string("a"), js_string(""));
+        let regex = f64::from_bits(JSValue::pointer(re as *const u8).bits());
+        let before = crate::regex::test_regex_ptr_validation_calls();
+        assert!(!is_undefined(js_segments_view_regexp_test(cursor, regex)));
+        assert_eq!(
+            crate::regex::test_regex_ptr_validation_calls() - before,
+            1,
+            "one exported call must perform exactly one RegExp brand validation"
+        );
     }
 
     /// SABOTAGE-SHAPED, kept as a test: patching `RegExp.prototype.test` AFTER

--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
@@ -643,10 +643,9 @@ pub extern "C" fn js_object_get_field_by_name(
                 {
                     return JSValue::from_bits(value.to_bits());
                 }
-                crate::hot_diag::native_note_typed_array_probe(
-                    crate::hot_diag::NativeProbeCaller::ObjectFieldByName,
-                );
-                if let Some(kind) = crate::typedarray::lookup_typed_array_kind(addr) {
+                if let Some(kind) =
+                    crate::typedarray_props::managed_or_registered_typed_array_kind(addr)
+                {
                     let elem_size = crate::typedarray::elem_size_for_kind(kind);
                     match key_bytes {
                         b"length" => {
@@ -1569,16 +1568,12 @@ pub extern "C" fn js_object_get_field_by_name(
         if crate::value::addr_class::is_plausible_heap_addr(raw) && !key.is_null() {
             {
                 unsafe {
-                    let gc_header = (raw - crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
-                    // Buffers / typed arrays are `std::alloc`-backed and carry
-                    // NO GcHeader, so the byte at `raw - 8` is unrelated memory
-                    // that can read as `GC_TYPE_PROMISE` (5) by coincidence on
-                    // an IC-miss read. Exclude them before acting — otherwise a
-                    // genuine buffer metadata read would early-return undefined.
-                    if (*gc_header).obj_type == crate::gc::GC_TYPE_PROMISE
-                        && !crate::buffer::is_registered_buffer(raw)
-                        && crate::typedarray::lookup_typed_array_kind(raw).is_none()
-                    {
+                    // Allocator membership proves the header before the type
+                    // load. Headerless Buffer/typed cells return `None`, while
+                    // a managed Promise is authoritative from its GC type.
+                    if crate::value::addr_class::try_read_tracked_gc_header(raw).is_some_and(
+                        |header| (*header.as_ptr()).obj_type == crate::gc::GC_TYPE_PROMISE,
+                    ) {
                         let name_ptr =
                             (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
                         let name_len = (*key).byte_len as usize;

--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
@@ -643,6 +643,9 @@ pub extern "C" fn js_object_get_field_by_name(
                 {
                     return JSValue::from_bits(value.to_bits());
                 }
+                crate::hot_diag::native_note_typed_array_probe(
+                    crate::hot_diag::NativeProbeCaller::ObjectFieldByName,
+                );
                 if let Some(kind) = crate::typedarray::lookup_typed_array_kind(addr) {
                     let elem_size = crate::typedarray::elem_size_for_kind(kind);
                     match key_bytes {

--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
@@ -267,16 +267,21 @@ pub(crate) fn get_field_by_name_object_tail(
         if let Some(val) = closure_dynamic_prop_by_key(obj as usize, key) {
             return JSValue::from_bits(val.to_bits());
         }
-        // Buffers: BufferHeader is allocated via raw `alloc()` (no GcHeader)
-        // and tracked in BUFFER_REGISTRY. Detect first so the GC header check
-        // below doesn't read garbage one word before the BufferHeader.
+        let tracked_header = crate::value::addr_class::try_read_tracked_gc_header(obj as usize);
+        let tracked_type = tracked_header.map(|header| (*header.as_ptr()).obj_type);
+        // Managed Buffer cells are authoritative from GC_TYPE_BUFFER. Only an
+        // external/SAB headerless cell reaches the address registry.
         // Route `.length` to `js_buffer_length` (matches the codegen path that
         // routes through PropertyGet for chained `Buffer.from(...).length`
         // expressions where the static type isn't recognized as Buffer).
-        crate::hot_diag::native_note_buffer_probe(
-            crate::hot_diag::NativeProbeCaller::ObjectFieldTail,
-        );
-        if crate::buffer::is_registered_buffer(obj as usize) {
+        let is_buffer = tracked_type == Some(crate::gc::GC_TYPE_BUFFER)
+            || (tracked_type.is_none() && {
+                crate::hot_diag::native_note_buffer_probe(
+                    crate::hot_diag::NativeProbeCaller::ObjectFieldTail,
+                );
+                crate::buffer::is_registered_buffer(obj as usize)
+            });
+        if is_buffer {
             if !key.is_null() {
                 let key_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
                 let key_len = (*key).byte_len as usize;
@@ -432,19 +437,24 @@ pub(crate) fn get_field_by_name_object_tail(
             }
             return JSValue::undefined();
         }
-        // Typed arrays (Int32Array/Float64Array/...): the `TypedArrayHeader` is
-        // `std::alloc`'d (small) or GC-old-allocated (large), but in both cases
-        // tracked in TYPED_ARRAY_REGISTRY, so detect via the side table before
-        // the GC-header read below (which would read garbage for the small
-        // `std::alloc` case). `.length`, `.byteLength`, `.byteOffset`, and
+        // Managed typed arrays carry GC_TYPE_TYPED_ARRAY and the element kind
+        // in their payload. Only a headerless native view needs the side table.
+        // `.length`, `.byteLength`, `.byteOffset`, and
         // `.BYTES_PER_ELEMENT` lower as generic PropertyGet for multi-byte
         // numeric-length views whose static type the codegen doesn't recognize;
         // pre-fix, only Uint8Array worked (it's a registered buffer) so
         // multi-byte `.byteLength` returned undefined.
-        crate::hot_diag::native_note_typed_array_probe(
-            crate::hot_diag::NativeProbeCaller::ObjectFieldTail,
-        );
-        if let Some(kind) = crate::typedarray::lookup_typed_array_kind(obj as usize) {
+        let typed_kind = if tracked_type == Some(crate::gc::GC_TYPE_TYPED_ARRAY) {
+            Some((*(obj as *const crate::typedarray::TypedArrayHeader)).kind)
+        } else if tracked_type.is_none() {
+            crate::hot_diag::native_note_typed_array_probe(
+                crate::hot_diag::NativeProbeCaller::ObjectFieldTail,
+            );
+            crate::typedarray::lookup_typed_array_kind(obj as usize)
+        } else {
+            None
+        };
+        if let Some(kind) = typed_kind {
             if !key.is_null() {
                 let key_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
                 let key_len = (*key).byte_len as usize;
@@ -509,18 +519,13 @@ pub(crate) fn get_field_by_name_object_tail(
             }
         }
 
-        // Buffer and TypedArray were the two headerless allocations that had
-        // to be classified first. A possible headerless Symbol returned above;
-        // every remaining supported receiver can now be classified once by
-        // the GcHeader the rest of this function already switches on.
-        if (obj as usize) < crate::gc::GC_HEADER_SIZE + 0x1000
-            || !is_valid_obj_ptr(obj as *const u8)
-        {
+        // A possible headerless Symbol returned above. Every remaining
+        // supported receiver must have the allocator-proven header already
+        // resolved once above.
+        let Some(gc_header) = tracked_header else {
             return JSValue::undefined();
-        }
-        let gc_header =
-            (obj as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
-        let gc_type = (*gc_header).obj_type;
+        };
+        let gc_type = (*gc_header.as_ptr()).obj_type;
 
         // Sets are arena_alloc_gc(_, _, GC_TYPE_SET) allocations. Let the
         // header rule every other receiver out before entering SET_REGISTRY;
@@ -1532,7 +1537,7 @@ pub(crate) fn get_field_by_name_object_tail(
         // Gate-neutral builtin accessors mark only their owning object. Consult
         // the descriptor table before an accessor's empty backing slot is read;
         // unrelated objects pay only this already-loaded header-bit test.
-        if (*gc_header)._reserved & crate::gc::OBJ_FLAG_HAS_DESCRIPTORS != 0 {
+        if (*gc_header.as_ptr())._reserved & crate::gc::OBJ_FLAG_HAS_DESCRIPTORS != 0 {
             if let Some(v) = builtin_reflection_accessor_read(obj, key_bytes) {
                 return v;
             }

--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
@@ -273,6 +273,9 @@ pub(crate) fn get_field_by_name_object_tail(
         // Route `.length` to `js_buffer_length` (matches the codegen path that
         // routes through PropertyGet for chained `Buffer.from(...).length`
         // expressions where the static type isn't recognized as Buffer).
+        crate::hot_diag::native_note_buffer_probe(
+            crate::hot_diag::NativeProbeCaller::ObjectFieldTail,
+        );
         if crate::buffer::is_registered_buffer(obj as usize) {
             if !key.is_null() {
                 let key_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
@@ -438,6 +441,9 @@ pub(crate) fn get_field_by_name_object_tail(
         // numeric-length views whose static type the codegen doesn't recognize;
         // pre-fix, only Uint8Array worked (it's a registered buffer) so
         // multi-byte `.byteLength` returned undefined.
+        crate::hot_diag::native_note_typed_array_probe(
+            crate::hot_diag::NativeProbeCaller::ObjectFieldTail,
+        );
         if let Some(kind) = crate::typedarray::lookup_typed_array_kind(obj as usize) {
             if !key.is_null() {
                 let key_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());

--- a/crates/perry-runtime/src/object/field_get_set/ic_miss.rs
+++ b/crates/perry-runtime/src/object/field_get_set/ic_miss.rs
@@ -683,17 +683,24 @@ pub extern "C" fn js_object_get_field_ic_miss(
                 }
                 return val;
             }
-            // Buffers have no GcHeader. The generic IC-miss object path below may
-            // inspect GC/object metadata, so mirror js_object_get_field_by_name's
-            // buffer-first dispatch here.
-            if crate::buffer::is_registered_buffer(obj as usize) {
+            // Managed Buffer/TypedArray cells are authoritative from their
+            // allocator-proven header. Only headerless external/SAB/native
+            // view storage reaches the address registries.
+            let tracked_type = crate::value::addr_class::try_read_tracked_gc_header(obj as usize)
+                .map(|header| (*header.as_ptr()).obj_type);
+            let is_buffer = tracked_type == Some(crate::gc::GC_TYPE_BUFFER)
+                || (tracked_type.is_none() && crate::buffer::is_registered_buffer(obj as usize));
+            if is_buffer {
                 if diag {
                     ic_diag_note(cache_slot, key, R::Buffer);
                 }
                 let value = js_object_get_field_by_name(obj, key);
                 return f64::from_bits(value.bits());
             }
-            if crate::typedarray::lookup_typed_array_kind(obj as usize).is_some() {
+            let is_typed_array = tracked_type == Some(crate::gc::GC_TYPE_TYPED_ARRAY)
+                || (tracked_type.is_none()
+                    && crate::typedarray::lookup_typed_array_kind(obj as usize).is_some());
+            if is_typed_array {
                 if diag {
                     ic_diag_note(cache_slot, key, R::TypedArray);
                 }

--- a/crates/perry-runtime/src/object/map_set_subclass.rs
+++ b/crates/perry-runtime/src/object/map_set_subclass.rs
@@ -60,12 +60,22 @@ unsafe fn instance_object_ptr(this: f64) -> Option<*mut ObjectHeader> {
     if raw < crate::gc::GC_HEADER_SIZE + 0x1000 {
         return None;
     }
-    // `this` can be a raw, header-less collection/buffer handle (a real Map/Set,
-    // a Buffer, or a typed array) when this runs before raw collection dispatch.
-    // Those allocations carry no `GcHeader`, so reading `raw - GC_HEADER_SIZE`
-    // would crash or misclassify allocator metadata. Magnitude-classify the
-    // address (rejecting the handle band + slab allocations) before any header
-    // read, and reject registered non-object collections outright.
+    // A tracked header is authoritative: only GC_TYPE_OBJECT has an
+    // ObjectHeader at `raw`. In particular, an ordinary object must not enter
+    // the Buffer / typed-array registries merely because this helper also sees
+    // headerless Map/Set receivers on other routes.
+    match crate::value::addr_class::try_read_tracked_gc_header(raw) {
+        Some(header) => {
+            if (*header.as_ptr()).obj_type != crate::gc::GC_TYPE_OBJECT {
+                return None;
+            }
+            return Some(raw as *mut ObjectHeader);
+        }
+        None => {}
+    }
+    // Preserve the legacy plausible-address fallback for allocations not yet
+    // represented in allocator metadata, but only after excluding every
+    // headerless/native storage class through its authoritative side table.
     if crate::map::is_registered_map(raw)
         || crate::set::is_registered_set(raw)
         || crate::buffer::is_registered_buffer(raw)
@@ -74,10 +84,28 @@ unsafe fn instance_object_ptr(this: f64) -> Option<*mut ObjectHeader> {
         return None;
     }
     let header = crate::value::addr_class::try_read_gc_header(raw)?;
-    if header.obj_type != crate::gc::GC_TYPE_OBJECT {
-        return None;
+    (header.obj_type == crate::gc::GC_TYPE_OBJECT).then_some(raw as *mut ObjectHeader)
+}
+
+/// Whether a tracked `GC_TYPE_OBJECT` class can be a `Map`/`Set` subclass.
+/// Real Map/Set cells carry `GC_TYPE_MAP` / `GC_TYPE_SET` and never use this
+/// predicate.
+#[inline]
+pub(crate) fn is_map_set_subclass_class_id(class_id: u32) -> bool {
+    const CLASS_ID_MAP: u32 = 0xFFFF_0022;
+    const CLASS_ID_SET: u32 = 0xFFFF_0023;
+    if class_id == 0 {
+        return false;
     }
-    Some(raw as *mut ObjectHeader)
+    let mut current = class_id;
+    for _ in 0..64 {
+        match crate::object::get_parent_class_id(current) {
+            Some(parent) if matches!(parent, CLASS_ID_MAP | CLASS_ID_SET) => return true,
+            Some(parent) if parent != 0 && parent != current => current = parent,
+            _ => return false,
+        }
+    }
+    false
 }
 
 /// If `value` is a Map/Set *subclass instance* (a plain object carrying the

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -129,7 +129,8 @@ unsafe fn class_vtable_fast_guard(object: f64, method_bytes: &[u8]) -> Option<(u
     // first — and it is the same screen the tower's own object-pointer
     // resolution uses, so the fast path cannot classify a receiver differently
     // from the code it is short-circuiting.
-    let (ptr, gc_type) = gc_pointer_and_type_from_value(object)?;
+    let (ptr, gc_type) =
+        gc_pointer_and_type_from_value(object, crate::hot_diag::NativeProbeCaller::NativeReceiver)?;
     if gc_type != crate::gc::GC_TYPE_OBJECT || ptr as usize != obj_addr {
         return None;
     }
@@ -137,6 +138,7 @@ unsafe fn class_vtable_fast_guard(object: f64, method_bytes: &[u8]) -> Option<(u
     // classifier `may_have_descriptor_entry` and `object_static_prototype` use,
     // so a `Some` here means both of those answer authoritatively from the meta
     // slot rather than falling back to a conservative `true`.
+    crate::hot_diag::native_note_buffer_probe(crate::hot_diag::NativeProbeCaller::NativeReceiver);
     let obj = super::prototype_chain::meta_capable_object(obj_addr)?;
     if !crate::object::object_is_regular(obj) {
         return None;
@@ -1021,7 +1023,10 @@ fn throw_object_to_string_not_function() -> ! {
 }
 
 #[inline]
-unsafe fn gc_pointer_and_type_from_value(value: f64) -> Option<(*const u8, u8)> {
+unsafe fn gc_pointer_and_type_from_value(
+    value: f64,
+    probe_caller: crate::hot_diag::NativeProbeCaller,
+) -> Option<(*const u8, u8)> {
     let jsval = JSValue::from_bits(value.to_bits());
     let ptr = if jsval.is_pointer() {
         jsval.as_pointer::<u8>()
@@ -1037,12 +1042,15 @@ unsafe fn gc_pointer_and_type_from_value(value: f64) -> Option<(*const u8, u8)> 
         return None;
     }
     let addr = ptr as usize;
+    crate::hot_diag::native_note_buffer_probe(probe_caller);
     if crate::buffer::is_any_array_buffer(addr) {
         return Some((ptr, crate::gc::GC_TYPE_BUFFER));
     }
+    crate::hot_diag::native_note_buffer_probe(probe_caller);
     if crate::buffer::is_uint8array_buffer(addr) {
         return Some((ptr, crate::gc::GC_TYPE_BUFFER));
     }
+    crate::hot_diag::native_note_typed_array_probe(probe_caller);
     if crate::typedarray::lookup_typed_array_kind(addr).is_some() {
         return Some((ptr, crate::gc::GC_TYPE_TYPED_ARRAY));
     }
@@ -1098,12 +1106,25 @@ unsafe fn gc_pointer_and_type_from_value(value: f64) -> Option<(*const u8, u8)> 
 /// receiver is still classified the same way it was before the re-ordering.
 #[cfg(test)]
 pub(crate) unsafe fn test_gc_pointer_and_type_from_value(value: f64) -> Option<(*const u8, u8)> {
-    gc_pointer_and_type_from_value(value)
+    gc_pointer_and_type_from_value(value, crate::hot_diag::NativeProbeCaller::Other)
 }
 
 #[inline]
 pub(crate) unsafe fn object_ptr_from_value(value: f64) -> Option<*mut ObjectHeader> {
-    let (ptr, gc_type) = gc_pointer_and_type_from_value(value)?;
+    object_ptr_from_value_with_probe_caller(value, crate::hot_diag::NativeProbeCaller::Other)
+}
+
+#[inline]
+pub(crate) unsafe fn object_ptr_from_value_for_view(value: f64) -> Option<*mut ObjectHeader> {
+    object_ptr_from_value_with_probe_caller(value, crate::hot_diag::NativeProbeCaller::ViewCursor)
+}
+
+#[inline]
+unsafe fn object_ptr_from_value_with_probe_caller(
+    value: f64,
+    probe_caller: crate::hot_diag::NativeProbeCaller,
+) -> Option<*mut ObjectHeader> {
+    let (ptr, gc_type) = gc_pointer_and_type_from_value(value, probe_caller)?;
     if gc_type == crate::gc::GC_TYPE_OBJECT {
         Some(ptr as *mut ObjectHeader)
     } else {

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -25,6 +25,8 @@ mod dispatch_arg_coercion_tests;
 #[cfg(test)]
 mod probe_dispatch_tests;
 #[cfg(test)]
+mod receiver_class_tests;
+#[cfg(test)]
 /// #8139: `toLocaleString` on an array / typed-array / buffer receiver.
 mod to_locale_string_tests;
 mod typed_array;
@@ -44,6 +46,136 @@ pub(crate) use proto_dispatch::{
     try_dispatch_instance_method_value, try_dispatch_value_called_proto_method,
 };
 pub(super) use typed_array::dispatch_typed_array_method;
+
+/// Receiver storage class established once at the dynamic-call boundary.
+/// Managed values are answered by their allocator-proven `GcHeader`; only a
+/// pointer with no tracked header is allowed to consult the Buffer / typed
+/// array registries.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum NativeReceiverClass {
+    Primitive,
+    Gc(u8),
+    HeaderlessBuffer,
+    HeaderlessTypedArray,
+    OtherPointer,
+}
+
+#[derive(Clone, Copy)]
+struct ReceiverKindCacheEntry {
+    site_id: u64,
+    class_id: u32,
+    gc_type: u8,
+}
+
+const EMPTY_RECEIVER_KIND_CACHE_ENTRY: ReceiverKindCacheEntry = ReceiverKindCacheEntry {
+    site_id: 0,
+    class_id: 0,
+    gc_type: 0,
+};
+const RECEIVER_KIND_CACHE_SLOTS: usize = 64;
+
+crate::perry_thread_local! {
+    static RECEIVER_KIND_CACHE: std::cell::RefCell<[ReceiverKindCacheEntry; RECEIVER_KIND_CACHE_SLOTS]> =
+        const { std::cell::RefCell::new([EMPTY_RECEIVER_KIND_CACHE_ENTRY; RECEIVER_KIND_CACHE_SLOTS]) };
+}
+
+#[cfg(test)]
+static RECEIVER_KIND_CACHE_HITS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+#[inline]
+fn receiver_kind_cache_slot(site_id: u64) -> usize {
+    (site_id as usize ^ (site_id >> 32) as usize) & (RECEIVER_KIND_CACHE_SLOTS - 1)
+}
+
+#[inline]
+fn receiver_kind_cache_lookup(
+    site_id: u64,
+    gc_type: u8,
+    class_id: u32,
+) -> Option<NativeReceiverClass> {
+    if site_id == 0 {
+        return None;
+    }
+    RECEIVER_KIND_CACHE.with(|cache| {
+        let entry = cache.borrow()[receiver_kind_cache_slot(site_id)];
+        if entry.site_id != site_id {
+            return None;
+        }
+        if entry.gc_type != gc_type || entry.class_id != class_id {
+            return None;
+        }
+        #[cfg(test)]
+        RECEIVER_KIND_CACHE_HITS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        Some(NativeReceiverClass::Gc(gc_type))
+    })
+}
+
+#[inline]
+fn receiver_kind_cache_store(site_id: u64, class_id: u32, answer: NativeReceiverClass) {
+    if site_id == 0 {
+        return;
+    }
+    let gc_type = match answer {
+        NativeReceiverClass::Gc(gc_type) => gc_type,
+        _ => return,
+    };
+    RECEIVER_KIND_CACHE.with(|cache| {
+        cache.borrow_mut()[receiver_kind_cache_slot(site_id)] = ReceiverKindCacheEntry {
+            site_id,
+            class_id,
+            gc_type,
+        };
+    });
+}
+
+#[cfg(test)]
+pub(crate) fn test_native_receiver_site_cache_hits() -> u64 {
+    RECEIVER_KIND_CACHE_HITS.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+#[inline]
+unsafe fn classify_native_receiver(
+    value: f64,
+    site_id: u64,
+    probe_caller: crate::hot_diag::NativeProbeCaller,
+) -> NativeReceiverClass {
+    let jsval = JSValue::from_bits(value.to_bits());
+    if !jsval.is_pointer() {
+        return NativeReceiverClass::Primitive;
+    }
+    let addr = jsval.as_pointer::<u8>() as usize;
+    if !crate::value::addr_class::is_above_handle_band(addr) {
+        return NativeReceiverClass::OtherPointer;
+    }
+    if let Some(header) = crate::value::addr_class::try_read_tracked_gc_header(addr) {
+        let gc_type = (*header.as_ptr()).obj_type;
+        let class_id = if gc_type == crate::gc::GC_TYPE_OBJECT {
+            (*(addr as *const ObjectHeader)).class_id
+        } else {
+            0
+        };
+        if let Some(answer) = receiver_kind_cache_lookup(site_id, gc_type, class_id) {
+            return answer;
+        }
+        let answer = NativeReceiverClass::Gc(gc_type);
+        receiver_kind_cache_store(site_id, class_id, answer);
+        return answer;
+    }
+
+    // A tracked-header miss is the only storage class whose identity is not
+    // already in the allocation. External buffers and the process-global SAB
+        // backing are headerless; native-arena typed views can be headerless too.
+    crate::hot_diag::native_note_buffer_probe(probe_caller);
+    if crate::buffer::is_registered_buffer(addr) {
+        return NativeReceiverClass::HeaderlessBuffer;
+    }
+    crate::hot_diag::native_note_typed_array_probe(probe_caller);
+    if crate::typedarray::lookup_typed_array_kind(addr).is_some() {
+        return NativeReceiverClass::HeaderlessTypedArray;
+    }
+    NativeReceiverClass::OtherPointer
+}
 
 /// #7769: skip the dispatch tower for an ordinary user-class instance whose
 /// `(class_id, method_name)` the tower has already resolved to a vtable method.
@@ -98,10 +230,8 @@ pub(super) use typed_array::dispatch_typed_array_method;
 /// * `GC_TYPE_OBJECT` without the class-object marker — excludes arrays,
 ///   strings, errors, maps, sets, regexes, closures, and class values, each of
 ///   which the tower routes to its own dispatcher;
-/// * not a registered `Buffer` and not a typed array — the two address-keyed
-///   probes the tower runs ahead of the class walk that a `GC_TYPE_OBJECT`
-///   receiver could in principle also answer. Both are latched (#7755), so in
-///   a program using neither this is two atomic loads;
+/// * allocator-proven `GC_TYPE_OBJECT` — this rules out Buffer and typed-array
+///   storage without consulting either address registry;
 /// * `meta` null — no `Object.setPrototypeOf` override, no per-key descriptor
 ///   state, no exotic-kind tag. STRICTER than the tower, which resolves
 ///   through a meta record;
@@ -111,6 +241,20 @@ pub(super) use typed_array::dispatch_typed_array_method;
 ///   `resolve_inherited_field` probe had nothing to shadow with.
 #[inline]
 unsafe fn class_vtable_fast_guard(object: f64, method_bytes: &[u8]) -> Option<(usize, u32)> {
+    let receiver_class = classify_native_receiver(
+        object,
+        0,
+        crate::hot_diag::NativeProbeCaller::NativeReceiver,
+    );
+    class_vtable_fast_guard_classified(object, method_bytes, receiver_class)
+}
+
+#[inline]
+unsafe fn class_vtable_fast_guard_classified(
+    object: f64,
+    method_bytes: &[u8],
+    receiver_class: NativeReceiverClass,
+) -> Option<(usize, u32)> {
     let bits = object.to_bits();
     if (bits >> 48) != (crate::value::POINTER_TAG >> 48) {
         return None;
@@ -119,27 +263,15 @@ unsafe fn class_vtable_fast_guard(object: f64, method_bytes: &[u8]) -> Option<(u
     if !crate::value::addr_class::is_above_handle_band(obj_addr) {
         return None;
     }
-    // `gc_pointer_and_type_from_value` — NOT a bare `obj - GC_HEADER_SIZE`
-    // read. Buffers, ArrayBuffers, typed arrays, Sets, Maps, RegExps, Symbols
-    // and AsyncResource handles are raw allocations with no `GcHeader` at that
-    // offset, so reading one directly loads foreign allocator bytes that can
-    // and do coincidentally equal a real GC type (see `handle_methods.rs`'s
-    // buffer comment, and #5625 where a typed array's stale bytes matched
-    // `GC_TYPE_TEMPORAL`). This helper screens every one of those registries
-    // first — and it is the same screen the tower's own object-pointer
-    // resolution uses, so the fast path cannot classify a receiver differently
-    // from the code it is short-circuiting.
-    let (ptr, gc_type) =
-        gc_pointer_and_type_from_value(object, crate::hot_diag::NativeProbeCaller::NativeReceiver)?;
-    if gc_type != crate::gc::GC_TYPE_OBJECT || ptr as usize != obj_addr {
+    // `classify_native_receiver` proved allocator membership before reading
+    // the header. A bare `obj - GC_HEADER_SIZE` read is unsound for external
+    // Buffer/SAB cells and native handles, whose preceding bytes are foreign.
+    if receiver_class != NativeReceiverClass::Gc(crate::gc::GC_TYPE_OBJECT) {
         return None;
     }
-    // `meta_capable_object` rather than a bare header read: it is the
-    // classifier `may_have_descriptor_entry` and `object_static_prototype` use,
-    // so a `Some` here means both of those answer authoritatively from the meta
-    // slot rather than falling back to a conservative `true`.
-    crate::hot_diag::native_note_buffer_probe(crate::hot_diag::NativeProbeCaller::NativeReceiver);
-    let obj = super::prototype_chain::meta_capable_object(obj_addr)?;
+    // Every allocator-proven GC_TYPE_OBJECT begins with ObjectHeader. Its meta
+    // slot is authoritative for descriptor/prototype state.
+    let obj = obj_addr as *mut ObjectHeader;
     if !crate::object::object_is_regular(obj) {
         return None;
     }
@@ -186,7 +318,7 @@ unsafe fn class_vtable_fast_guard(object: f64, method_bytes: &[u8]) -> Option<(u
 
     // A recorded prototype could carry a shadowing field; the tower consults it
     // before the class walk, so a fast path may not.
-    if super::prototype_chain::object_static_prototype(obj_addr).is_some() {
+    if super::prototype_chain::object_static_prototype_known_object(obj).is_some() {
         return None;
     }
 
@@ -212,18 +344,20 @@ pub(crate) fn method_name_is_fast_dispatch_ineligible(name: &str) -> bool {
 }
 
 #[inline]
-unsafe fn try_class_vtable_fast_dispatch(
+unsafe fn try_class_vtable_fast_dispatch_classified(
     object: f64,
     method_name_ptr: *const i8,
     method_name_len: usize,
     args_ptr: *const f64,
     args_len: usize,
+    receiver_class: NativeReceiverClass,
 ) -> Option<f64> {
     if method_name_ptr.is_null() || method_name_len == 0 {
         return None;
     }
     let method_bytes = std::slice::from_raw_parts(method_name_ptr as *const u8, method_name_len);
-    let (obj_addr, class_id) = class_vtable_fast_guard(object, method_bytes)?;
+    let (obj_addr, class_id) =
+        class_vtable_fast_guard_classified(object, method_bytes, receiver_class)?;
     let (func_ptr, param_count, has_synthetic_arguments, has_rest) =
         crate::object::class_registry::obj_dispatch_ic_lookup(class_id, method_bytes)?;
     // A synthesized `arguments` object or a user rest param makes
@@ -1042,21 +1176,7 @@ unsafe fn gc_pointer_and_type_from_value(
         return None;
     }
     let addr = ptr as usize;
-    crate::hot_diag::native_note_buffer_probe(probe_caller);
-    if crate::buffer::is_any_array_buffer(addr) {
-        return Some((ptr, crate::gc::GC_TYPE_BUFFER));
-    }
-    crate::hot_diag::native_note_buffer_probe(probe_caller);
-    if crate::buffer::is_uint8array_buffer(addr) {
-        return Some((ptr, crate::gc::GC_TYPE_BUFFER));
-    }
-    crate::hot_diag::native_note_typed_array_probe(probe_caller);
-    if crate::typedarray::lookup_typed_array_kind(addr).is_some() {
-        return Some((ptr, crate::gc::GC_TYPE_TYPED_ARRAY));
-    }
-    if !is_valid_obj_ptr(ptr as *const u8) {
-        return None;
-    }
+    let tracked_header = crate::value::addr_class::try_read_tracked_gc_header(addr);
     // #7850. This used to run FOUR side-registry probes unconditionally before
     // reading the `GcHeader` — and the header already records the kind that
     // three of them are looking for. `is_registered_symbol` in particular takes
@@ -1086,8 +1206,22 @@ unsafe fn gc_pointer_and_type_from_value(
     {
         return None;
     }
-    let gc_header = (ptr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
-    let obj_type = (*gc_header).obj_type;
+    let Some(gc_header) = tracked_header else {
+        // Headerless external buffers, process-global SAB backings and native
+        // typed views are the residual cases. Managed Buffer / TypedArray
+        // allocations reach the tail below with their authoritative GC type and do
+        // not touch any side registry.
+        crate::hot_diag::native_note_buffer_probe(probe_caller);
+        if crate::buffer::is_registered_buffer(addr) {
+            return Some((ptr, crate::gc::GC_TYPE_BUFFER));
+        }
+        crate::hot_diag::native_note_typed_array_probe(probe_caller);
+        if crate::typedarray::lookup_typed_array_kind(addr).is_some() {
+            return Some((ptr, crate::gc::GC_TYPE_TYPED_ARRAY));
+        }
+        return None;
+    };
+    let obj_type = (*gc_header.as_ptr()).obj_type;
     let excluded = match obj_type {
         crate::gc::GC_TYPE_SET => crate::set::is_registered_set(addr),
         crate::gc::GC_TYPE_MAP => crate::map::is_registered_map(addr),
@@ -1112,11 +1246,6 @@ pub(crate) unsafe fn test_gc_pointer_and_type_from_value(value: f64) -> Option<(
 #[inline]
 pub(crate) unsafe fn object_ptr_from_value(value: f64) -> Option<*mut ObjectHeader> {
     object_ptr_from_value_with_probe_caller(value, crate::hot_diag::NativeProbeCaller::Other)
-}
-
-#[inline]
-pub(crate) unsafe fn object_ptr_from_value_for_view(value: f64) -> Option<*mut ObjectHeader> {
-    object_ptr_from_value_with_probe_caller(value, crate::hot_diag::NativeProbeCaller::ViewCursor)
 }
 
 #[inline]
@@ -1239,6 +1368,24 @@ pub unsafe extern "C-unwind" fn js_native_call_method(
     args_ptr: *const f64,
     args_len: usize,
 ) -> f64 {
+    js_native_call_method_at_site(
+        0,
+        object,
+        method_name_ptr,
+        method_name_len,
+        args_ptr,
+        args_len,
+    )
+}
+
+pub(crate) unsafe fn js_native_call_method_at_site(
+    site_id: u64,
+    object: f64,
+    method_name_ptr: *const i8,
+    method_name_len: usize,
+    args_ptr: *const f64,
+    args_len: usize,
+) -> f64 {
     // #9675: a LEGACY BARE managed receiver — a real GC pointer that was never
     // NaN-boxed — must be reboxed under its true tag HERE, before the root
     // below and before the first probe. See `bare_receiver` for why the tail
@@ -1260,6 +1407,11 @@ pub unsafe extern "C-unwind" fn js_native_call_method(
             args_len,
         );
     }
+    let receiver_class = classify_native_receiver(
+        object,
+        site_id,
+        crate::hot_diag::NativeProbeCaller::NativeReceiver,
+    );
     if !method_name_ptr.is_null() && method_name_len > 0 {
         let method_name_bytes =
             std::slice::from_raw_parts(method_name_ptr as *const u8, method_name_len);
@@ -1304,9 +1456,14 @@ pub unsafe extern "C-unwind" fn js_native_call_method(
     // #7769: the tower's own previously-computed answer for this
     // (class_id, method_name) pair, when the receiver still satisfies every
     // per-object precondition. See `try_class_vtable_fast_dispatch`.
-    if let Some(result) =
-        try_class_vtable_fast_dispatch(object, method_name_ptr, method_name_len, args_ptr, args_len)
-    {
+    if let Some(result) = try_class_vtable_fast_dispatch_classified(
+        object,
+        method_name_ptr,
+        method_name_len,
+        args_ptr,
+        args_len,
+        receiver_class,
+    ) {
         return result;
     }
 
@@ -1972,6 +2129,7 @@ pub unsafe extern "C-unwind" fn js_native_call_method(
         method_name_len,
         args_ptr,
         args_len,
+        receiver_class,
     ) {
         return r;
     }

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -54,10 +54,30 @@ pub(super) use typed_array::dispatch_typed_array_method;
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum NativeReceiverClass {
     Primitive,
+    GcObject(u32),
     Gc(u8),
     HeaderlessBuffer,
     HeaderlessTypedArray,
     OtherPointer,
+}
+
+impl NativeReceiverClass {
+    #[inline]
+    fn may_dispatch_map_set(self) -> bool {
+        match self {
+            Self::GcObject(class_id) => {
+                super::map_set_subclass::is_map_set_subclass_class_id(class_id)
+            }
+            Self::Gc(gc_type) => {
+                matches!(gc_type, crate::gc::GC_TYPE_MAP | crate::gc::GC_TYPE_SET)
+            }
+            // Legacy/embedder-owned MapHeader and SetHeader allocations can be
+            // headerless; the collection registries remain authoritative for
+            // that residual storage class.
+            Self::OtherPointer => true,
+            _ => false,
+        }
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -107,7 +127,11 @@ fn receiver_kind_cache_lookup(
         }
         #[cfg(test)]
         RECEIVER_KIND_CACHE_HITS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        Some(NativeReceiverClass::Gc(gc_type))
+        Some(if gc_type == crate::gc::GC_TYPE_OBJECT {
+            NativeReceiverClass::GcObject(class_id)
+        } else {
+            NativeReceiverClass::Gc(gc_type)
+        })
     })
 }
 
@@ -117,6 +141,7 @@ fn receiver_kind_cache_store(site_id: u64, class_id: u32, answer: NativeReceiver
         return;
     }
     let gc_type = match answer {
+        NativeReceiverClass::GcObject(_) => crate::gc::GC_TYPE_OBJECT,
         NativeReceiverClass::Gc(gc_type) => gc_type,
         _ => return,
     };
@@ -158,14 +183,18 @@ unsafe fn classify_native_receiver(
         if let Some(answer) = receiver_kind_cache_lookup(site_id, gc_type, class_id) {
             return answer;
         }
-        let answer = NativeReceiverClass::Gc(gc_type);
+        let answer = if gc_type == crate::gc::GC_TYPE_OBJECT {
+            NativeReceiverClass::GcObject(class_id)
+        } else {
+            NativeReceiverClass::Gc(gc_type)
+        };
         receiver_kind_cache_store(site_id, class_id, answer);
         return answer;
     }
 
     // A tracked-header miss is the only storage class whose identity is not
     // already in the allocation. External buffers and the process-global SAB
-        // backing are headerless; native-arena typed views can be headerless too.
+    // backing are headerless; native-arena typed views can be headerless too.
     crate::hot_diag::native_note_buffer_probe(probe_caller);
     if crate::buffer::is_registered_buffer(addr) {
         return NativeReceiverClass::HeaderlessBuffer;
@@ -266,7 +295,7 @@ unsafe fn class_vtable_fast_guard_classified(
     // `classify_native_receiver` proved allocator membership before reading
     // the header. A bare `obj - GC_HEADER_SIZE` read is unsound for external
     // Buffer/SAB cells and native handles, whose preceding bytes are foreign.
-    if receiver_class != NativeReceiverClass::Gc(crate::gc::GC_TYPE_OBJECT) {
+    if !matches!(receiver_class, NativeReceiverClass::GcObject(_)) {
         return None;
     }
     // Every allocator-proven GC_TYPE_OBJECT begins with ObjectHeader. Its meta
@@ -2134,18 +2163,21 @@ pub(crate) unsafe fn js_native_call_method_at_site(
         return r;
     }
 
-    if let Some(r) = collection_methods::dispatch_map_set(
-        &root_scope,
-        &object_handle,
-        &arg_handles,
-        object(),
-        method_name,
-        method_name_ptr,
-        method_name_len,
-        args_ptr,
-        args_len,
-    ) {
-        return r;
+    if receiver_class.may_dispatch_map_set() {
+        if let Some(r) = collection_methods::dispatch_map_set(
+            &root_scope,
+            &object_handle,
+            &arg_handles,
+            object(),
+            method_name,
+            method_name_ptr,
+            method_name_len,
+            args_ptr,
+            args_len,
+            receiver_class,
+        ) {
+            return r;
+        }
     }
 
     if let Some(r) = collection_methods::dispatch_raw_pointer(

--- a/crates/perry-runtime/src/object/native_call_method/collection_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/collection_methods.rs
@@ -299,19 +299,10 @@ pub(super) unsafe fn dispatch_map_set(
                     _ => f64::from_bits(crate::value::TAG_UNDEFINED),
                 });
             }
-            // Buffer / Uint8Array dispatch — allocated raw, not behind a
-            // GcHeader, so it can't be discovered through the ObjectHeader
-            // path below. Tracked in BUFFER_REGISTRY. Routes Node-style
-            // numeric read/write/search/swap method family through
-            // `crate::buffer` helpers.
-            if crate::buffer::is_registered_buffer(check_ptr) {
-                return Some(dispatch_buffer_method(
-                    check_ptr,
-                    method_name,
-                    args_ptr,
-                    args_len,
-                ));
-            }
+            // Buffer and typed-array receivers were classified and dispatched
+            // by `dispatch_handle` before this residual raw Map/Set registry
+            // path. Re-probing the Buffer registry here made every ordinary
+            // object method call pay a second negative Buffer lookup.
         }
     }
 

--- a/crates/perry-runtime/src/object/native_call_method/collection_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/collection_methods.rs
@@ -54,6 +54,7 @@ pub(super) unsafe fn dispatch_map_set(
     method_name_len: usize,
     args_ptr: *const f64,
     args_len: usize,
+    receiver_class: NativeReceiverClass,
 ) -> Option<f64> {
     let jsval = JSValue::from_bits(object.to_bits());
     let raw_bits = object.to_bits();
@@ -69,7 +70,15 @@ pub(super) unsafe fn dispatch_map_set(
     //     (`m.set(a,1).set(b,2)`),
     //   * `forEach` callbacks receive the instance as their 3rd argument,
     // while `clear` → undefined and `has`/`get`/`size`/`delete` read through.
-    if let Some(backing) = super::super::map_set_subclass::subclass_backing_of(object) {
+    let subclass_backing = match receiver_class {
+        NativeReceiverClass::GcObject(_) => {
+            super::super::map_set_subclass::subclass_backing_of(object)
+        }
+        NativeReceiverClass::Gc(crate::gc::GC_TYPE_MAP | crate::gc::GC_TYPE_SET)
+        | NativeReceiverClass::OtherPointer => None,
+        _ => return None,
+    };
+    if let Some(backing) = subclass_backing {
         // Only redirect ACTUAL collection methods to the backing. A non-collection
         // method (`hasOwnProperty`, `propertyIsEnumerable`, `toString`, a
         // user-defined subclass method, …) must fall through to the normal
@@ -103,13 +112,15 @@ pub(super) unsafe fn dispatch_map_set(
             }
             return Some(undefined);
         }
-        let backing_value = match backing {
-            super::super::map_set_subclass::CollectionBacking::Map(m) => {
-                f64::from_bits(JSValue::pointer(m as *const u8).bits())
-            }
-            super::super::map_set_subclass::CollectionBacking::Set(s) => {
-                f64::from_bits(JSValue::pointer(s as *const u8).bits())
-            }
+        let (backing_value, backing_class) = match backing {
+            super::super::map_set_subclass::CollectionBacking::Map(m) => (
+                f64::from_bits(JSValue::pointer(m as *const u8).bits()),
+                NativeReceiverClass::Gc(crate::gc::GC_TYPE_MAP),
+            ),
+            super::super::map_set_subclass::CollectionBacking::Set(s) => (
+                f64::from_bits(JSValue::pointer(s as *const u8).bits()),
+                NativeReceiverClass::Gc(crate::gc::GC_TYPE_SET),
+            ),
         };
         let result = dispatch_map_set(
             root_scope,
@@ -121,6 +132,7 @@ pub(super) unsafe fn dispatch_map_set(
             method_name_len,
             args_ptr,
             args_len,
+            backing_class,
         );
         // `Map.prototype.set` / `Set.prototype.add` return the receiver — the
         // SUBCLASS INSTANCE, not the hidden backing — so chains preserve identity.
@@ -139,9 +151,15 @@ pub(super) unsafe fn dispatch_map_set(
         }
         return result;
     }
-    // Check Map/Set registries for raw or NaN-boxed pointers.
-    // Maps/Sets are allocated with plain alloc (no GcHeader), so they can't be
-    // dispatched through the ObjectHeader path below.
+    // A tracked object that reached this dispatcher has Map/Set ancestry, but
+    // without a backing it is not a raw collection. A MapHeader / SetHeader is
+    // a distinct GC layout and can never be read from this ObjectHeader cell.
+    if matches!(receiver_class, NativeReceiverClass::GcObject(_)) {
+        return None;
+    }
+    // Check Map/Set registries for raw or NaN-boxed pointers. MapHeader and
+    // SetHeader have their own GC layouts, so they cannot be dispatched through
+    // an ObjectHeader path.
     {
         let check_ptr = if jsval.is_pointer() {
             (raw_bits & 0x0000_FFFF_FFFF_FFFF) as usize

--- a/crates/perry-runtime/src/object/native_call_method/handle_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/handle_methods.rs
@@ -62,6 +62,7 @@ pub(super) unsafe fn dispatch_handle(
     method_name_len: usize,
     args_ptr: *const f64,
     args_len: usize,
+    receiver_class: NativeReceiverClass,
 ) -> Option<f64> {
     let jsval = JSValue::from_bits(object.to_bits());
     let raw_bits = object.to_bits();
@@ -131,7 +132,11 @@ pub(super) unsafe fn dispatch_handle(
         // before the buffer storage and may accidentally match GC_TYPE_OBJECT.
         // Detect buffers via the BUFFER_REGISTRY first and route through the
         // dedicated dispatcher.
-        if crate::buffer::is_registered_buffer(raw_ptr) {
+        if matches!(
+            receiver_class,
+            NativeReceiverClass::Gc(crate::gc::GC_TYPE_BUFFER)
+                | NativeReceiverClass::HeaderlessBuffer
+        ) {
             return Some(dispatch_buffer_method(
                 raw_ptr,
                 method_name,
@@ -147,7 +152,11 @@ pub(super) unsafe fn dispatch_handle(
         // callback-bearing + immutable methods to the shared helper before the
         // GC_TYPE_ARRAY check below (which only matches plain arrays).
         // Issues #2797 / #2798 / #2799.
-        if crate::typedarray::lookup_typed_array_kind(raw_ptr).is_some() {
+        if matches!(
+            receiver_class,
+            NativeReceiverClass::Gc(crate::gc::GC_TYPE_TYPED_ARRAY)
+                | NativeReceiverClass::HeaderlessTypedArray
+        ) {
             let ta = raw_ptr as *mut crate::typedarray::TypedArrayHeader;
             if let Some(r) = dispatch_typed_array_method(ta, method_name, args_ptr, args_len) {
                 return Some(r);

--- a/crates/perry-runtime/src/object/native_call_method/object_proto.rs
+++ b/crates/perry-runtime/src/object/native_call_method/object_proto.rs
@@ -308,7 +308,8 @@ pub(crate) unsafe fn js_object_is_prototype_of_value(receiver: f64, target: f64)
     // `object_ptr_from_value` (which only accepts GC_TYPE_OBJECT) returned
     // `None` and the walk bailed. #4549: use the raw GC pointer instead.
     let heap_addr = |v: f64| -> Option<usize> {
-        gc_pointer_and_type_from_value(v).map(|(ptr, _)| ptr as usize)
+        gc_pointer_and_type_from_value(v, crate::hot_diag::NativeProbeCaller::Other)
+            .map(|(ptr, _)| ptr as usize)
     };
     let receiver_addr = match heap_addr(receiver) {
         Some(addr) => addr,
@@ -348,7 +349,10 @@ pub(crate) unsafe fn js_object_is_prototype_of_value(receiver: f64, target: f64)
     }
 
     let target_jsval = JSValue::from_bits(target.to_bits());
-    if !target_jsval.is_pointer() && gc_pointer_and_type_from_value(target).is_none() {
+    if !target_jsval.is_pointer()
+        && gc_pointer_and_type_from_value(target, crate::hot_diag::NativeProbeCaller::Other)
+            .is_none()
+    {
         return false;
     }
 
@@ -399,10 +403,12 @@ pub(crate) unsafe fn js_object_is_prototype_of_value(receiver: f64, target: f64)
             }
         }
     } else {
-        let (_, target_gc_type) = match gc_pointer_and_type_from_value(target) {
-            Some(info) => info,
-            None => return false,
-        };
+        let (_, target_gc_type) =
+            match gc_pointer_and_type_from_value(target, crate::hot_diag::NativeProbeCaller::Other)
+            {
+                Some(info) => info,
+                None => return false,
+            };
         // #4549: arrays and typed arrays are objects whose `[[Prototype]]`
         // chain is modeled (`Array.prototype` → `Object.prototype`,
         // `Uint8Array.prototype` → `%TypedArray%.prototype` →

--- a/crates/perry-runtime/src/object/native_call_method/primitive_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/primitive_methods.rs
@@ -908,6 +908,9 @@ pub(super) unsafe fn dispatch_primitive(
         let top16 = raw_bits >> 48;
         if top16 == 0 && raw_bits >= 0x10000 {
             let addr = raw_bits as usize;
+            crate::hot_diag::native_note_typed_array_probe(
+                crate::hot_diag::NativeProbeCaller::DispatchPrimitive,
+            );
             if crate::typedarray::lookup_typed_array_kind(addr).is_some() {
                 let ta = addr as *mut crate::typedarray::TypedArrayHeader;
                 if let Some(r) = dispatch_typed_array_method(ta, method_name, args_ptr, args_len) {

--- a/crates/perry-runtime/src/object/native_call_method/receiver_class_tests.rs
+++ b/crates/perry-runtime/src/object/native_call_method/receiver_class_tests.rs
@@ -1,0 +1,232 @@
+//! Load-bearing tests for native-call receiver classification.
+//!
+//! A result-only test would stay green if every call went back through the
+//! Buffer and typed-array registries. These tests assert the registry-counter
+//! deltas as well as the dispatch answer, then change the receiver kind at the
+//! same feedback site so a cache that fails to revalidate goes wrong.
+
+use super::*;
+
+const SITE: u64 = 0x4E41_5449_5645_0001;
+
+fn boxed(ptr: usize) -> f64 {
+    f64::from_bits(JSValue::pointer(ptr as *mut u8).bits())
+}
+
+unsafe fn call_at(site: u64, receiver: f64, name: &[u8], args: &[f64]) -> f64 {
+    js_native_call_method_at_site(
+        site,
+        receiver,
+        name.as_ptr() as *const i8,
+        name.len(),
+        args.as_ptr(),
+        args.len(),
+    )
+}
+
+fn result_string(value: f64) -> String {
+    let jv = JSValue::from_bits(value.to_bits());
+    assert!(
+        jv.is_any_string(),
+        "expected string result, got {:#x}",
+        value.to_bits()
+    );
+    let ptr = crate::value::js_get_string_pointer_unified(value) as *const crate::StringHeader;
+    crate::string::string_as_str(ptr).to_owned()
+}
+
+/// Sabotage case one: with both registries armed, an ordinary shaped object at
+/// a warmed typed-feedback site must cause zero Buffer and typed-array registry
+/// probes. Removing the header/class gate makes either counter move.
+#[test]
+fn cached_plain_object_receiver_probes_zero_buffer_registries() {
+    let _buffer = crate::buffer::js_buffer_alloc(1, 0);
+    let _typed =
+        crate::typedarray::js_typed_array_new_empty(crate::typedarray::KIND_INT16 as i32, 1);
+    let object = crate::object::js_object_alloc(0, 1);
+    let buffer_key = crate::string::js_string_from_bytes(b"buffer".as_ptr(), 6);
+    crate::object::js_object_set_field_by_name(object, buffer_key, 17.0);
+    let receiver = boxed(object as usize);
+
+    assert_eq!(
+        result_string(unsafe { call_at(SITE, receiver, b"toString", &[]) }),
+        "[object Object]",
+        "an own property named `buffer` must not change the receiver brand"
+    );
+    let buffer_before = crate::buffer::test_buffer_registry_probe_count();
+    let typed_before = crate::typedarray::test_typed_array_registry_probe_count();
+    let cache_before = test_native_receiver_site_cache_hits();
+
+    assert_eq!(
+        result_string(unsafe { call_at(SITE, receiver, b"toString", &[]) }),
+        "[object Object]"
+    );
+    assert_eq!(
+        crate::buffer::test_buffer_registry_probe_count(),
+        buffer_before,
+        "a cached plain-object receiver must enter no Buffer registry"
+    );
+    assert_eq!(
+        crate::typedarray::test_typed_array_registry_probe_count(),
+        typed_before,
+        "a cached plain-object receiver must enter no typed-array registry"
+    );
+    assert!(
+        test_native_receiver_site_cache_hits() > cache_before,
+        "test premise: the measured call must hit the per-site kind cache"
+    );
+}
+
+#[test]
+fn primitive_receiver_tag_skips_byte_storage_registries() {
+    let _buffer = crate::buffer::js_buffer_alloc(1, 0);
+    let _typed =
+        crate::typedarray::js_typed_array_new_empty(crate::typedarray::KIND_INT16 as i32, 1);
+    let string = crate::string::js_string_from_bytes(b"tagged".as_ptr(), 6);
+    let receiver = f64::from_bits(JSValue::string_ptr(string).bits());
+    let buffer_before = crate::buffer::test_buffer_registry_probe_count();
+    let typed_before = crate::typedarray::test_typed_array_registry_probe_count();
+
+    assert_eq!(
+        result_string(unsafe { call_at(SITE + 7, receiver, b"toString", &[]) }),
+        "tagged"
+    );
+    assert_eq!(
+        crate::buffer::test_buffer_registry_probe_count(),
+        buffer_before
+    );
+    assert_eq!(
+        crate::typedarray::test_typed_array_registry_probe_count(),
+        typed_before
+    );
+}
+
+/// Sabotage case two: replace the plain receiver with a real `Buffer.from`
+/// result at the SAME site. A cache keyed only by site returns Object here and
+/// produces `[object Object]`; revalidation by GC type routes Buffer.toString.
+#[test]
+fn cached_site_revalidates_when_plain_receiver_becomes_buffer() {
+    let object = crate::object::js_object_alloc(0, 0);
+    let receiver = boxed(object as usize);
+    let _ = unsafe { call_at(SITE + 1, receiver, b"toString", &[]) };
+
+    let source = crate::string::js_string_from_bytes(b"A".as_ptr(), 1);
+    let buffer = crate::buffer::js_buffer_from_string(source, 0);
+    let buffer_probes = crate::buffer::test_buffer_registry_probe_count();
+    let typed_probes = crate::typedarray::test_typed_array_registry_probe_count();
+    assert_eq!(
+        result_string(unsafe { call_at(SITE + 1, boxed(buffer as usize), b"toString", &[]) }),
+        "A",
+        "the changed receiver kind must take Buffer dispatch"
+    );
+    assert_eq!(
+        crate::buffer::test_buffer_registry_probe_count(),
+        buffer_probes,
+        "a managed Buffer is identified by GC_TYPE_BUFFER, not its registry"
+    );
+    assert_eq!(
+        crate::typedarray::test_typed_array_registry_probe_count(),
+        typed_probes,
+        "Buffer classification must not fall through to the typed-array registry"
+    );
+}
+
+/// The three managed byte-storage brands are all `GC_TYPE_BUFFER` cells; their
+/// finer distinction remains inside buffer dispatch, where method semantics
+/// need it. Receiver classification must not flatten those answers.
+#[test]
+fn buffer_uint8array_and_arraybuffer_keep_their_method_paths() {
+    let uint8 = crate::buffer::js_uint8array_new(2.0);
+    assert!(crate::buffer::is_uint8array_buffer(uint8 as usize));
+    assert_eq!(
+        unsafe { call_at(SITE + 5, boxed(uint8 as usize), b"length", &[]) },
+        2.0,
+        "a Uint8Array-branded Buffer cell must retain Uint8Array dispatch"
+    );
+
+    let array_buffer = crate::buffer::js_buffer_alloc(3, 9);
+    crate::buffer::mark_as_array_buffer(array_buffer as usize);
+    let sliced = unsafe { call_at(SITE + 6, boxed(array_buffer as usize), b"slice", &[]) };
+    let sliced_addr = JSValue::from_bits(sliced.to_bits()).as_pointer::<u8>() as usize;
+    assert!(
+        crate::buffer::is_array_buffer(sliced_addr),
+        "ArrayBuffer.prototype.slice must still return an ArrayBuffer"
+    );
+}
+
+/// The residual headerless cases still use their authoritative registries.
+/// This covers an embedder-owned external Buffer and a typed-array view over a
+/// process-global SharedArrayBuffer backing while pinning their old dispatch.
+#[test]
+fn external_buffer_and_sab_backed_view_keep_native_dispatch() {
+    let layout = std::alloc::Layout::from_size_align(
+        std::mem::size_of::<crate::buffer::BufferHeader>() + 1,
+        8,
+    )
+    .unwrap();
+    let external = unsafe { std::alloc::alloc_zeroed(layout) };
+    assert!(!external.is_null());
+    let header = external as *mut crate::buffer::BufferHeader;
+    unsafe {
+        (*header).length = 1;
+        (*header).capacity = 1;
+        *external.add(std::mem::size_of::<crate::buffer::BufferHeader>()) = b'X';
+    }
+    crate::buffer::js_buffer_register_external(header as usize);
+    assert_eq!(
+        result_string(unsafe { call_at(SITE + 2, boxed(header as usize), b"toString", &[]) }),
+        "X",
+        "an external headerless Buffer must still dispatch through its registry"
+    );
+    // The external allocation is intentionally leaked: registration is
+    // process-global and exposes no unregister operation.
+
+    let sab = crate::shared_sab::alloc_shared_sab(4);
+    unsafe { *crate::buffer::buffer_data_mut(sab) = 7 };
+    let undefined = f64::from_bits(crate::value::TAG_UNDEFINED);
+    let view = crate::typedarray_view::js_typed_array_view(
+        crate::typedarray::KIND_INT32 as i32,
+        boxed(sab as usize),
+        0.0,
+        undefined,
+    );
+    assert_eq!(
+        unsafe { call_at(SITE + 3, boxed(view as usize), b"length", &[]) },
+        1.0,
+        "a typed-array view backed by a SharedArrayBuffer must keep typed-array dispatch"
+    );
+}
+
+extern "C" fn patched_to_string(_closure: *const crate::closure::ClosureHeader) -> f64 {
+    let s = crate::string::js_string_from_bytes(b"patched".as_ptr(), 7);
+    crate::value::js_nanbox_string(s as i64)
+}
+
+/// Receiver-kind caching must not cache prototype state. Reassigning the
+/// prototype after the site is warm has to affect the very next call.
+#[test]
+fn cached_receiver_kind_does_not_hide_reassigned_prototype() {
+    let object = crate::object::js_object_alloc(0, 0);
+    let receiver = boxed(object as usize);
+    assert_eq!(
+        result_string(unsafe { call_at(SITE + 4, receiver, b"toString", &[]) }),
+        "[object Object]"
+    );
+
+    let proto = crate::object::js_object_alloc(0, 1);
+    let closure = crate::closure::js_closure_alloc(patched_to_string as *const u8, 0);
+    crate::closure::js_register_closure_arity(patched_to_string as *const u8, 0);
+    let key = crate::string::js_string_from_bytes(b"toString".as_ptr(), 8);
+    crate::object::js_object_set_field_by_name(
+        proto,
+        key,
+        crate::value::js_nanbox_pointer(closure as i64),
+    );
+    crate::object::object_ops::js_object_set_prototype_of(receiver, boxed(proto as usize));
+
+    assert_eq!(
+        result_string(unsafe { call_at(SITE + 4, receiver, b"toString", &[]) }),
+        "patched",
+        "the kind cache must not cache a receiver's prototype resolution"
+    );
+}

--- a/crates/perry-runtime/src/object/prototype_chain.rs
+++ b/crates/perry-runtime/src/object/prototype_chain.rs
@@ -138,17 +138,15 @@ fn get_object_prototypes() -> &'static Mutex<HashMap<usize, u64>> {
 /// The classification is a pure function of the allocation, so an owner is
 /// always on exactly one of the two storages.
 pub(crate) unsafe fn meta_capable_object(obj_ptr: usize) -> Option<*mut crate::ObjectHeader> {
-    if !crate::value::addr_class::is_above_handle_band(obj_ptr)
-        // ArrayBuffer / SharedArrayBuffer / DataView use BufferHeader storage.
-        // Some of those headers pass the legacy ObjectHeader validity probe,
-        // but they do not have an ObjectMeta slot at the ObjectHeader offset.
-        || crate::buffer::is_registered_buffer(obj_ptr)
-        || !crate::object::is_valid_obj_ptr(obj_ptr as *const u8)
-    {
+    if !crate::value::addr_class::is_above_handle_band(obj_ptr) {
         return None;
     }
-    let header = crate::value::addr_class::try_read_gc_header(obj_ptr)?;
-    if header.obj_type != crate::gc::GC_TYPE_OBJECT {
+    // Allocator membership is the proof that `obj_ptr - GC_HEADER_SIZE` is
+    // readable. Managed Buffer / TypedArray cells carry distinct GC types;
+    // external buffers and SAB backings have no tracked header and therefore
+    // fall through to the residual prototype registry without a Buffer probe.
+    let header = crate::value::addr_class::try_read_tracked_gc_header(obj_ptr)?;
+    if (*header.as_ptr()).obj_type != crate::gc::GC_TYPE_OBJECT {
         return None;
     }
     Some(obj_ptr as *mut crate::ObjectHeader)
@@ -307,9 +305,6 @@ pub fn object_static_prototype(obj_ptr: usize) -> Option<u64> {
     // registry entry (the write path classifies identically), so a meta
     // miss for a shaped object is authoritative.
     unsafe {
-        crate::hot_diag::native_note_buffer_probe(
-            crate::hot_diag::NativeProbeCaller::ObjectStaticPrototype,
-        );
         if let Some(obj) = meta_capable_object(obj_ptr) {
             let meta = (*obj).meta;
             if !meta.is_null() {
@@ -321,6 +316,35 @@ pub fn object_static_prototype(obj_ptr: usize) -> Option<u64> {
             return None;
         }
     }
+    if !OBJECT_PROTOTYPES_NONEMPTY.load(Ordering::Acquire) {
+        return None;
+    }
+    get_object_prototypes()
+        .lock()
+        .ok()
+        .and_then(|map| map.get(&obj_ptr).copied())
+}
+
+/// Read the object-owned prototype slot when the caller has already proved a
+/// genuine `GC_TYPE_OBJECT`. The write path stores every such receiver in its
+/// `ObjectMeta`, so a null slot is authoritative and no residual registry or
+/// Buffer classification is needed.
+#[inline]
+pub(crate) unsafe fn object_static_prototype_known_object(
+    obj: *const crate::ObjectHeader,
+) -> Option<u64> {
+    let meta = (*obj).meta;
+    if meta.is_null() {
+        return None;
+    }
+    let bits = (*meta).prototype;
+    (bits != 0).then_some(bits)
+}
+
+/// Residual-prototype lookup for a caller that has already proved its receiver
+/// is not a shaped `GC_TYPE_OBJECT` (notably a validated RegExp cell).
+#[inline]
+pub(crate) fn object_static_prototype_known_non_object(obj_ptr: usize) -> Option<u64> {
     if !OBJECT_PROTOTYPES_NONEMPTY.load(Ordering::Acquire) {
         return None;
     }

--- a/crates/perry-runtime/src/object/prototype_chain.rs
+++ b/crates/perry-runtime/src/object/prototype_chain.rs
@@ -307,6 +307,9 @@ pub fn object_static_prototype(obj_ptr: usize) -> Option<u64> {
     // registry entry (the write path classifies identically), so a meta
     // miss for a shaped object is authoritative.
     unsafe {
+        crate::hot_diag::native_note_buffer_probe(
+            crate::hot_diag::NativeProbeCaller::ObjectStaticPrototype,
+        );
         if let Some(obj) = meta_capable_object(obj_ptr) {
             let meta = (*obj).meta;
             if !meta.is_null() {

--- a/crates/perry-runtime/src/object/regex_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/regex_proto_thunks.rs
@@ -394,7 +394,7 @@ pub(crate) fn regexp_prototype_test_is_canonical(value: f64) -> bool {
     // the object recorded below. `object_static_prototype` answers from the
     // object's own meta record, or from an atomic "nothing was ever recorded"
     // latch — no mutex, no chain walk.
-    if super::prototype_chain::object_static_prototype(recv_addr).is_some() {
+    if super::prototype_chain::object_static_prototype_known_non_object(recv_addr).is_some() {
         return false;
     }
     let proto_ptr = REGEXP_PROTOTYPE_PTR.load(std::sync::atomic::Ordering::Acquire);

--- a/crates/perry-runtime/src/object/to_string_tag.rs
+++ b/crates/perry-runtime/src/object/to_string_tag.rs
@@ -77,12 +77,25 @@ pub(crate) fn typed_array_to_string_tag_name(value: f64) -> Option<&'static str>
     if raw_addr < 0x1000 {
         return None;
     }
-    if let Some(kind) = crate::typedarray::lookup_typed_array_kind(raw_addr) {
+    let tracked_type = unsafe {
+        crate::value::addr_class::try_read_tracked_gc_header(raw_addr)
+            .map(|header| (*header.as_ptr()).obj_type)
+    };
+    let typed_kind = if tracked_type == Some(crate::gc::GC_TYPE_TYPED_ARRAY) {
+        Some(unsafe { (*(raw_addr as *const crate::typedarray::TypedArrayHeader)).kind })
+    } else if tracked_type.is_none() {
+        crate::typedarray::lookup_typed_array_kind(raw_addr)
+    } else {
+        None
+    };
+    if let Some(kind) = typed_kind {
         return Some(crate::typedarray::name_for_kind(kind));
     }
     // Buffer-backed `Uint8Array` (and Node `Buffer`) — registered as a buffer
     // but still a TypedArray. Exclude the non-TypedArray buffer flavours.
-    if crate::buffer::is_registered_buffer(raw_addr)
+    let is_buffer = tracked_type == Some(crate::gc::GC_TYPE_BUFFER)
+        || (tracked_type.is_none() && crate::buffer::is_registered_buffer(raw_addr));
+    if is_buffer
         && crate::buffer::crypto_key_meta(raw_addr).is_none()
         && !crate::buffer::is_array_buffer(raw_addr)
         && !crate::buffer::is_shared_array_buffer(raw_addr)
@@ -142,6 +155,12 @@ pub unsafe extern "C" fn js_object_to_string(value: f64) -> f64 {
     } else {
         0
     };
+    let tracked_type = if raw_addr >= 0x1000 {
+        crate::value::addr_class::try_read_tracked_gc_header(raw_addr)
+            .map(|header| (*header.as_ptr()).obj_type)
+    } else {
+        None
+    };
     // Proxy receiver (§20.1.3.6). A revocable Proxy is a POINTER_TAG value
     // whose payload is a small id in the proxy band, NOT a heap pointer, so it
     // must be handled before the brand blocks below dereference `raw_addr`.
@@ -183,7 +202,11 @@ pub unsafe extern "C" fn js_object_to_string(value: f64) -> f64 {
         let str_ptr = crate::string::js_string_from_bytes(b"[object Date]".as_ptr(), 13);
         return f64::from_bits(STRING_TAG | (str_ptr as u64 & POINTER_MASK));
     }
-    if raw_addr >= 0x1000 && crate::buffer::is_registered_buffer(raw_addr) {
+    let is_buffer = tracked_type == Some(crate::gc::GC_TYPE_BUFFER)
+        || (tracked_type.is_none()
+            && raw_addr >= 0x1000
+            && crate::buffer::is_registered_buffer(raw_addr));
+    if is_buffer {
         let tag = if crate::buffer::crypto_key_meta(raw_addr).is_some() {
             "CryptoKey"
         } else if crate::buffer::is_array_buffer(raw_addr) {
@@ -216,7 +239,13 @@ pub unsafe extern "C" fn js_object_to_string(value: f64) -> f64 {
             Some("RegExp")
         } else if crate::symbol::is_registered_symbol(raw_addr) {
             Some("Symbol")
-        } else if let Some(kind) = crate::typedarray::lookup_typed_array_kind(raw_addr) {
+        } else if let Some(kind) = if tracked_type == Some(crate::gc::GC_TYPE_TYPED_ARRAY) {
+            Some((*(raw_addr as *const crate::typedarray::TypedArrayHeader)).kind)
+        } else if tracked_type.is_none() {
+            crate::typedarray::lookup_typed_array_kind(raw_addr)
+        } else {
+            None
+        } {
             // Typed arrays are raw-i64 pointers with no brand arm; without this
             // they fall through to the `is_number()` fallback below (a small
             // raw-pointer bit pattern reads as a finite f64) → `[object Number]`.

--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -649,6 +649,8 @@ pub(crate) fn is_valid_ptr<T>(p: *const T) -> bool {
 /// read garbage from that object if we didn't gate them on this check.
 #[inline]
 pub(crate) fn is_valid_regex_ptr(p: *const RegExpHeader) -> bool {
+    #[cfg(test)]
+    REGEX_PTR_VALIDATION_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     if !is_valid_ptr(p) {
         return false;
     }
@@ -657,6 +659,15 @@ pub(crate) fn is_valid_regex_ptr(p: *const RegExpHeader) -> bool {
         return true;
     }
     regex_pointers_contains(p as usize)
+}
+
+#[cfg(test)]
+static REGEX_PTR_VALIDATION_CALLS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+#[cfg(test)]
+pub(crate) fn test_regex_ptr_validation_calls() -> u64 {
+    REGEX_PTR_VALIDATION_CALLS.load(std::sync::atomic::Ordering::Relaxed)
 }
 
 /// Public: is `addr` a RegExpHeader we allocated via `js_regexp_new`?
@@ -1459,9 +1470,9 @@ fn regexp_pattern_is_regexp_like(pattern: f64) -> bool {
 // caller (`js_segments_view_regexp_test`) references it only under this feature.
 #[cfg(feature = "regex-engine")]
 pub(crate) fn regexp_test_str_bounded(re: *const RegExpHeader, hay: &str) -> Option<bool> {
-    if !is_valid_regex_ptr(re) {
-        return None;
-    }
+    // The exported view entry established this pointer once. Keep this helper
+    // crate-private: repeating the brand check here reclassifies the same
+    // receiver for every accepted segment.
     unsafe {
         if (*re).global || (*re).sticky {
             return None;

--- a/crates/perry-runtime/src/regex/lazy.rs
+++ b/crates/perry-runtime/src/regex/lazy.rs
@@ -52,9 +52,8 @@ use regex::Regex;
 
 use super::grammar::{collapse_redos_guard_quantifiers, js_regex_to_rust_with_flags};
 use super::{
-    evict_regex_cache_if_full, get_or_compile_regex, is_valid_ptr, is_valid_regex_ptr,
-    string_as_str, RegExpHeader, FANCY_CACHE, REGEX_SOURCE_TABLE, REPEAT_MATCHER_CACHE,
-    VALIDATED_PATTERNS,
+    evict_regex_cache_if_full, get_or_compile_regex, is_valid_ptr, string_as_str, RegExpHeader,
+    FANCY_CACHE, REGEX_SOURCE_TABLE, REPEAT_MATCHER_CACHE, VALIDATED_PATTERNS,
 };
 
 /// The exact string `build_std_regex` is handed for `(pattern, flags)`: the
@@ -223,11 +222,10 @@ pub(crate) fn ensure_regex_compiled(re: *const RegExpHeader) {
 
 #[cold]
 fn build_and_install_programs(re: *const RegExpHeader) {
-    // The one place the precondition is re-checked, so a caller that has not
-    // validated cannot corrupt an unrelated allocation.
-    if !is_valid_regex_ptr(re) {
-        return;
-    }
+    // `ensure_regex_compiled` is reached only after the exported operation
+    // validated the receiver. Repeating `is_valid_regex_ptr` here made a cold
+    // first match perform the same brand check twice; the builder's safety
+    // contract is the same validated-live-header precondition as the hot path.
     let (pattern, flags) = source_and_flags(re);
     if crate::hot_diag::regex_on() {
         let cache_hit = super::REGEX_CACHE.with(|cache| {

--- a/crates/perry-runtime/src/typed_feedback/guards.rs
+++ b/crates/perry-runtime/src/typed_feedback/guards.rs
@@ -890,7 +890,8 @@ pub unsafe extern "C-unwind" fn js_typed_feedback_native_call_method(
     if !pass {
         record_fallback_call(site_id);
     }
-    crate::object::js_native_call_method(
+    crate::object::js_native_call_method_at_site(
+        site_id,
         object,
         method_name_ptr,
         method_name_len,

--- a/crates/perry-runtime/src/typedarray/mod.rs
+++ b/crates/perry-runtime/src/typedarray/mod.rs
@@ -523,8 +523,8 @@ fn lookup_registered_typed_array_kind(addr: usize) -> Option<u8> {
     kind
 }
 
-/// True for off-GC-heap, header-less allocations — small typed arrays and
-/// `Buffer`s, both raw-`alloc`'d with NO 8-byte `GcHeader` prefix and tracked
+/// True for off-GC-heap, header-less allocations — legacy small typed arrays,
+/// external buffers, and SAB backings with no tracked `GcHeader`, represented
 /// only in side tables. The runtime has many type probes of the form
 /// `*(ptr - GC_HEADER_SIZE)` (Promise/Date/Array obj_type checks); each MUST
 /// skip these allocations before that back-read, because reading the
@@ -533,6 +533,14 @@ fn lookup_registered_typed_array_kind(addr: usize) -> Option<u8> {
 /// tables only — never dereferences `addr`.
 #[inline]
 pub fn is_offheap_sidetable_alloc(addr: usize) -> bool {
+    // Managed Buffer / TypedArray cells (and every other GC allocation) are
+    // already classified by allocator-owned metadata. Only a tracked-header
+    // miss can be one of the legacy raw allocations represented solely by a
+    // side table; probing both registries for every managed pointer defeated
+    // the native-call receiver classification at each defensive header check.
+    if unsafe { crate::value::addr_class::try_read_tracked_gc_header(addr) }.is_some() {
+        return false;
+    }
     lookup_typed_array_kind(addr).is_some() || crate::buffer::is_registered_buffer(addr)
 }
 

--- a/crates/perry-runtime/src/typedarray_props.rs
+++ b/crates/perry-runtime/src/typedarray_props.rs
@@ -33,12 +33,34 @@ enum TypedArrayOwnerKind {
 
 #[inline]
 fn typed_array_owner_kind(owner: usize) -> Option<TypedArrayOwnerKind> {
-    if lookup_typed_array_kind(owner).is_some() {
-        Some(TypedArrayOwnerKind::TypedArray)
-    } else if crate::buffer::is_uint8array_buffer(owner) {
-        Some(TypedArrayOwnerKind::Uint8ArrayBuffer)
-    } else {
-        None
+    match unsafe { crate::value::addr_class::try_read_tracked_gc_header(owner) } {
+        Some(header) => match unsafe { (*header.as_ptr()).obj_type } {
+            crate::gc::GC_TYPE_TYPED_ARRAY => Some(TypedArrayOwnerKind::TypedArray),
+            crate::gc::GC_TYPE_BUFFER if crate::buffer::is_uint8array_buffer(owner) => {
+                Some(TypedArrayOwnerKind::Uint8ArrayBuffer)
+            }
+            _ => None,
+        },
+        None if lookup_typed_array_kind(owner).is_some() => Some(TypedArrayOwnerKind::TypedArray),
+        None if crate::buffer::is_uint8array_buffer(owner) => {
+            Some(TypedArrayOwnerKind::Uint8ArrayBuffer)
+        }
+        None => None,
+    }
+}
+
+/// Resolve a TypedArray element kind from the allocation header when one is
+/// present. Only a headerless native view needs the address registry.
+#[inline]
+pub(crate) fn managed_or_registered_typed_array_kind(owner: usize) -> Option<u8> {
+    match unsafe { crate::value::addr_class::try_read_tracked_gc_header(owner) } {
+        Some(header)
+            if unsafe { (*header.as_ptr()).obj_type == crate::gc::GC_TYPE_TYPED_ARRAY } =>
+        {
+            Some(unsafe { (*(owner as *const TypedArrayHeader)).kind })
+        }
+        Some(_) => None,
+        None => lookup_typed_array_kind(owner),
     }
 }
 
@@ -1051,7 +1073,7 @@ pub(crate) unsafe fn typed_array_prototype_chain_has(owner: usize, name: &str) -
 /// The element kind for a TypedArray owner address (`None` for the
 /// `BufferHeader`-backed `Uint8Array` representation).
 fn typed_array_owner_kind_id(owner: usize) -> Option<u8> {
-    lookup_typed_array_kind(owner)
+    managed_or_registered_typed_array_kind(owner)
 }
 
 /// Classify a string key against a typed array's CanonicalNumericIndexString


### PR DESCRIPTION
Runtime-only, on main `87dc33492`. Written by codex from the campaign's caller tables; **gated only partially** (archive-feature build green; the runtime test suite and the default compiler build not yet run; the last commit not yet compiled). Perrymaster runs the full gate ladder and the rows; they will be appended here.

## Why
On the best cc bundle, every native `receiver.method()` dispatch classifies its receiver through the Buffer / typed-array registries (`gc_pointer_and_type_from_value` → `is_registered_buffer`, `lookup_registered_typed_array_kind`, …): 11.5 M registry probes per 3300-char reply, 97 % of them rejections, 5.27 % of the main thread (125 of 2,373 samples), two thirds of it under the string-width loop. #9919 showed a cheaper probe does not help (a header read cost what the address filter cost); the cut has to be no probe for receivers whose kind is already known.

## What changes
- `NativeReceiverClass`: primitives by NaN-box tag return at once; managed addresses are admitted only by `try_read_tracked_gc_header`, whose GC type is authoritative, with `ObjectHeader.class_id` read only for `GC_TYPE_OBJECT`. Plain objects, boxed primitives, segment cursors and RegExp cells are allocator-owned allocations with explicit GC types, so they can never be a Buffer or typed array; the registries are consulted only after a tracked-header miss (external buffers registered without a GC header, the process-global SharedArrayBuffer backing, native-arena views) or for a finer Buffer / Uint8Array / ArrayBuffer / SAB brand that affects the requested operation.
- `js_native_call_method` classifies once at the call boundary and carries the answer into class and handle dispatch; typed feedback forwards its `site_id`. A 64-slot thread-local site cache stores `(site_id, gc_type, class_id)` only, never a pointer; every hit revalidates type and class id; headerless answers are never cached.
- The same allocator-proven decision replaces the registry questions in `object_static_prototype`, `js_object_get_field_by_name` / `get_field_by_name_object_tail`, `js_object_get_field_ic_miss` and `dispatch_primitive` (its registry question is confined to the residual untagged arm). The redundant Buffer retry at the end of Map/Set dispatch is removed.
- Segment view: `cursor_ptr` requires POINTER_TAG, current-arena membership, `GC_TYPE_OBJECT` and the fixed cursor class id; `js_segments_view_regexp_test` validates its RegExp argument exactly once per call (`regexp_test_str_bounded` no longer repeats it).
- Before-counter commit (`8ad6e0777`): a `[native-call-diag]` line splits the probes by caller (`native_receiver`, `view_cursor`, `object_static_prototype`, `field_by_name`, `field_tail`, `dispatch_primitive`, `other`), so the caller attribution is measured on the pre-fix runtime.

## Tests (named, authored; not yet executed)
`cached_plain_object_receiver_probes_zero_buffer_registries`, `cached_site_revalidates_when_plain_receiver_becomes_buffer`, `buffer_uint8array_and_arraybuffer_keep_their_method_paths`, `external_buffer_and_sab_backed_view_keep_native_dispatch`, `cached_receiver_kind_does_not_hide_reassigned_prototype`, `primitive_receiver_tag_skips_byte_storage_registries`, `view_cursor_brand_is_a_class_load_with_zero_registry_probes`, `view_regexp_pointer_is_validated_exactly_once_per_call`.

## Falsifiers on the cc reply
`[buffer-diag] probes=` from ≈ 11.5 M to ≤ 1,000,000 (prediction ≈ 0.8 M); `rejected` < 100,000; the registry group's self share from 5.27 % to ≤ 1 % with `js_native_call_method` inclusive down; turn CPU on 5 paired 3300-char turns vs the best bundle; RSS unchanged (the cache is 64 fixed entries per thread — any repeatable growth falsifies the mechanism).

## Gates
Run locally: `cargo build --release -p perry-runtime --features wasm-host` green (after four mechanical pointer/unsafe fixes); `llvm-nm -g` on the archive shows every touched export. Not run (disk floor): the runtime lib test target (it compiled after a fixture re-export fix; 0 tests executed), `cargo build --release -p perry` default features; commit `72b713b99` (the field-IC residual) not compiled at all. Draft until perrymaster's ladder and rows are on this PR.

## Gate history
- `72b713b99` on perrymaster (picked onto the best tree, and separately on this branch's own base): default build green, archive feature set green, `nm` all seven exports present; runtime lib suite **3 failed** on both trees, identically: `view_regexp_pointer_is_validated_exactly_once_per_call` (2 validations, not 1), `cached_plain_object_receiver_probes_zero_buffer_registries` (30–37 registry probes), `cached_site_revalidates_when_plain_receiver_becomes_buffer` (3–7 probes). So broken as filed, not a base interaction.
- `e02fb408b` (this head's code): three bypasses fixed with the assertions untouched — the cold `build_and_install_programs` path repeated the RegExp brand validation (`regex/lazy.rs`); `typedarray::is_offheap_sidetable_alloc` entered both byte-storage registries unconditionally from the pre-dispatch header-safety checks, now tracked-header-first with the registry fallback only for headerless storage (`typedarray/mod.rs`); `Object.prototype.toString` probed both registries for the brand, now derived from the GC type and payload (`object/to_string_tag.rs`). The suite has not yet run on this head (disk); perrymaster's ladder runs it before any measurement.
- `e02fb408b` on perrymaster (picked onto the best tree): default build, archive feature set and `nm` green; suite **1 failed** — `cached_plain_object_receiver_probes_zero_buffer_registries` (the second, site-cached `toString` on a plain object still entered the Buffer registry 5–8 times); the other seven tests, including the two named by the previous diagnosis, now pass.
- `bf1d91892` (this head's code): the residual path was `array/indexing.rs` — a plain object's internal keys array entering `js_array_get_f64`, which queried both registries unconditionally; it now reads the tracked GC type first and reserves the registries for headerless storage. Not yet run (disk); perrymaster's ladder runs it before any measurement.
- `6870b1db3` (this head's code) on perrymaster, picked onto the best tree: default build green, archive feature set green, `nm` all exports; runtime suite **3235 passed / 0 failed / 4 ignored** with all eight named tests green — the third path was the Map/Set subclass dispatcher unwrapping a plain receiver through the Buffer registry; it is now entered only when the tracked receiver class says Map/Set, the unwrap is header-first, and `is_node_buffer` follows the same discipline. The order-sensitive async-hooks failure seen once on the authoring host did not reproduce. Relinked with identity confirmed; the diag replies and rows follow.

## Measured — NR6 (perrymaster: this head's six commits on the best tree, runtime relinked on the best bundle's cache, identity equal; quiet box, paired 5-round rotation)
Counters, one 3300-char reply per arm: best bundle `[buffer-diag] probes=24 M, admits 27 %, true positives 241 k`; the counter-only arm 28.3 M with the split by caller (Buffer: view cursor 17.5 M, native receiver 6.8 M, static prototype 5.5 M, field tail 1.7 M; typed-array 8.7 / 3.4 / 1.7 M); this head crossed 1,048,576 probes once with `admits = 1050 = true positives` and every classified bucket at 0 — ≈ 28 M → 1–2 M by the counter.
Rows vs the best bundle: 3300 +1.7 / +6.7 / +2.5 / −0.4 / +1.3 % (median +1.7 %, min-vs-min +4.4 %), 400 +0.0 / +5.4 %; peak and settled RSS flat; after-idle 3300 483 → 463 MB.
Draw (999 Hz, 2,297 samples vs 2,373): gone — `is_registered_buffer_slow` 1.61 → 0.04 %, `is_registered_buffer` 1.15 → 0.09, `lookup_registered_typed_array_kind` 0.55 → 0, `object_static_prototype` 0.69 → 0.09, `js_object_get_field_ic_miss` 0.72 → 0.23, `js_segments_view_regexp_test` inclusive 6.8 → 0.5 %; appeared — `try_read_tracked_gc_header` 0.37 → 2.46 % (callers: the layout-table nursery check, `dispatch_primitive`, the IC-miss path, `js_native_call_method_at_site`, `js_array_get_f64`, the field tail), `js_native_call_method_at_site` 2.90 vs 2.31, `dispatch_primitive` 1.33 → 1.79. The receiver-dispatch family sums to ≈ 12.5 % before and ≈ 9.9 % after, inside one draw's variance of the rows. Collector/mutator split unchanged (34.3 / 65.7 → 34.7 / 65.3).
**Reading**: the mechanism is proven and correct, and the turn did not move — the registries are no longer probed, but classifying the receiver from a validated header read (`try_read_tracked_gc_header`, which classifies the address before it trusts the header) costs about what the registry filter cost, per call. The same shape as #9919. A uprobe count of the out-of-line registry entries during a reply came out orders of magnitude above the diag counter, so whether the counter undercounts through an LLVM clone that carries no counter is being checked before the next step. Either way the next cut is not a cheaper check but no per-call check: trusting the tagged pointer's header word without address classification on the native-call path, which needs the invariant proven and tested.
