### PR TITLE
Merge train: #9936

### DIFF
--- a/changelog.d/9936-module-constructor-parent-arity.md
+++ b/changelog.d/9936-module-constructor-parent-arity.md
@@ -1,0 +1,1 @@
+Fixed `new Module(id)` so an omitted parent is passed as `undefined` instead of reading an uninitialized native argument.

--- a/crates/perry-codegen/src/lower_call/native_table/node_core/module_sea_tls_test.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/node_core/module_sea_tls_test.rs
@@ -21,7 +21,10 @@ pub(crate) const NODE_CORE_MODULE_SEA_TLS_TEST_ROWS: &[NativeModSig] = &[
         method: "Module",
         class_filter: None,
         runtime: "js_module_module_new",
-        args: &[NA_F64],
+        // The runtime accepts the optional parent as its second argument.
+        // Keep the slot in the native signature so an omitted parent is
+        // explicitly padded with undefined instead of reading a stale register.
+        args: &[NA_F64, NA_F64],
         ret: NR_F64,
     },
     NativeModSig {
@@ -567,6 +570,15 @@ pub(crate) const NODE_CORE_MODULE_SEA_TLS_TEST_ROWS: &[NativeModSig] = &[
 #[cfg(test)]
 mod tests {
     use super::NODE_CORE_MODULE_SEA_TLS_TEST_ROWS;
+
+    #[test]
+    fn module_constructor_keeps_the_optional_parent_argument() {
+        let sig = NODE_CORE_MODULE_SEA_TLS_TEST_ROWS
+            .iter()
+            .find(|sig| sig.module == "module" && sig.method == "Module")
+            .expect("missing module.Module signature");
+        assert_eq!(sig.args.len(), 2, "Module must forward its optional parent");
+    }
 
     #[test]
     fn node_test_mock_accessor_calls_keep_the_options_argument() {


### PR DESCRIPTION
Merge train: **#9936**.

`new Module(id)` with the optional `parent` omitted read a **stale register**: the native signature declared a single argument slot, so the caller never padded the second one. Declaring the slot makes an omitted parent explicitly `undefined` rather than whatever the register happened to hold.

The added test asserts the signature carries both arguments, which is the right shape of check for a signature table — the defect is in the declared arity, so that is what it pins.

## Validation

`run_lint_gates: all 66 gates passed; 2 CI-only skipped`

| suite | passed | failed |
|---|---|---|
| perry-runtime | 3265 | 0 |
| perry-codegen | 1941 | 0 |
| perry-hir | 629 | 0 |
| perry-stdlib | 132 | 0 |
