### PR TITLE
perf(gc): scope the shape-table and box-roots minor scanners to young entries; per-minor pause_us

### DIFF
--- a/cc-perf-campaign/codex/REPORT_minor_scanner_young_logs.md
+++ b/cc-perf-campaign/codex/REPORT_minor_scanner_young_logs.md
@@ -1,0 +1,107 @@
+# Minor scanner young logs
+
+Implementation SHA: `d399c39ddb638a92b2735a6bacc2aef13def944a`
+
+## Map and mechanism
+
+- `object/shapes.rs:1972` scans two address-keyed structures. `families` maps a
+  keys-array address to every descriptor id whose slab record carries that
+  address; the descriptor record is the authoritative rewritable `keys` edge.
+  A family is a strong minor root only when an old receiver or an optimization
+  cache carries one of its descriptors. `indices` is a weak key-to-slot
+  accelerator keyed by the same keys-array address and needs only relocation
+  repair. Shape property-key payloads are strings/symbol headers, both GC
+  leaves. Nursery keys arrays can move; old arrays cannot; Longlived arrays do
+  not move or die but can temporarily contain a collectible key leaf.
+- Shapes already had #9755's `young_keys` address log and the four
+  `shapes.indices` arm sites. Its keep predicate was
+  `addr_is_minor_relevant`, so every Longlived keys array stayed in the log
+  forever. `object/shapes.rs:2154` now re-derives actual minor work: nursery
+  addresses remain for relocation, malloc roots remain while carrier-owned,
+  and a Longlived carrier remains only while its property-key payload contains
+  a collectible leaf. `object/shapes.rs:271` receives old/cache carrier notes
+  without recursively borrowing the shape table; `object/shapes.rs:801` is the
+  enforced structural-publication funnel that re-arms a same-address mutation.
+  Scanner-internal rekeys do not enqueue a duplicate visit.
+- `box.rs:954` previously walked every address in `BOX_REGISTRY`. These are
+  malloc-allocated mutable-capture/async state cells; the registry address is
+  not a GC pointer. Only the `Box::value` NaN-box can point into the nursery.
+  `I32Box` and `BoolBox` registries contain no GC edge and were never part of
+  this scanner. There was no partial box log.
+- `box.rs:123` adds the box remembered set. Both allocation arms and both
+  mutation ABIs arm it before publishing a minor-relevant payload
+  (`box.rs:133`, `box.rs:705`, `box.rs:725`, `box.rs:1318`, `box.rs:1357`).
+  The trusted setter is included because generated boxed-local stores use it;
+  omitting that silent path would violate the enforced-funnel rule. Release
+  paths only clear/de-register cells, and scanner rewrites compact their own
+  entries. `box.rs:1040` owns the priced `visited` counter.
+- Both minor walks sort/deduplicate their logged addresses, drop stale keys,
+  and keep only post-visit non-old entries. Full/major scans still enumerate
+  the authoritative whole tables and rebuild the logs. Under
+  `debug_assertions` and in lib tests, each minor scan re-derives the relevant
+  set from the whole table and asserts that the log is complete.
+- `gc/copying.rs:1889` now emits `pause_us=` and `scan_us=` together on every
+  completed `[gc-copy-minor] ran` line. `pause_us` is sampled as the final
+  action before the copied-minor returns to the mutator; `scan_us` is the
+  already-profiled scanner total returned by `gc/scanner_profile.rs:131`.
+  Timing remains behind the existing cached `PERRY_GC_DIAG` gate.
+
+## Tests and sabotages
+
+- `shape_table_minor_walk_visits_exactly_k_young_entries`: N old families and
+  k young families produce `visited == k`. Sabotage: remove
+  `note_young_keys`; the completeness re-derivation panics.
+- `shape_table_rederivation_rejects_a_suppressed_logging_site`: a test-only
+  suppression skips the production family arm and the scan must panic.
+- `shape_mutation_to_new_young_key_rearms_minor_log`: a Longlived carrier that
+  gains a new nursery key at the same address must move that key. Sabotage:
+  remove the re-arm in `stamp_object_shape_id_with_carrier_note`.
+- `box_roots_minor_walk_visits_exactly_k_young_entries`: N old payloads and k
+  young payloads produce `visited == k`. Sabotage: remove either allocator arm.
+- `box_root_rederivation_rejects_a_suppressed_mutation_hook`: a test-only
+  suppression skips `js_box_set_bits` logging and the authoritative registry
+  walk must panic.
+- `box_mutation_to_new_young_object_is_visited`: an old box changed to a new
+  nursery object is visited. Sabotage: remove the setter hook.
+- `promoted_shape_entry_leaves_young_log_and_remains_in_major_walk` and
+  `promoted_box_root_leaves_log_and_is_found_by_full_walk`: promotion makes
+  `kept == 0`, while the next authoritative full walk still visits the entry.
+  Sabotage: retain the pre-visit/from-space classification or scope the full
+  walk to the log.
+- Existing scanner-completeness and moving-witness suites are unchanged and
+  remain part of the requested runtime-lib gate.
+
+## Validation
+
+- `scripts/check_file_size.sh`: PASS.
+- `git diff --check`: PASS.
+- Cargo gates: NOT RUN. `df -g /` immediately before the first possible Cargo
+  invocation reported `0` GB available, below the binding 12 GB floor. Per the
+  task rule, no Cargo command was started and no wait for disk was attempted.
+- Not run for the same reason:
+  `cargo test -p perry-runtime --release --lib -- --test-threads=1`;
+  `cargo build --release -p perry-runtime --features wasm-host`;
+  `cargo build --release -p perry`.
+
+## Predictions and exact perrymaster request
+
+Predictions: on a zero-live steady minor,
+`object::shapes::scan_shape_table_rekey_mut` and
+`r#box::scan_box_roots_mut` each fall from about 2 ms to at most 0.2 ms;
+steady-minor scanner total falls from 7–8 ms to at most 3 ms; every completed
+minor reports `pause_us` and `scan_us`. CPU bound is about -3% at 3300 chars
+and larger at 400 chars, where minors are a larger share. RSS should be
+unchanged (small retained log capacities only, within the allowed 1–10%).
+
+Perrymaster request, from pushed SHA: relink on the I7-view tree
+(runtime-only), then run the three gates through
+`/Users/amlug/projects/perry/secret-tests/cc-perf-campaign/measure_lock.sh --build`
+at `-j4` using detached `nohup`: (1)
+`cargo test -p perry-runtime --release --lib -- --test-threads=1`, (2)
+`cargo build --release -p perry-runtime --features wasm-host`, and (3)
+`cargo build --release -p perry`. Because this is GC-adjacent, the coordinator
+must apply `run-extended-tests`. After green gates, do one graceful four-turn
+3300-char run and one 400-char run with `PERRY_GC_DIAG=1`, preserving complete
+`[gc-copy-minor] ran pause_us=... scan_us=...` and
+`[gc-scanner-profile] copying_minor` lines. Then run paired 5x3300 + 3x400
+against I7-view for CPU and RSS.

--- a/changelog.d/minor-scanner-young-logs.md
+++ b/changelog.d/minor-scanner-young-logs.md
@@ -1,0 +1,5 @@
+Copying-minor scans of shape descriptors and captured-variable boxes now walk
+only entries that can still expose non-old GC pointers. This removes the two
+largest table-size-dependent root-scan costs, while full collections retain
+their authoritative whole-table walks. `PERRY_GC_DIAG=1` also reports the
+whole copying-minor pause and its scanner share on each completed-minor line.

--- a/crates/perry-runtime/src/box.rs
+++ b/crates/perry-runtime/src/box.rs
@@ -117,6 +117,28 @@ crate::perry_thread_local! {
             16 * 1024,
             crate::fast_hash::PtrHasher,
         ));
+    /// Box addresses whose JSValue payload may matter to a minor collection.
+    /// The registry itself is the authoritative full/major root set; this is
+    /// only its minor remembered set.
+    static BOX_YOUNG_ROOTS: std::cell::RefCell<crate::gc::young_log::YoungLog<usize>> =
+        const { std::cell::RefCell::new(crate::gc::young_log::YoungLog::new()) };
+    #[cfg(test)]
+    static BOX_YOUNG_LOG_SUPPRESSED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+const BOX_YOUNG_LOG_NAME: &str = "box.roots";
+
+/// Arm the box minor-root log before publishing a young payload.
+#[inline]
+fn note_box_young_root(addr: usize, bits: u64) {
+    if !crate::gc::young_log::bits_are_minor_relevant(bits) {
+        return;
+    }
+    #[cfg(test)]
+    if BOX_YOUNG_LOG_SUPPRESSED.with(std::cell::Cell::get) {
+        return;
+    }
+    BOX_YOUNG_ROOTS.with(|log| log.borrow_mut().note(addr));
 }
 
 /// Number of slots in each registry's direct-mapped positive cache. Eight
@@ -680,6 +702,7 @@ pub extern "C" fn js_box_alloc_bits(initial_bits: i64) -> *mut Box {
         unsafe {
             (*ptr).value = initial_bits as u64;
         }
+        note_box_young_root(addr, initial_bits as u64);
         BOX_REGISTRY.with(|r| {
             r.borrow_mut().insert(addr);
         });
@@ -699,6 +722,7 @@ pub extern "C" fn js_box_alloc_bits(initial_bits: i64) -> *mut Box {
             return std::ptr::null_mut();
         }
         (*ptr).value = initial_bits as u64;
+        note_box_young_root(ptr as usize, initial_bits as u64);
         BOX_REGISTRY.with(|r| {
             r.borrow_mut().insert(ptr as usize);
         });
@@ -928,7 +952,14 @@ pub fn scan_box_roots(mark: &mut dyn FnMut(f64)) {
 }
 
 pub fn scan_box_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    if visitor.young_scope() {
+        scan_box_young_roots_mut(visitor);
+        return;
+    }
     let full_trace = crate::gc::full_trace_active();
+    let mut visited = 0u64;
+    let table_len = BOX_REGISTRY.with(|registry| registry.borrow().len()) as u64;
+    let mut kept = Vec::new();
     ASYNC_PENDING_RELEASES.with(|pending| {
         let pending = pending.borrow();
         BOX_REGISTRY.with(|r| {
@@ -957,11 +988,103 @@ pub fn scan_box_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
                 if addr >= 0x1000 && (addr as u64) < 0x0001_0000_0000_0000 && addr % 8 == 0 {
                     unsafe {
                         visitor.visit_nanbox_u64_raw_slot(&raw mut (*ptr).value);
+                        if crate::gc::young_log::bits_are_minor_relevant((*ptr).value) {
+                            kept.push(addr);
+                        }
                     }
+                    visited += 1;
                 }
             }
         });
     });
+    let kept_len = kept.len() as u64;
+    BOX_YOUNG_ROOTS.with(|log| {
+        let mut log = log.borrow_mut();
+        let _ = log.take_sorted();
+        log.extend(kept);
+    });
+    crate::gc::young_log::note_walk(
+        BOX_YOUNG_LOG_NAME,
+        crate::gc::young_log::YoungLogWalk {
+            partial: false,
+            logged: visited,
+            visited,
+            kept: kept_len,
+            table_len,
+        },
+    );
+}
+
+/// Every live box whose current payload a minor can move, mark through, or
+/// sweep. This is the authoritative debug re-derivation of the remembered set.
+fn relevant_box_roots() -> Vec<usize> {
+    let mut relevant = BOX_REGISTRY.with(|registry| {
+        registry
+            .borrow()
+            .iter()
+            .copied()
+            .filter(|&addr| {
+                let ptr = addr as *mut Box;
+                is_plausible_box_ptr(ptr)
+                    && unsafe { crate::gc::young_log::bits_are_minor_relevant((*ptr).value) }
+            })
+            .collect::<Vec<_>>()
+    });
+    relevant.sort_unstable();
+    relevant
+}
+
+/// Minor root scan: price only the logged boxes, and compact the log from the
+/// post-visit payloads. The visit counter lives here because this is the work
+/// whose fixed cost the counter measures.
+fn scan_box_young_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    let table_len = BOX_REGISTRY.with(|registry| registry.borrow().len()) as u64;
+    #[cfg(any(debug_assertions, test))]
+    BOX_YOUNG_ROOTS.with(|log| {
+        let relevant = relevant_box_roots();
+        log.borrow()
+            .debug_assert_logged(BOX_YOUNG_LOG_NAME, &relevant);
+    });
+
+    let mut logged = 0u64;
+    let mut visited = 0u64;
+    let mut kept = BOX_YOUNG_ROOTS.with(|log| log.borrow_mut().take_spare());
+    loop {
+        let batch = BOX_YOUNG_ROOTS.with(|log| log.borrow_mut().take_sorted());
+        if batch.is_empty() {
+            break;
+        }
+        logged += batch.len() as u64;
+        for addr in batch {
+            let registered = BOX_REGISTRY.with(|registry| registry.borrow().contains(&addr));
+            if !registered {
+                continue;
+            }
+            let ptr = addr as *mut Box;
+            if !is_plausible_box_ptr(ptr) {
+                continue;
+            }
+            visited += 1;
+            unsafe {
+                visitor.visit_nanbox_u64_raw_slot(&raw mut (*ptr).value);
+                if crate::gc::young_log::bits_are_minor_relevant((*ptr).value) {
+                    kept.push(addr);
+                }
+            }
+        }
+    }
+    let kept_len = kept.len() as u64;
+    BOX_YOUNG_ROOTS.with(|log| log.borrow_mut().extend(kept));
+    crate::gc::young_log::note_walk(
+        BOX_YOUNG_LOG_NAME,
+        crate::gc::young_log::YoungLogWalk {
+            partial: true,
+            logged,
+            visited,
+            kept: kept_len,
+            table_len,
+        },
+    );
 }
 
 /// Get the raw JSValue bit pattern from a box.
@@ -1213,6 +1336,7 @@ pub extern "C" fn js_box_set_bits(ptr: *mut Box, value_bits: i64) {
             return;
         }
         let bits = value_bits as u64;
+        note_box_young_root(ptr as usize, bits);
         (*ptr).value = bits;
         crate::gc::runtime_write_barrier_root_nanbox(bits);
     }
@@ -1232,6 +1356,7 @@ pub extern "C" fn js_box_set_bits(ptr: *mut Box, value_bits: i64) {
 #[no_mangle]
 pub unsafe extern "C" fn js_box_set_bits_trusted_no_barrier(ptr: *mut Box, value_bits: i64) {
     unsafe {
+        note_box_young_root(ptr as usize, value_bits as u64);
         (*ptr).value = value_bits as u64;
     }
 }
@@ -1479,6 +1604,7 @@ pub(crate) fn test_clear_box_registry() {
     BOX_REGISTRY.with(|r| r.borrow_mut().clear());
     I32_BOX_REGISTRY.with(|r| r.borrow_mut().clear());
     BOOL_BOX_REGISTRY.with(|r| r.borrow_mut().clear());
+    BOX_YOUNG_ROOTS.with(|log| log.borrow_mut().clear());
     BOX_FREE_HEAD.with(|h| h.set(0));
     I32_BOX_FREE_HEAD.with(|h| h.set(0));
     BOOL_BOX_FREE_HEAD.with(|h| h.set(0));
@@ -1498,6 +1624,25 @@ pub(crate) fn test_clear_box_registry() {
         for slot in cache {
             slot.set(0);
         }
+    }
+}
+
+/// Test-only sabotage of the box write-side arming hook. The production
+/// scanner's re-derivation must reject the missing log entry.
+#[cfg(test)]
+pub(crate) struct TestBoxYoungLogSuppression(bool);
+
+#[cfg(test)]
+impl TestBoxYoungLogSuppression {
+    pub(crate) fn new() -> Self {
+        Self(BOX_YOUNG_LOG_SUPPRESSED.with(|cell| cell.replace(true)))
+    }
+}
+
+#[cfg(test)]
+impl Drop for TestBoxYoungLogSuppression {
+    fn drop(&mut self) {
+        BOX_YOUNG_LOG_SUPPRESSED.with(|cell| cell.set(self.0));
     }
 }
 

--- a/crates/perry-runtime/src/gc/copying.rs
+++ b/crates/perry-runtime/src/gc/copying.rs
@@ -1872,9 +1872,23 @@ pub(super) fn run_copied_minor_attempt(
         collector.stats.copied_bytes,
         collector.stats.survivor_live_bytes,
     );
+    if let Some(d) = collector.survival.as_ref() {
+        d.report(super::survival_diag::next_minor_seq());
+    }
+    crate::arena::alloc_sample::report("minor");
+    super::diag_sites::report_primitive_dispatch("minor");
+    crate::object::shapes::id_list_report();
+    report_forwarding_refusals("copying_minor");
+    let scan_us = super::scanner_profile::report_and_reset("copying_minor");
     if crate::gc::gc_diag_enabled() {
+        // This is intentionally the last diagnostic action before returning to
+        // the mutator: `pause_us` prices the whole copied-minor path, including
+        // finalization, pruning, policy feedback and the diagnostic work above.
+        let pause_us = start.elapsed().as_micros() as u64;
         eprintln!(
-            "[gc-copy-minor] ran in_place={} untraced={} untraced_cycles={} untraced_objects={} in_place_blocks={} in_place_dead_bytes={} sparse_blocks={} survival_permille={} copied_objects={} copied_bytes={} promoted_objects={} promoted_bytes={} freed_bytes={} tenuring_survivals={} eden_live_bytes={} trigger={:?} declared_safepoint={}",
+            "[gc-copy-minor] ran pause_us={} scan_us={} in_place={} untraced={} untraced_cycles={} untraced_objects={} in_place_blocks={} in_place_dead_bytes={} sparse_blocks={} survival_permille={} copied_objects={} copied_bytes={} promoted_objects={} promoted_bytes={} freed_bytes={} tenuring_survivals={} eden_live_bytes={} trigger={:?} declared_safepoint={}",
+            pause_us,
+            scan_us,
             collector.stats.in_place_promotion,
             untraced,
             super::untraced_promotion_cycles(),
@@ -1894,14 +1908,6 @@ pub(super) fn run_copied_minor_attempt(
             super::policy::GC_AT_DECLARED_SAFEPOINT.with(std::cell::Cell::get)
         );
     }
-    if let Some(d) = collector.survival.as_ref() {
-        d.report(super::survival_diag::next_minor_seq());
-    }
-    crate::arena::alloc_sample::report("minor");
-    super::diag_sites::report_primitive_dispatch("minor");
-    crate::object::shapes::id_list_report();
-    report_forwarding_refusals("copying_minor");
-    super::scanner_profile::report_and_reset("copying_minor");
     CopiedMinorAttempt::Done(Some(CopiedMinorFastPathOutcome {
         freed_bytes,
         malloc_swept: malloc_sweep_due,

--- a/crates/perry-runtime/src/gc/scanner_profile.rs
+++ b/crates/perry-runtime/src/gc/scanner_profile.rs
@@ -128,14 +128,14 @@ pub(super) fn note_scanner(
 
 /// Print the per-scanner breakdown accumulated since the last report, then
 /// clear it. Called once per copied minor from the `[gc-copy-minor]` diag site.
-pub(super) fn report_and_reset(cycle_label: &str) {
+pub(super) fn report_and_reset(cycle_label: &str) -> u64 {
     if !scanner_profile_enabled() {
-        return;
+        return 0;
     }
     super::young_log::report_and_reset(cycle_label);
     let mut rows = SCANNER_PROFILE.with(|rows| std::mem::take(&mut *rows.borrow_mut()));
     if rows.is_empty() {
-        return;
+        return 0;
     }
     rows.sort_by(|a, b| b.1.nanos.cmp(&a.1.nanos));
     let total_ns: u64 = rows.iter().map(|(_, row)| row.nanos).sum();
@@ -159,4 +159,5 @@ pub(super) fn report_and_reset(cycle_label: &str) {
             row.rewrites
         );
     }
+    total_ns / 1000
 }

--- a/crates/perry-runtime/src/gc/tests/young_log_tests.rs
+++ b/crates/perry-runtime/src/gc/tests/young_log_tests.rs
@@ -38,6 +38,10 @@ fn old_closure() -> usize {
     ptr as usize
 }
 
+fn old_leaf() -> usize {
+    crate::arena::arena_alloc_gc_old(32, 8, GC_TYPE_STRING) as usize
+}
+
 unsafe fn young_keys_array() -> *mut crate::array::ArrayHeader {
     let arr = crate::arena::arena_alloc_gc(
         std::mem::size_of::<crate::array::ArrayHeader>(),
@@ -601,4 +605,242 @@ fn installing_an_external_shape_id_arms_the_family_log() {
         !crate::object::shapes::test_shape_ids_for_keys(moved).is_empty(),
         "the family must have followed the keys array"
     );
+}
+
+// ------------------------------------------------------ fixed-cost scanners
+
+/// N old shape families plus k young ones must price exactly k entries in the
+/// minor-scoped scanner. Sabotage: make `note_young_keys` a no-op; the
+/// re-derivation fails before this count can be observed.
+#[test]
+fn shape_table_minor_walk_visits_exactly_k_young_entries() {
+    const N: usize = 96;
+    const K: usize = 3;
+    let _guard = CopyingNurseryTestGuard::new(K as u32);
+    gc_register_mutable_root_scanner(crate::object::shapes::scan_shape_table_rekey_mut);
+    crate::object::shapes::test_clear_shape_table();
+
+    for _ in 0..N {
+        let keys = crate::arena::arena_alloc_gc_old(
+            std::mem::size_of::<crate::array::ArrayHeader>(),
+            std::mem::align_of::<crate::array::ArrayHeader>(),
+            GC_TYPE_ARRAY,
+        ) as *mut crate::array::ArrayHeader;
+        unsafe {
+            (*keys).length = 0;
+            (*keys).capacity = 0;
+        }
+        crate::object::shapes::shape_descriptor_ensure(keys, 0, 0).expect("old shape");
+    }
+    for slot in 0..K {
+        let keys = unsafe { young_keys_array() };
+        js_shadow_slot_set(slot as u32, ptr_bits(keys as usize));
+        crate::object::shapes::shape_descriptor_ensure(keys, 0, 0).expect("young shape");
+    }
+
+    let _ = gc_collect_minor();
+    let row = walk("shapes.families+indices");
+    assert!(row.partial, "{row:?}");
+    assert_eq!(
+        row.visited, K as u64,
+        "minor work must be young-sized: {row:?}"
+    );
+    assert!(
+        row.table_len >= (N + K) as u64,
+        "fixture did not build N+k: {row:?}"
+    );
+}
+
+/// The debug/test authoritative walk is the proof that every shape writer
+/// arms the log. This deliberately suppresses the production family funnel;
+/// deleting the assertion makes the sabotage go green.
+#[test]
+fn shape_table_rederivation_rejects_a_suppressed_logging_site() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    crate::object::shapes::test_clear_shape_table();
+    let keys = unsafe { young_keys_array() };
+    {
+        let _sabotage = crate::object::shapes::TestShapeYoungLogSuppression::new();
+        crate::object::shapes::shape_descriptor_ensure(keys, 0, 0).expect("shape");
+    }
+    let valid = build_valid_pointer_set();
+    let mut visitor = RuntimeRootVisitor::for_mark_scoped(&valid, true);
+    let rejected = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        crate::object::shapes::scan_shape_table_rekey_mut(&mut visitor);
+    }));
+    assert!(
+        rejected.is_err(),
+        "a missing shape log note must be detected"
+    );
+}
+
+/// Promotion removes a shape address from the minor log, without removing the
+/// descriptor from the authoritative table used by the next full/major walk.
+/// Sabotage: change the post-visit keep predicate back to
+/// `addr_is_minor_relevant(from_space)`; `kept` never reaches zero.
+#[test]
+fn promoted_shape_entry_leaves_young_log_and_remains_in_major_walk() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+    gc_register_mutable_root_scanner(crate::object::shapes::scan_shape_table_rekey_mut);
+    crate::object::shapes::test_clear_shape_table();
+    let keys = unsafe { young_keys_array() };
+    js_shadow_slot_set(0, ptr_bits(keys as usize));
+    let id = crate::object::shapes::shape_descriptor_ensure(keys, 0, 0).expect("shape");
+
+    for _ in 0..4 {
+        let _ = gc_collect_minor();
+    }
+    let promoted = (js_shadow_slot_get(0) & POINTER_MASK) as usize;
+    assert!(
+        !crate::arena::pointer_in_nursery(promoted),
+        "fixture must promote"
+    );
+    assert_eq!(walk("shapes.families+indices").kept, 0);
+
+    let valid = build_valid_pointer_set();
+    let mut visitor = RuntimeRootVisitor::for_rewrite(&valid);
+    crate::object::shapes::scan_shape_table_rekey_mut(&mut visitor);
+    let row = walk("shapes.families+indices");
+    assert!(
+        !row.partial,
+        "major/full walk must remain authoritative: {row:?}"
+    );
+    assert!(
+        row.visited >= 1,
+        "major/full walk must still see the descriptor"
+    );
+    assert_eq!(
+        crate::object::shapes::shape_descriptor_by_id(id).map(|d| d.keys),
+        Some(promoted as u64)
+    );
+}
+
+/// An already-Longlived keys array can gain a new nursery key at the same
+/// address. Re-stamping the old receiver is the structural publication
+/// chokepoint that must re-arm it.
+#[test]
+fn shape_mutation_to_new_young_key_rearms_minor_log() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    gc_register_mutable_root_scanner(crate::object::shapes::scan_shape_table_rekey_mut);
+    crate::object::shapes::test_clear_shape_table();
+    unsafe {
+        let bytes = std::mem::size_of::<crate::array::ArrayHeader>() + 8;
+        let keys = crate::arena::arena_alloc_gc_longlived(bytes, 8, GC_TYPE_ARRAY)
+            as *mut crate::array::ArrayHeader;
+        (*keys).length = 1;
+        (*keys).capacity = 1;
+        let slot =
+            (keys as *mut u8).add(std::mem::size_of::<crate::array::ArrayHeader>()) as *mut f64;
+        *slot = f64::from_bits(string_bits(old_leaf()));
+        let id = crate::object::shapes::shape_descriptor_ensure(keys, 1, 0).expect("shape");
+        let (owner, _) = alloc_old_test_object(0);
+        crate::object::shapes::stamp_object_shape_id_with_carrier_note(owner, id);
+        let _ = gc_collect_minor();
+        assert_eq!(walk("shapes.families+indices").kept, 0);
+
+        let young = young_leaf();
+        *slot = f64::from_bits(string_bits(young));
+        crate::object::shapes::stamp_object_shape_id_with_carrier_note(owner, id);
+        let _ = gc_collect_minor();
+        let moved = ((*slot).to_bits() & POINTER_MASK) as usize;
+        assert_ne!(
+            moved, young,
+            "the mutation hook must make the new key visible"
+        );
+        assert!(walk("shapes.families+indices").visited >= 1);
+    }
+}
+
+/// N old box payloads plus k young payloads must price exactly k registry
+/// entries. The counter is recorded inside `scan_box_young_roots_mut`.
+#[test]
+fn box_roots_minor_walk_visits_exactly_k_young_entries() {
+    const N: usize = 128;
+    const K: usize = 4;
+    let _guard = CopyingNurseryTestGuard::new(0);
+    gc_register_mutable_root_scanner(crate::r#box::scan_box_roots_mut);
+    for _ in 0..N {
+        crate::r#box::js_box_alloc_bits(string_bits(old_leaf()) as i64);
+    }
+    for _ in 0..K {
+        crate::r#box::js_box_alloc_bits(string_bits(young_leaf()) as i64);
+    }
+
+    let _ = gc_collect_minor();
+    let row = walk("box.roots");
+    assert!(row.partial, "{row:?}");
+    assert_eq!(
+        row.visited, K as u64,
+        "minor work must be young-sized: {row:?}"
+    );
+    assert_eq!(
+        row.table_len,
+        (N + K) as u64,
+        "fixture registry mismatch: {row:?}"
+    );
+}
+
+/// Suppress the real `js_box_set_bits` arming site and prove the full-registry
+/// re-derivation catches the omission.
+#[test]
+fn box_root_rederivation_rejects_a_suppressed_mutation_hook() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let cell = crate::r#box::js_box_alloc_bits(string_bits(old_leaf()) as i64);
+    let young = young_leaf();
+    {
+        let _sabotage = crate::r#box::TestBoxYoungLogSuppression::new();
+        crate::r#box::js_box_set_bits(cell, string_bits(young) as i64);
+    }
+    let valid = build_valid_pointer_set();
+    let mut visitor = RuntimeRootVisitor::for_mark_scoped(&valid, true);
+    let rejected = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        crate::r#box::scan_box_roots_mut(&mut visitor);
+    }));
+    assert!(
+        rejected.is_err(),
+        "a missing box mutation note must be detected"
+    );
+}
+
+#[test]
+fn box_mutation_to_new_young_object_is_visited() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    gc_register_mutable_root_scanner(crate::r#box::scan_box_roots_mut);
+    let cell = crate::r#box::js_box_alloc_bits(string_bits(old_leaf()) as i64);
+    let young = young_leaf();
+    crate::r#box::js_box_set_bits(cell, string_bits(young) as i64);
+
+    let _ = gc_collect_minor();
+    let moved = (crate::r#box::js_box_get_bits(cell) as u64 & POINTER_MASK) as usize;
+    assert_ne!(moved, young, "setter must re-arm a previously old box");
+    assert_eq!(walk("box.roots").visited, 1);
+}
+
+#[test]
+fn promoted_box_root_leaves_log_and_is_found_by_full_walk() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    gc_register_mutable_root_scanner(crate::r#box::scan_box_roots_mut);
+    let cell = crate::r#box::js_box_alloc_bits(string_bits(young_leaf()) as i64);
+    for _ in 0..4 {
+        let _ = gc_collect_minor();
+    }
+    let promoted_bits = crate::r#box::js_box_get_bits(cell) as u64;
+    let promoted = (promoted_bits & POINTER_MASK) as usize;
+    assert!(
+        !crate::arena::pointer_in_nursery(promoted),
+        "fixture must promote"
+    );
+    assert_eq!(walk("box.roots").kept, 0);
+
+    let mut seen = false;
+    crate::r#box::scan_box_roots(&mut |value| {
+        if value.to_bits() == promoted_bits {
+            seen = true;
+        }
+    });
+    assert!(
+        seen,
+        "the unchanged full walk must still enumerate promoted roots"
+    );
+    assert!(!walk("box.roots").partial);
 }

--- a/crates/perry-runtime/src/gc/young_log.rs
+++ b/crates/perry-runtime/src/gc/young_log.rs
@@ -155,7 +155,7 @@ impl<K: Copy + Ord> YoungLog<K> {
     /// Rule 2: the log must name every key in `relevant`. `relevant` is the
     /// set the caller re-derived from the authoritative table under
     /// `debug_assertions`; a miss is a writer that publishes without noting.
-    #[cfg(debug_assertions)]
+    #[cfg(any(debug_assertions, test))]
     pub(crate) fn debug_assert_logged(&self, table: &'static str, relevant: &[K])
     where
         K: std::fmt::Debug,
@@ -207,6 +207,44 @@ pub(crate) fn addr_is_minor_relevant(addr: usize) -> bool {
                     (addr - GC_HEADER_SIZE) as *const super::GcHeader,
                 )
         }
+    }
+}
+
+/// Can a minor move or reclaim the object at `addr`?
+///
+/// This is narrower than [`addr_is_minor_relevant`]: `Longlived` objects must
+/// sometimes be traced *through*, but they are never themselves moved or
+/// swept.  Side tables whose entries name known GC leaves (shape property
+/// keys are strings/symbol headers) use this predicate so an immortal leaf
+/// does not pin its entry in a young log forever.
+#[inline]
+pub(crate) fn addr_is_minor_collectible(addr: usize) -> bool {
+    if addr == 0 {
+        return false;
+    }
+    match crate::arena::classify_heap_space(addr) {
+        HeapSpace::NurseryEden
+        | HeapSpace::Survivor0
+        | HeapSpace::Survivor1
+        | HeapSpace::PromotedYoung => true,
+        HeapSpace::Old | HeapSpace::Longlived => false,
+        HeapSpace::Unknown => {
+            addr > GC_HEADER_SIZE
+                && super::malloc::gc_malloc_header_is_tracked(
+                    (addr - GC_HEADER_SIZE) as *const super::GcHeader,
+                )
+        }
+    }
+}
+
+/// [`addr_is_minor_collectible`] for a NaN-boxed value.
+#[inline]
+pub(crate) fn bits_are_minor_collectible(bits: u64) -> bool {
+    let tag = bits & TAG_MASK;
+    if tag == POINTER_TAG || tag == STRING_TAG || tag == BIGINT_TAG {
+        addr_is_minor_collectible((bits & POINTER_MASK) as usize)
+    } else {
+        false
     }
 }
 

--- a/crates/perry-runtime/src/object/shapes.rs
+++ b/crates/perry-runtime/src/object/shapes.rs
@@ -264,6 +264,28 @@ struct ShapeTableInner {
 
 const SHAPE_YOUNG_LOG_NAME: &str = "shapes.families+indices";
 
+crate::perry_thread_local! {
+    /// Carrier notes can be produced while a GC walk already borrows the shape
+    /// table. Keep that write-side stream separate and merge it at the next
+    /// scanner entry rather than re-borrowing `ShapeTableInner` recursively.
+    static SHAPE_CARRIER_YOUNG_KEYS: RefCell<crate::gc::young_log::YoungLog<u64>> =
+        const { RefCell::new(crate::gc::young_log::YoungLog::new()) };
+    #[cfg(test)]
+    static SHAPE_YOUNG_LOG_SUPPRESSED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+#[inline]
+fn note_shape_carrier_candidate(keys: u64) {
+    if !crate::gc::young_log::addr_is_minor_relevant(keys as usize) {
+        return;
+    }
+    #[cfg(test)]
+    if SHAPE_YOUNG_LOG_SUPPRESSED.with(std::cell::Cell::get) {
+        return;
+    }
+    SHAPE_CARRIER_YOUNG_KEYS.with(|log| log.borrow_mut().note(keys));
+}
+
 /// Re-export of the id-list operation counters' report, so the collector does
 /// not have to name a private sibling module. One `[gc-idlist]` line per
 /// copying minor under `PERRY_GC_DIAG=1`; `elems_moved` is the falsifier for
@@ -281,7 +303,11 @@ impl ShapeTableInner {
     /// call this themselves.
     #[inline]
     fn note_young_keys(&mut self, keys: u64) {
-        if crate::gc::young_log::addr_is_minor_relevant(keys as usize) {
+        #[cfg(test)]
+        if SHAPE_YOUNG_LOG_SUPPRESSED.with(std::cell::Cell::get) {
+            return;
+        }
+        if crate::gc::young_log::addr_is_minor_collectible(keys as usize) {
             self.young_keys.note(keys);
         }
     }
@@ -692,8 +718,12 @@ pub(crate) unsafe fn note_old_generation_carrier(descriptor: Option<ShapeDescrip
         return;
     }
     let record = descriptor.record as *mut ShapeRecord;
+    let first_note_this_epoch = !(*record).has(RECORD_FLAG_OLD_CARRIER_SEEN);
     // GC_STORE_AUDIT(POINTER_FREE): liveness bookkeeping bits, never a heap reference.
     (*record).set(RECORD_FLAG_OLD_CARRIER | RECORD_FLAG_OLD_CARRIER_SEEN, true);
+    if first_note_this_epoch {
+        note_shape_carrier_candidate(descriptor.keys);
+    }
 }
 
 /// Note that a complete full trace visited a receiver carrying this shape.
@@ -734,8 +764,12 @@ pub(crate) unsafe fn note_cache_carrier(descriptor: Option<ShapeDescriptor>) {
         return;
     }
     let record = descriptor.record as *mut ShapeRecord;
+    let newly_armed = !(*record).has(RECORD_FLAG_CACHE_CARRIER);
     // GC_STORE_AUDIT(POINTER_FREE): liveness bookkeeping bit, never a heap reference.
     (*record).set(RECORD_FLAG_CACHE_CARRIER, true);
+    if newly_armed {
+        note_shape_carrier_candidate(descriptor.keys);
+    }
 }
 
 /// The post-birth publication point for a ShapeId into a receiver's header
@@ -770,7 +804,15 @@ pub(crate) unsafe fn stamp_object_shape_id_with_carrier_note(
 ) {
     (*obj).parent_class_id = id;
     if !crate::arena::pointer_in_nursery(obj as usize) {
-        note_old_generation_carrier(shape_descriptor_by_id(id));
+        let descriptor = shape_descriptor_by_id(id);
+        note_old_generation_carrier(descriptor);
+        // This stamp is the structural-mutation publication funnel. Re-arm
+        // even when the descriptor was already an old carrier: an owned
+        // Longlived keys array may have just gained a nursery key at the same
+        // address, and its carrier flag alone cannot express that transition.
+        if let Some(descriptor) = descriptor {
+            note_shape_carrier_candidate(descriptor.keys);
+        }
     }
 }
 
@@ -1930,6 +1972,8 @@ pub(crate) fn prune_dead_shape_keys_young(is_dead_owner: &dyn Fn(usize) -> bool)
 pub(crate) fn scan_shape_table_rekey_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
     let table = &crate::state::state().shapes;
     let mut inner = table.inner.borrow_mut();
+    let carrier_notes = SHAPE_CARRIER_YOUNG_KEYS.with(|log| log.borrow_mut().take_sorted());
+    inner.young_keys.extend(carrier_notes);
     let rewrite_phase = visitor.is_metadata_rewrite_phase();
     // #9754: a minor-scoped pass visits only the young-logged keys addresses;
     // the full walk below rebuilds the log from what it finds.
@@ -2045,7 +2089,7 @@ pub(crate) fn scan_shape_table_rekey_mut(visitor: &mut crate::gc::RuntimeRootVis
     }
 
     // A full walk is authoritative: rebuild the young log from the tables.
-    let kept = relevant_shape_keys(&inner);
+    let kept = relevant_shape_keys(table, &inner);
     let kept_len = kept.len() as u64;
     let _ = inner.young_keys.take_sorted();
     inner.young_keys.extend(kept);
@@ -2080,31 +2124,80 @@ fn move_shape_family(table: &ShapeTable, inner: &mut ShapeTableInner, old: u64, 
             inner.facts_remove(record.facts_key_with_keys(old), id);
             inner.facts_push_back(record.facts_key_with_keys(new), id);
         }
-        inner.family_push_back(new, id);
+        // Scanner-internal rekey: the caller keeps `new` from its post-visit
+        // relevance result (or the full walk rebuilds the log). Re-entering
+        // the writer funnel here would enqueue the same family mid-walk and
+        // price it twice in one minor.
+        inner.families.entry(new).or_default().push_back(id);
     }
 }
 
 /// Every keys address a minor can act on, re-derived from the authoritative
 /// tables (families and slot indices whose keys array is not old).
-fn relevant_shape_keys(inner: &ShapeTableInner) -> Vec<u64> {
-    use crate::gc::young_log::addr_is_minor_relevant;
-    let mut relevant: Vec<u64> = inner
-        .families
-        .keys()
-        .copied()
-        .filter(|&keys| keys != 0 && addr_is_minor_relevant(keys as usize))
-        .collect();
-    relevant.extend(
-        inner
-            .indices
-            .keys()
-            .copied()
-            .filter(|&keys| addr_is_minor_relevant(keys))
-            .map(|keys| keys as u64),
-    );
+fn relevant_shape_keys(table: &ShapeTable, inner: &ShapeTableInner) -> Vec<u64> {
+    let mut relevant: Vec<u64> = inner.families.keys().copied().collect();
+    relevant.extend(inner.indices.keys().copied().map(|keys| keys as u64));
     relevant.sort_unstable();
     relevant.dedup();
+    relevant.retain(|&keys| shape_keys_entry_is_minor_relevant(table, inner, keys));
     relevant
+}
+
+/// Exact minor-work predicate for one shape-table key.
+///
+/// Nursery addresses must be rekeyed even for weak metadata entries. Malloc
+/// arrays must be rooted when a carrier owns the family. A Longlived keys
+/// array never moves or dies, so it matters only while a rooted family exposes
+/// a collectible property-key leaf from its payload. Property keys are
+/// strings/symbol headers and both are GC leaves; tracing through an immortal
+/// key cannot discover a younger grandchild.
+fn shape_keys_entry_is_minor_relevant(
+    table: &ShapeTable,
+    inner: &ShapeTableInner,
+    keys: u64,
+) -> bool {
+    if keys == 0 {
+        return false;
+    }
+    let addr = keys as usize;
+    match crate::arena::classify_heap_space(addr) {
+        crate::arena::HeapSpace::NurseryEden
+        | crate::arena::HeapSpace::Survivor0
+        | crate::arena::HeapSpace::Survivor1
+        | crate::arena::HeapSpace::PromotedYoung => return true,
+        crate::arena::HeapSpace::Old => return false,
+        crate::arena::HeapSpace::Unknown => {
+            return family_has_root_carrier(table, inner, keys)
+                && crate::gc::young_log::addr_is_minor_collectible(addr);
+        }
+        crate::arena::HeapSpace::Longlived => {}
+    }
+    if !family_has_root_carrier(table, inner, keys) {
+        return false;
+    }
+    unsafe {
+        let Some(header) = crate::value::addr_class::try_read_tracked_gc_header(addr) else {
+            return false;
+        };
+        if (*header.as_ptr()).obj_type != crate::gc::GC_TYPE_ARRAY {
+            return false;
+        }
+        let (slots, len) = super::keys_array_dense_slots(addr as *const ArrayHeader);
+        (0..len).any(|index| {
+            crate::gc::young_log::bits_are_minor_collectible((*slots.add(index)).to_bits())
+        })
+    }
+}
+
+fn family_has_root_carrier(table: &ShapeTable, inner: &ShapeTableInner, keys: u64) -> bool {
+    inner.families.get(&keys).is_some_and(|ids| {
+        ids.as_slice().iter().any(|&id| {
+            table
+                .slab()
+                .get(id)
+                .is_some_and(|record| record.has(RECORD_FLAG_OLD_CARRIER) || record.cache_carrier())
+        })
+    })
 }
 
 /// The minor-scoped walk (#9754): only the young-logged keys addresses, each
@@ -2118,9 +2211,9 @@ fn scan_shape_table_young(
     rewrite_phase: bool,
 ) {
     let table_len = (inner.families.len() + inner.indices.len()) as u64;
-    #[cfg(debug_assertions)]
+    #[cfg(any(debug_assertions, test))]
     {
-        let relevant = relevant_shape_keys(inner);
+        let relevant = relevant_shape_keys(table, inner);
         inner
             .young_keys
             .debug_assert_logged(SHAPE_YOUNG_LOG_NAME, &relevant);
@@ -2242,10 +2335,7 @@ fn scan_shape_keys_address(
             inner.indices.remove(&addr);
         }
     }
-    (
-        post,
-        crate::gc::young_log::addr_is_minor_relevant(post as usize),
-    )
+    (post, shape_keys_entry_is_minor_relevant(table, inner, post))
 }
 
 // #8112 sabotage switch. Suppressing the descriptor edge proves the fixture's

--- a/crates/perry-runtime/src/object/shapes_test_support.rs
+++ b/crates/perry-runtime/src/object/shapes_test_support.rs
@@ -44,6 +44,25 @@ pub(crate) struct TestRecycledKeysCheckSuppression {
     previous: bool,
 }
 
+/// Suppress both shape-table young-log writer funnels. A test using this guard
+/// must be rejected by the scanner's authoritative re-derivation.
+#[cfg(test)]
+pub(crate) struct TestShapeYoungLogSuppression(bool);
+
+#[cfg(test)]
+impl TestShapeYoungLogSuppression {
+    pub(crate) fn new() -> Self {
+        Self(SHAPE_YOUNG_LOG_SUPPRESSED.with(|cell| cell.replace(true)))
+    }
+}
+
+#[cfg(test)]
+impl Drop for TestShapeYoungLogSuppression {
+    fn drop(&mut self) {
+        SHAPE_YOUNG_LOG_SUPPRESSED.with(|cell| cell.set(self.0));
+    }
+}
+
 #[cfg(test)]
 impl TestRecycledKeysCheckSuppression {
     pub(crate) fn new() -> Self {
@@ -84,6 +103,7 @@ pub(crate) fn test_clear_shape_table() {
     inner.by_facts.clear();
     inner.families.clear();
     inner.young_keys.clear();
+    SHAPE_CARRIER_YOUNG_KEYS.with(|log| log.borrow_mut().clear());
     // SAFETY: test-only reset with no slab reference held.
     unsafe { table.slab_mut().clear() };
     drop(inner);


### PR DESCRIPTION
Runtime-only, on main `616a2cb84`. Written by codex from the campaign's per-minor scanner profile; **not yet compiled** (the authoring host had no disk) — perrymaster's gate ladder and rows will be appended here. GC-adjacent: needs `run-extended-tests`.

## Why
On cc (4-turn 3300-char replies, `[gc-scanner-profile] copying_minor`), a steady-state copying minor's scanner time is 7–20 ms, and a minor whose young live set is **0 MB** still pays 7.4–7.8 ms. Two scanners own ~70 % of it at every nursery size: `object::shapes::scan_shape_table_rekey_mut` (4.8–7.3 ms median, 42–48 %) and `r#box::scan_box_roots_mut` (3.3–3.7 ms, 22–29 %). Their cost is a function of table size, not of how many young entries exist — the term the young-entry logs of #9755 removed for the other side tables. Steady survival per minor on cc is 0–9 %, and a run has 8–13 minors, so the bound is ≈ 10 ms × minors (≈ 3 % of turn CPU at 3300, more at 400 where minors are a larger share), at every nursery size.

## What changes
- **Shapes**: the table already had #9755's `young_keys` log, but its keep predicate kept every long-lived keys array in the log forever. The minor walk now re-derives actual minor work: nursery addresses stay for relocation, malloc roots stay while carrier-owned, and a long-lived carrier stays only while its property-key payload contains a collectible leaf. Carrier notes are received without re-borrowing the table; the structural-publication funnel re-arms a same-address mutation; scanner-internal rekeys do not enqueue duplicate visits.
- **Box roots**: `scan_box_roots_mut` walked every address in `BOX_REGISTRY` (malloc cells whose only GC edge is the `Box::value` NaN-box). A box remembered set is armed on both allocation arms and both mutation ABIs, including the trusted setter used by generated boxed-local stores (the enforced-funnel rule). Release paths only clear; scanner rewrites compact their own entries.
- Both minor walks sort and deduplicate their logged addresses, drop stale keys and keep only post-visit non-old entries. Full and major walks still enumerate the whole tables and rebuild the logs. Under `debug_assertions` and in lib tests every minor scan re-derives the relevant set from the whole table and asserts the log is complete.
- `[gc-copy-minor] ran` now prints `pause_us=` (sampled as the last action before the mutator resumes) and `scan_us=`, so a steady minor's whole cost becomes a number for the first time. `PERRY_GC_DIAG` only.

## Tests (named, sabotage stated in the campaign report; not yet executed)
`shape_table_minor_walk_visits_exactly_k_young_entries`, `shape_table_rederivation_rejects_a_suppressed_logging_site`, `shape_mutation_to_new_young_key_rearms_minor_log`, `box_roots_minor_walk_visits_exactly_k_young_entries`, `box_root_rederivation_rejects_a_suppressed_mutation_hook`, `box_mutation_to_new_young_object_is_visited`, `promoted_shape_entry_leaves_young_log_and_remains_in_major_walk`, `promoted_box_root_leaves_log_and_is_found_by_full_walk`; the existing scanner-completeness and moving-witness suites unchanged.

## Predictions (falsifiers on the cc diag run)
On a zero-live steady minor both scanners fall from ~2 ms to ≤ 0.2 ms; a steady minor's scanner total from 7–8 ms to ≤ 3 ms; `pause_us` and `scan_us` on every completed minor; paired turn CPU vs the best bundle ≈ −3 % at 3300, more at 400; RSS unchanged (small retained log capacities only).

## Measured — MS2 (perrymaster, control = main `504e180d0` + `c81ea9043` (the young-log rollback fix this PR's hunks depend on) vs the same + this commit, both relinked on main's cache; gate ladder green; quiet box, stamped rows)
| | 3300 turn CPU, 5 rounds | 400 turn CPU, 3 rounds | peak RSS | settled RSS |
|---|---|---|---|---|
| main | 2.75, 2.79, 2.71, 2.77, 2.78 | 1.05, 1.05, 1.04 | 601–612 | 480–496 |
| **this PR** | **2.66, 2.68, 2.65, 2.68, 2.68** | **0.97, 0.96, 1.00** | 615–620 | 496–506 |
| paired Δ | −3.3, −3.9, −2.2, −3.2, −3.6 % (faster 5/5) | −7.6, −8.6, −3.8 % (faster 3/3) | +1…+3 % | +1…+5 % |

The predicted bound (≈ −3 % at 3300, more at 400 where minors are a larger share) held; the small RSS increase is the retained young-entry log capacity, inside the campaign's +1–10 % rule. Per-scanner and `pause_us` numbers from the same run are appended below once read.

## Per-minor numbers from the same run (this PR's runtime, 4-turn 3300 run, 27 minors)
`[gc-copy-minor] ran pause_us= scan_us=` now exists: startup minors 57–164 ms whole (13–25 MB copied or promoted each); **steady minors 32–59 ms whole, of which 11–18 ms is scanner time** (median scanner total 15.4 ms over 16 steady minors; whole-minor mean 57.6 ms including startup). `scan_box_roots_mut` no longer appears among the top scanners of any steady minor. `scan_shape_table_rekey_mut` dropped from the first place on every minor to 3–5 ms on some steady minors and absent from the top four on the rest, so the "≤ 0.2 ms on a zero-live minor" prediction is only partly met and the remaining long-lived carriers are the next thing to look at. The scanners that now lead a steady minor: `scan_descriptor_roots_mut` 3–6 ms, `scan_closure_dynamic_props_roots_mut` 1–6 ms, `scan_builtin_closure_metadata_roots_mut` 2–3 ms, `scan_template_raw_roots_mut` 1–3 ms, the symbol side table 1–2 ms — the same table-size shape this PR removed for shapes and boxes. The larger number the new counter exposes is the non-scanner part of a steady minor, 20–45 ms, which the diag cannot yet attribute.

## Control vs this PR, same-time pairs (MS2c: 4-turn 3300 runs, two rounds alternating, 27 minors each side)
Steady-minor scanner medians, control → this PR: `scan_shape_table_rekey_mut` 3.9 / 3.3 ms → **0**, `scan_box_roots_mut` 3.4 / 3.4 → **0.06 ms**; every other scanner identical on both sides (`scan_descriptor_roots_mut` 4.1 / 4.2 vs 4.1, closure dynamic props 3.4 vs 3.6, template raw roots 1.8 / 1.9 vs 1.8, symbol side table 1.7 / 1.9 vs 1.7, builtin closure metadata 1.5 vs 1.6). Steady scanner total 22.4 / 20.6 → 15.3 ms. Whole run: `minor_us` 1.750 / 1.723 s → 1.570 s (−10 %), GC share 40 / 38 → 35 ‰, mean whole-minor cost 64.8 / 63.8 → 58.1 ms — the ~7 ms scanner saving shows up one-for-one in the minor. Steady `pause_us` on this PR's runtime: median ≈ 46 ms (30–76), so the profiled scanners are about a third of a steady minor and the rest is the next instrument's job. The five scanners left are the same table-size shape on this bundle and the next candidates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved minor garbage-collection scans to visit only shape and captured-variable entries that may contain collectible young objects.
  - Added detailed diagnostics showing total minor-collection pause time and scanner time when enabled.
  - Full collections continue to perform comprehensive table scans.

- **Bug Fixes**
  - Improved handling of remembered references when objects are promoted or later acquire young references.

- **Documentation**
  - Added release documentation and a technical report describing the scanner optimization, validation, and benchmark guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->